### PR TITLE
Hotfix: remove keychain-access-groups entitlement (blocks app launch)

### DIFF
--- a/NotionBridge.entitlements
+++ b/NotionBridge.entitlements
@@ -12,15 +12,18 @@
     <true/>
     <key>com.apple.security.personal-information.addressbook</key>
     <true/>
-    <!-- PKT-933: scope Keychain to this app's partition so SecItem* queries
-         never surface foreign (system / third-party) items. This is the app's
-         IMPLICIT default access group (Team ID VP24Z9CS22 + bundle ID), so
-         existing credentials already live here — declaring it is non-destructive.
-         codesign does not expand $(AppIdentifierPrefix); the literal Team ID is
-         used here, mirroring SIGNING_ID in the Makefile. -->
-    <key>keychain-access-groups</key>
-    <array>
-        <string>VP24Z9CS22.kup.solutions.notion-bridge</string>
-    </array>
+    <!-- PKT-933 / hotfix 2026-05-30: keychain-access-groups was REMOVED.
+         A Developer-ID app distributed outside the App Store (no embedded
+         provisioning profile) that declares keychain-access-groups is refused
+         by launchd/RunningBoard at spawn time ("Launchd job spawn failed",
+         POSIX 163) even though codesign, notarization, and Gatekeeper all pass
+         — the app would not launch. The credentials leak is fully closed
+         WITHOUT this entitlement by the e550401 read-time post-filter, which
+         now resolves the access group correctly via AppIdentifierPrefix in
+         Info.plist (verified live: foreign items filtered, Bridge items intact).
+         The system-level scoping code in CredentialManager stays in place but is
+         dormant (its entitlement probe returns nil → falls back to the filter);
+         re-enabling it requires shipping a provisioning profile that authorizes
+         the access group. -->
 </dict>
 </plist>


### PR DESCRIPTION
**Critical:** PKT-933's `keychain-access-groups` entitlement (merged in #23) prevents The Bridge from launching. A Developer-ID app with no provisioning profile is refused by launchd/RunningBoard at spawn (`Launchd job spawn failed`, POSIX 163) despite passing codesign/notarization/Gatekeeper — which is why pre-merge signing checks missed it.

The credentials leak remains fixed without the entitlement: the `e550401` read-time post-filter resolves the access group via `AppIdentifierPrefix` in Info.plist. Verified on the rebuilt+notarized app: foreign items filtered to 0, all Bridge credentials intact, app cold-launches.

Scoping code in `CredentialManager` is left dormant (entitlement probe → nil → post-filter). Re-enabling needs a provisioning profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)