### PR TITLE
feat(pkt-v3.6.8): universal Standing Orders composer fix + tests

### DIFF
--- a/NotionBridge/Modules/StandingOrders/StandingOrdersComposer.swift
+++ b/NotionBridge/Modules/StandingOrders/StandingOrdersComposer.swift
@@ -28,6 +28,18 @@ public enum StandingOrdersComposer {
     /// Per-client overlay. Bridge supports tailoring a short addendum
     /// based on the connecting client's name. Pass nil for the global
     /// default.
+    ///
+    /// PKT v3.6·8 design decision: the on-disk `orders.md` is authored
+    /// as a **universal chief-of-staff preamble** that serves every
+    /// MCP client equally well via the principle-first / Notion-impl-
+    /// footnote dual-register pattern. Overlays are intentionally empty
+    /// by default — the unified-preamble thesis is that one center
+    /// across every system compounds operator alignment more than
+    /// per-client tailoring would. This mechanism remains available
+    /// as a future lever if any single client proves problematic
+    /// (e.g. a host whose own system prompt collides hard with the
+    /// universal preamble), but reaching for it should require a
+    /// fresh design decision, not a default.
     public struct ClientOverlay: Equatable, Sendable {
         public let clientName: String   // e.g. "claude-code", "cursor", "chatgpt-dev-mode"
         public let addendum: String

--- a/NotionBridge/Modules/StandingOrders/StandingOrdersComposer.swift
+++ b/NotionBridge/Modules/StandingOrders/StandingOrdersComposer.swift
@@ -56,7 +56,13 @@ public enum StandingOrdersComposer {
             parts.append("---\n\n## Client-specific notes (\(client))\n\n\(overlay.addendum.trimmingCharacters(in: .whitespacesAndNewlines))")
         }
 
-        parts.append("---\n\n\(RoutingIndex.render(skills))")
+        // PKT v3.6·8: suppress auto-trailer when the standing-orders body
+        // already carries a curated "Routing skills" section inline.
+        // Prevents the double-render observed at handshake when on-disk
+        // orders.md contains the section header itself.
+        if !trimmed.contains("## Routing skills") {
+            parts.append("---\n\n\(RoutingIndex.render(skills))")
+        }
 
         let text = parts.joined(separator: "\n\n")
         return ComposedInstructions(

--- a/NotionBridgeTests/StandingOrdersTests.swift
+++ b/NotionBridgeTests/StandingOrdersTests.swift
@@ -185,6 +185,78 @@ func runStandingOrdersTests() async {
         try expect(composed.estimatedTokens > 0)
     }
 
+    // MARK: - PKT v3.6·8 — Universal Standing Orders amendment
+
+    await test("Composer: trailer is suppressed when standing-orders already has ## Routing skills") {
+        let body = """
+        # orders
+
+        body content
+
+        ## Routing skills
+
+        - **inline-keepr** — already curated inline
+        """
+        let composed = StandingOrdersComposer.compose(
+            standingOrders: body,
+            skills: [sampleSkill("foo", name: "Foo")]
+        )
+        // Trailer auto-render is suppressed; only the inline curated section remains.
+        let matches = composed.text.components(separatedBy: "## Routing skills").count - 1
+        try expect(matches == 1, "expected exactly one '## Routing skills' header, got \(matches)")
+        // The skill from the array is NOT auto-rendered when inline section is present.
+        try expect(!composed.text.contains("(`foo`"),
+                   "auto-trailer should be suppressed when inline routing section present")
+    }
+
+    await test("Composer: trailer still appended when standing-orders has no inline routing section") {
+        // Regression guard for the prior contract — empty/no-routing input still gets the trailer.
+        let composed = StandingOrdersComposer.compose(
+            standingOrders: "# orders\n\nno routing section here",
+            skills: [sampleSkill("foo", name: "Foo")]
+        )
+        try expect(composed.text.contains("## Routing skills available"))
+        try expect(composed.text.contains("(`foo`"))
+    }
+
+    await test("Composer: v6.5.0 principle anchors survive composition") {
+        let body = """
+        # Standing Orders
+
+        ## 1. Role overlay — Keepr
+
+        Adopt the **Keepr** role.
+
+        ## 2. Capabilities & delegation
+
+        When work exceeds your scope, **write a packet**.
+
+        ## 5. Context priority & the Pillars
+
+        **PLEASE — the receive side (generate, restore, fuel):**
+
+        ## 7. The Bridge — operational context
+
+        **Sensitive paths.** The Bridge enforces a Sensitive Paths list.
+
+        **Notion implementation:** PACKETS DS row.
+
+        SSOT: https://www.notion.so/28acbb58889e80d5b111ed23b996c304
+        """
+        let composed = StandingOrdersComposer.compose(
+            standingOrders: body,
+            skills: []
+        )
+        // These anchors must survive composition unchanged so any MCP client
+        // receives the universal chief-of-staff frame at handshake.
+        try expect(composed.text.contains("Role overlay — Keepr"))
+        try expect(composed.text.contains("write a packet"))
+        try expect(composed.text.contains("PLEASE — the receive side"))
+        try expect(composed.text.contains("Notion implementation:"))
+        try expect(composed.text.contains("Sensitive paths."))
+        try expect(composed.text.contains("https://www.notion.so/28acbb58889e80d5b111ed23b996c304"))
+    }
+
     // MARK: - Hash determinism
 
     await test("Hash: same input yields same hash; tiny diff changes it") {


### PR DESCRIPTION
## Summary

- Composer trailer-suppression guard fixes a confirmed **double-render** bug at MCP handshake — when on-disk `orders.md` already carries an inline `## Routing skills` section, the auto-rendered routing-index trailer is no longer appended.
- 3 new tests covering the new behavior + a regression guard + universal v6.5.0 principle anchors. All 1280 tests green.
- Companion (operator-data, not committed): on-disk `~/Library/Application Support/The Bridge/standing-orders/orders.md` rewritten as the universal chief-of-staff preamble (role overlay, dual-register Notion-impl footnotes, inline Pillars, curated routing index). Token budget held: 3,427 → 3,422 tok.
- Notion SSOT v6.5.0 amendment staged: [draft sub-page](https://www.notion.so/Keepr-v6-5-0-DRAFT-Universal-Standing-Orders-amendment-36acbb58889e81249c7dd41a27e64f4e)

**Packet:** [Bridge v3.6 · 8 — Universal Standing Orders content rewrite](https://www.notion.so/Bridge-v3-6-8-Universal-Standing-Orders-content-rewrite-principle-first-dual-register-compose-36acbb58889e81e78a2bcabae7a0a398)
**Stacks on:** #20 (v3.5 ship)

## Changes

| File | Change |
|---|---|
| `NotionBridge/Modules/StandingOrders/StandingOrdersComposer.swift` | +8/-1 — trailer guard |
| `NotionBridgeTests/StandingOrdersTests.swift` | +72 — 3 new tests under PKT v3.6·8 marker |

## Test plan

- [x] `swift run NotionBridgeTests` — 1280 / 1280 passed (3 new green)
- [ ] Bridge restart → verify handshake payload in fresh Claude Code session contains the v6.5.0 principle anchors and exactly **one** `## Routing skills` header
- [ ] Spot-check in Cursor session — confirm role-overlay frame doesn't conflict with host identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)