### PR TITLE
chore: gitignore stray test_output.txt log dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ build/
 AGENT_FEEDBACK.md
 RELEASE_HANDOFF.md
 design/
+
+# Stray test-run log dumps (redirected suite output)
+test_output.txt


### PR DESCRIPTION
## What
Adds `test_output.txt` to `.gitignore` and removes the stray file.

## Why
During the v3.6.1 release sprint, several test-floor-gate runs redirected suite output to `test_output.txt` in the repo root. It's a build artifact (258 lines of `Results:`/✅ test log), not source — it lingered untracked and showed as a dirty working tree. Ignoring the pattern keeps the tree clean and prevents an accidental future commit of run logs.

## Reviewer notes
- Only `.gitignore` changes (+3 lines). The artifact itself was never tracked, so there's no file deletion in the diff.
- Separate from and additive to the v3.6.1 release, which already shipped to `main` via #25 (merged) + the appcast/release publish.
- No code, no test, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)