### PR TITLE
v3.7: test-infra reliability + Mac/iCloud tool families + Cloud Access (Mac-side)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           swift-version: "6.2"
 
+      - name: Install ripgrep (code_search dependency — CodeEditModule tests require `rg` on PATH)
+        run: brew install ripgrep
+
       - name: Build release
         # Per-step timeout — Swift release build on macos-26 with strict
         # concurrency takes ~6-8 min locally; 15min cap catches a stuck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           swift-version: "6.2"
 
+      - name: Install ripgrep (code_search dependency — CodeEditModule tests require `rg` on PATH)
+        run: brew install ripgrep
+
       - name: Run test suite
         run: make test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@
 ### Known issues
 - Intermittent test-binary hang under heavy concurrent machine load (multiple test runners). Mitigated by running the gate solo; a per-test harness watchdog is a tracked follow-up.
 
+## [unreleased] — v3.7·C UI polish round (PKT-934)
+
+> Draft release-notes entry. Minimal-intervention UX polish on the existing visual language — NOT a redesign. Anything that conflicts with Design System v1 is re-implemented later when that redesign lands. No theme changes, no new components, no animation overhauls.
+
+### Changed — visual consistency polish (5 carve-outs)
+
+- **Card spacing aligned to the grid (Tools + Jobs).** The Tools (`ModuleGroupList`) and Jobs (`JobsView`) card stacks shared an off-grid literal `10`pt gap; both now use `BridgeSpacing.sm` (12) with a `BridgeSpacing.md` (16) outer inset, so the two card pages read on one tier. (Skills uses a native grouped `Form`, governed by carve-out 3 below rather than a literal gap.)
+- **Skills row wrap + status-indicator alignment.** Long skill titles (80+ chars) now truncate with a tail ellipsis instead of wrapping unbounded and shoving the trailing toggles out of line; the row is top-aligned so the leading enable toggle (status indicator) tracks the title line when the summary wraps. Applied to both Notion-source and file-source rows.
+- **Jobs cells.** Each job card now shows a last-updated relative timestamp in the app-wide compact format (`just now` / `Xm` / `Xh` / `Xd ago`, matching `DashboardView` and `SettingsWindow`); empty-state spacing aligned to the BridgeSpacing grid; bulk-action **failures** now surface as a consistent warning pill (shared `BridgeBadge`) rather than bare grey text, while success notices stay quiet.
+- **Credentials onboarding / all-foreign-filtered banner.** When the feature is enabled but no Bridge-scoped credentials exist, a single `BridgeEmptyState` onboarding banner explains how to add the first credential and that foreign Keychain items are intentionally hidden — covering both the brand-new-user empty case and the post-hotfix all-foreign-filtered case, which previously rendered as three bare "No saved X" rows that read like an error.
+
+### Notes
+
+- No credential logic, biometrics, Keychain storage, signing, or Sparkle paths were touched — UI-only.
+- Test floor held at **1501 / 1501**, 0 failures (floor not lowered, no tests removed).
+- Residual (visual QA): before/after screenshots under `design/audit/v3.7c/` are an operator capture step — a headless agent cannot render the live AppKit UI.
+
 ## [unreleased] — Credentials leak hotfix + Keychain entitlement hardening (PKT-933)
 
 ### Fixed — Credentials page leak (hotfix)

--- a/Info.plist
+++ b/Info.plist
@@ -18,23 +18,23 @@
 	<string>The Bridge</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.7.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleURLName</key>
-			<string>kup.solutions.notion-bridge.cloud-auth</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>kup.solutions.notion-bridge.cloud-auth</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>bridge-auth</string>
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleShortVersionString</key>
-	<string>3.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>43</string>
+	<string>45</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/Info.plist
+++ b/Info.plist
@@ -18,6 +18,19 @@
 	<string>The Bridge</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>kup.solutions.notion-bridge.cloud-auth</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bridge-auth</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>3.6.1</string>
 	<key>CFBundleVersion</key>

--- a/NotionBridge.entitlements
+++ b/NotionBridge.entitlements
@@ -12,6 +12,26 @@
     <true/>
     <key>com.apple.security.personal-information.addressbook</key>
     <true/>
+    <!-- PKT-957 / v3.7·D (2026-06-01): calendars entitlement for the new
+         reminders_* tool family (EventKit EKEventStore .reminder entities,
+         RemindersModule). EventKit reminder access is gated behind this
+         entitlement + a runtime Reminders TCC grant.
+
+         ⚠️ OPERATOR ACTION REQUIRED — VALIDATE AGAINST NOTARIZE BEFORE SHIP.
+         Per the PKT-933 lesson (keychain-access-groups, removed 2026-05-30):
+         a Developer-ID app distributed outside the App Store has NO embedded
+         provisioning profile, and an entitlement the profile/notarization
+         refuses can make launchd reject the app at spawn ("Launchd job spawn
+         failed", POSIX 163) even when codesign + notarize + Gatekeeper pass.
+         This packet DECLARES the entitlement but did NOT sign/notarize/launch
+         the app. The operator MUST: (1) build+sign+notarize a Developer-ID
+         build with this key, (2) confirm the notarized app LAUNCHES, and
+         (3) confirm the Reminders TCC prompt appears + reminders_* tools work
+         live. If notarize/launch refuses this key, the documented fallback is
+         AppleScript via the existing com.apple.security.automation.apple-events
+         entitlement (already present above) — remove this key in that case. -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
     <!-- PKT-933 / hotfix 2026-05-30: keychain-access-groups was REMOVED.
          A Developer-ID app distributed outside the App Store (no embedded
          provisioning profile) that declares keychain-access-groups is refused

--- a/NotionBridge/App/AppDelegate.swift
+++ b/NotionBridge/App/AppDelegate.swift
@@ -249,6 +249,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // WS-D (PKT-921): Bridge Cloud Access master toggle flipped — start/stop
+        // the health heartbeat and register/deregister the `bridge_status` MCP
+        // tool on the running server WITHOUT a relaunch. (Launch-time wiring is
+        // handled inside ServerManager.setup() from BridgeDefaults.)
+        NotificationCenter.default.addObserver(forName: .cloudAccessEnabledDidChange, object: nil, queue: .main) { [weak self] note in
+            let enabled = (note.userInfo?[cloudAccessEnabledKey] as? Bool) ?? BridgeDefaults.cloudAccessEnabledValue
+            Task {
+                await self?.serverManager?.setCloudAccessEnabled(enabled)
+            }
+        }
+
         // PKT-349 B2: Observe reset onboarding notification from Settings.
         // Dispatch to MainActor to satisfy Swift 6 strict concurrency.
         NotificationCenter.default.addObserver(forName: .resetOnboarding, object: nil, queue: .main) { [weak self] _ in

--- a/NotionBridge/App/AppDelegate.swift
+++ b/NotionBridge/App/AppDelegate.swift
@@ -105,9 +105,26 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         permissionManager: permissionManager
     )
 
+    /// Detect the standalone NotionBridgeTests executable. The test harness
+    /// constructs a real `AppDelegate()` (e.g. to assert the Commands palette
+    /// master toggle persists), and the harness pumps a live main run loop to
+    /// service MainActor + CFRunLoop system callbacks. With `startingUpdater:
+    /// true`, Sparkle schedules an automatic appcast check on the main dispatch
+    /// queue; once that async fetch returns INTO the pumped main run loop it can
+    /// present an `NSAlert runModal` (a new-version / permission dialog), which
+    /// wedges the main thread in a nested modal event loop and hangs/SIGTRAPs the
+    /// suite at teardown. A headless unit-test binary must never auto-check for
+    /// updates, so we start the updater disarmed in that process (production
+    /// startup is unchanged). Mirrors the SecurityGate.runningInTestProcess idiom.
+    private static var runningInTestProcess: Bool {
+        let processName = ProcessInfo.processInfo.processName.lowercased()
+        if processName.contains("notionbridgetests") { return true }
+        return CommandLine.arguments.joined(separator: " ").lowercased().contains("notionbridgetests")
+    }
+
     public override init() {
         updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: !Self.runningInTestProcess,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )

--- a/NotionBridge/App/AppDelegate.swift
+++ b/NotionBridge/App/AppDelegate.swift
@@ -312,6 +312,30 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    // MARK: - WS-F: bridge-auth:// callback (Bridge Cloud Access)
+
+    /// Handle inbound `bridge-auth://callback?code=…` URLs opened against the
+    /// app's registered CFBundleURLTypes scheme. Delegates the brittle
+    /// parse → WorkOS token-exchange → Keychain-write → Notification-post to
+    /// the unit-tested `CloudAuthCallbackHandler` (lib). The in-flight
+    /// `EnableCloudAccessFlow` observes `.cloudAuthCallbackReceived` to
+    /// advance from `.signingIn` to `.provisioning`.
+    ///
+    /// The live code→token exchange requires the operator's WorkOS tenant
+    /// (PKT-810) + a real client id; until then `URLSessionTokenExchange`
+    /// is wired but no live tenant will mint a token (live-QA gate).
+    public func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls where url.scheme?.lowercased() == "bridge-auth" {
+            cloudAuthCallbackHandler.handle(url)
+        }
+    }
+
+    /// The WS-F callback handler, assembled over the production seams
+    /// (URLSession exchange + Keychain persistence).
+    private lazy var cloudAuthCallbackHandler = CloudAuthCallbackHandler(
+        exchange: URLSessionTokenExchange()
+    )
+
     // MARK: - Public API (V1-QUALITY-C2)
 
     /// Open the Settings window. WS-H (PKT-804): optional `section` deep-links

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -66,7 +66,8 @@ public enum BridgeConstants {
     ///   + 1 file_edit new (file_str_replace + file_apply_patch kept as aliases)
     ///   + 2 jobs_pause_all / jobs_resume_all reinstated as catalog-present aliases routing to job_pause/_resume all:true
     /// Aliases all carry one-cycle deprecation prefix; full removal in 3.5.0 (Sprint B's release in the patch ladder).
-    public static let staticFeatureModuleToolCount = 172
+    /// v3.7·D (PKT-957): + 6 reminders_* tools (reminders_lists/list/create/update/complete/delete) = 178.
+    public static let staticFeatureModuleToolCount = 178
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -74,5 +75,6 @@ public enum BridgeConstants {
     /// v2.2 · integration closeout: + jobs + cursor + computer = 19.
     /// v2.3 · 0.1 (PKT-804): − cursor family = 18.
     /// v2.3 · WS-D (PKT-2135a9e9): + snippets family = 19.
-    public static let staticFeatureModuleFamilyCount = 19
+    /// v3.7·D (PKT-957): + reminders family = 20.
+    public static let staticFeatureModuleFamilyCount = 20
 }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -66,7 +66,8 @@ public enum BridgeConstants {
     ///   + 1 file_edit new (file_str_replace + file_apply_patch kept as aliases)
     ///   + 2 jobs_pause_all / jobs_resume_all reinstated as catalog-present aliases routing to job_pause/_resume all:true
     /// Aliases all carry one-cycle deprecation prefix; full removal in 3.5.0 (Sprint B's release in the patch ladder).
-    public static let staticFeatureModuleToolCount = 172
+    ///   + 4 standing_orders_{list,read,save,delete} (PKT-931, v3.7·B): new standing_orders family.
+    public static let staticFeatureModuleToolCount = 176
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -74,5 +75,6 @@ public enum BridgeConstants {
     /// v2.2 · integration closeout: + jobs + cursor + computer = 19.
     /// v2.3 · 0.1 (PKT-804): − cursor family = 18.
     /// v2.3 · WS-D (PKT-2135a9e9): + snippets family = 19.
-    public static let staticFeatureModuleFamilyCount = 19
+    /// v3.7·B (PKT-931): + standing_orders family = 20.
+    public static let staticFeatureModuleFamilyCount = 20
 }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -15,7 +15,9 @@ public enum AppVersion {
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
-    public static let build = "43"
+    /// v3.7 WS-D (PKT-921): 43 → 44 — heartbeat wiring + cloud-gated
+    /// `bridge_status` MCP tool + tools/list cloud conditional.
+    public static let build = "44"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }
@@ -73,6 +75,12 @@ public enum BridgeConstants {
     ///   + 5 mail_* tools (PKT-961, v3.7·H): mail_list/read/search/draft/send (Apple Mail).
     ///   + 6 notes_* tools (PKT-960, v3.7·G): notes_list/read/search/create/update/delete (Apple Notes).
     /// v3.7 Wave-1 integration: 182 + 2 (shortcuts) + 5 (mail) + 6 (notes) = 195.
+    /// v3.7 WS-D (PKT-921): UNCHANGED at 195. `bridge_status` is registered
+    ///   ONLY when `BridgeDefaults.cloudAccessEnabled` (via
+    ///   `BridgeModuleRegistry.registerCloudStatusTool`, NOT
+    ///   `registerStaticFeatureModules`), so it deliberately does NOT count
+    ///   toward this always-present static surface. A default (cloud-off)
+    ///   install exposes exactly these 195 module tools.
     public static let staticFeatureModuleToolCount = 195
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -66,7 +66,8 @@ public enum BridgeConstants {
     ///   + 1 file_edit new (file_str_replace + file_apply_patch kept as aliases)
     ///   + 2 jobs_pause_all / jobs_resume_all reinstated as catalog-present aliases routing to job_pause/_resume all:true
     /// Aliases all carry one-cycle deprecation prefix; full removal in 3.5.0 (Sprint B's release in the patch ladder).
-    public static let staticFeatureModuleToolCount = 172
+    /// v3.7·G (PKT-960): + notes (6 notes_* tools — Apple Notes via AppleScript) = 178.
+    public static let staticFeatureModuleToolCount = 178
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -74,5 +75,6 @@ public enum BridgeConstants {
     /// v2.2 · integration closeout: + jobs + cursor + computer = 19.
     /// v2.3 · 0.1 (PKT-804): − cursor family = 18.
     /// v2.3 · WS-D (PKT-2135a9e9): + snippets family = 19.
-    public static let staticFeatureModuleFamilyCount = 19
+    /// v3.7·G (PKT-960): + notes family (Apple Notes) = 20.
+    public static let staticFeatureModuleFamilyCount = 20
 }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -11,13 +11,14 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "3.6.1"
+    public static let marketing = "3.7.0"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
     /// v3.7 WS-D (PKT-921): 43 → 44 — heartbeat wiring + cloud-gated
     /// `bridge_status` MCP tool + tools/list cloud conditional.
-    public static let build = "44"
+    /// v3.7.0 release: 44 → 45 — marketing 3.6.1 → 3.7.0; Info.plist CFBundleVersion reconciled to 45.
+    public static let build = "45"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -69,7 +69,9 @@ public enum BridgeConstants {
     ///   + 4 standing_orders_{list,read,save,delete} (PKT-931, v3.7·B): new standing_orders family.
     ///   + 6 reminders_* tools (PKT-957, v3.7·D): reminders_lists/list/create/update/complete/delete.
     /// v3.7 review-batch integration: 172 + 4 (standing_orders) + 6 (reminders) = 182.
-    public static let staticFeatureModuleToolCount = 182
+    ///   + 2 shortcuts_* tools (PKT-959, v3.7·F): shortcuts_list/run over the /usr/bin/shortcuts CLI.
+    /// v3.7·F: 182 + 2 (shortcuts) = 184.
+    public static let staticFeatureModuleToolCount = 184
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -80,5 +82,6 @@ public enum BridgeConstants {
     /// v3.7·B (PKT-931): + standing_orders family.
     /// v3.7·D (PKT-957): + reminders family.
     /// v3.7 review-batch integration: 19 + 1 (standing_orders) + 1 (reminders) = 21.
-    public static let staticFeatureModuleFamilyCount = 21
+    /// v3.7·F (PKT-959): + shortcuts family = 22.
+    public static let staticFeatureModuleFamilyCount = 22
 }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -73,7 +73,10 @@ public enum BridgeConstants {
     ///   + 5 mail_* tools (PKT-961, v3.7·H): mail_list/read/search/draft/send (Apple Mail).
     ///   + 6 notes_* tools (PKT-960, v3.7·G): notes_list/read/search/create/update/delete (Apple Notes).
     /// v3.7 Wave-1 integration: 182 + 2 (shortcuts) + 5 (mail) + 6 (notes) = 195.
-    public static let staticFeatureModuleToolCount = 195
+    ///   + 5 calendar_* tools (PKT-962, v3.7·I): calendar_list/events/create/update/delete
+    ///     (native EventKit .event entities; reuses v3.7·D's store + calendars entitlement).
+    /// v3.7·I (PKT-962): 195 + 5 (calendar) = 200.
+    public static let staticFeatureModuleToolCount = 200
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -88,5 +91,6 @@ public enum BridgeConstants {
     /// v3.7·H (PKT-961): + mail family.
     /// v3.7·G (PKT-960): + notes family.
     /// v3.7 Wave-1 integration: 21 + 1 (shortcuts) + 1 (mail) + 1 (notes) = 24.
-    public static let staticFeatureModuleFamilyCount = 24
+    /// v3.7·I (PKT-962): + calendar family = 25.
+    public static let staticFeatureModuleFamilyCount = 25
 }

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -69,7 +69,8 @@ public enum BridgeConstants {
     ///   + 4 standing_orders_{list,read,save,delete} (PKT-931, v3.7·B): new standing_orders family.
     ///   + 6 reminders_* tools (PKT-957, v3.7·D): reminders_lists/list/create/update/complete/delete.
     /// v3.7 review-batch integration: 172 + 4 (standing_orders) + 6 (reminders) = 182.
-    public static let staticFeatureModuleToolCount = 182
+    /// v3.7·H (PKT-961): + 5 mail_* tools (mail_list/read/search/draft/send) = 187.
+    public static let staticFeatureModuleToolCount = 187
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -80,5 +81,6 @@ public enum BridgeConstants {
     /// v3.7·B (PKT-931): + standing_orders family.
     /// v3.7·D (PKT-957): + reminders family.
     /// v3.7 review-batch integration: 19 + 1 (standing_orders) + 1 (reminders) = 21.
-    public static let staticFeatureModuleFamilyCount = 21
+    /// v3.7·H (PKT-961): + 1 (mail) family = 22.
+    public static let staticFeatureModuleFamilyCount = 22
 }

--- a/NotionBridge/Core/BridgeDefaults.swift
+++ b/NotionBridge/Core/BridgeDefaults.swift
@@ -105,4 +105,10 @@ public enum BridgeDefaults {
     /// (`.connected`). String. Written by the Enable flow on success; read by
     /// RemoteAccessView to populate the MCP URL row. ABSENT ⇒ no URL yet.
     public static let cloudTunnelHostname = "com.notionbridge.cloudTunnelHostname"
+
+    /// WS-G (PKT-923): one-time gate for the FirstRunCloudAccessModal. Bool.
+    /// Written `true` when the user dismisses the first-run guide (the "Got it"
+    /// button); read by RemoteAccessSection before presenting the sheet on the
+    /// first transition to `.online`. ABSENT ⇒ not yet seen (modal shows once).
+    public static let hasSeenCloudAccessFirstRun = "com.notionbridge.hasSeenCloudAccessFirstRun"
 }

--- a/NotionBridge/Core/BridgeDefaults.swift
+++ b/NotionBridge/Core/BridgeDefaults.swift
@@ -93,4 +93,16 @@ public enum BridgeDefaults {
 
     /// Whether the user has accepted legal terms. Bool.
     public static let hasAcceptedLegalTerms = "hasAcceptedLegalTerms"
+
+    // MARK: - Bridge Cloud Access (WS-F)
+
+    /// Master ON/OFF for Bridge Cloud Access. Bool. Written by the Remote
+    /// Access toggle; the Enable flow reverts it to `false` on `.failed`.
+    /// ABSENT ⇒ OFF.
+    public static let cloudAccessEnabled = "com.notionbridge.cloudAccessEnabled"
+
+    /// The cloudflared tunnel hostname surfaced after a successful provision
+    /// (`.connected`). String. Written by the Enable flow on success; read by
+    /// RemoteAccessView to populate the MCP URL row. ABSENT ⇒ no URL yet.
+    public static let cloudTunnelHostname = "com.notionbridge.cloudTunnelHostname"
 }

--- a/NotionBridge/Core/BridgeDefaults.swift
+++ b/NotionBridge/Core/BridgeDefaults.swift
@@ -101,6 +101,15 @@ public enum BridgeDefaults {
     /// ABSENT ⇒ OFF.
     public static let cloudAccessEnabled = "com.notionbridge.cloudAccessEnabled"
 
+    /// WS-D (PKT-921): effective ON/OFF read of `cloudAccessEnabled`.
+    /// `ServerManager.setup()` consults this at launch to decide whether to
+    /// register the cloud-gated `bridge_status` tool + start the heartbeat.
+    /// ABSENT ⇒ `false` (cloud access off), matching the key's documented
+    /// default so a default install is byte-for-byte its prior self.
+    public static var cloudAccessEnabledValue: Bool {
+        UserDefaults.standard.bool(forKey: cloudAccessEnabled)
+    }
+
     /// The cloudflared tunnel hostname surfaced after a successful provision
     /// (`.connected`). String. Written by the Enable flow on success; read by
     /// RemoteAccessView to populate the MCP URL row. ABSENT ⇒ no URL yet.

--- a/NotionBridge/Core/BridgeNotifications.swift
+++ b/NotionBridge/Core/BridgeNotifications.swift
@@ -27,4 +27,16 @@ public extension Notification.Name {
     /// final step. Observers (AppDelegate) bring attention to the menu
     /// bar so the user lands in the Dashboard popover, not raw Settings.
     static let onboardingDidComplete = Notification.Name("com.notionbridge.onboardingDidComplete")
+
+    /// WS-F: posted by `AppDelegate.application(_:open:options:)` after a
+    /// `bridge-auth://callback` URL is handled — the auth code has been
+    /// exchanged for a WorkOS token and persisted to the Keychain. The
+    /// in-flight `EnableCloudAccessFlow` observes this to advance from
+    /// `.signingIn` to `.provisioning`. The `userInfo` carries no secret
+    /// material — only a `success: Bool` under `cloudAuthSuccessKey`.
+    static let cloudAuthCallbackReceived = Notification.Name("com.notionbridge.cloudAuthCallbackReceived")
 }
+
+/// `userInfo` key on `.cloudAuthCallbackReceived` carrying whether the code
+/// exchange succeeded (`Bool`). Never carries the token itself.
+public let cloudAuthSuccessKey = "success"

--- a/NotionBridge/Core/BridgeNotifications.swift
+++ b/NotionBridge/Core/BridgeNotifications.swift
@@ -35,7 +35,19 @@ public extension Notification.Name {
     /// `.signingIn` to `.provisioning`. The `userInfo` carries no secret
     /// material — only a `success: Bool` under `cloudAuthSuccessKey`.
     static let cloudAuthCallbackReceived = Notification.Name("com.notionbridge.cloudAuthCallbackReceived")
+
+    /// WS-D (PKT-921): posted when `BridgeDefaults.cloudAccessEnabled` flips
+    /// (the Enable flow reached `.connected` → ON, or reverted to OFF on
+    /// failure/cancel). `AppDelegate` observes this to start/stop the cloud
+    /// health heartbeat + register/deregister the `bridge_status` MCP tool on
+    /// the running `ServerManager` WITHOUT a relaunch. The `userInfo` carries
+    /// the new boolean under `cloudAccessEnabledKey`.
+    static let cloudAccessEnabledDidChange = Notification.Name("com.notionbridge.cloudAccessEnabledDidChange")
 }
+
+/// `userInfo` key on `.cloudAccessEnabledDidChange` carrying the new
+/// enabled-state (`Bool`).
+public let cloudAccessEnabledKey = "enabled"
 
 /// `userInfo` key on `.cloudAuthCallbackReceived` carrying whether the code
 /// exchange succeeded (`Bool`). Never carries the token itself.

--- a/NotionBridge/Core/ModuleGroup.swift
+++ b/NotionBridge/Core/ModuleGroup.swift
@@ -38,6 +38,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
     case file
     case notion
     case messages
+    case notes
     case contacts
     case screen
     case chrome
@@ -67,6 +68,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .file:          return "file"
         case .notion:        return "notion"
         case .messages:      return "messages"
+        case .notes:         return "notes"
         case .contacts:      return "contacts"
         case .screen:        return "screen"
         case .chrome:        return "chrome"
@@ -98,6 +100,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .file:          return "local file I/O — sensitive-path-aware"
         case .notion:        return "workspace data sources, pages, comments"
         case .messages:      return "Messages.app — iMessage / SMS"
+        case .notes:         return "Apple Notes — list, read, write, search"
         case .contacts:      return "handle resolution for relationship work"
         case .screen:        return "capture, OCR, recording"
         case .chrome:        return "tab inspection, JS exec, navigation"
@@ -129,6 +132,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .file:          return "doc.fill"
         case .notion:        return "n.square.fill"
         case .messages:      return "bubble.left.and.bubble.right.fill"
+        case .notes:         return "note.text"
         case .contacts:      return "person.crop.circle.fill"
         case .screen:        return "rectangle.on.rectangle"
         case .chrome:        return "globe"
@@ -314,6 +318,7 @@ public enum ModuleGroupDerivation {
         "file":        .file,
         "notion":      .notion,
         "messages":    .messages,
+        "notes":       .notes,
         "contacts":    .contacts,
         "screen":      .screen,
         "chrome":      .chrome,
@@ -367,6 +372,10 @@ public enum ModuleGroupDerivation {
             ]
         case .messages:
             return [ModuleGroupDependency(label: "Full Disk Access", route: "permissions") ]
+        case .notes:
+            // Notes is driven over Apple events; the per-app Notes Automation
+            // grant is a macOS first-use operator prompt (no entitlement change).
+            return [ModuleGroupDependency(label: "Automation", route: "permissions") ]
         case .contacts:
             return [ModuleGroupDependency(label: "Contacts permission", route: "permissions") ]
         case .screen:

--- a/NotionBridge/Core/ModuleGroup.swift
+++ b/NotionBridge/Core/ModuleGroup.swift
@@ -39,6 +39,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
     case notion
     case messages
     case contacts
+    case reminders
     case screen
     case chrome
     case stripe
@@ -68,6 +69,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notion:        return "notion"
         case .messages:      return "messages"
         case .contacts:      return "contacts"
+        case .reminders:     return "reminders"
         case .screen:        return "screen"
         case .chrome:        return "chrome"
         case .stripe:        return "stripe"
@@ -99,6 +101,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notion:        return "workspace data sources, pages, comments"
         case .messages:      return "Messages.app — iMessage / SMS"
         case .contacts:      return "handle resolution for relationship work"
+        case .reminders:     return "iCloud Reminders — list, create, complete"
         case .screen:        return "capture, OCR, recording"
         case .chrome:        return "tab inspection, JS exec, navigation"
         case .stripe:        return "billing, payments, customers"
@@ -130,6 +133,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notion:        return "n.square.fill"
         case .messages:      return "bubble.left.and.bubble.right.fill"
         case .contacts:      return "person.crop.circle.fill"
+        case .reminders:     return "checklist"
         case .screen:        return "rectangle.on.rectangle"
         case .chrome:        return "globe"
         case .stripe:        return "dollarsign.circle.fill"
@@ -315,6 +319,7 @@ public enum ModuleGroupDerivation {
         "notion":      .notion,
         "messages":    .messages,
         "contacts":    .contacts,
+        "reminders":   .reminders,
         "screen":      .screen,
         "chrome":      .chrome,
         "stripe":      .stripe,
@@ -369,6 +374,8 @@ public enum ModuleGroupDerivation {
             return [ModuleGroupDependency(label: "Full Disk Access", route: "permissions") ]
         case .contacts:
             return [ModuleGroupDependency(label: "Contacts permission", route: "permissions") ]
+        case .reminders:
+            return [ModuleGroupDependency(label: "Reminders permission", route: "permissions") ]
         case .screen:
             return [ModuleGroupDependency(label: "Screen Recording", route: "permissions") ]
         case .chrome:

--- a/NotionBridge/Core/ModuleGroup.swift
+++ b/NotionBridge/Core/ModuleGroup.swift
@@ -41,6 +41,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
     case notes
     case contacts
     case reminders
+    case calendar
     case screen
     case chrome
     case stripe
@@ -72,6 +73,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notes:         return "notes"
         case .contacts:      return "contacts"
         case .reminders:     return "reminders"
+        case .calendar:      return "calendar"
         case .screen:        return "screen"
         case .chrome:        return "chrome"
         case .stripe:        return "stripe"
@@ -105,6 +107,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notes:         return "Apple Notes — list, read, write, search"
         case .contacts:      return "handle resolution for relationship work"
         case .reminders:     return "iCloud Reminders — list, create, complete"
+        case .calendar:      return "Calendar — list, query events, create/update/delete"
         case .screen:        return "capture, OCR, recording"
         case .chrome:        return "tab inspection, JS exec, navigation"
         case .stripe:        return "billing, payments, customers"
@@ -138,6 +141,7 @@ public enum ModuleGroupID: String, CaseIterable, Sendable, Hashable {
         case .notes:         return "note.text"
         case .contacts:      return "person.crop.circle.fill"
         case .reminders:     return "checklist"
+        case .calendar:      return "calendar"
         case .screen:        return "rectangle.on.rectangle"
         case .chrome:        return "globe"
         case .stripe:        return "dollarsign.circle.fill"
@@ -325,6 +329,7 @@ public enum ModuleGroupDerivation {
         "notes":       .notes,
         "contacts":    .contacts,
         "reminders":   .reminders,
+        "calendar":    .calendar,
         "screen":      .screen,
         "chrome":      .chrome,
         "stripe":      .stripe,
@@ -385,6 +390,8 @@ public enum ModuleGroupDerivation {
             return [ModuleGroupDependency(label: "Contacts permission", route: "permissions") ]
         case .reminders:
             return [ModuleGroupDependency(label: "Reminders permission", route: "permissions") ]
+        case .calendar:
+            return [ModuleGroupDependency(label: "Calendar permission", route: "permissions") ]
         case .screen:
             return [ModuleGroupDependency(label: "Screen Recording", route: "permissions") ]
         case .chrome:

--- a/NotionBridge/Modules/CalendarModule.swift
+++ b/NotionBridge/Modules/CalendarModule.swift
@@ -1,0 +1,606 @@
+// CalendarModule.swift – Calendar Tools (native EventKit Calendar CRUD)
+// NotionBridge · Modules
+//
+// Five tools: calendar_list (open), calendar_events (open),
+// calendar_create (notify), calendar_update (notify),
+// calendar_delete (request).
+//
+// Created by PKT-962 (v3.7·I): first-class native Calendar module over
+// EventKit `.event` entities, replacing connector/cloud-only calendar access
+// so agents enumerate calendars, query events by date range, and CRUD events
+// without a cloud round-trip.
+//
+// ── REUSES v3.7·D (PKT-957)'s EventKit infrastructure ─────────────────────
+// This module DOES NOT recreate the EventKit store or re-declare any
+// entitlement. It mirrors RemindersModule's injectable-seam pattern — all
+// store access routes through a `CalendarStoring` protocol so the unit tests
+// never touch live EventKit / TCC. Production uses `EventKitCalendarStore`,
+// which constructs an `EKEventStore` exactly as `EventKitRemindersStore` does
+// (the same EventKit type backs both `.reminder` and `.event` entities); a
+// single process may share one `EKEventStore` between the two production
+// stores. Tests inject a deterministic in-memory mock.
+//
+// ── ENTITLEMENT / OPERATOR GATE (shared with PKT-957) ─────────────────────
+// Live use requires:
+//   1. com.apple.security.personal-information.calendars in
+//      NotionBridge.entitlements — ALREADY DECLARED by PKT-957 (v3.7·D).
+//      This packet REUSES it; it does NOT add a second entitlement key.
+//   2. a runtime Calendar TCC grant (operator, first-call prompt).
+// As with reminders, the calendars entitlement MUST be validated against
+// notarize BEFORE shipping; if notarize refuses it, the documented fallback
+// is AppleScript via the existing apple-events entitlement. This is an
+// OPERATOR step — the same notarize-validate residual as PKT-957, NOT
+// validated by this packet.
+
+import AppKit
+@preconcurrency import EventKit
+import Foundation
+import MCP
+
+// MARK: - Store Seam (injectable)
+
+/// Authorization state for the Calendar store, decoupled from EventKit so the
+/// mock seam can drive every branch (incl. the access-denied path). Mirrors
+/// `RemindersAuthStatus` but kept distinct so a future write-only calendar
+/// access state could be modelled independently of reminders.
+public enum CalendarAuthStatus: Sendable, Equatable {
+    case authorized
+    case denied
+    case restricted
+    case notDetermined
+}
+
+/// A plain calendar (EKCalendar of type `.event`). Decoupled from EKCalendar
+/// so the seam is testable without EventKit objects.
+public struct CalendarInfo: Sendable, Equatable {
+    public let id: String       // EKCalendar.calendarIdentifier
+    public let title: String
+    public let isDefault: Bool
+    public let allowsModify: Bool
+
+    public init(id: String, title: String, isDefault: Bool, allowsModify: Bool) {
+        self.id = id
+        self.title = title
+        self.isDefault = isDefault
+        self.allowsModify = allowsModify
+    }
+}
+
+/// A plain calendar-event record. `start` / `end` are ISO-8601. Decoupled
+/// from EKEvent so the seam is testable without EventKit objects.
+public struct CalendarEvent: Sendable, Equatable {
+    public let id: String       // EKEvent.eventIdentifier
+    public var title: String
+    public var start: String    // ISO-8601
+    public var end: String      // ISO-8601
+    public var allDay: Bool
+    public var calendarId: String
+    public var calendarTitle: String
+    public var location: String?
+    public var notes: String?
+
+    public init(
+        id: String,
+        title: String,
+        start: String,
+        end: String,
+        allDay: Bool,
+        calendarId: String,
+        calendarTitle: String,
+        location: String?,
+        notes: String?
+    ) {
+        self.id = id
+        self.title = title
+        self.start = start
+        self.end = end
+        self.allDay = allDay
+        self.calendarId = calendarId
+        self.calendarTitle = calendarTitle
+        self.location = location
+        self.notes = notes
+    }
+}
+
+/// Date-range filter for `calendar_events`. `start` / `end` are ISO-8601 and
+/// both required (an unbounded EventKit event query is not meaningful).
+public struct CalendarEventQuery: Sendable {
+    public var start: String       // ISO-8601 (range lower bound)
+    public var end: String         // ISO-8601 (range upper bound)
+    public var calendarId: String? // nil = all event calendars
+
+    public init(start: String, end: String, calendarId: String? = nil) {
+        self.start = start
+        self.end = end
+        self.calendarId = calendarId
+    }
+}
+
+/// Draft for `calendar_create` / `calendar_update`. Optional fields mean
+/// "leave unchanged" on update. Recurrence editing is intentionally out of
+/// scope (see packet Scope OUT) — these drafts model single events only.
+public struct CalendarEventDraft: Sendable {
+    public var title: String?
+    public var start: String?      // ISO-8601
+    public var end: String?        // ISO-8601
+    public var allDay: Bool?
+    public var calendarId: String?
+    public var location: String?
+    public var notes: String?
+
+    public init(
+        title: String? = nil,
+        start: String? = nil,
+        end: String? = nil,
+        allDay: Bool? = nil,
+        calendarId: String? = nil,
+        location: String? = nil,
+        notes: String? = nil
+    ) {
+        self.title = title
+        self.start = start
+        self.end = end
+        self.allDay = allDay
+        self.calendarId = calendarId
+        self.location = location
+        self.notes = notes
+    }
+}
+
+/// The injectable store seam. Production = `EventKitCalendarStore`;
+/// tests = a deterministic in-memory mock. All methods are async + throwing
+/// so the mock can drive the access-denied path uniformly.
+public protocol CalendarStoring: Sendable {
+    func authorizationStatus() -> CalendarAuthStatus
+    /// Ensures access is authorized, triggering the TCC prompt if
+    /// `.notDetermined`. Throws `CalendarModuleError.accessDenied` otherwise.
+    func ensureAccess() async throws
+    func calendars() async throws -> [CalendarInfo]
+    func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent]
+    func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent
+    func update(id: String, _ draft: CalendarEventDraft) async throws -> CalendarEvent
+    func delete(id: String) async throws
+}
+
+// MARK: - Errors
+
+public enum CalendarModuleError: LocalizedError, Equatable {
+    case accessDenied
+    case notFound(String)
+    case calendarNotFound(String)
+    case immutableCalendar(String)
+    case invalidDate(String)
+    case missingRequired(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "Calendar access not granted. Enable in System Settings > Privacy & Security > Calendars for NotionBridge."
+        case .notFound(let id):
+            return "Event not found: \(id)"
+        case .calendarNotFound(let id):
+            return "Calendar not found: \(id)"
+        case .immutableCalendar(let id):
+            return "Calendar does not allow modification: \(id)"
+        case .invalidDate(let s):
+            return "Invalid ISO-8601 date: \(s)"
+        case .missingRequired(let field):
+            return "Missing required field: \(field)"
+        }
+    }
+}
+
+// MARK: - EventKit-backed store (production)
+
+/// Live EventKit implementation over `.event` entities. Requires the
+/// calendars entitlement (declared by PKT-957) + a Calendar TCC grant
+/// (operator). Not exercised by the unit tests — those use the mock.
+///
+/// Shares the same `EKEventStore` *type* as `EventKitRemindersStore`; a
+/// process that wants one store for both entity kinds can construct this with
+/// the reminders store's `EKEventStore`. The default initializer makes its own.
+public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
+    private let store: EKEventStore
+
+    public init(store: EKEventStore = EKEventStore()) {
+        self.store = store
+    }
+
+    public func authorizationStatus() -> CalendarAuthStatus {
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .authorized, .fullAccess:
+            return .authorized
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        case .notDetermined:
+            return .notDetermined
+        case .writeOnly:
+            // Write-only grants can create events but not read them back;
+            // fail-closed for the read paths (treat as restricted).
+            return .restricted
+        @unknown default:
+            return .restricted
+        }
+    }
+
+    public func ensureAccess() async throws {
+        switch authorizationStatus() {
+        case .authorized:
+            return
+        case .notDetermined:
+            await MainActor.run {
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+            let granted: Bool
+            if #available(macOS 14.0, *) {
+                granted = (try? await store.requestFullAccessToEvents()) ?? false
+            } else {
+                granted = await withCheckedContinuation { cont in
+                    store.requestAccess(to: .event) { ok, _ in cont.resume(returning: ok) }
+                }
+            }
+            if !granted { throw CalendarModuleError.accessDenied }
+        case .denied, .restricted:
+            throw CalendarModuleError.accessDenied
+        }
+    }
+
+    /// A fresh formatter per call — `ISO8601DateFormatter` is not `Sendable`,
+    /// so it cannot be a shared static across the actor-hopping handlers.
+    /// (Same rationale as `EventKitRemindersStore.makeISO`.)
+    private static func makeISO() -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }
+
+    private func dateToISO(_ date: Date?) -> String {
+        guard let date else { return "" }
+        return Self.makeISO().string(from: date)
+    }
+
+    private func isoToDate(_ iso: String) throws -> Date {
+        guard let date = Self.makeISO().date(from: iso) else {
+            throw CalendarModuleError.invalidDate(iso)
+        }
+        return date
+    }
+
+    private func toEvent(_ e: EKEvent) -> CalendarEvent {
+        CalendarEvent(
+            id: e.eventIdentifier ?? "",
+            title: e.title ?? "",
+            start: dateToISO(e.startDate),
+            end: dateToISO(e.endDate),
+            allDay: e.isAllDay,
+            calendarId: e.calendar?.calendarIdentifier ?? "",
+            calendarTitle: e.calendar?.title ?? "",
+            location: e.location,
+            notes: e.notes
+        )
+    }
+
+    public func calendars() async throws -> [CalendarInfo] {
+        try await ensureAccess()
+        return store.calendars(for: .event).map { cal in
+            CalendarInfo(
+                id: cal.calendarIdentifier,
+                title: cal.title,
+                isDefault: cal.calendarIdentifier
+                    == store.defaultCalendarForNewEvents?.calendarIdentifier,
+                allowsModify: cal.allowsContentModifications
+            )
+        }
+    }
+
+    public func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
+        try await ensureAccess()
+        let startDate = try isoToDate(query.start)
+        let endDate = try isoToDate(query.end)
+        let calendars: [EKCalendar]?
+        if let calendarId = query.calendarId {
+            guard let cal = store.calendar(withIdentifier: calendarId) else {
+                throw CalendarModuleError.calendarNotFound(calendarId)
+            }
+            calendars = [cal]
+        } else {
+            calendars = nil
+        }
+        let predicate = store.predicateForEvents(
+            withStart: startDate, end: endDate, calendars: calendars)
+        // Map EKEvent → Sendable CalendarEvent before returning so no
+        // non-Sendable EventKit object escapes this call.
+        let ek = store.events(matching: predicate)
+        return ek.map(toEvent).sorted { $0.start < $1.start }
+    }
+
+    private func resolveCalendar(_ calendarId: String?) throws -> EKCalendar {
+        if let calendarId {
+            guard let cal = store.calendar(withIdentifier: calendarId) else {
+                throw CalendarModuleError.calendarNotFound(calendarId)
+            }
+            return cal
+        }
+        guard let def = store.defaultCalendarForNewEvents else {
+            throw CalendarModuleError.calendarNotFound("default")
+        }
+        return def
+    }
+
+    public func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        try await ensureAccess()
+        guard let start = draft.start else { throw CalendarModuleError.missingRequired("start") }
+        guard let end = draft.end else { throw CalendarModuleError.missingRequired("end") }
+        let event = EKEvent(eventStore: store)
+        event.calendar = try resolveCalendar(draft.calendarId)
+        event.title = draft.title ?? ""
+        event.startDate = try isoToDate(start)
+        event.endDate = try isoToDate(end)
+        if let allDay = draft.allDay { event.isAllDay = allDay }
+        if let location = draft.location { event.location = location }
+        if let notes = draft.notes { event.notes = notes }
+        try store.save(event, span: .thisEvent, commit: true)
+        return toEvent(event)
+    }
+
+    private func fetchEvent(id: String) throws -> EKEvent {
+        if let event = store.event(withIdentifier: id) {
+            return event
+        }
+        throw CalendarModuleError.notFound(id)
+    }
+
+    public func update(id: String, _ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        try await ensureAccess()
+        let event = try fetchEvent(id: id)
+        if let title = draft.title { event.title = title }
+        if let start = draft.start { event.startDate = try isoToDate(start) }
+        if let end = draft.end { event.endDate = try isoToDate(end) }
+        if let allDay = draft.allDay { event.isAllDay = allDay }
+        if let location = draft.location { event.location = location }
+        if let notes = draft.notes { event.notes = notes }
+        if let calendarId = draft.calendarId {
+            event.calendar = try resolveCalendar(calendarId)
+        }
+        try store.save(event, span: .thisEvent, commit: true)
+        return toEvent(event)
+    }
+
+    public func delete(id: String) async throws {
+        try await ensureAccess()
+        let event = try fetchEvent(id: id)
+        try store.remove(event, span: .thisEvent, commit: true)
+    }
+}
+
+// MARK: - CalendarModule
+
+/// Provides EventKit-backed calendar tools through an injectable store seam.
+public enum CalendarModule {
+
+    public static let moduleName = "calendar"
+
+    /// Register all CalendarModule tools on the given router. `store`
+    /// defaults to the live EventKit store; tests inject a mock seam.
+    public static func register(
+        on router: ToolRouter,
+        store: CalendarStoring = EventKitCalendarStore()
+    ) async {
+
+        // MARK: 1. calendar_list – open (read-only)
+        await router.register(ToolRegistration(
+            name: "calendar_list",
+            module: moduleName,
+            tier: .open,
+            description: "Enumerate Calendar calendars (EKCalendar of type .event). Returns id, title, isDefault, allowsModify. Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "required": .array([])
+            ]),
+            handler: { _ in
+                let cals = try await store.calendars()
+                return .object([
+                    "count": .int(cals.count),
+                    "calendars": .array(cals.map(formatCalendar))
+                ])
+            }
+        ))
+
+        // MARK: 2. calendar_events – open (read-only)
+        await router.register(ToolRegistration(
+            name: "calendar_events",
+            module: moduleName,
+            tier: .open,
+            description: "List calendar events within a date range. Requires start + end (ISO-8601); optional calendarId scopes to one calendar (default: all). Returns id, title, start, end, allDay, calendar, location, notes. Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "start": .object(["type": .string("string"), "description": .string("ISO-8601 range lower bound (required)")]),
+                    "end": .object(["type": .string("string"), "description": .string("ISO-8601 range upper bound (required)")]),
+                    "calendarId": .object(["type": .string("string"), "description": .string("EKCalendar.calendarIdentifier to scope to a single calendar (default: all event calendars)")])
+                ]),
+                "required": .array([.string("start"), .string("end")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let start = stringArg(args, "start") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_events", reason: "missing 'start'")
+                }
+                guard let end = stringArg(args, "end") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_events", reason: "missing 'end'")
+                }
+                let query = CalendarEventQuery(
+                    start: start,
+                    end: end,
+                    calendarId: stringArg(args, "calendarId")
+                )
+                let events = try await store.events(query)
+                return .object([
+                    "count": .int(events.count),
+                    "events": .array(events.map(formatEvent))
+                ])
+            }
+        ))
+
+        // MARK: 3. calendar_create – notify (write, non-destructive)
+        await router.register(ToolRegistration(
+            name: "calendar_create",
+            module: moduleName,
+            tier: .notify,
+            description: "Create a calendar event. Requires title, start, end (ISO-8601); optional allDay, calendarId, location, notes. Returns the new event id + record.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "title": .object(["type": .string("string"), "description": .string("Event title (required)")]),
+                    "start": .object(["type": .string("string"), "description": .string("Start ISO-8601 (required)")]),
+                    "end": .object(["type": .string("string"), "description": .string("End ISO-8601 (required)")]),
+                    "allDay": .object(["type": .string("boolean"), "description": .string("All-day event (default: false)")]),
+                    "calendarId": .object(["type": .string("string"), "description": .string("Target calendar identifier (default: the default Calendar for new events)")]),
+                    "location": .object(["type": .string("string"), "description": .string("Location (optional)")]),
+                    "notes": .object(["type": .string("string"), "description": .string("Freeform notes (optional)")])
+                ]),
+                "required": .array([.string("title"), .string("start"), .string("end")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let title = stringArg(args, "title") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_create", reason: "missing 'title'")
+                }
+                guard let start = stringArg(args, "start") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_create", reason: "missing 'start'")
+                }
+                guard let end = stringArg(args, "end") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_create", reason: "missing 'end'")
+                }
+                let draft = CalendarEventDraft(
+                    title: title,
+                    start: start,
+                    end: end,
+                    allDay: boolArg(args, "allDay"),
+                    calendarId: stringArg(args, "calendarId"),
+                    location: stringArg(args, "location"),
+                    notes: stringArg(args, "notes")
+                )
+                let event = try await store.create(draft)
+                return .object([
+                    "id": .string(event.id),
+                    "event": formatEvent(event)
+                ])
+            }
+        ))
+
+        // MARK: 4. calendar_update – notify (write, non-destructive)
+        await router.register(ToolRegistration(
+            name: "calendar_update",
+            module: moduleName,
+            tier: .notify,
+            description: "Update a calendar event by id. Any of title, start, end, allDay, location, notes, calendarId. Returns the updated record.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string"), "description": .string("EKEvent.eventIdentifier (required)")]),
+                    "title": .object(["type": .string("string"), "description": .string("New title")]),
+                    "start": .object(["type": .string("string"), "description": .string("New start ISO-8601")]),
+                    "end": .object(["type": .string("string"), "description": .string("New end ISO-8601")]),
+                    "allDay": .object(["type": .string("boolean"), "description": .string("Set all-day flag")]),
+                    "calendarId": .object(["type": .string("string"), "description": .string("Move to a different calendar")]),
+                    "location": .object(["type": .string("string"), "description": .string("New location")]),
+                    "notes": .object(["type": .string("string"), "description": .string("New notes")])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_update", reason: "missing 'id'")
+                }
+                let draft = CalendarEventDraft(
+                    title: stringArg(args, "title"),
+                    start: stringArg(args, "start"),
+                    end: stringArg(args, "end"),
+                    allDay: boolArg(args, "allDay"),
+                    calendarId: stringArg(args, "calendarId"),
+                    location: stringArg(args, "location"),
+                    notes: stringArg(args, "notes")
+                )
+                let event = try await store.update(id: id, draft)
+                return .object([
+                    "id": .string(event.id),
+                    "event": formatEvent(event)
+                ])
+            }
+        ))
+
+        // MARK: 5. calendar_delete – request (DESTRUCTIVE)
+        await router.register(ToolRegistration(
+            name: "calendar_delete",
+            module: moduleName,
+            tier: .request,
+            description: "Delete a calendar event by id. DESTRUCTIVE / irreversible — gated at tier .request (confirmation required). Returns the deleted id.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string"), "description": .string("EKEvent.eventIdentifier (required)")])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "calendar_delete", reason: "missing 'id'")
+                }
+                try await store.delete(id: id)
+                return .object([
+                    "id": .string(id),
+                    "deleted": .bool(true)
+                ])
+            }
+        ))
+    }
+
+    // MARK: - Formatting
+
+    static func formatCalendar(_ cal: CalendarInfo) -> Value {
+        .object([
+            "id": .string(cal.id),
+            "title": .string(cal.title),
+            "isDefault": .bool(cal.isDefault),
+            "allowsModify": .bool(cal.allowsModify)
+        ])
+    }
+
+    static func formatEvent(_ event: CalendarEvent) -> Value {
+        var entry: [String: Value] = [
+            "id": .string(event.id),
+            "title": .string(event.title),
+            "start": .string(event.start),
+            "end": .string(event.end),
+            "allDay": .bool(event.allDay),
+            "calendarId": .string(event.calendarId),
+            "calendar": .string(event.calendarTitle)
+        ]
+        if let location = event.location { entry["location"] = .string(location) }
+        if let notes = event.notes { entry["notes"] = .string(notes) }
+        return .object(entry)
+    }
+
+    // MARK: - Argument helpers
+
+    private static func objectArgs(_ value: Value) -> [String: Value] {
+        if case .object(let args) = value { return args }
+        return [:]
+    }
+
+    private static func stringArg(_ args: [String: Value], _ key: String) -> String? {
+        if case .string(let s)? = args[key] { return s }
+        return nil
+    }
+
+    private static func boolArg(_ args: [String: Value], _ key: String) -> Bool? {
+        if case .bool(let b)? = args[key] { return b }
+        return nil
+    }
+}

--- a/NotionBridge/Modules/ChromeModule.swift
+++ b/NotionBridge/Modules/ChromeModule.swift
@@ -574,7 +574,11 @@ public enum ChromeModule {
 
     /// Returns the window ID of the first on-screen Chrome window, or nil if none visible on current Space.
     private static func visibleChromeWindowID() async -> Int? {
-        guard let content = try? await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true) else {
+        // Fast short-circuit when Screen Recording is denied — never enter SCK.
+        guard CGPreflightScreenCaptureAccess() else { return nil }
+        // SCK delivers its reply on the main run loop; an off-main call leaks
+        // the continuation and hangs. Route through the main-actor boundary.
+        guard let content = try? await SCKBoundary.fetchShareableContent() else {
             return nil
         }
         let chromeWindow = content.windows.first {
@@ -586,7 +590,11 @@ public enum ChromeModule {
 
     /// Returns the set of all on-screen Chrome window IDs on the current Space.
     private static func visibleChromeWindowIDs() async -> Set<Int> {
-        guard let content = try? await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true) else {
+        // Fast short-circuit when Screen Recording is denied — never enter SCK.
+        guard CGPreflightScreenCaptureAccess() else { return [] }
+        // SCK delivers its reply on the main run loop; an off-main call leaks
+        // the continuation and hangs. Route through the main-actor boundary.
+        guard let content = try? await SCKBoundary.fetchShareableContent() else {
             return []
         }
         let ids = content.windows

--- a/NotionBridge/Modules/Cloud/BridgeCloudManager.swift
+++ b/NotionBridge/Modules/Cloud/BridgeCloudManager.swift
@@ -82,7 +82,19 @@ public protocol CloudProvisioning: Sendable {
     func startTunnel() async throws
 }
 
-public actor BridgeCloudManager: CloudProvisioning {
+/// WS-G: the teardown seam the Disable flow depends on. Lets the Disable
+/// confirmation tear the tunnel down against a deterministic mock in unit
+/// tests (no cloudflared, no network). `BridgeCloudManager.disable()` is the
+/// production conformer — it stops the tunnel and returns the machine to
+/// `.disabled` from any state.
+public protocol CloudTeardown: Sendable {
+    /// Stop the tunnel and return cloud access to its off state. Safe from any
+    /// state (a not-running stop is swallowed). Returns the resulting state.
+    @discardableResult
+    func disable() async -> CloudConnectionState
+}
+
+public actor BridgeCloudManager: CloudProvisioning, CloudTeardown {
 
     // MARK: Dependencies (all injected — fakes in tests)
 

--- a/NotionBridge/Modules/Cloud/BridgeCloudManager.swift
+++ b/NotionBridge/Modules/Cloud/BridgeCloudManager.swift
@@ -67,7 +67,22 @@ public enum CloudDelegationDecision: Sendable, Equatable {
     case refused(CloudDelegationRefusal)
 }
 
-public actor BridgeCloudManager {
+/// WS-F: the provisioning seam the Enable flow depends on. Lets
+/// `EnableCloudAccessFlow` drive `provision()` + `startTunnel()` against a
+/// deterministic mock in unit tests (no cloudflared, no network, no live
+/// Worker — the live path is gated on PKT-810 + WS-A). `BridgeCloudManager`
+/// is the production conformer.
+public protocol CloudProvisioning: Sendable {
+    /// Provision this Mac as a Bridge Cloud node against `baseURL`
+    /// (configurable so tests/un-provisioned builds never hit the live
+    /// Worker). Returns the assigned tunnel hostname on success; throws on
+    /// failure.
+    func provision(baseURL: String) async throws -> String
+    /// Bring the cloudflared tunnel up after a successful provision.
+    func startTunnel() async throws
+}
+
+public actor BridgeCloudManager: CloudProvisioning {
 
     // MARK: Dependencies (all injected — fakes in tests)
 
@@ -116,6 +131,35 @@ public actor BridgeCloudManager {
             state = .offline
         }
         return state
+    }
+
+    // MARK: - Provisioning (WS-F · CloudProvisioning)
+
+    /// Provision this Mac as a Bridge Cloud node against `baseURL`. The base
+    /// URL is configurable so unit tests and an un-provisioned local build
+    /// never reach the live Worker (WS-A) — full live provisioning is gated
+    /// on PKT-810 + WS-A. The production implementation will POST the node
+    /// registration to the Worker and parse back the assigned hostname; until
+    /// WS-A is live it returns a deterministic, hostname-shaped value derived
+    /// from the local node so the Enable flow + `BridgeDefaults` wiring can be
+    /// exercised end-to-end against the real type.
+    public func provision(baseURL: String) async throws -> String {
+        // LIVE PATH (PKT-810 + WS-A): POST `\(baseURL)/provision` with the
+        // node identity, await the assigned hostname. Intentionally NOT wired
+        // to a live network call here — see the packet's live-QA gate.
+        let host = "\(node.deviceID).bridge.kup.solutions"
+        return host
+    }
+
+    /// Bring the cloudflared tunnel up after provisioning. Delegates to the
+    /// injected `TunnelProcess` seam (a fake in tests) and reconciles the
+    /// connection-state machine.
+    public func startTunnel() async throws {
+        if state != .online && state != .degraded {
+            state = .connecting
+        }
+        try await tunnel.start()
+        await refreshHealth()
     }
 
     /// Disable Bridge Cloud Access: stop the tunnel and return to

--- a/NotionBridge/Modules/Cloud/CloudAccessFirstRun.swift
+++ b/NotionBridge/Modules/Cloud/CloudAccessFirstRun.swift
@@ -1,0 +1,108 @@
+// CloudAccessFirstRun.swift — WS-G (Bridge Cloud Access · first-run + Claude.ai)
+// NotionBridge · Modules · Cloud
+//
+// Pure, Sendable decision helpers for the WS-G (PKT-923) terminal packet:
+//
+//   1. FirstRunCloudAccessGate — the one-time presentation gate for the
+//      FirstRunCloudAccessModal. Factored out of the SwiftUI view so the
+//      "shown exactly once" rule is unit-asserted headlessly (no sheet, no
+//      WindowServer) — the same headless-decision shape ProvisioningPresentation
+//      uses.
+//
+//   2. ClaudeAIIntegration — builds the claude.ai integrations deep link and
+//      the copy+hint fallback string. Q3 (COA 2026-05-27) locked the URL shape
+//      to `https://claude.ai/settings/integrations?mcp_url={encoded}` IF the
+//      format could be confirmed to navigate correctly; otherwise fall back to
+//      copy + an inline instruction. Verification at build time (2026-06-02)
+//      could NOT confirm the format — claude.ai rejects unauthenticated
+//      navigation (HTTP 403, Cloudflare bot wall) and there is no public doc
+//      confirming the `mcp_url` query param is honored on the integrations
+//      page. Per the Q3 lock we therefore ship the COPY + HINT fallback. The
+//      encoded-URL builder is retained (and unit-tested) so a future confirmed
+//      format flips a single `mode` flag rather than re-deriving the encoding.
+
+import Foundation
+
+// MARK: - First-run gate
+
+/// Decides whether the first-run cloud-access guide should be presented.
+///
+/// The rule (Q2 lock, COA 2026-05-27): the modal is shown exactly once, the
+/// first time cloud access reaches the online/connected state, and never
+/// again once the user has dismissed it (persisted via
+/// `BridgeDefaults.hasSeenCloudAccessFirstRun`).
+public enum FirstRunCloudAccessGate {
+
+    /// Whether to present the first-run modal.
+    ///
+    /// - Parameters:
+    ///   - isOnline: true when cloud access has reached the connected/online
+    ///     state (RemoteAccessSection.DisplayState.online).
+    ///   - hasSeenFirstRun: the persisted `hasSeenCloudAccessFirstRun` flag.
+    /// - Returns: true only when online AND the flag is not yet set.
+    public static func shouldPresent(isOnline: Bool, hasSeenFirstRun: Bool) -> Bool {
+        isOnline && !hasSeenFirstRun
+    }
+}
+
+// MARK: - Add to Claude.ai
+
+/// Builds the artifacts the "Add to Claude.ai" button uses: the MCP URL the
+/// user pastes, the (retained-but-gated) claude.ai deep link, and the
+/// copy+hint fallback shipped per the Q3 verification outcome.
+public enum ClaudeAIIntegration {
+
+    /// How the "Add to Claude.ai" affordance behaves.
+    public enum Mode: Sendable, Equatable {
+        /// Open `claude.ai/settings/integrations?mcp_url=…` in the browser.
+        /// Reserved for when the deep-link format is confirmed (Q3).
+        case openBrowser
+        /// Copy the MCP URL to the clipboard and show an inline paste hint.
+        /// The shipped default (Q3 unconfirmed → fallback).
+        case copyAndHint
+    }
+
+    /// The shipped mode for this build. Q3 verification (2026-06-02) could not
+    /// confirm the deep-link format, so we ship `.copyAndHint`.
+    public static let shippedMode: Mode = .copyAndHint
+
+    /// The claude.ai integrations base (no query).
+    public static let integrationsBase = "https://claude.ai/settings/integrations"
+
+    /// The inline hint shown beneath the button in `.copyAndHint` mode.
+    public static let pasteHint = "Copied. Paste in Claude.ai → Settings → Integrations."
+
+    /// The MCP URL the user connects with, derived from the cloudflared tunnel
+    /// hostname. `nil` when no hostname is provisioned yet (button disabled).
+    public static func mcpURL(forHostname hostname: String?) -> String? {
+        guard let host = hostname, !host.isEmpty else { return nil }
+        return "https://\(host)/mcp"
+    }
+
+    /// The claude.ai deep link with the MCP URL percent-encoded into the
+    /// `mcp_url` query parameter. Retained + unit-tested so a future confirmed
+    /// Q3 format is a one-line `shippedMode` flip. `nil` when no MCP URL exists
+    /// or encoding fails.
+    ///
+    /// Encoding uses `addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)`
+    /// per the packet, then additionally escapes the sub-delimiters that
+    /// `.urlQueryAllowed` leaves intact but that would corrupt a value embedded
+    /// in a query (`&`, `+`, `=`, `?`, `/`, `:`), so the round-tripped value is
+    /// exactly the original MCP URL.
+    public static func deepLink(forHostname hostname: String?) -> URL? {
+        guard let mcp = mcpURL(forHostname: hostname) else { return nil }
+        guard let encoded = encodeQueryValue(mcp) else { return nil }
+        return URL(string: "\(integrationsBase)?mcp_url=\(encoded)")
+    }
+
+    /// Percent-encode a value for safe embedding as a query-parameter value.
+    /// Exposed for direct unit assertion of the URL-encoding contract.
+    public static func encodeQueryValue(_ value: String) -> String? {
+        // Start from .urlQueryAllowed (per packet), then remove the
+        // sub-delimiters that are legal in a query *component* but ambiguous
+        // inside a single parameter *value*.
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&+=?/:;@$,")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed)
+    }
+}

--- a/NotionBridge/Modules/Cloud/CloudAuth.swift
+++ b/NotionBridge/Modules/Cloud/CloudAuth.swift
@@ -1,0 +1,184 @@
+// CloudAuth.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · Modules · Cloud
+//
+// The WorkOS sign-in primitives for the Enable Cloud Access flow, kept in
+// the LIB target (not App/) so every branch is unit-testable headlessly —
+// no NSWorkspace, no live WorkOS network, no .app bundle. Three pieces:
+//
+//   1. `WorkOSConfig`        — env-configurable client_id + base URL +
+//                              redirect_uri. Live values come from the
+//                              operator's WorkOS tenant (PKT-810); tests
+//                              and the un-provisioned local build fall back
+//                              to documented placeholders. NO secret here.
+//   2. `WorkOSAuthURLBuilder`— builds the system-browser authorization URL
+//                              (Q1 decision lock: system browser + the
+//                              `bridge-auth://callback` redirect, no
+//                              WKWebView).
+//   3. `CloudAuthCallback`   — the PURE parse of an inbound
+//                              `bridge-auth://callback?code=…` URL into an
+//                              auth code (or a typed failure). The Keychain
+//                              write + Notification post that wrap it live
+//                              in `AppDelegate` (App target), but the brittle
+//                              URL-shape logic is here and fully tested.
+//
+// Per the packet OUT-of-scope note: this builds the URL builder with an
+// env-configurable WORKOS_CLIENT_ID; a LIVE code→token exchange requires
+// the real client id + redirect_uri configured in the WorkOS dashboard
+// (PKT-810 operator provisioning). The token-exchange HTTP call is modeled
+// behind the injectable `CloudTokenExchanging` seam so unit tests never
+// touch the network.
+
+import Foundation
+
+/// Env-configurable WorkOS OAuth configuration. Live values are provisioned
+/// by the operator (PKT-810); absent env vars fall back to documented
+/// placeholders so the local build compiles and the Enable flow can be
+/// exercised end-to-end against mocks. Carries NO client secret — the
+/// public OAuth client_id + the `bridge-auth://callback` redirect only.
+public struct WorkOSConfig: Sendable, Equatable {
+    /// WorkOS authorization base, e.g. `https://api.workos.com`.
+    public let baseURL: String
+    /// The public OAuth client id (env `WORKOS_CLIENT_ID`). A placeholder
+    /// until PKT-810 provisions the real tenant.
+    public let clientID: String
+    /// The OAuth redirect — the custom scheme the app registers (Q1 lock).
+    public let redirectURI: String
+
+    public init(baseURL: String, clientID: String, redirectURI: String) {
+        self.baseURL = baseURL
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+    }
+
+    /// Documented placeholder for an un-provisioned build / tests.
+    public static let placeholder = WorkOSConfig(
+        baseURL: "https://api.workos.com",
+        clientID: "client_PLACEHOLDER_pkt810",
+        redirectURI: "bridge-auth://callback"
+    )
+
+    /// Resolve config from the environment, falling back to `placeholder`
+    /// for any unset value. Injectable `environment` keeps this pure for
+    /// tests (no real `ProcessInfo` dependency).
+    public static func resolved(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> WorkOSConfig {
+        WorkOSConfig(
+            baseURL: environment["WORKOS_BASE_URL"]?.nonEmpty ?? placeholder.baseURL,
+            clientID: environment["WORKOS_CLIENT_ID"]?.nonEmpty ?? placeholder.clientID,
+            redirectURI: environment["WORKOS_REDIRECT_URI"]?.nonEmpty ?? placeholder.redirectURI
+        )
+    }
+}
+
+/// Builds the WorkOS authorization URL opened in the system browser. Pure
+/// + deterministic so the query shape is unit-asserted without opening a
+/// browser.
+public enum WorkOSAuthURLBuilder {
+    /// The authorization URL for `config`. Returns `nil` only if the base
+    /// URL is unparseable (a misconfigured tenant) — callers treat that as
+    /// `CloudError.authURLUnavailable`.
+    public static func authorizationURL(for config: WorkOSConfig) -> URL? {
+        guard var components = URLComponents(string: config.baseURL) else { return nil }
+        // WorkOS AuthKit / User Management authorization endpoint.
+        let basePath = components.path
+        components.path = (basePath.hasSuffix("/") ? String(basePath.dropLast()) : basePath)
+            + "/user_management/authorize"
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: config.clientID),
+            URLQueryItem(name: "redirect_uri", value: config.redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "provider", value: "authkit"),
+        ]
+        return components.url
+    }
+}
+
+/// The two ways parsing an inbound auth callback URL can resolve.
+public enum CloudAuthCallback: Sendable, Equatable {
+    /// A well-formed `bridge-auth://callback?code=…` — carries the code to
+    /// exchange. The code is an opaque one-time grant, NOT a credential.
+    case code(String)
+    /// The URL is not a usable auth callback (wrong scheme/host, no code,
+    /// or WorkOS returned an `error` query param).
+    case invalid(reason: String)
+
+    /// Pure parse of an inbound URL. Accepts only the `bridge-auth` scheme
+    /// with host `callback` and a non-empty `code` query item. A WorkOS
+    /// `error=…` param (user denied, etc.) maps to `.invalid`.
+    ///
+    /// This is the brittle bit AppDelegate's `application(_:open:options:)`
+    /// delegates to before it writes the Keychain + posts the Notification.
+    public static func parse(_ url: URL) -> CloudAuthCallback {
+        guard url.scheme?.lowercased() == "bridge-auth" else {
+            return .invalid(reason: "wrong scheme: \(url.scheme ?? "nil")")
+        }
+        guard url.host?.lowercased() == "callback" else {
+            return .invalid(reason: "wrong host: \(url.host ?? "nil")")
+        }
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        if let err = items.first(where: { $0.name == "error" })?.value, !err.isEmpty {
+            return .invalid(reason: "workos error: \(err)")
+        }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            return .invalid(reason: "missing code")
+        }
+        return .code(code)
+    }
+}
+
+/// The injectable code→token exchange seam (POST WorkOS `/oauth/token`).
+/// Production wraps `URLSession`; tests inject a deterministic fake so no
+/// live WorkOS call is made (per the packet's hard "mocks only" rule).
+public protocol CloudTokenExchanging: Sendable {
+    /// Exchange a one-time auth `code` for a session token string. Throws on
+    /// any non-success / transport failure.
+    func exchange(code: String, config: WorkOSConfig) async throws -> String
+}
+
+/// Production `URLSession`-backed exchange. NOT used by unit tests. Left
+/// thin: the live wire-up is gated on PKT-810 (real client id + a tenant
+/// that will actually mint a token), so this is the seam the operator
+/// completes, not a network path the test suite ever drives.
+public struct URLSessionTokenExchange: CloudTokenExchanging {
+    private let session: URLSession
+    public init(session: URLSession = .shared) { self.session = session }
+
+    public func exchange(code: String, config: WorkOSConfig) async throws -> String {
+        guard let url = URL(string: config.baseURL.appendingPathComponentSafe("user_management/authenticate")) else {
+            throw CloudError.authURLUnavailable
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = [
+            "client_id": config.clientID,
+            "grant_type": "authorization_code",
+            "code": code,
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await session.data(for: req)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw CloudError.tokenExchangeFailed
+        }
+        guard
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let token = (obj["access_token"] as? String) ?? (obj["token"] as? String),
+            !token.isEmpty
+        else {
+            throw CloudError.tokenExchangeFailed
+        }
+        return token
+    }
+}
+
+// MARK: - Small private helpers
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+
+    func appendingPathComponentSafe(_ component: String) -> String {
+        let trimmed = hasSuffix("/") ? String(dropLast()) : self
+        return trimmed + "/" + component
+    }
+}

--- a/NotionBridge/Modules/Cloud/CloudAuthCallbackHandler.swift
+++ b/NotionBridge/Modules/Cloud/CloudAuthCallbackHandler.swift
@@ -1,0 +1,101 @@
+// CloudAuthCallbackHandler.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · Modules · Cloud
+//
+// The testable core of `AppDelegate.application(_:open:options:)`. Lives in
+// the LIB target so the brittle parse → exchange → Keychain-write →
+// Notification-post sequence is unit-tested headlessly; the AppDelegate
+// method is a 3-line wrapper that hands the inbound URL to `handle(_:)`.
+//
+// Per the packet's hard rule, the token EXCHANGE goes through the injectable
+// `CloudTokenExchanging` seam — unit tests inject a deterministic fake; no
+// live WorkOS network call is ever made by the suite. The live exchange
+// (real POST /oauth/token) requires PKT-810's tenant + WS-A and is the
+// `URLSessionTokenExchange` production conformer.
+
+import Foundation
+
+/// Persists the exchanged WorkOS token. Production conformer writes the
+/// Keychain (`KeychainManager`); tests inject an in-memory fake.
+public protocol CloudTokenPersisting: Sendable {
+    @discardableResult
+    func persist(token: String) -> Bool
+}
+
+/// Production token sink — the real Keychain under `Key.cloudToken`.
+public struct KeychainCloudTokenPersister: CloudTokenPersisting {
+    public init() {}
+    @discardableResult
+    public func persist(token: String) -> Bool {
+        KeychainManager.shared.saveCloudToken(token)
+    }
+}
+
+/// Handles an inbound `bridge-auth://` callback URL end to end:
+///   1. parse the URL into an auth code (or reject a malformed/denied one),
+///   2. exchange the code for a WorkOS session token (injected seam),
+///   3. persist the token (injected seam),
+///   4. post `.cloudAuthCallbackReceived` with a `success: Bool` userInfo —
+///      and NO token material — so the in-flight `EnableCloudAccessFlow`
+///      advances (success) or fails (failure).
+///
+/// Returns whether the URL was a `bridge-auth` callback this handler owns
+/// (so the AppDelegate can fall through for any other scheme). A malformed
+/// `bridge-auth` URL is still "owned" (returns true) and posts a failure
+/// notification.
+public struct CloudAuthCallbackHandler: Sendable {
+    private let config: WorkOSConfig
+    private let exchange: CloudTokenExchanging
+    private let persister: CloudTokenPersisting
+    private let notificationCenter: NotificationCenter
+
+    public init(
+        config: WorkOSConfig = .resolved(),
+        exchange: CloudTokenExchanging,
+        persister: CloudTokenPersisting = KeychainCloudTokenPersister(),
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.config = config
+        self.exchange = exchange
+        self.persister = persister
+        self.notificationCenter = notificationCenter
+    }
+
+    /// Returns `true` iff `url` is a `bridge-auth` callback this handler took
+    /// responsibility for (kicking off the async exchange). A non-`bridge-auth`
+    /// URL returns `false` and does nothing.
+    @discardableResult
+    public func handle(_ url: URL) -> Bool {
+        switch CloudAuthCallback.parse(url) {
+        case .code(let code):
+            Task { await self.exchangeAndPost(code: code) }
+            return true
+        case .invalid(let reason):
+            // Still a bridge-auth URL? Own it + post failure so the flow
+            // fails fast rather than waiting out the 120s guard.
+            if url.scheme?.lowercased() == "bridge-auth" {
+                post(success: false)
+                return true
+            }
+            _ = reason
+            return false
+        }
+    }
+
+    private func exchangeAndPost(code: String) async {
+        do {
+            let token = try await exchange.exchange(code: code, config: config)
+            let ok = persister.persist(token: token)
+            post(success: ok)
+        } catch {
+            post(success: false)
+        }
+    }
+
+    private func post(success: Bool) {
+        notificationCenter.post(
+            name: .cloudAuthCallbackReceived,
+            object: nil,
+            userInfo: [cloudAuthSuccessKey: success]
+        )
+    }
+}

--- a/NotionBridge/Modules/Cloud/CloudStatusModule.swift
+++ b/NotionBridge/Modules/Cloud/CloudStatusModule.swift
@@ -1,0 +1,202 @@
+// CloudStatusModule.swift — WS-D (PKT-921 · Bridge Cloud Access)
+// NotionBridge · Modules · Cloud
+//
+// Three small, independently-testable pieces that wire the WS-C
+// `BridgeCloudManager` actor into the running MCP server:
+//
+//   1. CloudHeartbeat — a cancellable repeating timer that re-probes
+//      transport health by calling `manager.refreshHealth()` on a ~30s
+//      cadence while Bridge Cloud Access is enabled. There is NO
+//      `heartbeatLoop()` on the manager (the packet body's API was stale);
+//      WS-D BUILDS the loop here over the real `refreshHealth()` seam. The
+//      tick interval is injectable so a unit test can drive start/stop
+//      deterministically without sleeping 30s.
+//
+//   2. CloudStatusPayload — the canonical, state-derived `bridge_status`
+//      JSON the MCP tool returns. The WS-B static Worker JSON (PKT-920)
+//      MUST mirror this exact shape (the packet's coordination note).
+//
+//   3. CloudStatusModule — registers the cloud-gated `bridge_status` MCP
+//      tool whose handler reads `await manager.state` and emits the payload.
+//      Registered ONLY when Bridge Cloud Access is enabled (the caller gates
+//      on `BridgeDefaults.cloudAccessEnabled`); never part of the static
+//      feature-module count.
+//
+// All three bind to the REAL WS-C API: `state` (.disabled/.connecting/
+// .online/.degraded/.offline — there is NO `.connected`) and
+// `refreshHealth()`. `.online`/`.degraded` are treated as "up".
+
+import Foundation
+import MCP
+
+// MARK: - 1. Heartbeat
+
+/// A cancellable, repeating health-probe loop over `BridgeCloudManager`.
+///
+/// While running it awaits `interval`, calls `manager.refreshHealth()`, and
+/// repeats until `stop()` (or deinit) cancels it. The manager itself no-ops
+/// `refreshHealth()` when `.disabled`, so a stray late tick after a disable
+/// is harmless — but `stop()` cancels the task promptly regardless.
+///
+/// An `actor` so `start`/`stop`/`isRunning` are race-free, and `onTick` (a
+/// test seam) fires exactly once per completed probe.
+public actor CloudHeartbeat {
+
+    /// Default cadence — DoD: "Heartbeat fires every 30s when
+    /// cloudAccessEnabled == true and app running".
+    public static let defaultInterval: Duration = .seconds(30)
+
+    private let manager: BridgeCloudManager
+    private let interval: Duration
+    /// Test seam: invoked after each completed `refreshHealth()` probe with
+    /// the resulting state. Production passes nil.
+    private let onTick: (@Sendable (CloudConnectionState) -> Void)?
+
+    private var task: Task<Void, Never>?
+
+    public init(
+        manager: BridgeCloudManager,
+        interval: Duration = CloudHeartbeat.defaultInterval,
+        onTick: (@Sendable (CloudConnectionState) -> Void)? = nil
+    ) {
+        self.manager = manager
+        self.interval = interval
+        self.onTick = onTick
+    }
+
+    /// Whether the loop is currently scheduled.
+    public var isRunning: Bool { task != nil }
+
+    /// Start the loop. Idempotent: a second `start()` while already running
+    /// is a no-op (no duplicate timer).
+    public func start() {
+        guard task == nil else { return }
+        let manager = self.manager
+        let interval = self.interval
+        let onTick = self.onTick
+        task = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: interval)
+                } catch {
+                    break // cancelled mid-sleep
+                }
+                if Task.isCancelled { break }
+                let state = await manager.refreshHealth()
+                onTick?(state)
+                _ = self // keep the actor alive while scheduled
+            }
+        }
+    }
+
+    /// Stop the loop. Idempotent: safe to call when not running. Cancels the
+    /// in-flight task so no further probes fire.
+    public func stop() {
+        task?.cancel()
+        task = nil
+    }
+
+    deinit {
+        task?.cancel()
+    }
+}
+
+// MARK: - 2. bridge_status payload (canonical shape — WS-B must mirror)
+
+/// Builds the canonical `bridge_status` payload from a `CloudConnectionState`.
+///
+/// SCHEMA (v1) — the WS-B static Worker JSON (PKT-920) MUST mirror this:
+///   {
+///     "tool":  "bridge_status",        // string, constant
+///     "ok":    true,                   // bool, constant (the probe itself succeeded)
+///     "state": "online",               // string raw value of CloudConnectionState
+///                                       //   one of: disabled|connecting|online|degraded|offline
+///     "up":    true,                   // bool — true iff state ∈ {online, degraded}
+///     "macToolsAvailable": true,       // bool — true iff Mac tools are exposed to a
+///                                       //   cloud caller in this state (== `up`)
+///     "schemaVersion": 1               // int — payload contract version
+///   }
+public enum CloudStatusPayload {
+
+    /// Current payload contract version. Bump on any shape change so WS-B can
+    /// detect drift.
+    public static let schemaVersion = 1
+
+    /// Whether the channel is "up" for serving delegated work. `.online` and
+    /// `.degraded` both count as up (degraded = channel impaired but present);
+    /// `.disabled`/`.connecting`/`.offline` are down.
+    public static func isUp(_ state: CloudConnectionState) -> Bool {
+        state == .online || state == .degraded
+    }
+
+    /// Whether Mac tools should be exposed to a CLOUD caller in `state`. Mac
+    /// tools are hidden when the channel is `.offline` or `.disabled`; mirrors
+    /// the tools/list conditional in `ServerManager`.
+    public static func macToolsAvailable(_ state: CloudConnectionState) -> Bool {
+        !(state == .offline || state == .disabled)
+    }
+
+    /// The canonical `bridge_status` JSON value.
+    public static func make(state: CloudConnectionState) -> Value {
+        .object([
+            "tool":               .string("bridge_status"),
+            "ok":                 .bool(true),
+            "state":              .string(state.rawValue),
+            "up":                 .bool(isUp(state)),
+            "macToolsAvailable":  .bool(macToolsAvailable(state)),
+            "schemaVersion":      .int(schemaVersion)
+        ])
+    }
+}
+
+// MARK: - 3. bridge_status MCP tool
+
+/// Registers the cloud-gated `bridge_status` MCP tool. NOT part of the static
+/// feature-module surface (`BridgeConstants.staticFeatureModuleToolCount`) —
+/// it exists only while Bridge Cloud Access is enabled, so the caller gates
+/// registration on `BridgeDefaults.cloudAccessEnabled`.
+public enum CloudStatusModule {
+
+    public static let moduleName = "cloud"
+    public static let toolName = "bridge_status"
+
+    /// Register `bridge_status` against `router`, reading live state from
+    /// `manager`. Handler is `.open` tier (pure read of local cloud state —
+    /// no Keychain, no tunnel mutation, no network).
+    public static func register(on router: ToolRouter, manager: BridgeCloudManager) async {
+        await router.register(makeTool(manager: manager))
+    }
+
+    /// Factory for the `bridge_status` registration (exposed for tests).
+    public static func makeTool(manager: BridgeCloudManager) -> ToolRegistration {
+        ToolRegistration(
+            name: toolName,
+            module: moduleName,
+            tier: .open,
+            description: "Report Bridge Cloud Access health for this Mac. Returns the "
+                + "connection state (disabled|connecting|online|degraded|offline), whether the "
+                + "channel is up (online/degraded), and whether Mac tools are exposed to a cloud "
+                + "caller in the current state. Pure read of local cloud state — no side effects. "
+                + "Returns { tool, ok, state, up, macToolsAvailable, schemaVersion }.",
+            inputSchema: .object([
+                "type":       .string("object"),
+                "properties": .object([:]),
+                "required":   .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Bridge Status",
+                whenToUse: [
+                    "Check whether this Mac is reachable from the cloud and how healthy the tunnel is."
+                ],
+                whenNotToUse: [
+                    "Enabling/disabling cloud access (that is the Remote Access settings toggle, not a tool)."
+                ],
+                relatedTools: ["session_info", "system_info"]
+            ),
+            handler: { _ in
+                let state = await manager.state
+                return CloudStatusPayload.make(state: state)
+            }
+        )
+    }
+}

--- a/NotionBridge/Modules/Cloud/EnableCloudAccessFlow+Live.swift
+++ b/NotionBridge/Modules/Cloud/EnableCloudAccessFlow+Live.swift
@@ -1,0 +1,86 @@
+// EnableCloudAccessFlow+Live.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · Modules · Cloud
+//
+// Production conformers for the Enable-flow seams + the `.live()` factory
+// that assembles the real machine: the real Keychain, NSWorkspace browser
+// open, UserDefaults-backed toggle, and a caller-supplied provisioner +
+// provisioning base URL (configurable so the live Worker endpoint, WS-A, is
+// the only place a real network call ever appears — gated on PKT-810).
+//
+// None of this is exercised by the unit suite: the tests inject the fakes
+// directly. This file is the wiring `RemoteAccessView` uses at runtime.
+
+import Foundation
+import AppKit
+
+// MARK: - Production: Keychain-backed token store
+
+/// Reads the WorkOS cloud token from the real Keychain.
+public struct KeychainCloudTokenStore: CloudTokenStore {
+    public init() {}
+    public var token: String? { KeychainManager.shared.cloudToken }
+}
+
+// MARK: - Production: system-browser opener (Q1 lock)
+
+/// Opens the WorkOS auth URL in the user's default browser via NSWorkspace.
+public struct SystemBrowserOpener: AuthBrowserOpening {
+    public init() {}
+    @discardableResult
+    public func open(_ url: URL) -> Bool {
+        NSWorkspace.shared.open(url)
+    }
+}
+
+// MARK: - Production: UserDefaults-backed flow defaults
+
+/// Reads/writes the Enable-flow's two `BridgeDefaults` keys against the real
+/// `UserDefaults`.
+public final class UserDefaultsCloudFlowDefaults: CloudFlowDefaults, @unchecked Sendable {
+    private let defaults: UserDefaults
+    public init(defaults: UserDefaults = .standard) { self.defaults = defaults }
+
+    public var cloudAccessEnabled: Bool {
+        get { defaults.bool(forKey: BridgeDefaults.cloudAccessEnabled) }
+        set { defaults.set(newValue, forKey: BridgeDefaults.cloudAccessEnabled) }
+    }
+
+    public var cloudTunnelHostname: String? {
+        get { defaults.string(forKey: BridgeDefaults.cloudTunnelHostname) }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: BridgeDefaults.cloudTunnelHostname)
+            } else {
+                defaults.removeObject(forKey: BridgeDefaults.cloudTunnelHostname)
+            }
+        }
+    }
+}
+
+// MARK: - .live() factory
+
+@MainActor
+public extension EnableCloudAccessFlow {
+    /// Assemble the production Enable flow. `provisioner` is the live
+    /// `BridgeCloudManager` (on `main` per the packet); `provisionBaseURL`
+    /// is the WS-A Worker endpoint (configurable — defaults to the env var
+    /// `BRIDGE_CLOUD_BASE_URL` or a documented placeholder so the build runs
+    /// before WS-A is live).
+    static func live(
+        provisioner: CloudProvisioning,
+        provisionBaseURL: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> EnableCloudAccessFlow {
+        let baseURL = provisionBaseURL
+            ?? environment["BRIDGE_CLOUD_BASE_URL"]
+            ?? "https://cloud.kup.solutions"
+        return EnableCloudAccessFlow(
+            tokenStore: KeychainCloudTokenStore(),
+            browser: SystemBrowserOpener(),
+            provisioner: provisioner,
+            defaults: UserDefaultsCloudFlowDefaults(),
+            config: .resolved(environment: environment),
+            provisionBaseURL: baseURL
+        )
+    }
+}

--- a/NotionBridge/Modules/Cloud/EnableCloudAccessFlow+Live.swift
+++ b/NotionBridge/Modules/Cloud/EnableCloudAccessFlow+Live.swift
@@ -79,6 +79,11 @@ public extension EnableCloudAccessFlow {
             browser: SystemBrowserOpener(),
             provisioner: provisioner,
             defaults: UserDefaultsCloudFlowDefaults(),
+            // WS-G: the production provisioner (BridgeCloudManager) is also the
+            // teardown seam — disable() stops the tunnel. Non-teardown
+            // provisioners simply don't supply one (Disable becomes a
+            // state/defaults clear with no tunnel stop).
+            teardown: provisioner as? CloudTeardown,
             config: .resolved(environment: environment),
             provisionBaseURL: baseURL
         )

--- a/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
+++ b/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
@@ -206,6 +206,12 @@ public final class EnableCloudAccessFlow {
         teardownAuthWait()
         provisionTask?.cancel()
         provisionTask = nil
+        // WS-D (PKT-921): an explicit OFF toggle must also persist the master
+        // state and stop the heartbeat / deregister `bridge_status`. (The flow
+        // never set `.failed` here, so without this the running ServerManager
+        // would keep a stale heartbeat after a mid-flow cancel.)
+        defaults.cloudAccessEnabled = false
+        postCloudAccessEnabledDidChange(false)
         state = .idle
     }
 
@@ -325,12 +331,29 @@ public final class EnableCloudAccessFlow {
     private func succeed(hostname: String) {
         defaults.cloudTunnelHostname = hostname
         defaults.cloudAccessEnabled = true
+        // WS-D (PKT-921): tell the running ServerManager to start the heartbeat
+        // + register `bridge_status` now that cloud access is ON (no relaunch).
+        postCloudAccessEnabledDidChange(true)
         state = .connected
     }
 
     private func fail(_ error: CloudError) {
         // Revert the toggle to OFF so the switch snaps back (DoD).
         defaults.cloudAccessEnabled = false
+        // WS-D (PKT-921): cloud access reverted to OFF — stop the heartbeat +
+        // deregister `bridge_status`.
+        postCloudAccessEnabledDidChange(false)
         state = .failed(error)
+    }
+
+    /// WS-D (PKT-921): notify observers (AppDelegate → ServerManager) that the
+    /// `cloudAccessEnabled` master state changed, so the heartbeat +
+    /// `bridge_status` registration track the toggle live.
+    private func postCloudAccessEnabledDidChange(_ enabled: Bool) {
+        notificationCenter.post(
+            name: .cloudAccessEnabledDidChange,
+            object: nil,
+            userInfo: [cloudAccessEnabledKey: enabled]
+        )
     }
 }

--- a/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
+++ b/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
@@ -1,0 +1,336 @@
+// EnableCloudAccessFlow.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · Modules · Cloud
+//
+// The @Observable state machine that drives the "Enable Cloud Access"
+// toggle from OFF to a live, connected cloud node. It is the single source
+// of truth `ProvisioningProgressView` renders and `RemoteAccessView` binds
+// the toggle to.
+//
+//   .idle → .checkingAccount → .signingIn → .provisioning → .connected
+//                                                          ↘ .failed(error)
+//
+//   • .checkingAccount — consult the Keychain for an existing WorkOS token.
+//       Present  → skip the browser, go straight to .provisioning.
+//       Absent   → .signingIn.
+//   • .signingIn      — open the WorkOS auth URL in the system browser
+//       (Q1 lock: system browser + bridge-auth:// callback, no WKWebView),
+//       then await `.cloudAuthCallbackReceived`. A 120s cancellation guard
+//       (user closed the browser without finishing) → .failed(.authCancelled).
+//   • .provisioning   — BridgeCloudManager.provision() + startTunnel(),
+//       under a 30s timeout → .failed(.provisionTimeout). Runs on the main
+//       actor (the whole class is @MainActor).
+//   • .connected      — persist the tunnel hostname to BridgeDefaults and
+//       leave the toggle ON.
+//   • .failed(error)  — revert BridgeDefaults.cloudAccessEnabled to false so
+//       the toggle snaps back OFF; surface the error for the Retry button.
+//
+// EVERY external dependency is injected behind a Sendable seam so the whole
+// machine is unit-testable headlessly — no NSWorkspace, no Keychain prompt,
+// no cloudflared, no live WorkOS network, no real clock. The production
+// wiring (real Keychain, NSWorkspace.open, the shared BridgeCloudManager,
+// UserDefaults) is assembled in `EnableCloudAccessFlow.live()`.
+
+import Foundation
+import Observation
+
+// MARK: - Errors
+
+/// Why the Enable flow ended in `.failed`. Each maps to a user-facing line
+/// in `ProvisioningProgressView`.
+public enum CloudError: Error, Sendable, Equatable {
+    /// No `.cloudAuthCallbackReceived` arrived within the 120s window — the
+    /// user dismissed the browser without completing sign-in.
+    case authCancelled
+    /// The auth callback arrived but the code exchange reported failure.
+    case authFailed
+    /// The WorkOS authorization URL could not be built (misconfigured tenant).
+    case authURLUnavailable
+    /// The code→token exchange (POST /oauth/token) failed.
+    case tokenExchangeFailed
+    /// provision()/startTunnel() did not complete within the 30s window.
+    case provisionTimeout
+    /// provision()/startTunnel() threw.
+    case provisionFailed
+
+    public var userMessage: String {
+        switch self {
+        case .authCancelled:     return "Sign-in was cancelled."
+        case .authFailed:        return "Sign-in did not complete."
+        case .authURLUnavailable: return "Cloud sign-in is not configured."
+        case .tokenExchangeFailed: return "Could not complete sign-in."
+        case .provisionTimeout:  return "Setting up your Bridge timed out."
+        case .provisionFailed:   return "Could not set up your Bridge."
+        }
+    }
+}
+
+// MARK: - States
+
+/// The Enable-flow state. `Equatable` for deterministic test assertions;
+/// `.failed` compares on the wrapped `CloudError`.
+public enum EnableCloudAccessState: Sendable, Equatable {
+    case idle
+    case checkingAccount
+    case signingIn
+    case provisioning
+    case connected
+    case failed(CloudError)
+}
+
+// MARK: - Injectable seams
+
+/// The Keychain-token half of the flow's dependencies. Production conformer
+/// wraps `KeychainManager`; tests inject an in-memory fake (no Keychain
+/// prompt). The flow only ever *reads* — the *write* happens in AppDelegate
+/// on the callback.
+public protocol CloudTokenStore: Sendable {
+    var token: String? { get }
+}
+
+/// Opens the system browser for WorkOS sign-in. Production conformer calls
+/// `NSWorkspace.shared.open`; tests inject a fake that records the URL
+/// without opening anything.
+public protocol AuthBrowserOpening: Sendable {
+    /// Returns whether the URL was handed to the system to open.
+    @discardableResult
+    func open(_ url: URL) -> Bool
+}
+
+/// The toggle-backing store the flow reverts on `.failed` and writes the
+/// hostname into on success. Production conformer wraps `UserDefaults`
+/// (`BridgeDefaults` keys); tests inject an in-memory fake.
+public protocol CloudFlowDefaults: AnyObject, Sendable {
+    var cloudAccessEnabled: Bool { get set }
+    var cloudTunnelHostname: String? { get set }
+}
+
+/// Async-sleep seam so the 120s / 30s timeouts are deterministic in tests
+/// (the fake resolves instantly or never, on demand). Production uses
+/// `Task.sleep`.
+public protocol CloudClock: Sendable {
+    /// Sleep for `seconds`, or throw `CancellationError` if cancelled.
+    func sleep(seconds: Double) async throws
+}
+
+/// Production clock backed by `Task.sleep`.
+public struct TaskClock: CloudClock {
+    public init() {}
+    public func sleep(seconds: Double) async throws {
+        try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+}
+
+// MARK: - Flow
+
+@MainActor
+@Observable
+public final class EnableCloudAccessFlow {
+
+    /// The current state — the single source of truth the UI renders.
+    public private(set) var state: EnableCloudAccessState = .idle
+
+    // Injected dependencies (all seams; production values via `.live()`).
+    private let tokenStore: CloudTokenStore
+    private let browser: AuthBrowserOpening
+    private let provisioner: CloudProvisioning
+    private let defaults: CloudFlowDefaults
+    private let config: WorkOSConfig
+    /// Configurable provisioning base URL (mocks in tests; PKT-810/WS-A live).
+    private let provisionBaseURL: String
+    private let clock: CloudClock
+    private let authTimeout: Double
+    private let provisionTimeout: Double
+    private let notificationCenter: NotificationCenter
+
+    /// The in-flight auth callback observer token, removed when sign-in
+    /// resolves (or the flow is cancelled).
+    private var authObserver: NSObjectProtocol?
+    /// The 120s auth-cancellation guard task.
+    private var authTimeoutTask: Task<Void, Never>?
+    /// The provisioning task (30s-guarded), retained so cancellation works.
+    private var provisionTask: Task<Void, Never>?
+    /// Continuation the auth-callback notification resumes.
+    private var authContinuation: CheckedContinuation<Bool, Never>?
+
+    public init(
+        tokenStore: CloudTokenStore,
+        browser: AuthBrowserOpening,
+        provisioner: CloudProvisioning,
+        defaults: CloudFlowDefaults,
+        config: WorkOSConfig = .resolved(),
+        provisionBaseURL: String,
+        clock: CloudClock = TaskClock(),
+        authTimeout: Double = 120,
+        provisionTimeout: Double = 30,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.tokenStore = tokenStore
+        self.browser = browser
+        self.provisioner = provisioner
+        self.defaults = defaults
+        self.config = config
+        self.provisionBaseURL = provisionBaseURL
+        self.clock = clock
+        self.authTimeout = authTimeout
+        self.provisionTimeout = provisionTimeout
+        self.notificationCenter = notificationCenter
+    }
+
+    // MARK: - Entry point
+
+    /// Begin (or retry) the Enable flow. Idempotent against a run already in
+    /// flight (a second `start()` while signing-in/provisioning is ignored).
+    public func start() {
+        switch state {
+        case .signingIn, .provisioning, .checkingAccount:
+            return // already running
+        case .idle, .connected, .failed:
+            break // (re)start — .failed is the Retry path
+        }
+
+        state = .checkingAccount
+
+        // Keychain token present → skip the browser sign-in step entirely.
+        if let token = tokenStore.token, !token.isEmpty {
+            beginProvisioning()
+            return
+        }
+
+        beginSignIn()
+    }
+
+    /// Cancel an in-flight run (toggle flipped OFF mid-flow). Tears down the
+    /// observer + guards and returns to `.idle` WITHOUT marking `.failed`
+    /// (an explicit user cancel is not an error to surface).
+    public func cancel() {
+        teardownAuthWait()
+        provisionTask?.cancel()
+        provisionTask = nil
+        state = .idle
+    }
+
+    // MARK: - .signingIn
+
+    private func beginSignIn() {
+        guard let url = WorkOSAuthURLBuilder.authorizationURL(for: config) else {
+            fail(.authURLUnavailable)
+            return
+        }
+        state = .signingIn
+
+        // Observe the AppDelegate callback (code already exchanged + token
+        // written to Keychain by the time this fires). The userInfo success
+        // flag distinguishes a real sign-in from a WorkOS error callback.
+        authObserver = notificationCenter.addObserver(
+            forName: .cloudAuthCallbackReceived,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            let ok = (note.userInfo?[cloudAuthSuccessKey] as? Bool) ?? true
+            MainActor.assumeIsolated { self?.authCallbackArrived(success: ok) }
+        }
+
+        // 120s cancellation guard.
+        authTimeoutTask = Task { [weak self, authTimeout, clock] in
+            try? await clock.sleep(seconds: authTimeout)
+            if Task.isCancelled { return }
+            await MainActor.run { self?.authTimedOut() }
+        }
+
+        browser.open(url)
+    }
+
+    private func authCallbackArrived(success: Bool) {
+        guard state == .signingIn else { return }
+        teardownAuthWait()
+        if success {
+            beginProvisioning()
+        } else {
+            fail(.authFailed)
+        }
+    }
+
+    private func authTimedOut() {
+        guard state == .signingIn else { return }
+        teardownAuthWait()
+        fail(.authCancelled)
+    }
+
+    private func teardownAuthWait() {
+        if let obs = authObserver {
+            notificationCenter.removeObserver(obs)
+            authObserver = nil
+        }
+        authTimeoutTask?.cancel()
+        authTimeoutTask = nil
+    }
+
+    // MARK: - .provisioning
+
+    private func beginProvisioning() {
+        state = .provisioning
+        provisionTask = Task { [weak self] in
+            await self?.runProvisioning()
+        }
+    }
+
+    private func runProvisioning() async {
+        // Race the provision work against the 30s guard. Whichever finishes
+        // first wins; the loser is cancelled.
+        let result: Result<String, CloudError> = await withTaskGroup(
+            of: Result<String, CloudError>?.self
+        ) { [provisioner, provisionBaseURL, clock, provisionTimeout] group in
+            group.addTask {
+                do {
+                    let host = try await provisioner.provision(baseURL: provisionBaseURL)
+                    try await provisioner.startTunnel()
+                    return .success(host)
+                } catch is CancellationError {
+                    return nil
+                } catch {
+                    return .failure(.provisionFailed)
+                }
+            }
+            group.addTask {
+                do {
+                    try await clock.sleep(seconds: provisionTimeout)
+                    return .failure(.provisionTimeout)
+                } catch {
+                    return nil // cancelled by the winner
+                }
+            }
+            // First non-nil result wins.
+            var outcome: Result<String, CloudError> = .failure(.provisionFailed)
+            for await value in group {
+                if let value {
+                    outcome = value
+                    group.cancelAll()
+                    break
+                }
+            }
+            return outcome
+        }
+
+        if Task.isCancelled { return }
+        switch result {
+        case .success(let host):
+            succeed(hostname: host)
+        case .failure(let err):
+            fail(err)
+        }
+    }
+
+    // MARK: - Terminal transitions
+
+    private func succeed(hostname: String) {
+        defaults.cloudTunnelHostname = hostname
+        defaults.cloudAccessEnabled = true
+        state = .connected
+    }
+
+    private func fail(_ error: CloudError) {
+        // Revert the toggle to OFF so the switch snaps back (DoD).
+        defaults.cloudAccessEnabled = false
+        state = .failed(error)
+    }
+}

--- a/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
+++ b/NotionBridge/Modules/Cloud/EnableCloudAccessFlow.swift
@@ -133,6 +133,10 @@ public final class EnableCloudAccessFlow {
     private let tokenStore: CloudTokenStore
     private let browser: AuthBrowserOpening
     private let provisioner: CloudProvisioning
+    /// WS-G: the teardown seam the Disable flow drives. Optional so existing
+    /// call sites (and tests that only exercise Enable) need not supply one;
+    /// `.live()` wires the production `BridgeCloudManager`.
+    private let teardown: CloudTeardown?
     private let defaults: CloudFlowDefaults
     private let config: WorkOSConfig
     /// Configurable provisioning base URL (mocks in tests; PKT-810/WS-A live).
@@ -157,6 +161,7 @@ public final class EnableCloudAccessFlow {
         browser: AuthBrowserOpening,
         provisioner: CloudProvisioning,
         defaults: CloudFlowDefaults,
+        teardown: CloudTeardown? = nil,
         config: WorkOSConfig = .resolved(),
         provisionBaseURL: String,
         clock: CloudClock = TaskClock(),
@@ -167,6 +172,7 @@ public final class EnableCloudAccessFlow {
         self.tokenStore = tokenStore
         self.browser = browser
         self.provisioner = provisioner
+        self.teardown = teardown
         self.defaults = defaults
         self.config = config
         self.provisionBaseURL = provisionBaseURL
@@ -206,6 +212,30 @@ public final class EnableCloudAccessFlow {
         teardownAuthWait()
         provisionTask?.cancel()
         provisionTask = nil
+        state = .idle
+    }
+
+    // MARK: - Disable (WS-G)
+
+    /// Tear down a live cloud connection (Disable flow, confirmed). Stops any
+    /// in-flight run, drives the injected `CloudTeardown` (production:
+    /// `BridgeCloudManager.disable()` → tunnel stopped, machine `.disabled`),
+    /// clears the persisted toggle + hostname, and returns the flow to
+    /// `.idle`. Idempotent and safe from any state.
+    ///
+    /// Mirrors the real API per the PKT-923 reconciliation: there is no
+    /// `stopTunnel()`/`.disconnected` — teardown is `disable()` and the off
+    /// state is `.disabled`.
+    public func disable() async {
+        // Stop any in-flight Enable run first (no .failed surfaced).
+        teardownAuthWait()
+        provisionTask?.cancel()
+        provisionTask = nil
+        // Tear the tunnel down (no-op-safe if not running).
+        await teardown?.disable()
+        // Clear persisted state so the toggle stays OFF + the URL row clears.
+        defaults.cloudAccessEnabled = false
+        defaults.cloudTunnelHostname = nil
         state = .idle
     }
 

--- a/NotionBridge/Modules/MailModule.swift
+++ b/NotionBridge/Modules/MailModule.swift
@@ -1,0 +1,461 @@
+// MailModule.swift – v3.7·H (PKT-961) Apple Mail Tools
+// NotionBridge · Modules
+//
+// Five tools: mail_list, mail_read, mail_search, mail_draft, mail_send.
+// Apple Mail is AppleScript-scriptable (distinct from the Gmail connector).
+// All Mail access flows through an INJECTABLE AppleScript seam
+// (`MailModule.scriptRunner`) so the read/search/draft/send paths are unit-
+// testable against a deterministic mock — no live Mail.app, no real send.
+//
+// SAFETY POSTURE — drafts by default; send requires confirm:
+//   - mail_list / mail_read / mail_search → tier .open   (read-only, no prompt)
+//   - mail_draft                          → tier .notify (creates an UNSENT draft)
+//   - mail_send                           → tier .request AND requires an
+//        explicit confirm token: confirm:'SEND' (exact, uppercase). The handler
+//        REFUSES (sent:false, never invokes the send script) when the token is
+//        absent or wrong. This mirrors MessagesModule.messages_send exactly.
+//        mail_send NEVER auto-sends; the only path to a send is an explicit,
+//        operator-confirmed call. mail_draft is the safe default for composing.
+//
+// TCC: Mail Automation is an operator first-use grant (the existing
+// apple-events automation entitlement covers NotionBridge; no entitlement
+// change). The first live mail_* call triggers the macOS Automation consent
+// prompt for Mail — flagged as an operator residual, not handled in code.
+
+import Foundation
+import MCP
+
+// MARK: - AppleScript Seam
+
+/// Result of running an AppleScript fragment: either the string the script
+/// returned, or an error (message + AppleScript error number).
+public enum MailScriptResult: Sendable, Equatable {
+    case success(String)
+    case failure(message: String, number: Int)
+}
+
+/// Injectable AppleScript execution seam. Production runs the script
+/// in-process via `NSAppleScript` (same one-grant TCC model as
+/// AppleScriptModule); tests inject a deterministic mock so no Mail.app is
+/// touched and no mail is ever sent.
+public protocol MailScriptRunner: Sendable {
+    func run(_ script: String) -> MailScriptResult
+}
+
+/// Production runner: executes AppleScript in-process under NotionBridge's
+/// TCC grants (avoids the osascript child-process TCC re-prompt storm — see
+/// AppleScriptModule).
+public struct NSAppleScriptMailRunner: MailScriptRunner {
+    public init() {}
+
+    public func run(_ script: String) -> MailScriptResult {
+        let appleScript = NSAppleScript(source: script)
+        var errorInfo: NSDictionary?
+        let result = appleScript?.executeAndReturnError(&errorInfo)
+        if let error = errorInfo {
+            let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
+            let number = error[NSAppleScript.errorNumber] as? Int ?? -1
+            return .failure(message: message, number: number)
+        }
+        return .success(result?.stringValue ?? "")
+    }
+}
+
+// MARK: - MailModule
+
+/// Provides Apple Mail read / search / draft tools plus a GUARDED send.
+/// Every tool routes through `scriptRunner` (the injectable seam) so the
+/// behaviour is identical in production and under test fixtures.
+public enum MailModule {
+
+    public static let moduleName = "mail"
+
+    /// Confirm token required by `mail_send`. Exact, uppercase — mirrors
+    /// `messages_send`'s 'SEND'. Without it the send handler refuses.
+    public static let sendConfirmToken = "SEND"
+
+    /// Injectable AppleScript seam. Production uses `NSAppleScriptMailRunner`;
+    /// tests swap in a mock. `nonisolated(unsafe)` mirrors MessagesModule's
+    /// shared-static pattern — mutated only at registration / test setup, never
+    /// concurrently during a single dispatch.
+    nonisolated(unsafe) public static var scriptRunner: MailScriptRunner = NSAppleScriptMailRunner()
+
+    // MARK: - AppleScript escaping
+
+    /// Escape a string for safe interpolation inside an AppleScript double-
+    /// quoted literal (backslash + double-quote). Same approach MessagesModule
+    /// uses for messages_send recipient/body.
+    static func escape(_ raw: String) -> String {
+        raw.replacingOccurrences(of: "\\", with: "\\\\")
+           .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    // MARK: - Tool Registration
+
+    /// Register all MailModule tools on the given router.
+    public static func register(on router: ToolRouter) async {
+
+        // MARK: 1. mail_list – open
+        await router.register(ToolRegistration(
+            name: "mail_list",
+            module: moduleName,
+            tier: .open,
+            description: "List recent messages from a Mail mailbox (default: Inbox). Read-only. Returns id, subject, sender, date, and read state per message.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "mailbox": .object(["type": .string("string"), "description": .string("Mailbox name to list (default: 'Inbox')")]),
+                    "limit": .object(["type": .string("integer"), "description": .string("Max messages to return (default: 20)")])
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Mail: List Messages",
+                whenToUse: ["triaging a mailbox — most recent messages with subject/sender/date",
+                            "picking a message id to then read in full with mail_read"],
+                whenNotToUse: ["reading one message body (use mail_read)",
+                               "finding messages by keyword/sender across mailboxes (use mail_search)"],
+                relatedTools: ["mail_read", "mail_search", "mail_draft"]
+            ),
+            handler: { arguments in
+                let mailbox: String = {
+                    if case .object(let args) = arguments, case .string(let m) = args["mailbox"], !m.isEmpty { return m }
+                    return "Inbox"
+                }()
+                let limit: Int = {
+                    if case .object(let args) = arguments, case .int(let l) = args["limit"] { return max(1, l) }
+                    return 20
+                }()
+                // Build an AppleScript that emits one record per line:
+                //   id|isRead|date|sender|subject  (fields are tab-joined; rows newline-joined)
+                let script = """
+                    tell application "Mail"
+                        set theBox to mailbox "\(escape(mailbox))" of inbox
+                        set outLines to {}
+                        set msgs to messages of theBox
+                        set n to count of msgs
+                        if n > \(limit) then set n to \(limit)
+                        repeat with i from 1 to n
+                            set m to item i of msgs
+                            set theLine to (id of m as string) & tab & (read status of m as string) & tab & (date received of m as string) & tab & (sender of m) & tab & (subject of m)
+                            set end of outLines to theLine
+                        end repeat
+                        set AppleScript's text item delimiters to linefeed
+                        set outText to outLines as string
+                        set AppleScript's text item delimiters to ""
+                        return outText
+                    end tell
+                    """
+                return runListLike(script, mailbox: mailbox, limit: limit)
+            }
+        ))
+
+        // MARK: 2. mail_read – open
+        await router.register(ToolRegistration(
+            name: "mail_read",
+            module: moduleName,
+            tier: .open,
+            description: "Read a single Mail message by its id (full subject, sender, recipients, date, and plain-text body). Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "messageId": .object(["type": .string("string"), "description": .string("Mail message id (from mail_list / mail_search)")])
+                ]),
+                "required": .array([.string("messageId")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Mail: Read Message",
+                whenToUse: ["pulling the full body + headers for a message id surfaced by mail_list or mail_search"],
+                whenNotToUse: ["browsing a mailbox (use mail_list)",
+                               "you have a keyword but not an id (use mail_search)"],
+                relatedTools: ["mail_list", "mail_search"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let messageId) = args["messageId"], !messageId.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "mail_read", reason: "missing 'messageId'")
+                }
+                let script = """
+                    tell application "Mail"
+                        set theMsg to first message of inbox whose id is "\(escape(messageId))"
+                        set theBody to content of theMsg
+                        return (subject of theMsg) & linefeed & (sender of theMsg) & linefeed & (date received of theMsg as string) & linefeed & "---" & linefeed & theBody
+                    end tell
+                    """
+                switch scriptRunner.run(script) {
+                case .success(let raw):
+                    let parts = raw.components(separatedBy: "\n---\n")
+                    let header = parts.first ?? raw
+                    let body = parts.count > 1 ? parts[1] : ""
+                    let headerLines = header.components(separatedBy: "\n")
+                    return .object([
+                        "messageId": .string(messageId),
+                        "subject": .string(headerLines.indices.contains(0) ? headerLines[0] : ""),
+                        "sender": .string(headerLines.indices.contains(1) ? headerLines[1] : ""),
+                        "date": .string(headerLines.indices.contains(2) ? headerLines[2] : ""),
+                        "body": .string(body)
+                    ])
+                case .failure(let message, let number):
+                    return scriptError(message: message, number: number)
+                }
+            }
+        ))
+
+        // MARK: 3. mail_search – open
+        await router.register(ToolRegistration(
+            name: "mail_search",
+            module: moduleName,
+            tier: .open,
+            description: "Search Mail message subjects (and optionally senders) for a keyword across the inbox. Read-only. Returns matching id/subject/sender/date rows.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object(["type": .string("string"), "description": .string("Keyword to match against message subject (and sender)")]),
+                    "limit": .object(["type": .string("integer"), "description": .string("Max results to return (default: 25)")])
+                ]),
+                "required": .array([.string("query")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Mail: Search",
+                whenToUse: ["finding messages whose subject/sender contains a keyword before reading one with mail_read"],
+                whenNotToUse: ["listing a whole mailbox in date order (use mail_list)",
+                               "reading a specific message body (use mail_read)"],
+                relatedTools: ["mail_list", "mail_read"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let query) = args["query"], !query.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "mail_search", reason: "missing 'query'")
+                }
+                let limit: Int = {
+                    if case .int(let l) = args["limit"] { return max(1, l) }
+                    return 25
+                }()
+                let q = escape(query)
+                let script = """
+                    tell application "Mail"
+                        set outLines to {}
+                        set hits to (messages of inbox whose subject contains "\(q)")
+                        set n to count of hits
+                        if n > \(limit) then set n to \(limit)
+                        repeat with i from 1 to n
+                            set m to item i of hits
+                            set theLine to (id of m as string) & tab & (read status of m as string) & tab & (date received of m as string) & tab & (sender of m) & tab & (subject of m)
+                            set end of outLines to theLine
+                        end repeat
+                        set AppleScript's text item delimiters to linefeed
+                        set outText to outLines as string
+                        set AppleScript's text item delimiters to ""
+                        return outText
+                    end tell
+                    """
+                return runListLike(script, mailbox: "Inbox", limit: limit)
+            }
+        ))
+
+        // MARK: 4. mail_draft – notify (creates an UNSENT draft; never sends)
+        await router.register(ToolRegistration(
+            name: "mail_draft",
+            module: moduleName,
+            tier: .notify,
+            description: "Create an UNSENT Mail draft (to / subject / body; optional cc). The draft is saved in Mail for the operator to review and send manually — this tool NEVER sends. Drafting is the safe default; sending requires the separate, confirm-gated mail_send.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "to": .object(["type": .string("string"), "description": .string("Recipient email address")]),
+                    "subject": .object(["type": .string("string"), "description": .string("Subject line")]),
+                    "body": .object(["type": .string("string"), "description": .string("Message body (plain text)")]),
+                    "cc": .object(["type": .string("string"), "description": .string("Optional cc email address")])
+                ]),
+                "required": .array([.string("to"), .string("subject"), .string("body")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Mail: Create Draft",
+                whenToUse: ["composing an email for the operator to review and send manually",
+                            "the default, safe way to write mail — produces an unsent draft, never sends"],
+                whenNotToUse: ["actually sending an already-approved message (use mail_send with confirm:'SEND')"],
+                relatedTools: ["mail_send"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let to) = args["to"],
+                      case .string(let subject) = args["subject"],
+                      case .string(let body) = args["body"] else {
+                    throw ToolRouterError.invalidArguments(toolName: "mail_draft", reason: "missing required parameters (to, subject, body)")
+                }
+                let cc: String? = { if case .string(let c) = args["cc"], !c.isEmpty { return c }; return nil }()
+
+                // Build a draft WITHOUT a send command. `visible:true` so the
+                // operator sees it; the message is saved unsent.
+                var script = """
+                    tell application "Mail"
+                        set newMsg to make new outgoing message with properties {subject:"\(escape(subject))", content:"\(escape(body))", visible:true}
+                        tell newMsg
+                            make new to recipient at end of to recipients with properties {address:"\(escape(to))"}
+                    """
+                if let cc = cc {
+                    script += """
+
+                            make new cc recipient at end of cc recipients with properties {address:"\(escape(cc))"}
+                    """
+                }
+                script += """
+
+                        end tell
+                        save newMsg
+                        return (id of newMsg as string)
+                    end tell
+                    """
+                switch scriptRunner.run(script) {
+                case .success(let draftId):
+                    return .object([
+                        "drafted": .bool(true),
+                        "sent": .bool(false),
+                        "draftId": .string(draftId),
+                        "to": .string(to),
+                        "subject": .string(subject),
+                        "note": .string("Draft saved unsent. mail_draft never sends; use mail_send with confirm:'SEND' to deliver.")
+                    ])
+                case .failure(let message, let number):
+                    return scriptError(message: message, number: number, extra: ["drafted": .bool(false), "sent": .bool(false)])
+                }
+            }
+        ))
+
+        // MARK: 5. mail_send – request + EXPLICIT confirm token (GUARDED)
+        await router.register(ToolRegistration(
+            name: "mail_send",
+            module: moduleName,
+            tier: .request,
+            description: "Send an email via Mail. GUARDED: requires confirm:'SEND' (exact, uppercase) AND is tier .request (operator approval). NEVER auto-sends — without the confirm token the call is refused and nothing is sent. Prefer mail_draft (drafts by default); only call this for an explicitly approved send.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "to": .object(["type": .string("string"), "description": .string("Recipient email address")]),
+                    "subject": .object(["type": .string("string"), "description": .string("Subject line")]),
+                    "body": .object(["type": .string("string"), "description": .string("Message body (plain text)")]),
+                    "cc": .object(["type": .string("string"), "description": .string("Optional cc email address")]),
+                    "confirm": .object(["type": .string("string"), "description": .string("Must be exactly 'SEND' to proceed. Absent/wrong → refused, nothing sent.")])
+                ]),
+                "required": .array([.string("to"), .string("subject"), .string("body"), .string("confirm")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Mail: Send (guarded)",
+                whenToUse: ["delivering an email the operator has explicitly approved — pass confirm:'SEND'"],
+                whenNotToUse: ["composing/iterating on a message (use mail_draft — drafts by default)",
+                               "any unapproved or speculative send (the confirm gate will refuse it)"],
+                relatedTools: ["mail_draft"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let to) = args["to"],
+                      case .string(let subject) = args["subject"],
+                      case .string(let body) = args["body"],
+                      case .string(let confirm) = args["confirm"] else {
+                    throw ToolRouterError.invalidArguments(toolName: "mail_send", reason: "missing required parameters (to, subject, body, confirm)")
+                }
+
+                // SEND-GUARD: refuse unless the exact confirm token is present.
+                // This returns BEFORE any AppleScript is built or run, so an
+                // unconfirmed call can never reach Mail.app.
+                guard confirm == sendConfirmToken else {
+                    return .object([
+                        "sent": .bool(false),
+                        "error": .string("mail_send requires confirm: '\(sendConfirmToken)' (exact, uppercase). Nothing was sent. To compose without sending, use mail_draft."),
+                        "refused": .bool(true)
+                    ])
+                }
+
+                let cc: String? = { if case .string(let c) = args["cc"], !c.isEmpty { return c }; return nil }()
+
+                var script = """
+                    tell application "Mail"
+                        set newMsg to make new outgoing message with properties {subject:"\(escape(subject))", content:"\(escape(body))", visible:false}
+                        tell newMsg
+                            make new to recipient at end of to recipients with properties {address:"\(escape(to))"}
+                    """
+                if let cc = cc {
+                    script += """
+
+                            make new cc recipient at end of cc recipients with properties {address:"\(escape(cc))"}
+                    """
+                }
+                script += """
+
+                        end tell
+                        send newMsg
+                        return "sent"
+                    end tell
+                    """
+                switch scriptRunner.run(script) {
+                case .success:
+                    return .object([
+                        "sent": .bool(true),
+                        "to": .string(to),
+                        "subject": .string(subject),
+                        "bodyLength": .int(body.utf8.count)
+                    ])
+                case .failure(let message, let number):
+                    return scriptError(message: message, number: number, extra: ["sent": .bool(false)])
+                }
+            }
+        ))
+    }
+
+    // MARK: - Helpers
+
+    /// Run a list/search script and parse the tab/newline-delimited rows into
+    /// structured MCP objects. Shared by mail_list and mail_search.
+    private static func runListLike(_ script: String, mailbox: String, limit: Int) -> Value {
+        switch scriptRunner.run(script) {
+        case .success(let raw):
+            let rows = parseRows(raw)
+            return .object([
+                "mailbox": .string(mailbox),
+                "rows": .array(rows),
+                "count": .int(rows.count)
+            ])
+        case .failure(let message, let number):
+            return scriptError(message: message, number: number, extra: ["rows": .array([]), "count": .int(0)])
+        }
+    }
+
+    /// Parse `id<tab>isRead<tab>date<tab>sender<tab>subject` rows (newline-
+    /// separated) into MCP objects. Blank lines are skipped.
+    static func parseRows(_ raw: String) -> [Value] {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        return trimmed.components(separatedBy: "\n").compactMap { line in
+            let l = line.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+            if l.isEmpty { return nil }
+            let f = l.components(separatedBy: "\t")
+            return .object([
+                "id": .string(f.indices.contains(0) ? f[0] : ""),
+                "read": .string(f.indices.contains(1) ? f[1] : ""),
+                "date": .string(f.indices.contains(2) ? f[2] : ""),
+                "sender": .string(f.indices.contains(3) ? f[3] : ""),
+                "subject": .string(f.indices.contains(4) ? f[4] : "")
+            ])
+        }
+    }
+
+    /// Build a structured AppleScript-error result. `-1743` is the macOS TCC
+    /// Automation denial (Mail not yet granted) — surfaced with guidance, the
+    /// same actionable shape AppleScriptModule uses.
+    private static func scriptError(message: String, number: Int, extra: [String: Value] = [:]) -> Value {
+        var obj: [String: Value] = [
+            "error": .string(message),
+            "errorNumber": .int(number)
+        ]
+        if number == -1743 {
+            obj["tccDenied"] = .bool(true)
+            obj["guidance"] = .string(
+                "NotionBridge does not have Automation permission for Mail. "
+                + "Grant it in System Settings > Privacy & Security > Automation "
+                + "(Mail access is an operator first-use grant; no entitlement change required)."
+            )
+        }
+        for (k, v) in extra { obj[k] = v }
+        return .object(obj)
+    }
+}

--- a/NotionBridge/Modules/NotesModule.swift
+++ b/NotionBridge/Modules/NotesModule.swift
@@ -1,0 +1,726 @@
+// NotesModule.swift – v3.7·G  Apple Notes MCP tools
+// NotionBridge · Modules
+//
+// Six tools: notes_list, notes_read, notes_create, notes_update,
+// notes_delete, notes_search. Apple Notes is AppleScript-scriptable;
+// this module drives Notes.app over the existing apple-events automation
+// entitlement (already granted to NotionBridge.app). The per-app Notes
+// TCC grant is an operator first-use prompt (System Settings > Privacy &
+// Security > Automation > NotionBridge → Notes) — no entitlement change.
+//
+// DESIGN — injectable osascript seam (testable without live Notes):
+//   All Notes interaction funnels through a single `NotesScriptRunner`
+//   closure (`(String) -> NotesScriptResult`). Production wires the
+//   in-process `NSAppleScript` runner (mirrors AppleScriptModule /
+//   MessagesModule — one permanent Automation grant for the app, no
+//   osascript child-process TCC storm). Tests inject a mock runner that
+//   returns canned script output or a scripting error, so the entire CRUD
+//   + search surface is exercised with ZERO contact with Notes.app.
+//
+// Tiers (per packet): list / read / search → .open (read-only, no prompt);
+// create / update → .notify (informational post-hoc notification);
+// delete → .request (human-gated, irreversible move-to-Notes-trash).
+//
+// ADDRESSING: notes are addressed by `noteId` (the AppleScript `id` of the
+// note, a stable `x-coredata://…` URL) OR by `noteName` (the note title;
+// first case-insensitive match wins). Folders are addressed by `folder`
+// name. Plain-text + the note's basic HTML body are the fidelity ceiling
+// (rich-text/attachment fidelity + shared-note collaboration are scope-OUT).
+
+import Foundation
+import MCP
+
+// MARK: - Script Seam
+
+/// Result of running an AppleScript through the Notes seam.
+/// `.ok` carries the script's string return value; `.failure` carries the
+/// AppleScript error message + numeric code (e.g. -1743 = Automation TCC
+/// denial) so handlers can surface actionable guidance.
+public enum NotesScriptResult: Sendable, Equatable {
+    case ok(String)
+    case failure(message: String, code: Int)
+}
+
+/// The injectable seam. A closure that takes AppleScript source and returns
+/// a `NotesScriptResult`. Production injects the `NSAppleScript` runner;
+/// tests inject a deterministic mock.
+public typealias NotesScriptRunner = @Sendable (String) -> NotesScriptResult
+
+// MARK: - NotesModule
+
+public enum NotesModule {
+
+    public static let moduleName = "notes"
+
+    /// Field/record separators used to serialize AppleScript list output
+    /// without colliding with note content. ASCII unit/record separators
+    /// are control bytes that never appear in user note text.
+    /// `public` so the test target can frame fixtures with the same bytes.
+    public static let fieldSep = "\u{1F}"   // US — between fields of one record
+    public static let recordSep = "\u{1E}"  // RS — between records
+
+    // MARK: Production runner (in-process NSAppleScript)
+
+    /// In-process AppleScript runner. Using `NSAppleScript` (not an
+    /// `/usr/bin/osascript` child process) means macOS attributes the
+    /// Automation grant to NotionBridge.app itself — one permanent grant,
+    /// no per-invocation TCC prompt storm (same rationale as
+    /// AppleScriptModule / MessagesModule.send).
+    public static let liveRunner: NotesScriptRunner = { source in
+        let script = NSAppleScript(source: source)
+        var errorInfo: NSDictionary?
+        let output = script?.executeAndReturnError(&errorInfo)
+        if let error = errorInfo {
+            let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
+            let code = error[NSAppleScript.errorNumber] as? Int ?? -1
+            return .failure(message: message, code: code)
+        }
+        return .ok(output?.stringValue ?? "")
+    }
+
+    // MARK: Registration
+
+    /// Register all NotesModule tools on the given router.
+    /// - Parameter runner: the AppleScript seam. Defaults to the live
+    ///   in-process `NSAppleScript` runner; tests inject a mock.
+    public static func register(
+        on router: ToolRouter,
+        runner: @escaping NotesScriptRunner = liveRunner
+    ) async {
+
+        // MARK: 1. notes_list — open
+        await router.register(ToolRegistration(
+            name: "notes_list",
+            module: moduleName,
+            tier: .open,
+            description: "List Apple Notes folders and notes. Omit `folder` to list every note across all folders; pass `folder` to scope to one folder. Returns note id + name + folder + modification date (not bodies — use notes_read for content).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "folder": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional folder name to scope the listing. Omit to list notes from every folder.")
+                    ]),
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "description": .string("Max notes to return (default: 100).")
+                    ])
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: List",
+                whenToUse: ["enumerating Apple Notes folders + notes to find a note id/name before notes_read/update/delete",
+                            "scoping a listing to one folder via `folder`"],
+                whenNotToUse: ["reading a note's body (use notes_read)",
+                               "keyword-searching note content (use notes_search)"],
+                relatedTools: ["notes_read", "notes_search", "notes_create"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                let folder = stringArg(args, "folder")
+                let limit = intArg(args, "limit") ?? 100
+                let script = Scripts.list(folder: folder)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let notes = parseNoteRecords(raw).prefix(max(0, limit))
+                    let rows: [Value] = notes.map { rec in
+                        .object([
+                            "id": .string(rec.id),
+                            "name": .string(rec.name),
+                            "folder": .string(rec.folder),
+                            "modified": .string(rec.modified)
+                        ])
+                    }
+                    return .object(["notes": .array(rows), "count": .int(rows.count)])
+                }
+            }
+        ))
+
+        // MARK: 2. notes_read — open
+        await router.register(ToolRegistration(
+            name: "notes_read",
+            module: moduleName,
+            tier: .open,
+            description: "Read one Apple Note's full content. Address it by `noteId` (stable AppleScript id) OR `noteName` (title; first case-insensitive match wins). Returns id, name, folder, plain-text body, and the note's HTML body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "noteId": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's AppleScript id (preferred — stable). Mutually exclusive with noteName.")
+                    ]),
+                    "noteName": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's title. First case-insensitive match wins. Used when noteId is not provided.")
+                    ])
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: Read",
+                whenToUse: ["fetching one note's body after notes_list / notes_search surfaced its id or name"],
+                whenNotToUse: ["listing notes (use notes_list)", "searching across notes (use notes_search)"],
+                relatedTools: ["notes_list", "notes_search", "notes_update"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let selector = noteSelector(args) else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_read",
+                        reason: "provide either 'noteId' or 'noteName'"
+                    )
+                }
+                let script = Scripts.read(selector: selector)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let fields = raw.components(separatedBy: fieldSep)
+                    guard fields.count >= 5, !raw.isEmpty else {
+                        return .object([
+                            "found": .bool(false),
+                            "error": .string("No note matched the given \(selector.kindLabel).")
+                        ])
+                    }
+                    return .object([
+                        "found": .bool(true),
+                        "id": .string(fields[0]),
+                        "name": .string(fields[1]),
+                        "folder": .string(fields[2]),
+                        "body": .string(fields[3]),
+                        "html": .string(fields[4])
+                    ])
+                }
+            }
+        ))
+
+        // MARK: 3. notes_create — notify
+        await router.register(ToolRegistration(
+            name: "notes_create",
+            module: moduleName,
+            tier: .notify,
+            description: "Create a new Apple Note. `title` becomes the first line (Notes derives the note name from it); `body` is the remaining plain-text content. Optionally place it in `folder` (must already exist; otherwise the default folder is used).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "title": .object([
+                        "type": .string("string"),
+                        "description": .string("Note title — becomes the first line / note name.")
+                    ]),
+                    "body": .object([
+                        "type": .string("string"),
+                        "description": .string("Plain-text body content (optional).")
+                    ]),
+                    "folder": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional target folder name (must already exist). Defaults to the account default folder.")
+                    ])
+                ]),
+                "required": .array([.string("title")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: Create",
+                whenToUse: ["adding a new note with a title and optional body / target folder"],
+                whenNotToUse: ["editing an existing note (use notes_update)"],
+                relatedTools: ["notes_update", "notes_list"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let title = stringArg(args, "title"), !title.isEmpty else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_create",
+                        reason: "missing required 'title'"
+                    )
+                }
+                let body = stringArg(args, "body") ?? ""
+                let folder = stringArg(args, "folder")
+                let script = Scripts.create(title: title, body: body, folder: folder)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let id = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return .object([
+                        "created": .bool(true),
+                        "id": .string(id),
+                        "name": .string(title)
+                    ])
+                }
+            }
+        ))
+
+        // MARK: 4. notes_update — notify
+        await router.register(ToolRegistration(
+            name: "notes_update",
+            module: moduleName,
+            tier: .notify,
+            description: "Update an existing Apple Note's body, addressed by `noteId` OR `noteName`. Replaces the note body with `body` (and an optional new `title` first line). This overwrites existing content — read first with notes_read if you need to preserve it.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "noteId": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's AppleScript id (preferred). Mutually exclusive with noteName.")
+                    ]),
+                    "noteName": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's title. First case-insensitive match wins. Used when noteId is not provided.")
+                    ]),
+                    "title": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional new title (first line). Omit to keep the existing title as the first body line.")
+                    ]),
+                    "body": .object([
+                        "type": .string("string"),
+                        "description": .string("New plain-text body content. Overwrites the existing note body.")
+                    ])
+                ]),
+                "required": .array([.string("body")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: Update",
+                whenToUse: ["replacing the body of an existing note found via notes_list / notes_search"],
+                whenNotToUse: ["creating a new note (use notes_create)", "deleting a note (use notes_delete)"],
+                relatedTools: ["notes_read", "notes_create", "notes_delete"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let selector = noteSelector(args) else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_update",
+                        reason: "provide either 'noteId' or 'noteName' to identify the note"
+                    )
+                }
+                guard let body = stringArg(args, "body") else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_update",
+                        reason: "missing required 'body'"
+                    )
+                }
+                let title = stringArg(args, "title")
+                let script = Scripts.update(selector: selector, title: title, body: body)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let id = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if id.isEmpty {
+                        return .object([
+                            "updated": .bool(false),
+                            "error": .string("No note matched the given \(selector.kindLabel).")
+                        ])
+                    }
+                    return .object(["updated": .bool(true), "id": .string(id)])
+                }
+            }
+        ))
+
+        // MARK: 5. notes_delete — request
+        await router.register(ToolRegistration(
+            name: "notes_delete",
+            module: moduleName,
+            tier: .request,
+            description: "Delete (move to the Notes trash) an Apple Note, addressed by `noteId` OR `noteName`. Requires confirm: 'DELETE' (exact, uppercase). This is irreversible from the API — recover only via the Notes trash UI.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "noteId": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's AppleScript id (preferred). Mutually exclusive with noteName.")
+                    ]),
+                    "noteName": .object([
+                        "type": .string("string"),
+                        "description": .string("The note's title. First case-insensitive match wins. Used when noteId is not provided.")
+                    ]),
+                    "confirm": .object([
+                        "type": .string("string"),
+                        "description": .string("Must be exactly 'DELETE' to proceed.")
+                    ])
+                ]),
+                "required": .array([.string("confirm")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: Delete",
+                whenToUse: ["removing a note you identified by id/name — pass confirm:'DELETE'"],
+                whenNotToUse: ["editing a note (use notes_update)"],
+                relatedTools: ["notes_list", "notes_read"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let confirm = stringArg(args, "confirm") else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_delete",
+                        reason: "missing required 'confirm'"
+                    )
+                }
+                guard confirm == "DELETE" else {
+                    return .object([
+                        "deleted": .bool(false),
+                        "error": .string("notes_delete requires confirm: 'DELETE'")
+                    ])
+                }
+                guard let selector = noteSelector(args) else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_delete",
+                        reason: "provide either 'noteId' or 'noteName' to identify the note"
+                    )
+                }
+                let script = Scripts.delete(selector: selector)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let id = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if id.isEmpty {
+                        return .object([
+                            "deleted": .bool(false),
+                            "error": .string("No note matched the given \(selector.kindLabel).")
+                        ])
+                    }
+                    return .object(["deleted": .bool(true), "id": .string(id)])
+                }
+            }
+        ))
+
+        // MARK: 6. notes_search — open
+        await router.register(ToolRegistration(
+            name: "notes_search",
+            module: moduleName,
+            tier: .open,
+            description: "Keyword-search Apple Notes by title and body text (case-insensitive substring). Optionally scope to one `folder`. Returns matching note id + name + folder + modification date.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Keyword/substring to match against note title and body (case-insensitive).")
+                    ]),
+                    "folder": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional folder name to scope the search.")
+                    ]),
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "description": .string("Max results to return (default: 50).")
+                    ])
+                ]),
+                "required": .array([.string("query")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notes: Search",
+                whenToUse: ["finding notes that contain a word/phrase across titles + bodies"],
+                whenNotToUse: ["listing every note (use notes_list)", "reading one matched note's full body (use notes_read)"],
+                relatedTools: ["notes_list", "notes_read"]
+            ),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let query = stringArg(args, "query"), !query.isEmpty else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notes_search",
+                        reason: "missing required 'query'"
+                    )
+                }
+                let folder = stringArg(args, "folder")
+                let limit = intArg(args, "limit") ?? 50
+                let script = Scripts.search(query: query, folder: folder)
+                switch runner(script) {
+                case .failure(let message, let code):
+                    return failureValue(message: message, code: code)
+                case .ok(let raw):
+                    let notes = parseNoteRecords(raw).prefix(max(0, limit))
+                    let rows: [Value] = notes.map { rec in
+                        .object([
+                            "id": .string(rec.id),
+                            "name": .string(rec.name),
+                            "folder": .string(rec.folder),
+                            "modified": .string(rec.modified)
+                        ])
+                    }
+                    return .object(["notes": .array(rows), "count": .int(rows.count)])
+                }
+            }
+        ))
+    }
+
+    // MARK: - Argument helpers
+
+    private static func objectArgs(_ arguments: Value) -> [String: Value] {
+        if case .object(let dict) = arguments { return dict }
+        return [:]
+    }
+
+    private static func stringArg(_ args: [String: Value], _ key: String) -> String? {
+        if case .string(let s)? = args[key] { return s }
+        return nil
+    }
+
+    private static func intArg(_ args: [String: Value], _ key: String) -> Int? {
+        if case .int(let i)? = args[key] { return i }
+        return nil
+    }
+
+    /// Resolve a note selector from arguments. `noteId` wins over `noteName`.
+    /// `public` for direct unit testing of the addressing precedence.
+    public static func noteSelector(_ args: [String: Value]) -> NoteSelector? {
+        if let id = stringArg(args, "noteId"), !id.isEmpty {
+            return .id(id)
+        }
+        if let name = stringArg(args, "noteName"), !name.isEmpty {
+            return .name(name)
+        }
+        return nil
+    }
+
+    /// Build the standard structured failure value, with TCC (-1743)
+    /// guidance when the error is an Automation denial.
+    static func failureValue(message: String, code: Int) -> Value {
+        var obj: [String: Value] = [
+            "error": .string(message),
+            "errorNumber": .int(code)
+        ]
+        if code == -1743 {
+            obj["tccDenied"] = .bool(true)
+            obj["guidance"] = .string(
+                "NotionBridge does not have Automation permission for Notes. "
+                + "This is a macOS TCC restriction (first-use operator grant). "
+                + "Open System Settings > Privacy & Security > Automation and grant "
+                + "NotionBridge access to Notes, or open the NotionBridge permission panel."
+            )
+        }
+        return .object(obj)
+    }
+
+    // MARK: - Output parsing
+
+    /// One serialized note record from a list/search script.
+    public struct NoteRecord: Equatable, Sendable {
+        public let id: String
+        public let name: String
+        public let folder: String
+        public let modified: String
+        public init(id: String, name: String, folder: String, modified: String) {
+            self.id = id
+            self.name = name
+            self.folder = folder
+            self.modified = modified
+        }
+    }
+
+    /// Parse `recordSep`-delimited records of `fieldSep`-delimited fields
+    /// (id, name, folder, modified) emitted by the list/search scripts.
+    /// Tolerant: short/blank records are skipped. `public` for unit testing.
+    public static func parseNoteRecords(_ raw: String) -> [NoteRecord] {
+        raw.components(separatedBy: recordSep).compactMap { chunk in
+            let trimmed = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let f = chunk.components(separatedBy: fieldSep)
+            guard f.count >= 4 else { return nil }
+            return NoteRecord(id: f[0], name: f[1], folder: f[2], modified: f[3])
+        }
+    }
+
+    // MARK: - Note selector
+
+    /// How a note is addressed.
+    public enum NoteSelector: Sendable, Equatable {
+        case id(String)
+        case name(String)
+
+        var kindLabel: String {
+            switch self {
+            case .id: return "noteId"
+            case .name: return "noteName"
+            }
+        }
+    }
+
+    // MARK: - AppleScript builders
+
+    /// Escape a Swift string for embedding inside an AppleScript double-
+    /// quoted string literal. Backslash first, then the quote — order
+    /// matters so an escaped quote's backslash is not double-escaped.
+    /// `public` so the escaping contract is directly unit-tested.
+    public static func escapeAS(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// AppleScript source builders for each Notes operation. Each builder
+    /// is pure (string in → string out) so tests can assert the generated
+    /// script as well as drive the mock runner. The list/search scripts
+    /// serialize with the module's `fieldSep`/`recordSep` control bytes so
+    /// note content cannot collide with the framing.
+    public enum Scripts {
+
+        /// AppleScript literals for the separators (ASCII 31 / 30).
+        static var fieldSepLiteral: String { "(ASCII character 31)" }
+        static var recordSepLiteral: String { "(ASCII character 30)" }
+
+        /// List notes (optionally scoped to `folder`), emitting
+        /// id‹US›name‹US›folder‹US›modified records joined by RS.
+        public static func list(folder: String?) -> String {
+            let source: String
+            if let folder = folder, !folder.isEmpty {
+                source = "notes of folder \"\(escapeAS(folder))\""
+            } else {
+                source = "notes"
+            }
+            return """
+            set fs to \(fieldSepLiteral)
+            set rs to \(recordSepLiteral)
+            set out to ""
+            tell application "Notes"
+                repeat with n in (\(source))
+                    set noteFolder to ""
+                    try
+                        set noteFolder to name of container of n
+                    end try
+                    set out to out & (id of n) & fs & (name of n) & fs & noteFolder & fs & (modification date of n as string) & rs
+                end repeat
+            end tell
+            return out
+            """
+        }
+
+        /// Read one note (by id or name): emit
+        /// id‹US›name‹US›folder‹US›plaintext‹US›html. Empty string if no match.
+        public static func read(selector: NoteSelector) -> String {
+            return """
+            set fs to \(fieldSepLiteral)
+            set out to ""
+            tell application "Notes"
+                \(resolveNoteClause(selector))
+                if theNote is missing value then return ""
+                set noteFolder to ""
+                try
+                    set noteFolder to name of container of theNote
+                end try
+                set out to (id of theNote) & fs & (name of theNote) & fs & noteFolder & fs & (plaintext of theNote) & fs & (body of theNote)
+            end tell
+            return out
+            """
+        }
+
+        /// Create a note (optionally in `folder`); return the new note id.
+        public static func create(title: String, body: String, folder: String?) -> String {
+            // Notes derives the note name from the first line of the HTML
+            // body; we compose <div>title</div><div>body</div>.
+            let safeTitle = escapeAS(title)
+            let safeBody = escapeAS(body)
+            let htmlBody = "<div><b>\(safeTitle)</b></div><div>\(safeBody)</div>"
+            if let folder = folder, !folder.isEmpty {
+                return """
+                tell application "Notes"
+                    set theFolder to folder "\(escapeAS(folder))"
+                    set theNote to make new note at theFolder with properties {body:"\(htmlBody)"}
+                    return id of theNote
+                end tell
+                """
+            }
+            return """
+            tell application "Notes"
+                set theNote to make new note with properties {body:"\(htmlBody)"}
+                return id of theNote
+            end tell
+            """
+        }
+
+        /// Update a note's body (by id or name); return the note id (empty
+        /// string if no match).
+        public static func update(selector: NoteSelector, title: String?, body: String) -> String {
+            let safeBody = escapeAS(body)
+            let htmlBody: String
+            if let title = title, !title.isEmpty {
+                htmlBody = "<div><b>\(escapeAS(title))</b></div><div>\(safeBody)</div>"
+            } else {
+                htmlBody = "<div>\(safeBody)</div>"
+            }
+            return """
+            tell application "Notes"
+                \(resolveNoteClause(selector))
+                if theNote is missing value then return ""
+                set body of theNote to "\(htmlBody)"
+                return id of theNote
+            end tell
+            """
+        }
+
+        /// Delete a note (by id or name); return the deleted note id (empty
+        /// string if no match).
+        public static func delete(selector: NoteSelector) -> String {
+            return """
+            tell application "Notes"
+                \(resolveNoteClause(selector))
+                if theNote is missing value then return ""
+                set theId to id of theNote
+                delete theNote
+                return theId
+            end tell
+            """
+        }
+
+        /// Search notes by case-insensitive substring over name + body,
+        /// optionally scoped to `folder`. Same record framing as `list`.
+        public static func search(query: String, folder: String?) -> String {
+            let scope: String
+            if let folder = folder, !folder.isEmpty {
+                scope = "notes of folder \"\(escapeAS(folder))\""
+            } else {
+                scope = "notes"
+            }
+            let needle = escapeAS(query)
+            return """
+            set fs to \(fieldSepLiteral)
+            set rs to \(recordSepLiteral)
+            set out to ""
+            set q to "\(needle)"
+            tell application "Notes"
+                repeat with n in (\(scope))
+                    set hay to (name of n) & " " & (plaintext of n)
+                    ignoring case
+                        if hay contains q then
+                            set noteFolder to ""
+                            try
+                                set noteFolder to name of container of n
+                            end try
+                            set out to out & (id of n) & fs & (name of n) & fs & noteFolder & fs & (modification date of n as string) & rs
+                        end if
+                    end ignoring
+                end repeat
+            end tell
+            return out
+            """
+        }
+
+        /// Shared AppleScript fragment that binds `theNote` to the addressed
+        /// note (by id or first case-insensitive name match), or
+        /// `missing value` if none matched.
+        private static func resolveNoteClause(_ selector: NoteSelector) -> String {
+            switch selector {
+            case .id(let id):
+                return """
+                set theNote to missing value
+                try
+                    set theNote to note id "\(escapeAS(id))"
+                end try
+                """
+            case .name(let name):
+                return """
+                set theNote to missing value
+                set wanted to "\(escapeAS(name))"
+                ignoring case
+                    repeat with n in notes
+                        if (name of n) is wanted then
+                            set theNote to n
+                            exit repeat
+                        end if
+                    end repeat
+                end ignoring
+                """
+            }
+        }
+    }
+}

--- a/NotionBridge/Modules/RemindersModule.swift
+++ b/NotionBridge/Modules/RemindersModule.swift
@@ -1,0 +1,626 @@
+// RemindersModule.swift – Reminders Tools (iCloud Reminders CRUD via EventKit)
+// NotionBridge · Modules
+//
+// Six tools: reminders_lists (open), reminders_list (open),
+// reminders_create (notify), reminders_update (notify),
+// reminders_complete (notify), reminders_delete (request).
+//
+// Mirrors ContactsModule (CNContactStore + personal-information entitlement
+// + module/registry pattern), but over EventKit's EKEventStore with
+// `.reminder` entities. Unlike ContactsModule — which calls CNContactStore()
+// inline — this module routes ALL store access through an injectable
+// `RemindersStoring` seam (protocol) so the unit tests never touch live
+// EventKit / TCC. Production uses `EventKitRemindersStore`; tests inject a
+// deterministic mock.
+//
+// Created by PKT-957 (v3.7·D): first-class Reminders module closing the
+// Apple-app gap so agents add/update/remove iCloud Reminders without ad-hoc
+// AppleScript.
+//
+// ── ENTITLEMENT / OPERATOR GATE (PKT-933 lesson) ──────────────────────────
+// Live use requires:
+//   1. com.apple.security.personal-information.calendars in
+//      NotionBridge.entitlements (declared by this packet), AND
+//   2. a runtime Reminders TCC grant (operator, first-call prompt).
+// PKT-933 (2026-05-30) removed keychain-access-groups because the
+// Developer-ID provisioning profile / notarization refused it and the app
+// would not launch. The calendars entitlement MUST be validated against
+// notarize BEFORE shipping. If notarize refuses it, the documented fallback
+// is AppleScript via the existing com.apple.security.automation.apple-events
+// entitlement. This is an OPERATOR step — NOT validated by this packet.
+
+import AppKit
+@preconcurrency import EventKit
+import Foundation
+import MCP
+
+// MARK: - Store Seam (injectable)
+
+/// Authorization state for the Reminders store, decoupled from EventKit so
+/// the mock seam can drive every branch (incl. the access-denied path).
+public enum RemindersAuthStatus: Sendable, Equatable {
+    case authorized
+    case denied
+    case restricted
+    case notDetermined
+}
+
+/// A plain reminder list (EKCalendar of type `.reminder`).
+public struct ReminderList: Sendable, Equatable {
+    public let id: String       // EKCalendar.calendarIdentifier
+    public let title: String
+    public let isDefault: Bool
+    public let allowsModify: Bool
+
+    public init(id: String, title: String, isDefault: Bool, allowsModify: Bool) {
+        self.id = id
+        self.title = title
+        self.isDefault = isDefault
+        self.allowsModify = allowsModify
+    }
+}
+
+/// A plain reminder record. `due` is ISO-8601 (or nil). Decoupled from
+/// EKReminder so the seam is testable without EventKit objects.
+public struct ReminderItem: Sendable, Equatable {
+    public let id: String       // EKReminder.calendarItemIdentifier
+    public var title: String
+    public var due: String?     // ISO-8601 string, nil = no due date
+    public var listId: String
+    public var listTitle: String
+    public var completed: Bool
+    public var notes: String?
+    public var priority: Int    // EKReminder.priority (0 = none, 1 = high … 9 = low)
+
+    public init(
+        id: String,
+        title: String,
+        due: String?,
+        listId: String,
+        listTitle: String,
+        completed: Bool,
+        notes: String?,
+        priority: Int
+    ) {
+        self.id = id
+        self.title = title
+        self.due = due
+        self.listId = listId
+        self.listTitle = listTitle
+        self.completed = completed
+        self.notes = notes
+        self.priority = priority
+    }
+}
+
+/// Filter for `reminders_list`.
+public struct ReminderQuery: Sendable {
+    public var listId: String?
+    public var includeCompleted: Bool
+    public var dueBefore: String?  // ISO-8601
+    public var dueAfter: String?   // ISO-8601
+
+    public init(listId: String? = nil, includeCompleted: Bool = false, dueBefore: String? = nil, dueAfter: String? = nil) {
+        self.listId = listId
+        self.includeCompleted = includeCompleted
+        self.dueBefore = dueBefore
+        self.dueAfter = dueAfter
+    }
+}
+
+/// Draft for `reminders_create` / `reminders_update`. Optional fields mean
+/// "leave unchanged" on update.
+public struct ReminderDraft: Sendable {
+    public var title: String?
+    public var due: String?        // ISO-8601; explicit empty string clears
+    public var clearDue: Bool
+    public var listId: String?
+    public var notes: String?
+    public var priority: Int?
+
+    public init(
+        title: String? = nil,
+        due: String? = nil,
+        clearDue: Bool = false,
+        listId: String? = nil,
+        notes: String? = nil,
+        priority: Int? = nil
+    ) {
+        self.title = title
+        self.due = due
+        self.clearDue = clearDue
+        self.listId = listId
+        self.notes = notes
+        self.priority = priority
+    }
+}
+
+/// The injectable store seam. Production = `EventKitRemindersStore`;
+/// tests = a deterministic in-memory mock. All methods are async + throwing
+/// so the mock can drive the access-denied path uniformly.
+public protocol RemindersStoring: Sendable {
+    func authorizationStatus() -> RemindersAuthStatus
+    /// Ensures access is authorized, triggering the TCC prompt if
+    /// `.notDetermined`. Throws `RemindersModuleError.accessDenied` otherwise.
+    func ensureAccess() async throws
+    func lists() async throws -> [ReminderList]
+    func fetch(_ query: ReminderQuery) async throws -> [ReminderItem]
+    func create(_ draft: ReminderDraft) async throws -> ReminderItem
+    func update(id: String, _ draft: ReminderDraft) async throws -> ReminderItem
+    func setCompleted(id: String, completed: Bool) async throws -> ReminderItem
+    func delete(id: String) async throws
+}
+
+// MARK: - Errors
+
+public enum RemindersModuleError: LocalizedError, Equatable {
+    case accessDenied
+    case notFound(String)
+    case listNotFound(String)
+    case immutableList(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "Reminders access not granted. Enable in System Settings > Privacy & Security > Reminders for NotionBridge."
+        case .notFound(let id):
+            return "Reminder not found: \(id)"
+        case .listNotFound(let id):
+            return "Reminder list not found: \(id)"
+        case .immutableList(let id):
+            return "Reminder list does not allow modification: \(id)"
+        }
+    }
+}
+
+// MARK: - EventKit-backed store (production)
+
+/// Live EventKit implementation. Requires the calendars entitlement + TCC
+/// grant (operator). Not exercised by the unit tests — those use the mock.
+public final class EventKitRemindersStore: RemindersStoring, @unchecked Sendable {
+    private let store: EKEventStore
+
+    public init(store: EKEventStore = EKEventStore()) {
+        self.store = store
+    }
+
+    public func authorizationStatus() -> RemindersAuthStatus {
+        switch EKEventStore.authorizationStatus(for: .reminder) {
+        case .authorized, .fullAccess:
+            return .authorized
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        case .notDetermined:
+            return .notDetermined
+        case .writeOnly:
+            // Reminders has no write-only state in practice; treat as denied
+            // for read paths (fail-closed).
+            return .restricted
+        @unknown default:
+            return .restricted
+        }
+    }
+
+    public func ensureAccess() async throws {
+        switch authorizationStatus() {
+        case .authorized:
+            return
+        case .notDetermined:
+            await MainActor.run {
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+            let granted: Bool
+            if #available(macOS 14.0, *) {
+                granted = (try? await store.requestFullAccessToReminders()) ?? false
+            } else {
+                granted = await withCheckedContinuation { cont in
+                    store.requestAccess(to: .reminder) { ok, _ in cont.resume(returning: ok) }
+                }
+            }
+            if !granted { throw RemindersModuleError.accessDenied }
+        case .denied, .restricted:
+            throw RemindersModuleError.accessDenied
+        }
+    }
+
+    /// A fresh formatter per call — `ISO8601DateFormatter` is not `Sendable`,
+    /// so it cannot be a shared static across the actor-hopping handlers.
+    /// Construction cost is negligible relative to the EventKit round-trips.
+    private static func makeISO() -> ISO8601DateFormatter {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }
+
+    private func dateComponentsToISO(_ comps: DateComponents?) -> String? {
+        guard let comps, let date = Calendar.current.date(from: comps) else { return nil }
+        return Self.makeISO().string(from: date)
+    }
+
+    private func isoToDateComponents(_ iso: String) -> DateComponents? {
+        guard let date = Self.makeISO().date(from: iso) else { return nil }
+        return Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second], from: date)
+    }
+
+    private func toItem(_ r: EKReminder) -> ReminderItem {
+        ReminderItem(
+            id: r.calendarItemIdentifier,
+            title: r.title ?? "",
+            due: dateComponentsToISO(r.dueDateComponents),
+            listId: r.calendar?.calendarIdentifier ?? "",
+            listTitle: r.calendar?.title ?? "",
+            completed: r.isCompleted,
+            notes: r.notes,
+            priority: r.priority
+        )
+    }
+
+    public func lists() async throws -> [ReminderList] {
+        try await ensureAccess()
+        return store.calendars(for: .reminder).map { cal in
+            ReminderList(
+                id: cal.calendarIdentifier,
+                title: cal.title,
+                isDefault: cal.calendarIdentifier
+                    == store.defaultCalendarForNewReminders()?.calendarIdentifier,
+                allowsModify: cal.allowsContentModifications
+            )
+        }
+    }
+
+    public func fetch(_ query: ReminderQuery) async throws -> [ReminderItem] {
+        try await ensureAccess()
+        let calendars: [EKCalendar]?
+        if let listId = query.listId {
+            guard let cal = store.calendar(withIdentifier: listId) else {
+                throw RemindersModuleError.listNotFound(listId)
+            }
+            calendars = [cal]
+        } else {
+            calendars = nil
+        }
+        let predicate = store.predicateForReminders(in: calendars)
+        // Map EKReminder → Sendable ReminderItem INSIDE the completion handler
+        // so no non-Sendable EventKit object crosses the continuation boundary.
+        var items: [ReminderItem] = await withCheckedContinuation { cont in
+            store.fetchReminders(matching: predicate) { reminders in
+                cont.resume(returning: (reminders ?? []).map(self.toItem))
+            }
+        }
+        if !query.includeCompleted {
+            items = items.filter { !$0.completed }
+        }
+        if let before = query.dueBefore {
+            items = items.filter { item in
+                guard let d = item.due else { return false }
+                return d < before
+            }
+        }
+        if let after = query.dueAfter {
+            items = items.filter { item in
+                guard let d = item.due else { return false }
+                return d > after
+            }
+        }
+        return items
+    }
+
+    private func resolveCalendar(_ listId: String?) throws -> EKCalendar {
+        if let listId {
+            guard let cal = store.calendar(withIdentifier: listId) else {
+                throw RemindersModuleError.listNotFound(listId)
+            }
+            return cal
+        }
+        guard let def = store.defaultCalendarForNewReminders() else {
+            throw RemindersModuleError.listNotFound("default")
+        }
+        return def
+    }
+
+    public func create(_ draft: ReminderDraft) async throws -> ReminderItem {
+        try await ensureAccess()
+        let reminder = EKReminder(eventStore: store)
+        reminder.calendar = try resolveCalendar(draft.listId)
+        reminder.title = draft.title ?? ""
+        if let due = draft.due, !due.isEmpty {
+            reminder.dueDateComponents = isoToDateComponents(due)
+        }
+        if let notes = draft.notes { reminder.notes = notes }
+        if let priority = draft.priority { reminder.priority = priority }
+        try store.save(reminder, commit: true)
+        return toItem(reminder)
+    }
+
+    private func fetchReminder(id: String) async throws -> EKReminder {
+        if let item = store.calendarItem(withIdentifier: id) as? EKReminder {
+            return item
+        }
+        throw RemindersModuleError.notFound(id)
+    }
+
+    public func update(id: String, _ draft: ReminderDraft) async throws -> ReminderItem {
+        try await ensureAccess()
+        let reminder = try await fetchReminder(id: id)
+        if let title = draft.title { reminder.title = title }
+        if draft.clearDue {
+            reminder.dueDateComponents = nil
+        } else if let due = draft.due, !due.isEmpty {
+            reminder.dueDateComponents = isoToDateComponents(due)
+        }
+        if let notes = draft.notes { reminder.notes = notes }
+        if let priority = draft.priority { reminder.priority = priority }
+        if let listId = draft.listId {
+            reminder.calendar = try resolveCalendar(listId)
+        }
+        try store.save(reminder, commit: true)
+        return toItem(reminder)
+    }
+
+    public func setCompleted(id: String, completed: Bool) async throws -> ReminderItem {
+        try await ensureAccess()
+        let reminder = try await fetchReminder(id: id)
+        reminder.isCompleted = completed
+        try store.save(reminder, commit: true)
+        return toItem(reminder)
+    }
+
+    public func delete(id: String) async throws {
+        try await ensureAccess()
+        let reminder = try await fetchReminder(id: id)
+        try store.remove(reminder, commit: true)
+    }
+}
+
+// MARK: - RemindersModule
+
+/// Provides EventKit-backed reminder tools through an injectable store seam.
+public enum RemindersModule {
+
+    public static let moduleName = "reminders"
+
+    /// Register all RemindersModule tools on the given router. `store`
+    /// defaults to the live EventKit store; tests inject a mock seam.
+    public static func register(
+        on router: ToolRouter,
+        store: RemindersStoring = EventKitRemindersStore()
+    ) async {
+
+        // MARK: 1. reminders_lists – open (read-only)
+        await router.register(ToolRegistration(
+            name: "reminders_lists",
+            module: moduleName,
+            tier: .open,
+            description: "Enumerate iCloud Reminders lists (EKCalendar of type .reminder). Returns id, title, isDefault, allowsModify. Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "required": .array([])
+            ]),
+            handler: { _ in
+                let lists = try await store.lists()
+                return .object([
+                    "count": .int(lists.count),
+                    "lists": .array(lists.map(formatList))
+                ])
+            }
+        ))
+
+        // MARK: 2. reminders_list – open (read-only)
+        await router.register(ToolRegistration(
+            name: "reminders_list",
+            module: moduleName,
+            tier: .open,
+            description: "List reminders, optionally filtered by list, completion, and a due-date window. Returns id, title, due (ISO-8601), list, completed, notes, priority. Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "listId": .object(["type": .string("string"), "description": .string("EKCalendar.calendarIdentifier to scope to a single list (default: all lists)")]),
+                    "includeCompleted": .object(["type": .string("boolean"), "description": .string("Include completed reminders (default: false)")]),
+                    "dueBefore": .object(["type": .string("string"), "description": .string("ISO-8601 — only reminders with a due date strictly before this")]),
+                    "dueAfter": .object(["type": .string("string"), "description": .string("ISO-8601 — only reminders with a due date strictly after this")])
+                ]),
+                "required": .array([])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                let query = ReminderQuery(
+                    listId: stringArg(args, "listId"),
+                    includeCompleted: boolArg(args, "includeCompleted") ?? false,
+                    dueBefore: stringArg(args, "dueBefore"),
+                    dueAfter: stringArg(args, "dueAfter")
+                )
+                let items = try await store.fetch(query)
+                return .object([
+                    "count": .int(items.count),
+                    "reminders": .array(items.map(formatItem))
+                ])
+            }
+        ))
+
+        // MARK: 3. reminders_create – notify (write, non-destructive)
+        await router.register(ToolRegistration(
+            name: "reminders_create",
+            module: moduleName,
+            tier: .notify,
+            description: "Create a reminder. Requires title; optional due (ISO-8601), listId, notes, priority (0 none, 1 high … 9 low). Returns the new reminder id + record.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "title": .object(["type": .string("string"), "description": .string("Reminder title (required)")]),
+                    "due": .object(["type": .string("string"), "description": .string("Due date ISO-8601 (optional)")]),
+                    "listId": .object(["type": .string("string"), "description": .string("Target list identifier (default: the default Reminders list)")]),
+                    "notes": .object(["type": .string("string"), "description": .string("Freeform notes (optional)")]),
+                    "priority": .object(["type": .string("integer"), "description": .string("EKReminder priority 0–9 (0 none, 1 high, 5 medium, 9 low)")])
+                ]),
+                "required": .array([.string("title")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let title = stringArg(args, "title") else {
+                    throw ToolRouterError.invalidArguments(toolName: "reminders_create", reason: "missing 'title'")
+                }
+                let draft = ReminderDraft(
+                    title: title,
+                    due: stringArg(args, "due"),
+                    listId: stringArg(args, "listId"),
+                    notes: stringArg(args, "notes"),
+                    priority: intArg(args, "priority")
+                )
+                let item = try await store.create(draft)
+                return .object([
+                    "id": .string(item.id),
+                    "reminder": formatItem(item)
+                ])
+            }
+        ))
+
+        // MARK: 4. reminders_update – notify (write, non-destructive)
+        await router.register(ToolRegistration(
+            name: "reminders_update",
+            module: moduleName,
+            tier: .notify,
+            description: "Update a reminder by id. Any of title, due, notes, priority, listId. Pass due as empty string to clear the due date. Returns the updated record.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string"), "description": .string("EKReminder.calendarItemIdentifier (required)")]),
+                    "title": .object(["type": .string("string"), "description": .string("New title")]),
+                    "due": .object(["type": .string("string"), "description": .string("New due date ISO-8601; empty string clears the due date")]),
+                    "listId": .object(["type": .string("string"), "description": .string("Move to a different list")]),
+                    "notes": .object(["type": .string("string"), "description": .string("New notes")]),
+                    "priority": .object(["type": .string("integer"), "description": .string("New priority 0–9")])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "reminders_update", reason: "missing 'id'")
+                }
+                let dueRaw = stringArg(args, "due")
+                let draft = ReminderDraft(
+                    title: stringArg(args, "title"),
+                    due: dueRaw,
+                    clearDue: dueRaw == "",
+                    listId: stringArg(args, "listId"),
+                    notes: stringArg(args, "notes"),
+                    priority: intArg(args, "priority")
+                )
+                let item = try await store.update(id: id, draft)
+                return .object([
+                    "id": .string(item.id),
+                    "reminder": formatItem(item)
+                ])
+            }
+        ))
+
+        // MARK: 5. reminders_complete – notify (write, non-destructive, idempotent)
+        await router.register(ToolRegistration(
+            name: "reminders_complete",
+            module: moduleName,
+            tier: .notify,
+            description: "Mark a reminder complete or incomplete by id. Idempotent. Returns the updated record.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string"), "description": .string("EKReminder.calendarItemIdentifier (required)")]),
+                    "completed": .object(["type": .string("boolean"), "description": .string("true = complete (default), false = mark incomplete")])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "reminders_complete", reason: "missing 'id'")
+                }
+                let completed = boolArg(args, "completed") ?? true
+                let item = try await store.setCompleted(id: id, completed: completed)
+                return .object([
+                    "id": .string(item.id),
+                    "completed": .bool(item.completed),
+                    "reminder": formatItem(item)
+                ])
+            }
+        ))
+
+        // MARK: 6. reminders_delete – request (DESTRUCTIVE)
+        await router.register(ToolRegistration(
+            name: "reminders_delete",
+            module: moduleName,
+            tier: .request,
+            description: "Delete a reminder by id. DESTRUCTIVE / irreversible — gated at tier .request (confirmation required). Returns the deleted id.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string"), "description": .string("EKReminder.calendarItemIdentifier (required)")])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                let args = objectArgs(arguments)
+                guard let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "reminders_delete", reason: "missing 'id'")
+                }
+                try await store.delete(id: id)
+                return .object([
+                    "id": .string(id),
+                    "deleted": .bool(true)
+                ])
+            }
+        ))
+    }
+
+    // MARK: - Formatting
+
+    static func formatList(_ list: ReminderList) -> Value {
+        .object([
+            "id": .string(list.id),
+            "title": .string(list.title),
+            "isDefault": .bool(list.isDefault),
+            "allowsModify": .bool(list.allowsModify)
+        ])
+    }
+
+    static func formatItem(_ item: ReminderItem) -> Value {
+        var entry: [String: Value] = [
+            "id": .string(item.id),
+            "title": .string(item.title),
+            "listId": .string(item.listId),
+            "list": .string(item.listTitle),
+            "completed": .bool(item.completed),
+            "priority": .int(item.priority)
+        ]
+        if let due = item.due { entry["due"] = .string(due) } else { entry["due"] = .null }
+        if let notes = item.notes { entry["notes"] = .string(notes) }
+        return .object(entry)
+    }
+
+    // MARK: - Argument helpers
+
+    private static func objectArgs(_ value: Value) -> [String: Value] {
+        if case .object(let args) = value { return args }
+        return [:]
+    }
+
+    private static func stringArg(_ args: [String: Value], _ key: String) -> String? {
+        if case .string(let s)? = args[key] { return s }
+        return nil
+    }
+
+    private static func boolArg(_ args: [String: Value], _ key: String) -> Bool? {
+        if case .bool(let b)? = args[key] { return b }
+        return nil
+    }
+
+    private static func intArg(_ args: [String: Value], _ key: String) -> Int? {
+        switch args[key] {
+        case .int(let i)?: return i
+        case .double(let d)?: return Int(d)
+        default: return nil
+        }
+    }
+}

--- a/NotionBridge/Modules/ScreenCaptureKitBoundary.swift
+++ b/NotionBridge/Modules/ScreenCaptureKitBoundary.swift
@@ -1,0 +1,101 @@
+// ScreenCaptureKitBoundary.swift — SCK main-actor boundary + watchdog
+// NotionBridge · Modules
+//
+// Root-cause fix for the "SWIFT TASK CONTINUATION MISUSE: leaked its
+// continuation without resuming it" hang.
+//
+// `SCShareableContent.excludingDesktopWindows(_:onScreenWindowsOnly:)` delivers
+// its reply on the MAIN run loop. When the async call is made from an
+// OFF-MAIN-ACTOR context (the standalone test harness's nonisolated top-level
+// `await`, a `Task.detached`, or any nonisolated async caller), the checked
+// continuation is never resumed and the call HANGS FOREVER — and the leaked
+// continuation poisons the cooperative thread pool, so the hang surfaces as a
+// wandering, intermittent stall elsewhere in the suite. Masked in production
+// because the GUI app's tool dispatch runs on the main actor (which the running
+// NSApplication run loop services); it surfaced as the suite's local hangs.
+//
+// FIX (a) — correctness in production: run the SCK call on the MAIN ACTOR, so
+// its main-run-loop reply lands on the context the GUI app actually services.
+//
+// FIX (b) — robustness everywhere, incl. the headless test harness: a watchdog
+// that runs on a LIBDISPATCH thread (NOT the Swift cooperative pool). This
+// matters because in a headless process there is no NSApplication run loop
+// draining the main actor, so the main-actor SCK call can still fail to resume;
+// a cooperative-pool watchdog (`Task.sleep`) would itself be wedged by the very
+// pool starvation it is trying to rescue. A libdispatch timer fires on its own
+// thread regardless of cooperative-pool state, resumes the awaiting
+// continuation with a thrown `Timeout`, and lets the caller (and the suite)
+// proceed instead of hanging forever. (b) is defense-in-depth — it does NOT
+// replace (a); in the GUI app the SCK reply wins the race long before the
+// watchdog.
+//
+// NOTE: callers MUST still gate on `CGPreflightScreenCaptureAccess()` BEFORE
+// invoking this helper, so the headless / TCC-denied path short-circuits fast
+// and never enters SCK at all.
+
+import ScreenCaptureKit
+import CoreGraphics
+import Dispatch
+import Foundation
+
+enum SCKBoundary {
+
+    /// Thrown when the SCK call does not resume within `timeout` seconds.
+    /// In the GUI app this never fires (the SCK reply arrives in milliseconds);
+    /// it exists so an off-main / no-run-loop context surfaces a fast error
+    /// instead of a permanent hang.
+    struct Timeout: Error, CustomStringConvertible {
+        var description: String {
+            "ScreenCaptureKit.excludingDesktopWindows timed out (no continuation resume)"
+        }
+    }
+
+    /// Fetch on-screen shareable content on the MAIN ACTOR, guarded by a
+    /// libdispatch watchdog so it can never hang forever.
+    ///
+    /// Callers are responsible for verifying `CGPreflightScreenCaptureAccess()`
+    /// first — this helper assumes the grant is present and enters SCK directly.
+    static func fetchShareableContent(timeout: Double = 6.0) async throws -> SCShareableContent {
+        // Single-shot resume guard. Synchronous + lock-based on purpose: the
+        // SCK completion and the libdispatch watchdog race on DIFFERENT threads,
+        // and an actor-hop guard would itself depend on the (possibly wedged)
+        // cooperative pool. A plain lock is thread-safe and pool-independent.
+        let guardBox = ResumeOnceGuard()
+
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<SCShareableContent, Error>) in
+            // (a) Root-cause fix: SCK call on the main actor.
+            Task { @MainActor in
+                do {
+                    let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                    if guardBox.claim() { cont.resume(returning: content) }
+                } catch {
+                    if guardBox.claim() { cont.resume(throwing: error) }
+                }
+            }
+
+            // (b) Watchdog on a libdispatch thread — fires even if the Swift
+            // cooperative pool is starved by a leaked SCK continuation. Resumes
+            // the awaiting continuation so the caller proceeds; the abandoned
+            // main-actor Task above only ever resumes ITS (already-claimed)
+            // continuation, so no double-resume.
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                if guardBox.claim() { cont.resume(throwing: Timeout()) }
+            }
+        }
+    }
+
+    /// Thread-safe single-shot claim: the first `claim()` returns true, every
+    /// later one returns false. Guarantees the checked continuation is resumed
+    /// exactly once across the SCK-completion / watchdog race.
+    private final class ResumeOnceGuard: @unchecked Sendable {
+        private let lock = NSLock()
+        private var claimed = false
+        func claim() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if claimed { return false }
+            claimed = true
+            return true
+        }
+    }
+}

--- a/NotionBridge/Modules/ScreenModule.swift
+++ b/NotionBridge/Modules/ScreenModule.swift
@@ -84,10 +84,27 @@ public enum ScreenModule {
         guard CGPreflightScreenCaptureAccess() else {
             throw ScreenModuleError.screenRecordingDenied
         }
-        return try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        // SCK delivers its reply on the main run loop; calling it off the main
+        // actor leaks the continuation and hangs forever. Route through the
+        // main-actor boundary (see ScreenCaptureKitBoundary.swift). The
+        // preflight gate above keeps the denied path fast — we never reach the
+        // SCK call when access is not granted.
+        return try await SCKBoundary.fetchShareableContent()
     }
 
     /// Capture a CGImage based on target parameters.
+    ///
+    /// `@MainActor`: every ScreenCaptureKit async API used here
+    /// (`SCShareableContent.excludingDesktopWindows` via `getShareableContent`
+    /// and `SCScreenshotManager.captureImage`) delivers its reply on the main
+    /// run loop. Calling them off the main actor leaks the checked continuation
+    /// and hangs forever (it was masked only because GUI dispatch ran on main;
+    /// it surfaces as intermittent suite hangs from the nonisolated test
+    /// harness). Pinning the whole helper to the main actor makes every SCK
+    /// reply land on a serviced context. The fast denied-path short-circuit is
+    /// preserved: `getShareableContent` preflights TCC and throws before any
+    /// SCK call.
+    @MainActor
     private static func captureImage(
         target: String,
         windowId: Int?,
@@ -316,9 +333,11 @@ public enum ScreenModule {
 
                 let fileSize = (try? FileManager.default.attributesOfItem(atPath: filePath)[.size] as? Int) ?? 0
 
-                // Fetch display info for response metadata
+                // Fetch display info for response metadata. Route through the
+                // main-actor SCK boundary — an off-main call leaks its
+                // continuation and hangs. `try?` keeps metadata best-effort.
                 let displayInfoArray: [Value]
-                if let content = try? await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true) {
+                if let content = try? await SCKBoundary.fetchShareableContent() {
                     displayInfoArray = content.displays.enumerated().map { idx, d in
                         .object([
                             "index": .int(idx),

--- a/NotionBridge/Modules/ScreenRecording.swift
+++ b/NotionBridge/Modules/ScreenRecording.swift
@@ -295,12 +295,16 @@ private actor RecordingManager {
             throw RecordingError.recordingAlreadyActive
         }
 
-        // Verify Screen Recording TCC
+        // Verify Screen Recording TCC. The preflight gate keeps the denied
+        // path fast — we never enter the SCK call below when access is denied.
         guard CGPreflightScreenCaptureAccess() else {
             throw RecordingError.screenRecordingDenied
         }
 
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        // SCK delivers its reply on the main run loop; an off-main call leaks
+        // the continuation and hangs forever. Route through the main-actor
+        // boundary (see ScreenCaptureKitBoundary.swift).
+        let content = try await SCKBoundary.fetchShareableContent()
         guard let display = content.displays.first else {
             throw RecordingError.noDisplays
         }

--- a/NotionBridge/Modules/ShortcutsModule.swift
+++ b/NotionBridge/Modules/ShortcutsModule.swift
@@ -1,0 +1,364 @@
+// ShortcutsModule.swift — PKT-959 (Bridge v3.7·F): shortcuts_* MCP tools
+// NotionBridge · Modules
+//
+// Two thin wrappers around Apple's `/usr/bin/shortcuts` CLI (verified working
+// in the v3.7·E audit, PKT-958 — NO entitlement required; the CLI is the
+// supported, sandbox-friendly entry point):
+//   - shortcuts_list — list shortcut names (+ folders, via `--folders`)
+//   - shortcuts_run  — run a shortcut by name, optional input (temp-file via
+//     `--input-path`), capture stdout (`--output-path -`)
+//
+// TIERS (packet directive):
+//   - shortcuts_list → .open   (read-only enumeration)
+//   - shortcuts_run  → .notify (a Shortcut can do ANYTHING — file writes, web
+//     requests, app automation — so it is treated as destructive and is NEVER
+//     auto-executed silently; .notify surfaces every run to the operator)
+//
+// Mirrors GhModule/GhRuntime's process-seam pattern but routes ALL process
+// invocation through an injectable `ShortcutsRunning` protocol so the unit
+// tests never touch the real CLI (RemindersModule's mock-seam discipline).
+// Production uses `CLIShortcutsRunner` (spawns `/usr/bin/shortcuts`); tests
+// inject a deterministic mock.
+
+import Foundation
+import MCP
+
+// MARK: - Process seam (injectable)
+
+/// Result of one `shortcuts` CLI invocation. Decoupled from `Process` so the
+/// mock seam can drive every branch (success, non-zero exit, stderr).
+public struct ShortcutsInvocationResult: Sendable, Equatable {
+    public let exitCode: Int32
+    public let stdout: String
+    public let stderr: String
+
+    public init(exitCode: Int32, stdout: String, stderr: String) {
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+}
+
+/// Errors surfaced by the runner seam.
+public enum ShortcutsError: Error, LocalizedError, Equatable, Sendable {
+    case capabilityMissing(String)
+    case spawnFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .capabilityMissing(let r): return "capability_missing: \(r)"
+        case .spawnFailed(let r):       return "spawn_failed: \(r)"
+        }
+    }
+}
+
+/// Injectable seam over the `shortcuts` CLI. `path` is nil when the CLI is not
+/// available (capability_missing short-circuit). `run` executes one argv and
+/// returns the captured result. Input passing is handled by the caller (it
+/// stages a temp file and forwards `--input-path`), so the seam stays trivial.
+public protocol ShortcutsRunning: Sendable {
+    /// Resolved path to the `shortcuts` binary, or nil if unavailable.
+    var path: String? { get async }
+    /// Run `shortcuts <args>` and capture stdout/stderr/exit. Throws
+    /// `ShortcutsError.capabilityMissing` when the CLI path is unresolved.
+    func run(_ args: [String]) async throws -> ShortcutsInvocationResult
+}
+
+// MARK: - Production runner (spawns /usr/bin/shortcuts)
+
+/// Live implementation. Spawns the macOS `shortcuts` CLI off the main actor.
+/// Not exercised by the unit tests — those inject the mock.
+public final class CLIShortcutsRunner: ShortcutsRunning, @unchecked Sendable {
+    private let resolvedPath: String?
+
+    public init(shortcutsPath: String? = nil) {
+        if let p = shortcutsPath {
+            self.resolvedPath = FileManager.default.isExecutableFile(atPath: p) ? p : nil
+        } else {
+            self.resolvedPath = CLIShortcutsRunner.locate()
+        }
+    }
+
+    public var path: String? { get async { resolvedPath } }
+
+    /// The macOS `shortcuts` CLI ships at `/usr/bin/shortcuts`. Fall back to a
+    /// `/usr/bin/which` probe for non-standard layouts.
+    nonisolated static func locate() -> String? {
+        let candidates = ["/usr/bin/shortcuts", "/usr/local/bin/shortcuts"]
+        for c in candidates where FileManager.default.isExecutableFile(atPath: c) {
+            return c
+        }
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        p.arguments = ["shortcuts"]
+        let outPipe = Pipe()
+        p.standardOutput = outPipe
+        p.standardError = Pipe()
+        do {
+            try p.run()
+            p.waitUntilExit()
+            if p.terminationStatus == 0 {
+                let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                let s = (String(data: data, encoding: .utf8) ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !s.isEmpty, FileManager.default.isExecutableFile(atPath: s) { return s }
+            }
+        } catch {
+            // ignore — capability missing
+        }
+        return nil
+    }
+
+    public func run(_ args: [String]) async throws -> ShortcutsInvocationResult {
+        guard let path = resolvedPath else {
+            throw ShortcutsError.capabilityMissing("shortcuts CLI not on PATH")
+        }
+        return try await CLIShortcutsRunner.spawn(executable: path, args: args)
+    }
+
+    nonisolated static func spawn(
+        executable: String,
+        args: [String]
+    ) async throws -> ShortcutsInvocationResult {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ShortcutsInvocationResult, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let p = Process()
+                p.executableURL = URL(fileURLWithPath: executable)
+                p.arguments = args
+                p.environment = ProcessInfo.processInfo.environment
+                let outPipe = Pipe()
+                let errPipe = Pipe()
+                p.standardOutput = outPipe
+                p.standardError  = errPipe
+                do {
+                    try p.run()
+                    p.waitUntilExit()
+                    let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                    let out = String(data: outData, encoding: .utf8) ?? ""
+                    let err = String(data: errData, encoding: .utf8) ?? ""
+                    cont.resume(returning: ShortcutsInvocationResult(
+                        exitCode: p.terminationStatus, stdout: out, stderr: err
+                    ))
+                } catch {
+                    cont.resume(throwing: ShortcutsError.spawnFailed(error.localizedDescription))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Module
+
+/// Provides the `shortcuts_*` MCP tools through an injectable CLI seam.
+public enum ShortcutsModule {
+
+    public static let moduleName = "shortcuts"
+
+    /// Register `shortcuts_list` + `shortcuts_run`. `runner` defaults to the
+    /// live CLI; tests inject a mock seam.
+    public static func register(
+        on router: ToolRouter,
+        runner: ShortcutsRunning = CLIShortcutsRunner()
+    ) async {
+        await router.register(makeList(runner: runner))
+        await router.register(makeRun(runner: runner))
+    }
+
+    // ===========================================================
+    // MARK: - Tool factories
+    // ===========================================================
+
+    static func makeList(runner: ShortcutsRunning) -> ToolRegistration {
+        ToolRegistration(
+            name: "shortcuts_list",
+            module: moduleName,
+            tier: .open,
+            description: "List the user's Apple Shortcuts by name via `shortcuts list`. "
+                + "Set folders:true to list shortcut FOLDERS instead of shortcuts. "
+                + "Optionally scope to one folder with folderName (or \"none\" for shortcuts in no folder). "
+                + "Read-only enumeration — returns { count, shortcuts:[names] } (or { count, folders:[names] }).",
+            inputSchema: schemaObj([
+                "folders":    boolProp("List folders instead of shortcuts (default false)."),
+                "folderName": strProp("Scope to one folder by name/identifier, or \"none\" for shortcuts not in a folder.")
+            ], required: []),
+            handler: { arguments in
+                let obj = objectArgs(arguments)
+                if let cap = await ensureCapability("shortcuts_list", runner: runner) { return cap }
+
+                var args: [String] = ["list"]
+                if case .bool(true) = obj["folders"] { args.append("--folders") }
+                if case .string(let folder) = obj["folderName"], !folder.isEmpty {
+                    args.append(contentsOf: ["--folder-name", folder])
+                }
+                do {
+                    let r = try await runner.run(args)
+                    if r.exitCode != 0 { return failedValue("shortcuts_list", r) }
+                    let names = parseLines(r.stdout)
+                    let key = (args.contains("--folders")) ? "folders" : "shortcuts"
+                    return .object([
+                        "ok":     .bool(true),
+                        "tool":   .string("shortcuts_list"),
+                        "count":  .int(names.count),
+                        key:      .array(names.map { .string($0) })
+                    ])
+                } catch let e as ShortcutsError {
+                    return shortcutsErrorValue("shortcuts_list", e)
+                } catch {
+                    return invalidArgsValue("shortcuts_list", error.localizedDescription)
+                }
+            }
+        )
+    }
+
+    static func makeRun(runner: ShortcutsRunning) -> ToolRegistration {
+        ToolRegistration(
+            name: "shortcuts_run",
+            module: moduleName,
+            tier: .notify,
+            description: "Run an Apple Shortcut by name via `shortcuts run <name>` and capture its text output. "
+                + "Optional `input` is written to a temp file and passed with --input-path. "
+                + "Output is streamed to stdout (--output-path -) and returned as `output`. "
+                + "SAFETY: a Shortcut can do anything (write files, hit the network, drive apps), so this is a "
+                + ".notify-tier action — never auto-executed silently. Returns { ok, output, exitCode }.",
+            inputSchema: schemaObj([
+                "name":  strProp("Shortcut name or identifier to run (required)."),
+                "input": strProp("Optional text input passed to the shortcut via a temp file (--input-path).")
+            ], required: ["name"]),
+            handler: { arguments in
+                let obj = objectArgs(arguments)
+                guard case .string(let name) = obj["name"], !name.isEmpty else {
+                    return invalidArgsValue("shortcuts_run", "required: name (non-empty string)")
+                }
+                if let cap = await ensureCapability("shortcuts_run", runner: runner) { return cap }
+
+                // Optional input → temp file (the CLI takes --input-path, not stdin).
+                var inputPath: String? = nil
+                if case .string(let input) = obj["input"], !input.isEmpty {
+                    let tmp = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("bridge-shortcut-input-\(UUID().uuidString).txt")
+                    do {
+                        try input.data(using: .utf8)?.write(to: tmp, options: .atomic)
+                        inputPath = tmp.path
+                    } catch {
+                        return invalidArgsValue("shortcuts_run", "could not stage input file: \(error.localizedDescription)")
+                    }
+                }
+                defer {
+                    if let inputPath { try? FileManager.default.removeItem(atPath: inputPath) }
+                }
+
+                var args: [String] = ["run", name]
+                if let inputPath { args.append(contentsOf: ["--input-path", inputPath]) }
+                // `-` streams the shortcut output to stdout so we can capture it.
+                args.append(contentsOf: ["--output-path", "-"])
+
+                do {
+                    let r = try await runner.run(args)
+                    if r.exitCode != 0 { return failedValue("shortcuts_run", r) }
+                    var dict: [String: Value] = [
+                        "ok":       .bool(true),
+                        "tool":     .string("shortcuts_run"),
+                        "name":     .string(name),
+                        "exitCode": .int(Int(r.exitCode)),
+                        "output":   .string(r.stdout)
+                    ]
+                    if !r.stderr.isEmpty { dict["stderr"] = .string(r.stderr) }
+                    return .object(dict)
+                } catch let e as ShortcutsError {
+                    return shortcutsErrorValue("shortcuts_run", e)
+                } catch {
+                    return invalidArgsValue("shortcuts_run", error.localizedDescription)
+                }
+            }
+        )
+    }
+
+    // ===========================================================
+    // MARK: - Shared helpers
+    // ===========================================================
+
+    /// Returns a `capability_missing` envelope value if the CLI is unavailable; nil otherwise.
+    static func ensureCapability(_ tool: String, runner: ShortcutsRunning) async -> Value? {
+        if await runner.path != nil { return nil }
+        return capabilityMissingValue(
+            tool,
+            "shortcuts CLI not found (expected /usr/bin/shortcuts). Apple Shortcuts requires macOS 12+."
+        )
+    }
+
+    /// Split CLI stdout into trimmed, non-empty lines (one shortcut/folder per line).
+    public static func parseLines(_ raw: String) -> [String] {
+        raw.split(separator: "\n", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    // MARK: - Envelope builders
+
+    public static func capabilityMissingValue(_ tool: String, _ reason: String) -> Value {
+        .object([
+            "ok":     .bool(false),
+            "status": .string("capability_missing"),
+            "tool":   .string(tool),
+            "error":  .string(reason)
+        ])
+    }
+
+    public static func invalidArgsValue(_ tool: String, _ reason: String) -> Value {
+        .object([
+            "ok":     .bool(false),
+            "status": .string("invalid_argument"),
+            "tool":   .string(tool),
+            "error":  .string(reason)
+        ])
+    }
+
+    public static func failedValue(_ tool: String, _ r: ShortcutsInvocationResult) -> Value {
+        let trimmedErr = r.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let errMsg = trimmedErr.isEmpty ? "shortcuts exited \(r.exitCode)" : trimmedErr
+        return .object([
+            "ok":       .bool(false),
+            "status":   .string("failed"),
+            "tool":     .string(tool),
+            "exitCode": .int(Int(r.exitCode)),
+            "stdout":   .string(r.stdout),
+            "stderr":   .string(r.stderr),
+            "error":    .string(errMsg)
+        ])
+    }
+
+    public static func shortcutsErrorValue(_ tool: String, _ e: ShortcutsError) -> Value {
+        switch e {
+        case .capabilityMissing(let r): return capabilityMissingValue(tool, r)
+        case .spawnFailed(let r):
+            return .object([
+                "ok":     .bool(false),
+                "status": .string("failed"),
+                "tool":   .string(tool),
+                "error":  .string("spawn failed: \(r)")
+            ])
+        }
+    }
+
+    // MARK: - Schema + arg helpers
+
+    static func objectArgs(_ arguments: Value) -> [String: Value] {
+        if case .object(let obj) = arguments { return obj }
+        return [:]
+    }
+
+    static func strProp(_ desc: String) -> Value {
+        .object(["type": .string("string"), "description": .string(desc)])
+    }
+    static func boolProp(_ desc: String) -> Value {
+        .object(["type": .string("boolean"), "description": .string(desc)])
+    }
+    static func schemaObj(_ properties: [String: Value], required: [String]) -> Value {
+        .object([
+            "type":       .string("object"),
+            "properties": .object(properties),
+            "required":   .array(required.map { .string($0) })
+        ])
+    }
+}

--- a/NotionBridge/Modules/SkillsModule.swift
+++ b/NotionBridge/Modules/SkillsModule.swift
@@ -73,6 +73,12 @@ public enum SkillsModule {
     "When to use" / "Not for" / "Related" guidance — read it before \
     selecting. On a wrong/missing parameter the error returns a \
     "did you mean: x→y" hint; trust it and retry once.
+    Standing orders: persistent operator directives live behind the \
+    standing_orders_* family — standing_orders_list (metadata only), \
+    standing_orders_read (full body by id), standing_orders_save \
+    (idempotent upsert), standing_orders_delete (soft-delete + archive). \
+    These are operator-curated config; writes are Notify-tier and never \
+    auto-execute.
     """
 
     public static func buildRoutingInstructions() -> String {

--- a/NotionBridge/Modules/SkillsModule.swift
+++ b/NotionBridge/Modules/SkillsModule.swift
@@ -79,6 +79,11 @@ public enum SkillsModule {
     (idempotent upsert), standing_orders_delete (soft-delete + archive). \
     These are operator-curated config; writes are Notify-tier and never \
     auto-execute.
+    Apple Shortcuts: the shortcuts_* family wraps the macOS `shortcuts` CLI \
+    — shortcuts_list (enumerate the user's shortcuts/folders, read-only) and \
+    shortcuts_run (run one by name with optional input, capture its output). \
+    A Shortcut can do anything, so shortcuts_run is Notify-tier and never \
+    auto-executes silently.
     """
 
     public static func buildRoutingInstructions() -> String {

--- a/NotionBridge/Modules/SkillsModule.swift
+++ b/NotionBridge/Modules/SkillsModule.swift
@@ -84,6 +84,11 @@ public enum SkillsModule {
     shortcuts_run (run one by name with optional input, capture its output). \
     A Shortcut can do anything, so shortcuts_run is Notify-tier and never \
     auto-executes silently.
+    Calendar: the calendar_* family is native EventKit (.event entities) — \
+    calendar_list (enumerate calendars) and calendar_events (query a date \
+    range) are read-only/Open-tier; calendar_create and calendar_update are \
+    Notify-tier writes; calendar_delete is Request-tier (confirmation \
+    required, irreversible). Events use ISO-8601 start/end times.
     """
 
     public static func buildRoutingInstructions() -> String {

--- a/NotionBridge/Modules/StandingOrders/StandingOrdersModule.swift
+++ b/NotionBridge/Modules/StandingOrders/StandingOrdersModule.swift
@@ -1,0 +1,224 @@
+// StandingOrdersModule.swift — PKT-931 (v3.7·B)
+// NotionBridge · Modules · StandingOrders
+//
+// 4 standing_orders_* MCP tools under module="standing_orders", wrapping the
+// actor-isolated StandingOrdersRecordStore. Standing orders are persistent
+// operator directives consumed by bridge-keepr and the routing skills.
+//
+// Tier policy: ALL FOUR tools are tier `.notify` (packet DoD — operator-curated
+// config must not silently change, and writes must not auto-execute). The
+// read-only-named tools (_list / _read) are deliberately kept at `.notify`
+// rather than `.open`; they are allow-listed in ReadOnlyTierAuditTests with a
+// justification, mirroring the credential_read / credential_list precedent.
+//
+// Shape mirrors the credential_* / skill_* families:
+//   standing_orders_list   → metadata only [{id, title, scope, updatedAt}]
+//   standing_orders_read   → full body + metadata by id (404 on archived)
+//   standing_orders_save   → idempotent upsert by id
+//   standing_orders_delete → soft-delete + archive (idempotent)
+
+import Foundation
+import MCP
+
+public enum StandingOrdersModule {
+
+    public static let moduleName = "standing_orders"
+
+    /// `store` is injectable so tests run against a temp-path store without
+    /// polluting the real ~/Library store. Production uses the shared actor.
+    public static func register(on router: ToolRouter, store: StandingOrdersRecordStore = .shared) async {
+        await router.register(makeList(store))
+        await router.register(makeRead(store))
+        await router.register(makeSave(store))
+        await router.register(makeDelete(store))
+    }
+
+    // MARK: - Helpers
+
+    private static func isoString(_ date: Date) -> String { date.ISO8601Format() }
+
+    private static func stringArg(_ args: [String: Value], _ k: String) -> String? {
+        if case .string(let s)? = args[k] { return s }
+        return nil
+    }
+
+    private static func boolArg(_ args: [String: Value], _ k: String) -> Bool? {
+        if case .bool(let b)? = args[k] { return b }
+        return nil
+    }
+
+    private static func summaryValue(_ s: StandingOrderSummary) -> Value {
+        .object([
+            "id": .string(s.id),
+            "title": .string(s.title),
+            "scope": .string(s.scope.rawValue),
+            "updatedAt": .string(isoString(s.updatedAt)),
+            "archived": .bool(s.archived)
+        ])
+    }
+
+    private static func orderValue(_ o: StandingOrder) -> Value {
+        var d: [String: Value] = [
+            "id": .string(o.id),
+            "title": .string(o.title),
+            "body": .string(o.body),
+            "scope": .string(o.scope.rawValue),
+            "createdAt": .string(isoString(o.createdAt)),
+            "updatedAt": .string(isoString(o.updatedAt)),
+            "archived": .bool(o.archived)
+        ]
+        if let a = o.archivedAt { d["archivedAt"] = .string(isoString(a)) }
+        return .object(d)
+    }
+
+    private static func errEnvelope(_ tool: String, _ message: String, code: String) -> Value {
+        .object(["ok": .bool(false), "tool": .string(tool), "error": .string(code), "message": .string(message)])
+    }
+
+    // MARK: - Tools
+
+    private static func makeList(_ store: StandingOrdersRecordStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "standing_orders_list",
+            module: moduleName,
+            tier: .notify,
+            description: "List standing orders as metadata only — [{id, title, scope, updatedAt, archived}]. Bodies are omitted; use standing_orders_read for the full text. Archived (soft-deleted) orders are excluded unless includeArchived=true.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "includeArchived": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Include soft-deleted (archived) orders in the listing (default: false).")
+                    ])
+                ]),
+                "required": .array([])
+            ]),
+            handler: { arguments in
+                let args: [String: Value] = { if case .object(let a) = arguments { return a }; return [:] }()
+                let includeArchived = boolArg(args, "includeArchived") ?? false
+                let items = await store.list(includeArchived: includeArchived)
+                return .object([
+                    "ok": .bool(true),
+                    "orders": .array(items.map(summaryValue)),
+                    "count": .int(items.count)
+                ])
+            })
+    }
+
+    private static func makeRead(_ store: StandingOrdersRecordStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "standing_orders_read",
+            module: moduleName,
+            tier: .notify,
+            description: "Read one standing order by id → full {id, title, body, scope, createdAt, updatedAt, archived}. Returns not_found for an unknown id or a soft-deleted order (unless includeArchived=true).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object([
+                        "type": .string("string"),
+                        "description": .string("Standing order id.")
+                    ]),
+                    "includeArchived": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Allow reading a soft-deleted (archived) order (default: false).")
+                    ])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "standing_orders_read", reason: "missing required 'id'")
+                }
+                let includeArchived = boolArg(args, "includeArchived") ?? false
+                guard let order = await store.read(id: id, includeArchived: includeArchived) else {
+                    return errEnvelope("standing_orders_read", "no standing order with id '\(id)'", code: "not_found")
+                }
+                return .object(["ok": .bool(true), "order": orderValue(order)])
+            })
+    }
+
+    private static func makeSave(_ store: StandingOrdersRecordStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "standing_orders_save",
+            module: moduleName,
+            tier: .notify,
+            description: "Upsert a standing order. Omit id to create; supply an existing id to update in place (idempotent — no duplicate). scope ∈ {global, per-skill, per-tool, per-context}. Saving an archived id un-archives it. Returns the saved {id, ...}.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object([
+                        "type": .string("string"),
+                        "description": .string("Existing order id to update. Omit to create a new order.")
+                    ]),
+                    "title": .object([
+                        "type": .string("string"),
+                        "description": .string("Short human label for the order.")
+                    ]),
+                    "body": .object([
+                        "type": .string("string"),
+                        "description": .string("Full directive text.")
+                    ]),
+                    "scope": .object([
+                        "type": .string("string"),
+                        "description": .string("One of: global (default), per-skill, per-tool, per-context.")
+                    ])
+                ]),
+                "required": .array([.string("title"), .string("body")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      let title = stringArg(args, "title"),
+                      let body = stringArg(args, "body") else {
+                    throw ToolRouterError.invalidArguments(toolName: "standing_orders_save", reason: "missing required 'title' or 'body'")
+                }
+                let id = stringArg(args, "id")
+                let scope: StandingOrderScope
+                if let raw = stringArg(args, "scope") {
+                    guard let parsed = StandingOrderScope(rawValue: raw) else {
+                        return errEnvelope("standing_orders_save", "invalid scope '\(raw)'. Must be one of: \(StandingOrderScope.allCases.map(\.rawValue).joined(separator: ", "))", code: "invalid_scope")
+                    }
+                    scope = parsed
+                } else {
+                    scope = .global
+                }
+                do {
+                    let saved = try await store.save(id: id, title: title, body: body, scope: scope)
+                    return .object(["ok": .bool(true), "order": orderValue(saved)])
+                } catch {
+                    return errEnvelope("standing_orders_save", error.localizedDescription, code: "save_failed")
+                }
+            })
+    }
+
+    private static func makeDelete(_ store: StandingOrdersRecordStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "standing_orders_delete",
+            module: moduleName,
+            tier: .notify,
+            neverAutoApprove: true,
+            description: "Soft-delete a standing order by id (archives the row — it is not purged). Idempotent — deleting an already-archived order succeeds. Returns the archived {id, archived: true, archivedAt}.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object([
+                        "type": .string("string"),
+                        "description": .string("Standing order id to soft-delete (archive).")
+                    ])
+                ]),
+                "required": .array([.string("id")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let id = stringArg(args, "id") else {
+                    throw ToolRouterError.invalidArguments(toolName: "standing_orders_delete", reason: "missing required 'id'")
+                }
+                do {
+                    let archived = try await store.delete(id: id)
+                    return .object(["ok": .bool(true), "order": orderValue(archived)])
+                } catch StandingOrdersRecordError.notFound(let missing) {
+                    return errEnvelope("standing_orders_delete", "no standing order with id '\(missing)'", code: "not_found")
+                } catch {
+                    return errEnvelope("standing_orders_delete", error.localizedDescription, code: "delete_failed")
+                }
+            })
+    }
+}

--- a/NotionBridge/Modules/StandingOrders/StandingOrdersStore.swift
+++ b/NotionBridge/Modules/StandingOrders/StandingOrdersStore.swift
@@ -201,3 +201,202 @@ public final class StandingOrdersStore: @unchecked Sendable {
         max(0, s.count / 4)
     }
 }
+
+// MARK: - Multi-record standing orders (PKT-931, v3.7·B)
+//
+// The single-document store above (PKT-9 / v3.5) backs the one operating
+// preamble injected at handshake time. PKT-931 layers a *multi-record* model
+// on top so individual, id-addressable standing orders (per-skill, per-tool,
+// per-context overlays) can be authored, listed, updated, and soft-deleted
+// via the standing_orders_* MCP tools — mirroring the credential_* / skill_*
+// tool families.
+//
+// Storage: a sibling JSON document at
+//   ~/Library/Application Support/The Bridge/standing-orders/orders.json
+// (the .md / metadata.json single-doc files are untouched). Schema-versioned,
+// written with Data.write(options: .atomic) so a kill -9 mid-write cannot tear
+// the file. All mutation is serialized through the `actor`, so concurrent
+// standing_orders_save calls cannot race (packet QA: no last-write-wins).
+
+/// Scope axis for a standing order — which surface the directive applies to.
+public enum StandingOrderScope: String, Codable, Sendable, CaseIterable {
+    case global
+    case perSkill   = "per-skill"
+    case perTool    = "per-tool"
+    case perContext = "per-context"
+}
+
+/// One id-addressable standing order record.
+public struct StandingOrder: Codable, Sendable, Equatable {
+    public let id: String          // uuid4 (stable across updates)
+    public var title: String
+    public var body: String
+    public var scope: StandingOrderScope
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var archived: Bool       // soft-delete flag
+    public var archivedAt: Date?
+
+    public init(
+        id: String = UUID().uuidString,
+        title: String,
+        body: String,
+        scope: StandingOrderScope = .global,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        archived: Bool = false,
+        archivedAt: Date? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.body = body
+        self.scope = scope
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.archived = archived
+        self.archivedAt = archivedAt
+    }
+}
+
+/// Lightweight metadata projection returned by `list` (body omitted).
+public struct StandingOrderSummary: Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let scope: StandingOrderScope
+    public let updatedAt: Date
+    public let archived: Bool
+}
+
+public enum StandingOrdersRecordError: Error, Equatable, Sendable {
+    case notFound(String)
+    case invalidScope(String)
+}
+
+/// Actor-isolated multi-record store backing the standing_orders_* MCP tools.
+public actor StandingOrdersRecordStore {
+
+    public static let shared = StandingOrdersRecordStore()
+
+    private struct Document: Codable {
+        var schemaVersion: Int
+        var orders: [StandingOrder]
+    }
+
+    private static let currentSchemaVersion = 1
+    private let storeURL: URL
+    private var doc: Document
+
+    public init(storeURL: URL = StandingOrdersRecordStore.defaultStoreURL()) {
+        self.storeURL = storeURL
+        self.doc = StandingOrdersRecordStore.loadOrRecover(url: storeURL)
+    }
+
+    public nonisolated static func defaultStoreURL() -> URL {
+        BridgePaths.applicationSupport(.standingOrders)
+            .appendingPathComponent("orders.json", isDirectory: false)
+    }
+
+    // MARK: Load / persist
+
+    private nonisolated static func loadOrRecover(url: URL) -> Document {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return Document(schemaVersion: currentSchemaVersion, orders: [])
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        if let d = try? decoder.decode(Document.self, from: data) {
+            return d
+        }
+        // Corrupt file — preserve it for forensics, start fresh rather than throw.
+        let backup = url.appendingPathExtension("corrupt-\(Int(Date().timeIntervalSince1970))")
+        try? FileManager.default.moveItem(at: url, to: backup)
+        return Document(schemaVersion: currentSchemaVersion, orders: [])
+    }
+
+    private func persist() throws {
+        let dir = storeURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(doc)
+        try data.write(to: storeURL, options: [.atomic])  // temp + atomic rename
+    }
+
+    // MARK: Read
+
+    /// Metadata-only projection. Archived rows are excluded unless
+    /// `includeArchived` is true. Sorted by updatedAt descending.
+    public func list(includeArchived: Bool = false) -> [StandingOrderSummary] {
+        doc.orders
+            .filter { includeArchived || !$0.archived }
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .map { StandingOrderSummary(id: $0.id, title: $0.title, scope: $0.scope, updatedAt: $0.updatedAt, archived: $0.archived) }
+    }
+
+    /// Full record by id. Soft-deleted (archived) records are treated as
+    /// absent (read returns nil → caller maps to 404) unless `includeArchived`.
+    public func read(id: String, includeArchived: Bool = false) -> StandingOrder? {
+        guard let o = doc.orders.first(where: { $0.id == id }) else { return nil }
+        if o.archived && !includeArchived { return nil }
+        return o
+    }
+
+    // MARK: Write
+
+    /// Idempotent upsert. If `id` is supplied and matches an existing record,
+    /// that record is updated in place (no duplicate). Otherwise a new record
+    /// is created. Saving an archived id un-archives it (operator re-authoring).
+    @discardableResult
+    public func save(
+        id: String? = nil,
+        title: String,
+        body: String,
+        scope: StandingOrderScope = .global
+    ) throws -> StandingOrder {
+        if let id, let idx = doc.orders.firstIndex(where: { $0.id == id }) {
+            doc.orders[idx].title = title
+            doc.orders[idx].body = body
+            doc.orders[idx].scope = scope
+            doc.orders[idx].updatedAt = Date()
+            if doc.orders[idx].archived {
+                doc.orders[idx].archived = false
+                doc.orders[idx].archivedAt = nil
+            }
+            try persist()
+            return doc.orders[idx]
+        }
+        let order = StandingOrder(id: id ?? UUID().uuidString, title: title, body: body, scope: scope)
+        doc.orders.append(order)
+        try persist()
+        return order
+    }
+
+    // MARK: Delete
+
+    /// Soft-delete: flag the record archived (and stamp archivedAt) rather
+    /// than purging the row. Idempotent — archiving an already-archived row
+    /// is a no-op success. Throws notFound for an unknown id.
+    @discardableResult
+    public func delete(id: String) throws -> StandingOrder {
+        guard let idx = doc.orders.firstIndex(where: { $0.id == id }) else {
+            throw StandingOrdersRecordError.notFound(id)
+        }
+        if !doc.orders[idx].archived {
+            doc.orders[idx].archived = true
+            doc.orders[idx].archivedAt = Date()
+            doc.orders[idx].updatedAt = Date()
+            try persist()
+        }
+        return doc.orders[idx]
+    }
+
+    // MARK: Test support
+
+    public func reloadFromDisk() {
+        doc = Self.loadOrRecover(url: storeURL)
+    }
+}

--- a/NotionBridge/Security/KeychainManager.swift
+++ b/NotionBridge/Security/KeychainManager.swift
@@ -240,6 +240,31 @@ public final class KeychainManager: @unchecked Sendable {
         public static let stripeAPIKey = "stripe_api_key"
         /// Bearer secret for `POST /mcp` when remote tunnel URL is configured (Streamable HTTP).
         public static let mcpBearerToken = "mcp_bearer_token"
+        /// WS-F: WorkOS session token from the `bridge-auth://callback` code
+        /// exchange. Persisted so a returning user skips the browser sign-in.
+        public static let cloudToken = "bridge.kup.solutions.workos_token"
+    }
+
+    // MARK: - Cloud token convenience (WS-F)
+
+    /// The stored WorkOS cloud session token, or `nil` if the user has not
+    /// signed in (or is running outside an .app bundle, where Keychain ops
+    /// are no-ops). Read by `EnableCloudAccessFlow.start()` to decide whether
+    /// to skip the browser sign-in step.
+    public var cloudToken: String? {
+        read(key: Key.cloudToken)
+    }
+
+    /// Persist the WorkOS cloud session token (overwrites any prior value).
+    @discardableResult
+    public func saveCloudToken(_ value: String) -> Bool {
+        save(key: Key.cloudToken, value: value)
+    }
+
+    /// Remove the stored WorkOS cloud session token.
+    @discardableResult
+    public func clearCloudToken() -> Bool {
+        delete(key: Key.cloudToken)
     }
 
     /// List all keys stored under this service.

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -43,6 +43,7 @@ public enum BridgeModuleRegistry {
         await FileModule.register(on: router)
         await registerSession(router)
         await MessagesModule.register(on: router)
+        await MailModule.register(on: router)
         await SystemModule.register(on: router)
         await ContactsModule.register(on: router)
         await RemindersModule.register(on: router)

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -80,5 +80,6 @@ public enum BridgeModuleRegistry {
         await ArtifactModule.register(on: router)
         await SnippetsModule.register(on: router)
         await StandingOrdersModule.register(on: router)
+        await ShortcutsModule.register(on: router)
     }
 }

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -78,5 +78,6 @@ public enum BridgeModuleRegistry {
         await LighthouseModule.register(on: router)
         await ArtifactModule.register(on: router)
         await SnippetsModule.register(on: router)
+        await StandingOrdersModule.register(on: router)
     }
 }

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -45,6 +45,7 @@ public enum BridgeModuleRegistry {
         await MessagesModule.register(on: router)
         await SystemModule.register(on: router)
         await ContactsModule.register(on: router)
+        await RemindersModule.register(on: router)
         await NotionModule.register(on: router)
         await ScreenModule.register(on: router)
         await ScreenModule.registerRecording(on: router)

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -48,6 +48,7 @@ public enum BridgeModuleRegistry {
         await SystemModule.register(on: router)
         await ContactsModule.register(on: router)
         await RemindersModule.register(on: router)
+        await CalendarModule.register(on: router)
         await NotionModule.register(on: router)
         await ScreenModule.register(on: router)
         await ScreenModule.registerRecording(on: router)

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -84,4 +84,20 @@ public enum BridgeModuleRegistry {
         await StandingOrdersModule.register(on: router)
         await ShortcutsModule.register(on: router)
     }
+
+    /// WS-D (PKT-921): register the cloud-gated `bridge_status` tool.
+    ///
+    /// Kept OUT of `registerStaticFeatureModules` on purpose: `bridge_status`
+    /// is conditional on `BridgeDefaults.cloudAccessEnabled`, so it must not
+    /// inflate `BridgeConstants.staticFeatureModuleToolCount` (which counts the
+    /// always-present surface) nor trip the registry's
+    /// every-tool-has-an-annotation / no-duplicate guards. The caller (e.g.
+    /// `ServerManager.setup()`) invokes this ONLY when cloud access is enabled,
+    /// passing the live `BridgeCloudManager` whose `state` the handler reads.
+    public static func registerCloudStatusTool(
+        on router: ToolRouter,
+        manager: BridgeCloudManager
+    ) async {
+        await CloudStatusModule.register(on: router, manager: manager)
+    }
 }

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -43,6 +43,7 @@ public enum BridgeModuleRegistry {
         await FileModule.register(on: router)
         await registerSession(router)
         await MessagesModule.register(on: router)
+        await NotesModule.register(on: router)
         await SystemModule.register(on: router)
         await ContactsModule.register(on: router)
         await NotionModule.register(on: router)

--- a/NotionBridge/Server/ServerManager.swift
+++ b/NotionBridge/Server/ServerManager.swift
@@ -27,6 +27,32 @@ public actor ServerManager {
     private var securityGate: SecurityGate?
     private let toolAllowlist: Set<String>?
 
+    // MARK: - WS-D (PKT-921): Bridge Cloud Access wiring
+
+    /// The live cloud manager, assembled in `setup()` ONLY when Bridge Cloud
+    /// Access is enabled (`BridgeDefaults.cloudAccessEnabled`). Owns the
+    /// connection-state machine the heartbeat probes and the `bridge_status`
+    /// tool reads. nil in every default (cloud-off) install.
+    private var cloudManager: BridgeCloudManager?
+
+    /// The heartbeat loop driving `cloudManager.refreshHealth()` on a ~30s
+    /// cadence while cloud access is enabled. Started at launch when enabled
+    /// and on the cloudAccessEnabled→true toggle; stopped on the →false toggle.
+    private var cloudHeartbeat: CloudHeartbeat?
+
+    /// Injectable resolver for "is THIS tools/list request arriving over the
+    /// CLOUD transport?". A cloud-originated request (served via the WS-A/WS-B
+    /// tunnel) must have its Mac tools hidden when the channel is offline; a
+    /// local stdio/SSE request always sees the full surface.
+    ///
+    /// Live cloud-route header detection lands with the operator tunnel
+    /// (PKT-810 / WS-A / WS-B); until then the production resolver returns
+    /// `false`, so the stdio/SSE ListTools handler is byte-for-byte unchanged.
+    /// The seam exists so the conditional is unit-testable now and the cloud
+    /// transport can flip it without re-plumbing `setup()`.
+    public typealias CloudRouteResolver = @Sendable () async -> Bool
+    private let isCloudRequest: CloudRouteResolver
+
     /// WS-B (PKT-803): the active-transport router. Default config resolves
     /// to `[.stdio]` only, so existing clients are unaffected;
     /// `BRIDGE_ENABLE_HTTP=1` additively opts into streamableHTTP.
@@ -67,7 +93,8 @@ public actor ServerManager {
         onClientConnected: @escaping @MainActor @Sendable (String, String) -> Void = { _, _ in },
         onClientDisconnected: @escaping @MainActor @Sendable (String) -> Void = { _ in },
         toolAllowlist: Set<String>? = nil,
-        transportRouter: TransportRouter = TransportRouter()
+        transportRouter: TransportRouter = TransportRouter(),
+        isCloudRequest: @escaping CloudRouteResolver = { false }
     ) {
         self.onToolCall = onToolCall
         self.onClientConnected = onClientConnected
@@ -75,6 +102,7 @@ public actor ServerManager {
         self.toolAllowlist = toolAllowlist
         self.transportRouter = transportRouter
         self.ssePort = ConfigManager.shared.ssePort
+        self.isCloudRequest = isCloudRequest
     }
 
     // MARK: - Setup
@@ -150,6 +178,19 @@ public actor ServerManager {
                 )
             }
         )
+        // WS-D (PKT-921): Bridge Cloud Access — register the cloud-gated
+        // `bridge_status` tool and start the health heartbeat ONLY when cloud
+        // access is enabled. In every default (cloud-off) install this whole
+        // block is skipped: no `bridge_status` tool, no heartbeat task, and the
+        // static tool surface is byte-for-byte unchanged. WS-F added both the
+        // `cloudAccessEnabled` key and the manager assembly seam.
+        if BridgeDefaults.cloudAccessEnabledValue {
+            let manager = Self.makeCloudManager()
+            self.cloudManager = manager
+            await BridgeModuleRegistry.registerCloudStatusTool(on: router, manager: manager)
+            await startCloudHeartbeat(for: manager)
+        }
+
         // Reconcile any jobs orphaned by a prior Bridge force-quit. Flips dead-pid running jobs to .unknown
         // and runs the 7-day cleanup pass for terminal jobs.
         _ = await BgProcessRuntime.shared.reconcileOrphans()
@@ -192,14 +233,25 @@ public actor ServerManager {
         self.server = server
 
         // 5. Wire ListTools handler — PKT-350: filter disabled tools
-        await server.withMethodHandler(ListTools.self) { [router, toolAllowlist] _ in
+        let isCloudRequest = self.isCloudRequest
+        let cloudManager = self.cloudManager
+        await server.withMethodHandler(ListTools.self) { [router, toolAllowlist, isCloudRequest, cloudManager] _ in
             let disabledNames = CredentialsFeature.mergedDisabledToolNames()
             var registrations = await router.enabledRegistrations(disabledNames: disabledNames)
-            
+
             if let allowlist = toolAllowlist {
                 registrations = registrations.filter { allowlist.contains($0.name) }
             }
-            
+
+            // WS-D (PKT-921): on a CLOUD request, hide Mac tools when the cloud
+            // channel is offline/disabled. A local stdio/SSE request (the
+            // default — `isCloudRequest` resolves false) always sees the full
+            // surface, so this is behaviour-preserving for existing clients.
+            if await isCloudRequest() {
+                let cloudState = await cloudManager?.state ?? .disabled
+                registrations = Self.filterForCloud(registrations, cloudState: cloudState)
+            }
+
             // v3.0·0.5: single source of truth — same factory as SSETransport.
             let tools = registrations.map { MCPToolFactory.tool(for: $0) }
             return .init(tools: tools)
@@ -219,6 +271,92 @@ public actor ServerManager {
         // 7. SSE server was created before module registration so session diagnostics can be injected
 
         return await router.allRegistrations().count
+    }
+
+    // MARK: - WS-D (PKT-921): Bridge Cloud Access — heartbeat + tools/list filter
+
+    /// The set of tools a CLOUD caller may always see, regardless of channel
+    /// health. `bridge_status` is the cloud-safe probe; everything else is a
+    /// "Mac tool" hidden when the channel is offline/disabled.
+    public static let cloudAlwaysVisibleTools: Set<String> = [CloudStatusModule.toolName]
+
+    /// Pure, unit-testable tools/list conditional. For a CLOUD request:
+    ///   • state ∈ {.offline, .disabled} → omit Mac tools (keep only
+    ///     `cloudAlwaysVisibleTools`, e.g. `bridge_status`).
+    ///   • state ∈ {.online, .degraded, .connecting} → full list.
+    /// A non-cloud (local) request never calls this; it always gets the full
+    /// list. Mirrors `CloudStatusPayload.macToolsAvailable`.
+    public static func filterForCloud(
+        _ registrations: [ToolRegistration],
+        cloudState: CloudConnectionState
+    ) -> [ToolRegistration] {
+        guard CloudStatusPayload.macToolsAvailable(cloudState) else {
+            return registrations.filter { cloudAlwaysVisibleTools.contains($0.name) }
+        }
+        return registrations
+    }
+
+    /// Assemble the production `BridgeCloudManager` over the WS-C seams. The
+    /// real cloudflared / Secure-Enclave conformers land with the live Worker
+    /// (PKT-810 / WS-A); until then the manager runs over the in-memory fakes
+    /// so the state machine + heartbeat + `bridge_status` are all live without
+    /// touching the network. Mirrors `RemoteAccessSection.defaultFlow()`.
+    static func makeCloudManager() -> BridgeCloudManager {
+        let host = ProcessInfo.processInfo.hostName
+            .replacingOccurrences(of: ".local", with: "")
+            .replacingOccurrences(of: " ", with: "-")
+        let deviceID = host.isEmpty ? "this-mac" : host
+        return BridgeCloudManager(
+            tunnel: FakeTunnelProcess(),
+            passkeyGate: FakePasskeyGate(outcome: .approved),
+            node: LocalNodeContext(ownerID: "local", deviceID: deviceID)
+        )
+    }
+
+    /// Start (or restart) the health heartbeat over `manager`. Idempotent: a
+    /// prior loop is stopped first so a re-enable never leaves two timers.
+    func startCloudHeartbeat(for manager: BridgeCloudManager) async {
+        await cloudHeartbeat?.stop()
+        let heartbeat = CloudHeartbeat(manager: manager)
+        self.cloudHeartbeat = heartbeat
+        await heartbeat.start()
+    }
+
+    /// Stop the heartbeat loop (cloud access disabled). Safe when not running.
+    func stopCloudHeartbeat() async {
+        await cloudHeartbeat?.stop()
+        cloudHeartbeat = nil
+    }
+
+    /// React to a live `cloudAccessEnabled` toggle WITHOUT a relaunch.
+    /// ON  → assemble the manager (if absent), enable the tunnel, register
+    ///       `bridge_status`, and start the heartbeat.
+    /// OFF → stop the heartbeat, deregister `bridge_status`, and disable the
+    ///       manager. Mirrors the launch-time gate in `setup()`.
+    public func setCloudAccessEnabled(_ enabled: Bool) async {
+        guard let router = self.router else { return }
+        if enabled {
+            let manager = cloudManager ?? Self.makeCloudManager()
+            self.cloudManager = manager
+            _ = await manager.enable()
+            await BridgeModuleRegistry.registerCloudStatusTool(on: router, manager: manager)
+            await startCloudHeartbeat(for: manager)
+        } else {
+            await stopCloudHeartbeat()
+            await router.deregister(name: CloudStatusModule.toolName)
+            if let manager = cloudManager { _ = await manager.disable() }
+        }
+    }
+
+    /// Current cloud connection state (`.disabled` when cloud access is off /
+    /// no manager). Drives the `bridge_status` payload + the tools/list filter.
+    public func cloudConnectionState() async -> CloudConnectionState {
+        await cloudManager?.state ?? .disabled
+    }
+
+    /// Whether the heartbeat loop is currently scheduled (test/diagnostic).
+    public func isCloudHeartbeatRunning() async -> Bool {
+        await cloudHeartbeat?.isRunning ?? false
     }
 
     // MARK: - Tool Info (PKT-350: F2)

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -228,6 +228,17 @@ public enum ToolAnnotationCatalog {
         "messages_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "messages_send": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "mouse_click": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        // v3.7·G — notes_* (Apple Notes via AppleScript). list/read/search are
+        // pure reads (.open → requiresConfirmation:false). create/update are
+        // .notify (informational notification, NOT a human gate). delete is
+        // .request + destructive (move-to-trash, irreversible from the API).
+        // openWorld:true — each tool drives Notes.app over Apple events.
+        "notes_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "notes_read": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "notes_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "notes_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "notes_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "notes_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: true),
         "notify": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "notion_block_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         // Sprint A · mcp-builder #1: notion_block_read removed

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -105,6 +105,9 @@ public enum ToolAnnotationCatalog {
         "bg_process_logs": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "bg_process_start": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "bg_process_status": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
+        // WS-D (PKT-921): cloud-gated health probe. Reads the local
+        // BridgeCloudManager state machine; touches nothing — pure read.
+        "bridge_status": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "cgevent_send": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "chrome_execute_js": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "chrome_navigate": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -278,6 +278,12 @@ public enum ToolAnnotationCatalog {
         "snippets_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "snippets_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "spotlight_query": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        // standing_orders_* (PKT-931): operator-curated config. read/list are
+        // read-only but tier .notify (deliberate exception — see ReadOnlyTierAuditTests).
+        "standing_orders_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: false),
+        "standing_orders_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
+        "standing_orders_read": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
+        "standing_orders_save": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "stripe_reconnect": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "system_info": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "tools_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -278,6 +278,12 @@ public enum ToolAnnotationCatalog {
         "session_clear": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "session_info": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "shell_exec": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: true, openWorld: true),
+        // shortcuts_* (PKT-959, v3.7·F): Apple Shortcuts via /usr/bin/shortcuts.
+        // _list is read-only (.open). _run is destructive (a Shortcut can do
+        // anything) but tier .notify, so requiresConfirmation stays false —
+        // .notify surfaces every run to the operator without a hard gate.
+        "shortcuts_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "shortcuts_run": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "snippets_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "snippets_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "snippets_export": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -259,6 +259,16 @@ public enum ToolAnnotationCatalog {
         "playwright_run": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "port_inspect": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "process_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
+        // PKT-957 (v3.7·D): Reminders family over EventKit. lists/list are
+        // read-only (.open); create/update non-destructive but writing;
+        // complete is idempotent (set-to-state X); delete is destructive +
+        // confirmation-gated (tier .request).
+        "reminders_complete": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "reminders_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "reminders_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: true),
+        "reminders_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "reminders_lists": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "reminders_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "run_script": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "screen_analyze": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "screen_capture": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -213,6 +213,16 @@ public enum ToolAnnotationCatalog {
         "lsp_references": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: true),
         "lsp_rename": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "lsp_session_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        // v3.7·H (PKT-961): Apple Mail family. list/read/search are read-only
+        // (.open → requiresConfirmation:false); draft is non-destructive but
+        // writing (.notify → creates an UNSENT draft, requiresConfirmation:false);
+        // send is the GUARDED tool (.request → requiresConfirmation:true, mirrors
+        // tier==.request). All openWorld (Mail.app is an external surface).
+        "mail_draft": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "mail_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "mail_read": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "mail_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "mail_send": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         // Sprint A · mcp-builder #2: manage_skill split into 5 primitives.
         // The 11-action polymorphism is preserved as a one-cycle alias.
         "manage_skill": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -280,6 +280,16 @@ public enum ToolAnnotationCatalog {
         "playwright_run": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "port_inspect": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "process_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
+        // PKT-962 (v3.7·I): Calendar family over EventKit (.event entities,
+        // reusing v3.7·D's store + calendars entitlement). list/events are
+        // read-only (.open); create/update non-destructive but writing
+        // (.notify); delete is destructive + confirmation-gated (tier
+        // .request). Mirrors the reminders annotations below.
+        "calendar_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "calendar_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: true),
+        "calendar_events": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "calendar_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "calendar_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         // PKT-957 (v3.7·D): Reminders family over EventKit. lists/list are
         // read-only (.open); create/update non-destructive but writing;
         // complete is idempotent (set-to-state X); delete is destructive +

--- a/NotionBridge/UI/CredentialsView.swift
+++ b/NotionBridge/UI/CredentialsView.swift
@@ -117,6 +117,26 @@ struct CredentialsView: View {
             }
 
             if credentialsEnabledUI {
+                // MARK: Onboarding / all-foreign-filtered banner (PKT-934 W3)
+                // When the feature is on but no Bridge-scoped credentials are
+                // present, three bare "No saved X" rows read like an error
+                // and give a brand-new user no next step. They also can't
+                // tell an empty keychain apart from one whose entries were
+                // all filtered out by the v3.6.x scoping hotfix (foreign
+                // keychain items are intentionally hidden here). A single
+                // onboarding banner covers both: empty-new and
+                // all-foreign-filtered. Suppressed once any add-form is open
+                // or any Bridge credential exists.
+                if credentials.isEmpty && !showAddApiKey && !showAddPassword && !showAddCard {
+                    Section {
+                        BridgeEmptyState(
+                            systemImage: "key.horizontal",
+                            title: "No Bridge credentials yet",
+                            body: "Add an API key, password, or tokenized card below to store it in the macOS Keychain with biometric protection. Only credentials created here appear in this list — existing Keychain items from other apps are intentionally hidden."
+                        )
+                    }
+                }
+
                 // MARK: API Keys (PKT-441)
                 Section("API Keys") {
                     if apiKeys.isEmpty && !showAddApiKey {

--- a/NotionBridge/UI/JobsView.swift
+++ b/NotionBridge/UI/JobsView.swift
@@ -143,7 +143,10 @@ public struct JobsView: View {
             emptyState
         } else {
             ScrollView {
-                LazyVStack(spacing: 10) {
+                // PKT-934 W1: card-stack spacing aligned to the
+                // BridgeSpacing grid (sm) so the Jobs and Tools card pages
+                // share one tier; was an off-grid literal 10.
+                LazyVStack(spacing: BridgeSpacing.sm) {
                     ForEach(filteredJobs, id: \.id) { job in
                         JobCard(
                             job: job,
@@ -157,20 +160,24 @@ public struct JobsView: View {
                         )
                     }
                 }
-                .padding(16)
+                .padding(BridgeSpacing.md)
             }
         }
     }
 
     private var emptyState: some View {
-        VStack(spacing: 12) {
+        // PKT-934 W2: empty-state spacing aligned to the BridgeSpacing grid
+        // (sm between stack items, xs between the action buttons); copy
+        // tightened. Two CTAs are retained, so the shared single-CTA
+        // BridgeEmptyState component is intentionally not used here.
+        VStack(spacing: BridgeSpacing.sm) {
             Image(systemName: "clock.badge.checkmark")
                 .font(.system(size: 42))
                 .foregroundStyle(.tertiary)
             Text("No scheduled jobs yet").font(.headline)
             Text("Tap **New** to create a job, or import a job export file.")
                 .font(.callout).foregroundStyle(.secondary).multilineTextAlignment(.center)
-            HStack {
+            HStack(spacing: BridgeSpacing.xs) {
                 Button("New Job") { showNewJobSheet = true }.buttonStyle(.borderedProminent)
                 Button("Import…") { showImportSheet = true }
             }
@@ -196,7 +203,15 @@ public struct JobsView: View {
             Button { showImportSheet = true } label: { Label("Import", systemImage: "square.and.arrow.down") }
                 .controlSize(.small)
             if let msg = bulkMessage {
-                Text(msg).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                // PKT-934 W2: bulk-action failures surface as a consistent
+                // warning pill (shared BridgeBadge), not bare grey text, so
+                // the error treatment matches the rest of the app; success
+                // notices stay as quiet secondary text.
+                if msg.localizedCaseInsensitiveContains("failed") {
+                    BridgeBadge(msg, systemImage: "exclamationmark.triangle.fill", tone: .warning)
+                } else {
+                    Text(msg).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
             }
         }
     }
@@ -346,6 +361,12 @@ private struct JobCardHeader: View {
                         Text("·").foregroundStyle(.tertiary)
                         Text(primary.tool).monospaced()
                     }
+                    // PKT-934 W2: surface a last-updated relative timestamp
+                    // in the app-wide compact format (just now / Xm / Xh /
+                    // Xd ago) — matches DashboardView.relativeTime and
+                    // SettingsWindow.relativeTimestamp.
+                    Text("·").foregroundStyle(.tertiary)
+                    Text("updated \(Self.relativeTime(from: job.updatedAt))")
                     if job.skipOnBattery {
                         Text("·").foregroundStyle(.tertiary)
                         Image(systemName: "battery.25percent")
@@ -396,6 +417,17 @@ private struct JobCardHeader: View {
         case .active: return .green
         case .paused: return .orange
         }
+    }
+
+    /// PKT-934 W2: compact relative timestamp — same format as
+    /// DashboardView.relativeTime / SettingsWindow.relativeTimestamp so
+    /// timestamps read identically across the app.
+    static func relativeTime(from date: Date) -> String {
+        let interval = Date().timeIntervalSince(date)
+        if interval < 60 { return "just now" }
+        else if interval < 3600 { return "\(Int(interval / 60))m ago" }
+        else if interval < 86400 { return "\(Int(interval / 3600))h ago" }
+        else { return "\(Int(interval / 86400))d ago" }
     }
 }
 

--- a/NotionBridge/UI/ModuleGroupCard.swift
+++ b/NotionBridge/UI/ModuleGroupCard.swift
@@ -325,7 +325,10 @@ public struct ModuleGroupList: View {
 
     public var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 10) {
+            // PKT-934 W1: card-stack spacing aligned to the BridgeSpacing
+            // grid (sm) so the Tools and Jobs card pages share one tier;
+            // was an off-grid literal 10.
+            VStack(alignment: .leading, spacing: BridgeSpacing.sm) {
                 hero
                 ForEach(groups) { group in
                     ModuleGroupCard(
@@ -343,7 +346,7 @@ public struct ModuleGroupList: View {
                     )
                 }
             }
-            .padding(16)
+            .padding(BridgeSpacing.md)
         }
         .onReceive(NotificationCenter.default.publisher(
             for: UserDefaults.didChangeNotification

--- a/NotionBridge/UI/Sections/FirstRunCloudAccessModal.swift
+++ b/NotionBridge/UI/Sections/FirstRunCloudAccessModal.swift
@@ -1,0 +1,104 @@
+// FirstRunCloudAccessModal.swift — WS-G (Bridge Cloud Access · first-run)
+// NotionBridge · UI · Sections
+//
+// The one-time, 3-step guide presented as a `.sheet` from RemoteAccessSection
+// the first time cloud access reaches `.online`. Whether it shows at all is
+// decided by the pure `FirstRunCloudAccessGate` (unit-tested); this file is
+// the thin SwiftUI renderer + the "Got it" dismissal that sets
+// `BridgeDefaults.hasSeenCloudAccessFirstRun = true`.
+//
+// Q2 lock (COA 2026-05-27): shown one time only.
+
+import SwiftUI
+
+public struct FirstRunCloudAccessModal: View {
+    /// Called when the user taps "Got it". The parent persists the flag and
+    /// dismisses the sheet.
+    private let onDismiss: () -> Void
+
+    public init(onDismiss: @escaping () -> Void = {}) {
+        self.onDismiss = onDismiss
+    }
+
+    /// The three guide steps. `static` + `Equatable` so the content is
+    /// assertable headlessly without rendering the view.
+    public struct Step: Sendable, Equatable, Identifiable {
+        public let id: Int
+        public let symbol: String
+        public let title: String
+        public init(id: Int, symbol: String, title: String) {
+            self.id = id
+            self.symbol = symbol
+            self.title = title
+        }
+    }
+
+    /// `nonisolated` so the (pure value) step content is assertable headlessly
+    /// without a MainActor hop — the SF Symbols + copy are the packet contract.
+    public nonisolated static let steps: [Step] = [
+        Step(id: 1, symbol: "doc.on.clipboard", title: "Copy your MCP URL below."),
+        Step(id: 2, symbol: "safari", title: "Open Claude.ai → Settings → Integrations."),
+        Step(id: 3, symbol: "checkmark.circle", title: "Paste your URL and connect.")
+    ]
+
+    public var body: some View {
+        VStack(spacing: 18) {
+            VStack(spacing: 6) {
+                ZStack {
+                    Circle()
+                        .fill(NotionPalette.blue.opacity(0.20))
+                        .frame(width: 52, height: 52)
+                    Image(systemName: "cloud")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(NotionPalette.blue)
+                }
+                Text("Connect Claude to this Mac")
+                    .font(.system(size: 18, weight: .semibold))
+                Text("Three quick steps to add this Mac as a tool in Claude.ai.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.top, 8)
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(Self.steps) { step in
+                    stepRow(step)
+                }
+            }
+
+            Button(action: onDismiss) {
+                Text("Got it")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(24)
+        .frame(width: 360)
+    }
+
+    @ViewBuilder
+    private func stepRow(_ step: Step) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+                    .frame(width: 34, height: 34)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.10), lineWidth: 0.5)
+                    )
+                Image(systemName: step.symbol)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(NotionPalette.blue)
+            }
+            Text(step.title)
+                .font(.system(size: 13))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+    }
+}

--- a/NotionBridge/UI/Sections/ProvisioningProgressView.swift
+++ b/NotionBridge/UI/Sections/ProvisioningProgressView.swift
@@ -1,0 +1,138 @@
+// ProvisioningProgressView.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · UI · Sections
+//
+// Renders `EnableCloudAccessFlow.state` while the Enable Cloud Access toggle
+// is provisioning. Inline in `RemoteAccessSection` (under the toggle row).
+//
+// The state→presentation mapping is factored into the pure, Sendable
+// `ProvisioningPresentation` value so it is unit-asserted headlessly (no
+// SwiftUI render, no WindowServer) — the same headless-decision shape the
+// rest of the app uses (CommandsController, the streamableHTTP gate, …).
+// The SwiftUI view is a thin renderer over that mapping.
+
+import SwiftUI
+
+/// Pure, deterministic description of what the progress UI shows for a given
+/// flow state. Unit-tested directly (DoD: "ProvisioningProgressView shows
+/// correct state for all flow states").
+public struct ProvisioningPresentation: Sendable, Equatable {
+    /// Which visual the row leads with.
+    public enum Indicator: Sendable, Equatable {
+        case none           // .idle — nothing shown
+        case spinner        // .checkingAccount / .provisioning — indeterminate
+        case browser        // .signingIn — "opening browser" affordance
+        case success        // .connected — checkmark
+        case failure        // .failed — error glyph + Retry
+    }
+
+    public let indicator: Indicator
+    public let title: String
+    /// Whether a Retry affordance is offered (only on `.failed`).
+    public let showsRetry: Bool
+    /// Whether the connected MCP URL row is shown (only on `.connected`).
+    public let showsURL: Bool
+
+    public init(indicator: Indicator, title: String, showsRetry: Bool, showsURL: Bool) {
+        self.indicator = indicator
+        self.title = title
+        self.showsRetry = showsRetry
+        self.showsURL = showsURL
+    }
+
+    /// Map a flow state to its presentation. Total over the state enum.
+    public static func make(for state: EnableCloudAccessState) -> ProvisioningPresentation {
+        switch state {
+        case .idle:
+            return .init(indicator: .none, title: "", showsRetry: false, showsURL: false)
+        case .checkingAccount:
+            return .init(indicator: .spinner, title: "Checking your account…",
+                         showsRetry: false, showsURL: false)
+        case .signingIn:
+            return .init(indicator: .browser, title: "Opening browser for sign in…",
+                         showsRetry: false, showsURL: false)
+        case .provisioning:
+            return .init(indicator: .spinner, title: "Setting up your Bridge…",
+                         showsRetry: false, showsURL: false)
+        case .connected:
+            return .init(indicator: .success, title: "Connected",
+                         showsRetry: false, showsURL: true)
+        case .failed(let error):
+            return .init(indicator: .failure, title: error.userMessage,
+                         showsRetry: true, showsURL: false)
+        }
+    }
+}
+
+/// Inline progress UI for the Enable Cloud Access flow. Renders the pure
+/// `ProvisioningPresentation` for the flow's current state and exposes a
+/// `Retry` button (on `.failed`) that calls back into the flow.
+public struct ProvisioningProgressView: View {
+    private let state: EnableCloudAccessState
+    /// The connected MCP URL (shown on `.connected`).
+    private let mcpURL: String?
+    /// Retry handler — wired to `flow.start()` by the parent.
+    private let onRetry: () -> Void
+
+    public init(
+        state: EnableCloudAccessState,
+        mcpURL: String? = nil,
+        onRetry: @escaping () -> Void = {}
+    ) {
+        self.state = state
+        self.mcpURL = mcpURL
+        self.onRetry = onRetry
+    }
+
+    private var presentation: ProvisioningPresentation {
+        ProvisioningPresentation.make(for: state)
+    }
+
+    public var body: some View {
+        let p = presentation
+        if p.indicator == .none {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    indicatorView(p.indicator)
+                    Text(p.title)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(p.indicator == .failure ? Color.red : .primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    if p.showsRetry {
+                        Button("Retry", action: onRetry)
+                            .buttonStyle(.borderless)
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                }
+                if p.showsURL, let url = mcpURL, !url.isEmpty {
+                    Text(url)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func indicatorView(_ indicator: ProvisioningPresentation.Indicator) -> some View {
+        switch indicator {
+        case .none:
+            EmptyView()
+        case .spinner:
+            ProgressView()
+                .controlSize(.small)
+        case .browser:
+            Image(systemName: "safari")
+                .foregroundStyle(NotionPalette.blue)
+        case .success:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failure:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+        }
+    }
+}

--- a/NotionBridge/UI/Sections/RemoteAccessSection.swift
+++ b/NotionBridge/UI/Sections/RemoteAccessSection.swift
@@ -38,10 +38,54 @@ public struct RemoteAccessSection: View {
 
     @State private var displayState: DisplayState
     @State private var cloudAccessEnabled: Bool
+    /// WS-F: the Enable-flow state machine. Lazily built on first toggle-ON
+    /// so the static preview / non-interactive paths carry no live deps.
+    @State private var flow: EnableCloudAccessFlow?
 
-    public init(displayState: DisplayState = .disabled) {
+    /// WS-F: factory for the live Enable flow. Injectable so tests / previews
+    /// can supply a mock-backed flow; defaults to `.live()` over the shared
+    /// `BridgeCloudManager`-shaped provisioner.
+    private let makeFlow: @MainActor () -> EnableCloudAccessFlow
+
+    public init(
+        displayState: DisplayState = .disabled,
+        makeFlow: @escaping @MainActor () -> EnableCloudAccessFlow = { RemoteAccessSection.defaultFlow() }
+    ) {
         self._displayState = State(initialValue: displayState)
         self._cloudAccessEnabled = State(initialValue: displayState != .disabled)
+        self.makeFlow = makeFlow
+    }
+
+    /// Build the production Enable flow over a fresh `BridgeCloudManager`.
+    /// The manager runs on `main` (the flow is `@MainActor`); the live
+    /// Worker base URL is resolved by `.live()` (configurable; WS-A gates
+    /// the real network path).
+    ///
+    /// NOTE: WS-C shipped `BridgeCloudManager` with injectable `TunnelProcess`
+    /// / `PasskeyGate` seams but only the in-memory `Fake*` conformers; the
+    /// real cloudflared process + Secure-Enclave passkey conformers land with
+    /// the live Worker (WS-A) / operator tenant (PKT-810). Until then the
+    /// manager is assembled over those seams so the toggle, state machine,
+    /// and `BridgeDefaults` wiring are all live — only the underlying network
+    /// + cloudflared remain gated. The passkey gate is unused on the
+    /// provisioning path (it guards auth-passdown, not provision()).
+    @MainActor
+    public static func defaultFlow() -> EnableCloudAccessFlow {
+        let manager = BridgeCloudManager(
+            tunnel: FakeTunnelProcess(),
+            passkeyGate: FakePasskeyGate(outcome: .approved),
+            node: LocalNodeContext(ownerID: "local", deviceID: deviceIdentifier())
+        )
+        return EnableCloudAccessFlow.live(provisioner: manager)
+    }
+
+    /// A stable-ish device identifier for the local node (hostname-derived).
+    @MainActor
+    private static func deviceIdentifier() -> String {
+        let host = ProcessInfo.processInfo.hostName
+            .replacingOccurrences(of: ".local", with: "")
+            .replacingOccurrences(of: " ", with: "-")
+        return host.isEmpty ? "this-mac" : host
     }
 
     public var body: some View {
@@ -103,14 +147,72 @@ public struct RemoteAccessSection: View {
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .onChange(of: cloudAccessEnabled) { _, on in
-                            // Static slice: reflect intent locally only.
-                            displayState = on ? .connecting : .disabled
+                            handleToggle(on)
                         }
                 }
                 Divider().background(Color.white.opacity(0.08))
                 statusRow
+                if let flow, ProvisioningPresentation.make(for: flow.state).indicator != .none {
+                    ProvisioningProgressView(
+                        state: flow.state,
+                        mcpURL: connectedMCPURL,
+                        onRetry: { flow.start() }
+                    )
+                }
             }
         }
+        // Mirror the flow's terminal transitions back onto the toggle +
+        // status dot (DoD: success → green/.connected; failure → revert).
+        .onChange(of: flowStateKey) { _, _ in syncFromFlow() }
+    }
+
+    // MARK: - Toggle wiring (WS-F)
+
+    /// Toggle ON → start the Enable flow; toggle OFF → cancel any in-flight
+    /// run and return to disabled.
+    private func handleToggle(_ on: Bool) {
+        if on {
+            let f = flow ?? makeFlow()
+            flow = f
+            displayState = .connecting
+            f.start()
+        } else {
+            flow?.cancel()
+            displayState = .disabled
+        }
+    }
+
+    /// A hashable projection of the flow state so `.onChange` fires on every
+    /// transition (the flow itself isn't Equatable as a whole).
+    private var flowStateKey: String {
+        guard let flow else { return "nil" }
+        return String(describing: flow.state)
+    }
+
+    /// Reconcile the local display state + toggle from the flow's state.
+    private func syncFromFlow() {
+        guard let flow else { return }
+        switch flow.state {
+        case .idle:
+            displayState = .disabled
+        case .checkingAccount, .signingIn, .provisioning:
+            displayState = .connecting
+        case .connected:
+            displayState = .online
+        case .failed:
+            // Flow already reverted BridgeDefaults.cloudAccessEnabled = false;
+            // snap the toggle + dot back so the UI matches.
+            displayState = .offline
+            if cloudAccessEnabled { cloudAccessEnabled = false }
+        }
+    }
+
+    /// The connected MCP URL surfaced on success, from the persisted tunnel
+    /// hostname (BridgeDefaults), if any.
+    private var connectedMCPURL: String? {
+        guard let host = UserDefaults.standard.string(forKey: BridgeDefaults.cloudTunnelHostname),
+              !host.isEmpty else { return nil }
+        return "https://\(host)/mcp"
     }
 
     private var statusRow: some View {

--- a/NotionBridge/UI/Sections/RemoteAccessSection.swift
+++ b/NotionBridge/UI/Sections/RemoteAccessSection.swift
@@ -13,6 +13,7 @@
 // and states the security contract the user is opting into.
 
 import SwiftUI
+import AppKit
 
 public struct RemoteAccessSection: View {
     /// Mirrors the WS-C `CloudConnectionState` machine for display. Static
@@ -42,6 +43,18 @@ public struct RemoteAccessSection: View {
     /// so the static preview / non-interactive paths carry no live deps.
     @State private var flow: EnableCloudAccessFlow?
 
+    // MARK: WS-G state
+
+    /// Whether the one-time first-run guide sheet is presented.
+    @State private var showFirstRun = false
+    /// Whether the Disable-confirmation dialog is presented.
+    @State private var showDisableConfirm = false
+    /// Whether the Add-to-Claude.ai copy+hint has been shown (drives the
+    /// inline confirmation line under the button).
+    @State private var didCopyMCPURL = false
+    /// Backing store for the `hasSeenCloudAccessFirstRun` one-time gate.
+    private let defaults: UserDefaults
+
     /// WS-F: factory for the live Enable flow. Injectable so tests / previews
     /// can supply a mock-backed flow; defaults to `.live()` over the shared
     /// `BridgeCloudManager`-shaped provisioner.
@@ -49,10 +62,12 @@ public struct RemoteAccessSection: View {
 
     public init(
         displayState: DisplayState = .disabled,
+        defaults: UserDefaults = .standard,
         makeFlow: @escaping @MainActor () -> EnableCloudAccessFlow = { RemoteAccessSection.defaultFlow() }
     ) {
         self._displayState = State(initialValue: displayState)
         self._cloudAccessEnabled = State(initialValue: displayState != .disabled)
+        self.defaults = defaults
         self.makeFlow = makeFlow
     }
 
@@ -99,6 +114,27 @@ public struct RemoteAccessSection: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
+        // WS-G: one-time first-run guide, shown on the first transition to
+        // .online (gated by hasSeenCloudAccessFirstRun).
+        .sheet(isPresented: $showFirstRun) {
+            FirstRunCloudAccessModal {
+                defaults.set(true, forKey: BridgeDefaults.hasSeenCloudAccessFirstRun)
+                showFirstRun = false
+            }
+        }
+        // WS-G: Disable-while-online confirmation. Confirm tears the tunnel
+        // down + clears state; Cancel reverts the toggle to ON with no side
+        // effects.
+        .confirmationDialog(
+            "Disable Cloud Access?",
+            isPresented: $showDisableConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Disable", role: .destructive) { confirmDisable() }
+            Button("Cancel", role: .cancel) { cancelDisable() }
+        } message: {
+            Text("Your MCP URL will stop working until re-enabled.")
+        }
     }
 
     // MARK: - Hero
@@ -159,6 +195,7 @@ public struct RemoteAccessSection: View {
                         onRetry: { flow.start() }
                     )
                 }
+                addToClaudeRow
             }
         }
         // Mirror the flow's terminal transitions back onto the toggle +
@@ -168,18 +205,49 @@ public struct RemoteAccessSection: View {
 
     // MARK: - Toggle wiring (WS-F)
 
-    /// Toggle ON → start the Enable flow; toggle OFF → cancel any in-flight
-    /// run and return to disabled.
+    /// Toggle ON → start the Enable flow. Toggle OFF: if cloud access is
+    /// currently online (a live connection), intercept with the WS-G Disable
+    /// confirmation (the toggle visually flips OFF but no teardown happens
+    /// until the user confirms); otherwise (mid-flow / not yet online) just
+    /// cancel the in-flight run.
     private func handleToggle(_ on: Bool) {
         if on {
+            // Already online (e.g. the toggle was just reverted by a cancelled
+            // Disable) → the connection is live; do NOT restart provisioning.
+            guard displayState != .online else { return }
+            didCopyMCPURL = false
             let f = flow ?? makeFlow()
             flow = f
             displayState = .connecting
             f.start()
+        } else if displayState == .online {
+            // Guard the teardown behind a confirmation (DoD).
+            showDisableConfirm = true
         } else {
             flow?.cancel()
             displayState = .disabled
         }
+    }
+
+    // MARK: - Disable flow (WS-G)
+
+    /// User confirmed Disable: tear the tunnel down, clear persisted state,
+    /// and drop the UI to disabled. The toggle is already visually OFF.
+    private func confirmDisable() {
+        showDisableConfirm = false
+        didCopyMCPURL = false
+        let f = flow
+        Task { @MainActor in
+            await f?.disable()
+            displayState = .disabled
+        }
+    }
+
+    /// User cancelled Disable: revert the toggle back to ON. No teardown, no
+    /// state change — the tunnel keeps running.
+    private func cancelDisable() {
+        showDisableConfirm = false
+        if !cloudAccessEnabled { cloudAccessEnabled = true }
     }
 
     /// A hashable projection of the flow state so `.onChange` fires on every
@@ -199,6 +267,7 @@ public struct RemoteAccessSection: View {
             displayState = .connecting
         case .connected:
             displayState = .online
+            maybePresentFirstRun()
         case .failed:
             // Flow already reverted BridgeDefaults.cloudAccessEnabled = false;
             // snap the toggle + dot back so the UI matches.
@@ -210,9 +279,79 @@ public struct RemoteAccessSection: View {
     /// The connected MCP URL surfaced on success, from the persisted tunnel
     /// hostname (BridgeDefaults), if any.
     private var connectedMCPURL: String? {
-        guard let host = UserDefaults.standard.string(forKey: BridgeDefaults.cloudTunnelHostname),
+        guard let host = defaults.string(forKey: BridgeDefaults.cloudTunnelHostname),
               !host.isEmpty else { return nil }
         return "https://\(host)/mcp"
+    }
+
+    /// The persisted tunnel hostname (drives the Add-to-Claude.ai enabled
+    /// state — enabled only once a hostname exists).
+    private var cloudTunnelHostname: String? {
+        let host = defaults.string(forKey: BridgeDefaults.cloudTunnelHostname)
+        return (host?.isEmpty == false) ? host : nil
+    }
+
+    // MARK: - First-run gate (WS-G)
+
+    /// Present the one-time first-run guide if the gate allows (online + flag
+    /// not yet set). Idempotent — the gate + the `hasSeen` flag prevent a
+    /// second presentation.
+    private func maybePresentFirstRun() {
+        let hasSeen = defaults.bool(forKey: BridgeDefaults.hasSeenCloudAccessFirstRun)
+        if FirstRunCloudAccessGate.shouldPresent(isOnline: true, hasSeenFirstRun: hasSeen) {
+            showFirstRun = true
+        }
+    }
+
+    // MARK: - Add to Claude.ai (WS-G)
+
+    /// The "Add to Claude.ai" affordance — enabled only when a tunnel hostname
+    /// is provisioned. Q3 (COA 2026-05-27) shipped as copy + inline hint
+    /// (`ClaudeAIIntegration.shippedMode == .copyAndHint`): the deep-link
+    /// format could not be confirmed at build time, so we copy the MCP URL and
+    /// instruct the user to paste it in Claude.ai → Settings → Integrations.
+    @ViewBuilder
+    private var addToClaudeRow: some View {
+        if displayState == .online {
+            VStack(alignment: .leading, spacing: 6) {
+                Button {
+                    addToClaude()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus.circle")
+                        Text("Add to Claude.ai")
+                    }
+                    .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.borderless)
+                .disabled(cloudTunnelHostname == nil)
+                if didCopyMCPURL {
+                    Text(ClaudeAIIntegration.pasteHint)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    /// Execute the Add-to-Claude.ai action per the shipped mode. In
+    /// `.copyAndHint` (the Q3 fallback) it copies the MCP URL to the pasteboard
+    /// and reveals the inline hint. In `.openBrowser` (reserved, gated on a
+    /// confirmed Q3 format) it would open the encoded deep link.
+    private func addToClaude() {
+        guard let mcp = ClaudeAIIntegration.mcpURL(forHostname: cloudTunnelHostname) else { return }
+        switch ClaudeAIIntegration.shippedMode {
+        case .copyAndHint:
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(mcp, forType: .string)
+            didCopyMCPURL = true
+        case .openBrowser:
+            if let url = ClaudeAIIntegration.deepLink(forHostname: cloudTunnelHostname) {
+                NSWorkspace.shared.open(url)
+            }
+        }
     }
 
     private var statusRow: some View {

--- a/NotionBridge/UI/SkillsView.swift
+++ b/NotionBridge/UI/SkillsView.swift
@@ -274,7 +274,9 @@ struct SkillsView: View {
 
     @ViewBuilder
     private func fileSkillRow(_ fs: ParsedSkill) -> some View {
-        HStack(spacing: 12) {
+        // PKT-934 W2: parity with skillRow — top-align so the status
+        // toggle tracks the title line when the summary wraps.
+        HStack(alignment: .top, spacing: 12) {
             Toggle("", isOn: Binding(
                 get: { fileSkillEnabledMap[fs.path.path] ?? true },
                 set: { newValue in
@@ -290,6 +292,8 @@ struct SkillsView: View {
                 Text(fs.name)
                     .fontWeight(.medium)
                     .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 let summary: String = {
                     if case .string(let d) = fs.frontmatter["description"] { return d }
                     return ""
@@ -395,7 +399,10 @@ struct SkillsView: View {
 
     @ViewBuilder
     private func skillRow(_ skill: SkillsManager.Skill, at index: Int) -> some View {
-        HStack(spacing: 12) {
+        // PKT-934 W2: top-align the row so the leading status toggle and
+        // trailing controls sit against the title line even when the
+        // summary wraps to a second line (was center → toggle floated).
+        HStack(alignment: .top, spacing: 12) {
             Toggle("", isOn: Binding(
                 get: { skill.enabled },
                 set: { _ in skillsManager.toggleSkill(named: skill.name) }
@@ -430,9 +437,14 @@ struct SkillsView: View {
                     // glyph so its click-to-open affordance is visible without
                     // a hover. Double-click still enters rename mode.
                     HStack(spacing: 4) {
+                        // PKT-934 W2: long titles (80+ chars) truncate with a
+                        // tail glyph instead of wrapping unbounded and
+                        // shoving the trailing controls out of alignment.
                         Text(skill.name)
                             .fontWeight(.medium)
                             .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                         Image(systemName: "arrow.up.right.square")
                             .font(.caption2)
                             .foregroundStyle(.secondary)

--- a/NotionBridgeTests/CalendarModuleTests.swift
+++ b/NotionBridgeTests/CalendarModuleTests.swift
@@ -1,0 +1,384 @@
+// CalendarModuleTests.swift
+// NotionBridge · Tests
+//
+// PKT-962 (v3.7·I): unit tests for the calendar_* tool family against the
+// injectable `CalendarStoring` seam — no live EventKit / TCC. Covers tool
+// registration + tiering, CRUD round-trips, date-range filtering, and the
+// access-denied path. Handlers are invoked directly off their
+// `ToolRegistration` so dispatch (security gate / license / UserDefaults)
+// stays out of the unit boundary — the seam is what's under test. Mirrors
+// RemindersModuleTests (PKT-957), the v3.7·D template this packet reuses.
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+// MARK: - In-memory mock seam
+
+/// Deterministic in-memory `CalendarStoring` for tests. `authStatus` drives
+/// the access-denied branch; the dictionaries model calendars + events. The
+/// range filter is implemented exactly as the production EventKit predicate
+/// behaves: an event overlaps [start, end] when its start < query.end AND its
+/// end > query.start.
+final class MockCalendarStore: CalendarStoring, @unchecked Sendable {
+    var authStatus: CalendarAuthStatus
+    private(set) var cals: [CalendarInfo]
+    private(set) var items: [String: CalendarEvent] = [:]
+    private var seq = 0
+
+    init(authStatus: CalendarAuthStatus = .authorized, calendars: [CalendarInfo]? = nil) {
+        self.authStatus = authStatus
+        self.cals = calendars ?? [
+            CalendarInfo(id: "cal-home", title: "Home", isDefault: true, allowsModify: true),
+            CalendarInfo(id: "cal-work", title: "Work", isDefault: false, allowsModify: true)
+        ]
+    }
+
+    func authorizationStatus() -> CalendarAuthStatus { authStatus }
+
+    func ensureAccess() async throws {
+        switch authStatus {
+        case .authorized: return
+        case .notDetermined, .denied, .restricted:
+            throw CalendarModuleError.accessDenied
+        }
+    }
+
+    func calendars() async throws -> [CalendarInfo] {
+        try await ensureAccess()
+        return cals
+    }
+
+    private func calTitle(_ id: String) -> String {
+        cals.first(where: { $0.id == id })?.title ?? ""
+    }
+
+    func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
+        try await ensureAccess()
+        var out = Array(items.values)
+        if let calId = query.calendarId {
+            guard cals.contains(where: { $0.id == calId }) else {
+                throw CalendarModuleError.calendarNotFound(calId)
+            }
+            out = out.filter { $0.calendarId == calId }
+        }
+        // Overlap test (string ISO-8601 compares lexicographically when
+        // zero-padded + same offset — the harness uses Z-suffixed times).
+        out = out.filter { $0.start < query.end && $0.end > query.start }
+        return out.sorted { $0.start < $1.start }
+    }
+
+    func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        try await ensureAccess()
+        let calId = draft.calendarId ?? "cal-home"
+        guard cals.contains(where: { $0.id == calId }) else {
+            throw CalendarModuleError.calendarNotFound(calId)
+        }
+        guard let start = draft.start else { throw CalendarModuleError.missingRequired("start") }
+        guard let end = draft.end else { throw CalendarModuleError.missingRequired("end") }
+        seq += 1
+        let id = "evt-\(seq)"
+        let event = CalendarEvent(
+            id: id,
+            title: draft.title ?? "",
+            start: start,
+            end: end,
+            allDay: draft.allDay ?? false,
+            calendarId: calId,
+            calendarTitle: calTitle(calId),
+            location: draft.location,
+            notes: draft.notes
+        )
+        items[id] = event
+        return event
+    }
+
+    func update(id: String, _ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        try await ensureAccess()
+        guard var event = items[id] else { throw CalendarModuleError.notFound(id) }
+        if let t = draft.title { event.title = t }
+        if let s = draft.start { event.start = s }
+        if let e = draft.end { event.end = e }
+        if let a = draft.allDay { event.allDay = a }
+        if let loc = draft.location { event.location = loc }
+        if let n = draft.notes { event.notes = n }
+        if let c = draft.calendarId {
+            guard cals.contains(where: { $0.id == c }) else {
+                throw CalendarModuleError.calendarNotFound(c)
+            }
+            event.calendarId = c
+            event.calendarTitle = calTitle(c)
+        }
+        items[id] = event
+        return event
+    }
+
+    func delete(id: String) async throws {
+        try await ensureAccess()
+        guard items[id] != nil else { throw CalendarModuleError.notFound(id) }
+        items[id] = nil
+    }
+}
+
+// MARK: - Test helpers
+
+private func makeCalendarRouter(_ store: CalendarStoring) async -> ToolRouter {
+    let gate = SecurityGate()
+    let log = AuditLog()
+    let router = ToolRouter(securityGate: gate, auditLog: log)
+    await CalendarModule.register(on: router, store: store)
+    return router
+}
+
+/// Invoke a tool's handler directly (bypasses dispatch gating — the seam is
+/// the unit under test).
+private func callCalendarHandler(_ router: ToolRouter, _ name: String, _ args: Value) async throws -> Value {
+    let regs = await router.registrations(forModule: "calendar")
+    guard let reg = regs.first(where: { $0.name == name }) else {
+        throw TestError.assertion("tool \(name) not registered")
+    }
+    return try await reg.handler(args)
+}
+
+private func calField(_ v: Value, _ key: String) -> Value? {
+    if case .object(let d) = v { return d[key] }
+    return nil
+}
+
+func runCalendarModuleTests() async {
+    print("\n\u{1F4C5} CalendarModule Tests (PKT-962 · v3.7·I)")
+
+    // MARK: registration + tiering
+
+    await test("CalendarModule registers exactly 5 tools") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        let tools = await router.registrations(forModule: "calendar")
+        try expect(tools.count == 5, "expected 5 calendar tools, got \(tools.count)")
+    }
+
+    await test("calendar tiering: list/events open, create/update notify, delete request") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        let tools = await router.registrations(forModule: "calendar")
+        let byName = Dictionary(tools.map { ($0.name, $0) }, uniquingKeysWith: { a, _ in a })
+        try expect(byName["calendar_list"]?.tier == .open, "list must be .open")
+        try expect(byName["calendar_events"]?.tier == .open, "events must be .open")
+        try expect(byName["calendar_create"]?.tier == .notify, "create must be .notify")
+        try expect(byName["calendar_update"]?.tier == .notify, "update must be .notify")
+        try expect(byName["calendar_delete"]?.tier == .request, "delete must be .request")
+    }
+
+    // MARK: calendar_list
+
+    await test("calendar_list returns the seeded calendars with default flag") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        let result = try await callCalendarHandler(router, "calendar_list", .object([:]))
+        guard case .int(let count)? = calField(result, "count") else {
+            throw TestError.assertion("missing count")
+        }
+        try expect(count == 2, "expected 2 calendars, got \(count)")
+        guard case .array(let arr)? = calField(result, "calendars") else {
+            throw TestError.assertion("missing calendars array")
+        }
+        let defaults = arr.filter { calField($0, "isDefault") == .bool(true) }
+        try expect(defaults.count == 1, "exactly one default calendar expected")
+    }
+
+    // MARK: CRUD round-trip
+
+    await test("calendar_create returns a new id + record") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        let result = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Standup"),
+            "start": .string("2026-06-05T09:00:00Z"),
+            "end": .string("2026-06-05T09:30:00Z"),
+            "location": .string("Zoom")
+        ]))
+        guard case .string(let id)? = calField(result, "id") else {
+            throw TestError.assertion("create returned no id")
+        }
+        try expect(!id.isEmpty, "empty id")
+        let rec = calField(result, "event")!
+        try expect(calField(rec, "title") == .string("Standup"), "title mismatch")
+        try expect(calField(rec, "start") == .string("2026-06-05T09:00:00Z"), "start mismatch")
+        try expect(calField(rec, "end") == .string("2026-06-05T09:30:00Z"), "end mismatch")
+        try expect(calField(rec, "location") == .string("Zoom"), "location mismatch")
+        try expect(calField(rec, "calendar") == .string("Home"), "should default to Home calendar")
+    }
+
+    await test("calendar_create requires title, start, and end") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        // missing title
+        do {
+            _ = try await callCalendarHandler(router, "calendar_create", .object([
+                "start": .string("2026-06-05T09:00:00Z"), "end": .string("2026-06-05T10:00:00Z")
+            ]))
+            throw TestError.assertion("expected invalidArguments for missing title")
+        } catch is ToolRouterError { /* expected */ }
+        // missing end
+        do {
+            _ = try await callCalendarHandler(router, "calendar_create", .object([
+                "title": .string("x"), "start": .string("2026-06-05T09:00:00Z")
+            ]))
+            throw TestError.assertion("expected invalidArguments for missing end")
+        } catch is ToolRouterError { /* expected */ }
+    }
+
+    await test("calendar_update mutates fields and can move calendars") {
+        let store = MockCalendarStore()
+        let router = await makeCalendarRouter(store)
+        let created = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Draft"),
+            "start": .string("2026-06-10T12:00:00Z"),
+            "end": .string("2026-06-10T13:00:00Z")
+        ]))
+        guard case .string(let id)? = calField(created, "id") else { throw TestError.assertion("no id") }
+
+        let updated = try await callCalendarHandler(router, "calendar_update", .object([
+            "id": .string(id),
+            "title": .string("Final review"),
+            "start": .string("2026-06-10T14:00:00Z"),
+            "end": .string("2026-06-10T15:00:00Z"),
+            "calendarId": .string("cal-work")
+        ]))
+        let rec = calField(updated, "event")!
+        try expect(calField(rec, "title") == .string("Final review"), "title not updated")
+        try expect(calField(rec, "start") == .string("2026-06-10T14:00:00Z"), "start not updated")
+        try expect(calField(rec, "calendar") == .string("Work"), "calendar not moved")
+    }
+
+    await test("calendar_update on a missing event surfaces notFound") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        do {
+            _ = try await callCalendarHandler(router, "calendar_update", .object([
+                "id": .string("evt-nope"), "title": .string("ghost")
+            ]))
+            throw TestError.assertion("expected notFound")
+        } catch let e as CalendarModuleError {
+            try expect(e == .notFound("evt-nope"), "expected notFound, got \(e)")
+        }
+    }
+
+    // MARK: date-range filter
+
+    await test("calendar_events filters by date range (overlap semantics)") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        // June 5 morning event
+        _ = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Inside"),
+            "start": .string("2026-06-05T09:00:00Z"),
+            "end": .string("2026-06-05T10:00:00Z")
+        ]))
+        // June 20 event — outside the queried window
+        _ = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Outside"),
+            "start": .string("2026-06-20T09:00:00Z"),
+            "end": .string("2026-06-20T10:00:00Z")
+        ]))
+
+        let result = try await callCalendarHandler(router, "calendar_events", .object([
+            "start": .string("2026-06-05T00:00:00Z"),
+            "end": .string("2026-06-06T00:00:00Z")
+        ]))
+        guard case .int(let n)? = calField(result, "count") else { throw TestError.assertion("no count") }
+        try expect(n == 1, "expected 1 event in the June 5 window, got \(n)")
+        guard case .array(let arr)? = calField(result, "events") else { throw TestError.assertion("no events array") }
+        try expect(calField(arr[0], "title") == .string("Inside"), "wrong event returned")
+    }
+
+    await test("calendar_events scoped to a calendarId only returns that calendar's events") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        _ = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Home thing"), "start": .string("2026-06-05T09:00:00Z"),
+            "end": .string("2026-06-05T10:00:00Z"), "calendarId": .string("cal-home")
+        ]))
+        _ = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Work thing"), "start": .string("2026-06-05T11:00:00Z"),
+            "end": .string("2026-06-05T12:00:00Z"), "calendarId": .string("cal-work")
+        ]))
+        let result = try await callCalendarHandler(router, "calendar_events", .object([
+            "start": .string("2026-06-05T00:00:00Z"),
+            "end": .string("2026-06-06T00:00:00Z"),
+            "calendarId": .string("cal-work")
+        ]))
+        try expect(calField(result, "count") == .int(1), "expected 1 work event")
+        guard case .array(let arr)? = calField(result, "events") else { throw TestError.assertion("no events array") }
+        try expect(calField(arr[0], "title") == .string("Work thing"), "wrong scoped event")
+    }
+
+    await test("calendar_events requires start and end") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        do {
+            _ = try await callCalendarHandler(router, "calendar_events", .object([
+                "start": .string("2026-06-05T00:00:00Z")
+            ]))
+            throw TestError.assertion("expected invalidArguments for missing end")
+        } catch is ToolRouterError { /* expected */ }
+    }
+
+    // MARK: delete
+
+    await test("calendar_delete removes the event (re-delete throws notFound)") {
+        let router = await makeCalendarRouter(MockCalendarStore())
+        let created = try await callCalendarHandler(router, "calendar_create", .object([
+            "title": .string("Temp"), "start": .string("2026-06-05T09:00:00Z"),
+            "end": .string("2026-06-05T10:00:00Z")
+        ]))
+        guard case .string(let id)? = calField(created, "id") else { throw TestError.assertion("no id") }
+
+        let del = try await callCalendarHandler(router, "calendar_delete", .object(["id": .string(id)]))
+        try expect(calField(del, "deleted") == .bool(true), "delete should report true")
+
+        // gone from the range query
+        let listed = try await callCalendarHandler(router, "calendar_events", .object([
+            "start": .string("2026-06-05T00:00:00Z"), "end": .string("2026-06-06T00:00:00Z")
+        ]))
+        try expect(calField(listed, "count") == .int(0), "deleted event still listed")
+
+        // re-delete surfaces a notFound (no silent success on a missing id)
+        do {
+            _ = try await callCalendarHandler(router, "calendar_delete", .object(["id": .string(id)]))
+            throw TestError.assertion("expected notFound on re-delete")
+        } catch let e as CalendarModuleError {
+            try expect(e == .notFound(id), "expected notFound, got \(e)")
+        }
+    }
+
+    // MARK: access-denied path
+
+    await test("access-denied: every calendar tool surfaces accessDenied") {
+        let store = MockCalendarStore(authStatus: .denied)
+        let router = await makeCalendarRouter(store)
+
+        func expectDenied(_ name: String, _ args: Value) async {
+            await test("  \(name) → accessDenied when TCC denied") {
+                do {
+                    _ = try await callCalendarHandler(router, name, args)
+                    throw TestError.assertion("expected accessDenied")
+                } catch let e as CalendarModuleError {
+                    try expect(e == .accessDenied, "expected accessDenied, got \(e)")
+                }
+            }
+        }
+
+        await expectDenied("calendar_list", .object([:]))
+        await expectDenied("calendar_events", .object([
+            "start": .string("2026-06-05T00:00:00Z"), "end": .string("2026-06-06T00:00:00Z")
+        ]))
+        await expectDenied("calendar_create", .object([
+            "title": .string("x"), "start": .string("2026-06-05T09:00:00Z"),
+            "end": .string("2026-06-05T10:00:00Z")
+        ]))
+        await expectDenied("calendar_update", .object(["id": .string("evt-1"), "title": .string("y")]))
+        await expectDenied("calendar_delete", .object(["id": .string("evt-1")]))
+    }
+
+    await test("notDetermined status also throws accessDenied (no live TCC prompt in tests)") {
+        let router = await makeCalendarRouter(MockCalendarStore(authStatus: .notDetermined))
+        do {
+            _ = try await callCalendarHandler(router, "calendar_list", .object([:]))
+            throw TestError.assertion("expected accessDenied for notDetermined")
+        } catch let e as CalendarModuleError {
+            try expect(e == .accessDenied)
+        }
+    }
+}

--- a/NotionBridgeTests/CloudAccessWSGTests.swift
+++ b/NotionBridgeTests/CloudAccessWSGTests.swift
@@ -1,0 +1,206 @@
+// CloudAccessWSGTests.swift — WS-G (PKT-923 · Bridge Cloud Access)
+// NotionBridge · Tests (custom harness — no XCTest; see TestRunner.swift)
+//
+// Covers the terminal Cloud-Access UI packet end-to-end against fakes — NO
+// SwiftUI render, NO WindowServer, NO cloudflared, NO network:
+//
+//   • FirstRunCloudAccessGate — the one-time presentation rule (Q2 lock):
+//     online + unseen → present; online + seen → suppressed; offline → never.
+//   • Disable flow — EnableCloudAccessFlow.disable() drives the CloudTeardown
+//     seam (tunnel stop) AND clears the persisted toggle + hostname; the live
+//     BridgeCloudManager.disable() returns the machine to .disabled.
+//   • Cancel reverts — the gate + state model: cancelling the confirmation
+//     leaves the enabled flag and hostname untouched (no side effects).
+//   • Add-to-Claude.ai — MCP URL derivation + the .urlQueryAllowed-based
+//     percent-encoding contract (round-trips; escapes embedded delimiters);
+//     shipped mode is the Q3 copy+hint fallback.
+//   • FirstRunCloudAccessModal content — the 3-step guide is exactly the
+//     packet-specified SF Symbols + copy.
+
+import Foundation
+import NotionBridgeLib
+
+// MARK: - Fakes
+
+/// In-memory CloudFlowDefaults — starts ON with a hostname (a live connection)
+/// so disable() has something to clear.
+private final class WSGFakeDefaults: CloudFlowDefaults, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _enabled: Bool
+    private var _hostname: String?
+    init(enabled: Bool = true, hostname: String? = "device-A.bridge.kup.solutions") {
+        self._enabled = enabled
+        self._hostname = hostname
+    }
+    var cloudAccessEnabled: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _enabled }
+        set { lock.lock(); _enabled = newValue; lock.unlock() }
+    }
+    var cloudTunnelHostname: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _hostname }
+        set { lock.lock(); _hostname = newValue; lock.unlock() }
+    }
+}
+
+/// Records whether the teardown seam was driven.
+private final class RecordingTeardown: CloudTeardown, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls = 0
+    var calls: Int { lock.withLock { _calls } }
+    @discardableResult
+    func disable() async -> CloudConnectionState {
+        lock.withLock { _calls += 1 }
+        return .disabled
+    }
+}
+
+private final class WSGFakeTokenStore: CloudTokenStore, @unchecked Sendable {
+    let token: String?
+    init(token: String?) { self.token = token }
+}
+
+private final class WSGNoopBrowser: AuthBrowserOpening, @unchecked Sendable {
+    @discardableResult func open(_ url: URL) -> Bool { true }
+}
+
+private final class WSGFakeProvisioner: CloudProvisioning, @unchecked Sendable {
+    func provision(baseURL: String) async throws -> String { "device-A.bridge.kup.solutions" }
+    func startTunnel() async throws {}
+}
+
+@MainActor
+private func makeDisableFlow(
+    defaults: WSGFakeDefaults,
+    teardown: CloudTeardown?
+) -> EnableCloudAccessFlow {
+    EnableCloudAccessFlow(
+        tokenStore: WSGFakeTokenStore(token: "tok"),
+        browser: WSGNoopBrowser(),
+        provisioner: WSGFakeProvisioner(),
+        defaults: defaults,
+        teardown: teardown,
+        config: WorkOSConfig(baseURL: "https://api.workos.com",
+                             clientID: "client_test",
+                             redirectURI: "bridge-auth://callback"),
+        provisionBaseURL: "https://mock.local"
+    )
+}
+
+func runCloudAccessWSGTests() async {
+    print("\n\u{2601} Bridge Cloud Access · WS-G Tests (PKT-923)")
+
+    // MARK: - First-run gate (Q2: shown once)
+
+    await test("WS-G first-run: online + unseen → modal presents") {
+        try expect(FirstRunCloudAccessGate.shouldPresent(isOnline: true, hasSeenFirstRun: false),
+                   "first online with the flag unset must present the modal")
+    }
+
+    await test("WS-G first-run: online + already seen → suppressed (one-time gate)") {
+        try expect(!FirstRunCloudAccessGate.shouldPresent(isOnline: true, hasSeenFirstRun: true),
+                   "the hasSeen flag must prevent reappearance")
+    }
+
+    await test("WS-G first-run: not online → never presents (regardless of flag)") {
+        try expect(!FirstRunCloudAccessGate.shouldPresent(isOnline: false, hasSeenFirstRun: false),
+                   "must not present before reaching online")
+        try expect(!FirstRunCloudAccessGate.shouldPresent(isOnline: false, hasSeenFirstRun: true),
+                   "must not present before reaching online")
+    }
+
+    // MARK: - Disable flow (confirm → teardown + state clear)
+
+    await test("WS-G disable: confirm tears down tunnel + clears toggle + hostname") {
+        let defaults = WSGFakeDefaults(enabled: true, hostname: "device-A.bridge.kup.solutions")
+        let teardown = RecordingTeardown()
+        let flow = await makeDisableFlow(defaults: defaults, teardown: teardown)
+        await flow.disable()
+        try expect(teardown.calls == 1, "disable() must drive the teardown seam exactly once, got \(teardown.calls)")
+        try expect(defaults.cloudAccessEnabled == false, "cloudAccessEnabled must be cleared to false")
+        try expect(defaults.cloudTunnelHostname == nil, "cloudTunnelHostname must be cleared")
+        let state = await MainActor.run { flow.state }
+        try expect(state == .idle, "flow must return to .idle after disable, got \(state)")
+    }
+
+    await test("WS-G disable: live BridgeCloudManager.disable() returns .disabled (stops tunnel)") {
+        let mgr = BridgeCloudManager(
+            tunnel: FakeTunnelProcess(startSucceeds: true, health: .healthy),
+            passkeyGate: FakePasskeyGate(outcome: .approved),
+            node: LocalNodeContext(ownerID: "owner-1", deviceID: "device-A")
+        )
+        _ = await mgr.enable()
+        let online = await mgr.state
+        try expect(online == .online, "precondition: manager should be online, got \(online)")
+        let after = await mgr.disable()
+        try expect(after == .disabled, "disable() must return .disabled (NOT .disconnected), got \(after)")
+        let state = await mgr.state
+        try expect(state == .disabled, "manager state must be .disabled after teardown, got \(state)")
+    }
+
+    // MARK: - Cancel reverts (no side effects)
+
+    await test("WS-G disable: cancel path leaves enabled flag + hostname untouched") {
+        // The Cancel branch performs NO teardown and NO defaults mutation — it
+        // only re-flips the UI toggle. Model that here: a flow that is never
+        // told to disable() must leave the live connection fully intact.
+        let defaults = WSGFakeDefaults(enabled: true, hostname: "device-A.bridge.kup.solutions")
+        let teardown = RecordingTeardown()
+        _ = await makeDisableFlow(defaults: defaults, teardown: teardown)
+        // (No disable() call — this is the cancel branch.)
+        try expect(teardown.calls == 0, "cancel must not drive teardown")
+        try expect(defaults.cloudAccessEnabled == true, "cancel must leave the toggle ON")
+        try expect(defaults.cloudTunnelHostname == "device-A.bridge.kup.solutions",
+                   "cancel must leave the hostname intact")
+    }
+
+    // MARK: - Add to Claude.ai (URL derivation + encoding · Q3)
+
+    await test("WS-G claude.ai: MCP URL derives from hostname; nil when unprovisioned") {
+        try expect(ClaudeAIIntegration.mcpURL(forHostname: "host.example") == "https://host.example/mcp",
+                   "MCP URL must be https://{host}/mcp")
+        try expect(ClaudeAIIntegration.mcpURL(forHostname: nil) == nil, "nil hostname → no MCP URL")
+        try expect(ClaudeAIIntegration.mcpURL(forHostname: "") == nil, "empty hostname → no MCP URL")
+    }
+
+    await test("WS-G claude.ai: query-value encoding escapes embedded delimiters + round-trips") {
+        let mcp = "https://device-A.bridge.kup.solutions/mcp"
+        guard let encoded = ClaudeAIIntegration.encodeQueryValue(mcp) else {
+            throw TestError.assertion("encoding returned nil")
+        }
+        // The scheme separators that would corrupt a query value must be escaped.
+        try expect(!encoded.contains("://"), "':' and '/' must be percent-escaped, got \(encoded)")
+        try expect(encoded.contains("%3A") && encoded.contains("%2F"),
+                   "expected %3A (:) and %2F (/) in the encoded value, got \(encoded)")
+        // Round-trip: decoding the encoded value yields exactly the original.
+        try expect(encoded.removingPercentEncoding == mcp,
+                   "encoded value must round-trip back to the original MCP URL")
+    }
+
+    await test("WS-G claude.ai: deep link embeds encoded MCP URL under mcp_url=") {
+        guard let url = ClaudeAIIntegration.deepLink(forHostname: "device-A.bridge.kup.solutions") else {
+            throw TestError.assertion("deepLink returned nil for a valid hostname")
+        }
+        let s = url.absoluteString
+        try expect(s.hasPrefix("https://claude.ai/settings/integrations?mcp_url="),
+                   "deep link must target the integrations page with the mcp_url param, got \(s)")
+        try expect(ClaudeAIIntegration.deepLink(forHostname: nil) == nil,
+                   "no hostname → no deep link")
+    }
+
+    await test("WS-G claude.ai: shipped mode is the Q3 copy+hint fallback") {
+        try expect(ClaudeAIIntegration.shippedMode == .copyAndHint,
+                   "Q3 unconfirmed → ship copy+hint, not browser open")
+        try expect(!ClaudeAIIntegration.pasteHint.isEmpty, "the paste hint must be non-empty")
+    }
+
+    // MARK: - First-run modal content
+
+    await test("WS-G modal: 3-step guide carries the packet-specified symbols + copy") {
+        let steps = FirstRunCloudAccessModal.steps
+        try expect(steps.count == 3, "the guide must have exactly 3 steps, got \(steps.count)")
+        try expect(steps[0].symbol == "doc.on.clipboard", "step 1 symbol drift: \(steps[0].symbol)")
+        try expect(steps[1].symbol == "safari", "step 2 symbol drift: \(steps[1].symbol)")
+        try expect(steps[2].symbol == "checkmark.circle", "step 3 symbol drift: \(steps[2].symbol)")
+        try expect(steps.allSatisfy { !$0.title.isEmpty }, "every step must have copy")
+    }
+}

--- a/NotionBridgeTests/CloudStatusModuleTests.swift
+++ b/NotionBridgeTests/CloudStatusModuleTests.swift
@@ -1,0 +1,235 @@
+// CloudStatusModuleTests.swift — WS-D (PKT-921 · Bridge Cloud Access)
+// NotionBridge · Tests (custom harness — no XCTest; see TestRunner.swift)
+//
+// Covers WS-D's three seams against the REAL WS-C API (no real cloudflared,
+// no network, no 30s waits):
+//
+//   1. CloudHeartbeat — start fires `refreshHealth()` ticks; stop halts them;
+//      start is idempotent (no duplicate timer). The interval is shrunk and
+//      ticks are observed via `onTick` so the loop is deterministic.
+//   2. bridge_status registration is GATED — present after
+//      `registerCloudStatusTool`, absent after `deregister`; never in the
+//      static feature-module surface. Handler returns the canonical payload.
+//   3. CloudStatusPayload / tools/list conditional — `up` + `macToolsAvailable`
+//      by state, and `ServerManager.filterForCloud`: cloud+offline → only
+//      bridge_status; cloud+online/degraded → full; the local path is
+//      never filtered.
+
+import Foundation
+import NotionBridgeLib
+
+private let wsdNode = LocalNodeContext(ownerID: "owner-d", deviceID: "device-D")
+
+/// Build a manager whose tunnel reports `health`, already enabled so its
+/// `state` reflects that health (online/degraded). For offline/disabled we
+/// just leave it disabled or script a failing start.
+private func makeManager(health: TunnelHealth) async -> BridgeCloudManager {
+    let mgr = BridgeCloudManager(
+        tunnel: FakeTunnelProcess(startSucceeds: true, health: health),
+        passkeyGate: FakePasskeyGate(outcome: .approved),
+        node: wsdNode
+    )
+    _ = await mgr.enable()
+    return mgr
+}
+
+/// A couple of throwaway Mac-tool registrations so the filter has something to
+/// remove (we don't want to depend on the full 195-tool surface here).
+private func sampleMacTools() -> [ToolRegistration] {
+    func mk(_ name: String) -> ToolRegistration {
+        ToolRegistration(
+            name: name, module: "sample", tier: .open,
+            description: "x",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in .object([:]) }
+        )
+    }
+    return [mk("file_read"), mk("shell_exec"), mk("messages_send")]
+}
+
+func runCloudStatusModuleTests() async {
+    print("\n\u{2601} CloudStatusModule / WS-D (PKT-921) — heartbeat + bridge_status + tools/list")
+
+    // MARK: - 1. Heartbeat start/stop on toggle
+
+    await test("WS-D heartbeat: start fires refreshHealth ticks on the timer") {
+        let mgr = await makeManager(health: .healthy)
+        let collector = TickCollector()
+        let heartbeat = CloudHeartbeat(
+            manager: mgr,
+            interval: .milliseconds(20),
+            onTick: { state in Task { await collector.record(state) } }
+        )
+        await heartbeat.start()
+        try expect(await heartbeat.isRunning, "heartbeat should be running after start()")
+        // Wait (bounded) for at least 2 ticks so we know the timer is looping.
+        let got = await collector.waitForCount(2, timeoutMs: 2000)
+        await heartbeat.stop()
+        try expect(got, "expected >=2 heartbeat ticks within the window")
+        let states = await collector.states
+        try expect(states.allSatisfy { $0 == .online }, "healthy tunnel ticks should report .online, got \(states)")
+    }
+
+    await test("WS-D heartbeat: stop halts further ticks (toggle OFF)") {
+        let mgr = await makeManager(health: .healthy)
+        let collector = TickCollector()
+        let heartbeat = CloudHeartbeat(
+            manager: mgr,
+            interval: .milliseconds(20),
+            onTick: { state in Task { await collector.record(state) } }
+        )
+        await heartbeat.start()
+        _ = await collector.waitForCount(1, timeoutMs: 2000)
+        await heartbeat.stop()
+        try expect(!(await heartbeat.isRunning), "heartbeat should not be running after stop()")
+        let afterStop = await collector.count
+        // Give the (now-cancelled) loop ample time to NOT tick again.
+        try await Task.sleep(for: .milliseconds(120))
+        let later = await collector.count
+        try expect(later == afterStop, "no ticks may fire after stop(): \(afterStop) → \(later)")
+    }
+
+    await test("WS-D heartbeat: start is idempotent (no duplicate timer)") {
+        let mgr = await makeManager(health: .healthy)
+        let heartbeat = CloudHeartbeat(manager: mgr, interval: .seconds(30))
+        await heartbeat.start()
+        await heartbeat.start() // second start must be a no-op
+        try expect(await heartbeat.isRunning, "still running after double start()")
+        await heartbeat.stop()
+        try expect(!(await heartbeat.isRunning), "single stop() must fully halt a double-started heartbeat")
+    }
+
+    // MARK: - 2. bridge_status gated registration + payload
+
+    await test("WS-D bridge_status: registered then deregistered (cloud gate)") {
+        let gate = SecurityGate()
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: gate, auditLog: log)
+        let mgr = await makeManager(health: .healthy)
+
+        // Absent before registration.
+        let before = await router.allRegistrations().map(\.name)
+        try expect(!before.contains(CloudStatusModule.toolName), "bridge_status must be absent before registration")
+
+        await BridgeModuleRegistry.registerCloudStatusTool(on: router, manager: mgr)
+        let after = await router.allRegistrations().map(\.name)
+        try expect(after.contains(CloudStatusModule.toolName), "bridge_status must be present after registerCloudStatusTool")
+
+        await router.deregister(name: CloudStatusModule.toolName)
+        let final = await router.allRegistrations().map(\.name)
+        try expect(!final.contains(CloudStatusModule.toolName), "bridge_status must be gone after deregister (toggle OFF)")
+    }
+
+    await test("WS-D bridge_status: NOT part of the static feature-module count") {
+        // The static surface is registered without any cloud tool.
+        let gate = SecurityGate()
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: gate, auditLog: log)
+        await BridgeModuleRegistry.registerStaticFeatureModules(
+            on: router,
+            includeStripe: false,
+            registerSession: { r in await SessionModule.register(on: r, auditLog: log) }
+        )
+        let names = await router.allRegistrations().map(\.name)
+        try expect(!names.contains(CloudStatusModule.toolName),
+                   "bridge_status must NOT be in registerStaticFeatureModules (it is cloud-gated)")
+        try expect(names.count == BridgeConstants.staticFeatureModuleToolCount,
+                   "static count drift \(names.count) vs \(BridgeConstants.staticFeatureModuleToolCount) — WS-D must not change it")
+    }
+
+    await test("WS-D bridge_status: handler returns the canonical payload shape") {
+        let mgr = await makeManager(health: .healthy)   // → .online
+        let reg = CloudStatusModule.makeTool(manager: mgr)
+        let out = try await reg.handler(.object([:]))
+        guard case .object(let obj) = out else {
+            throw TestError.assertion("payload must be a JSON object, got \(out)")
+        }
+        try expect(obj["tool"] == .string("bridge_status"), "tool field")
+        try expect(obj["ok"] == .bool(true), "ok field")
+        try expect(obj["state"] == .string("online"), "state should be online, got \(String(describing: obj["state"]))")
+        try expect(obj["up"] == .bool(true), "online ⇒ up=true")
+        try expect(obj["macToolsAvailable"] == .bool(true), "online ⇒ macToolsAvailable=true")
+        try expect(obj["schemaVersion"] == .int(CloudStatusPayload.schemaVersion), "schemaVersion field")
+    }
+
+    await test("WS-D bridge_status: degraded is 'up'; offline/disabled are 'down'") {
+        // Pure payload-builder checks across all five states.
+        try expect(CloudStatusPayload.isUp(.online), "online up")
+        try expect(CloudStatusPayload.isUp(.degraded), "degraded up")
+        try expect(!CloudStatusPayload.isUp(.connecting), "connecting not up")
+        try expect(!CloudStatusPayload.isUp(.offline), "offline not up")
+        try expect(!CloudStatusPayload.isUp(.disabled), "disabled not up")
+
+        if case .object(let deg) = CloudStatusPayload.make(state: .degraded) {
+            try expect(deg["up"] == .bool(true) && deg["macToolsAvailable"] == .bool(true),
+                       "degraded ⇒ up + macToolsAvailable true")
+        } else { throw TestError.assertion("degraded payload not an object") }
+
+        if case .object(let off) = CloudStatusPayload.make(state: .offline) {
+            try expect(off["up"] == .bool(false) && off["macToolsAvailable"] == .bool(false),
+                       "offline ⇒ up + macToolsAvailable false")
+        } else { throw TestError.assertion("offline payload not an object") }
+    }
+
+    // MARK: - 3. tools/list conditional by state
+
+    await test("WS-D tools/list: CLOUD + .offline → only bridge_status (Mac tools hidden)") {
+        var regs = sampleMacTools()
+        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
+        let filtered = ServerManager.filterForCloud(regs, cloudState: .offline)
+        let names = Set(filtered.map(\.name))
+        try expect(names == [CloudStatusModule.toolName],
+                   "offline cloud request must expose ONLY bridge_status, got \(names.sorted())")
+    }
+
+    await test("WS-D tools/list: CLOUD + .disabled → only bridge_status") {
+        var regs = sampleMacTools()
+        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
+        let filtered = ServerManager.filterForCloud(regs, cloudState: .disabled)
+        try expect(Set(filtered.map(\.name)) == [CloudStatusModule.toolName],
+                   "disabled cloud request must expose ONLY bridge_status")
+    }
+
+    await test("WS-D tools/list: CLOUD + .online/.degraded → full list (Mac tools shown)") {
+        var regs = sampleMacTools()
+        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
+        for state in [CloudConnectionState.online, .degraded] {
+            let filtered = ServerManager.filterForCloud(regs, cloudState: state)
+            try expect(filtered.count == regs.count,
+                       "\(state) must keep the full list (\(filtered.count) vs \(regs.count))")
+        }
+    }
+
+    await test("WS-D tools/list: non-cloud (local) request is never filtered") {
+        // The local stdio/SSE path never calls filterForCloud (isCloudRequest
+        // defaults to false). Prove the default resolver + that an unfiltered
+        // pass keeps everything even when the cloud state is offline.
+        let mgr = ServerManager(onToolCall: {})  // default isCloudRequest = { false }
+        try expect(!(await mgr.isCloudHeartbeatRunning()), "fresh manager has no heartbeat")
+        // A local request would skip filterForCloud entirely; the filter, if it
+        // WERE applied with a non-down state, is also a no-op — assert the
+        // online passthrough as the local-equivalent invariant.
+        let regs = sampleMacTools()
+        let passthrough = ServerManager.filterForCloud(regs, cloudState: .online)
+        try expect(passthrough.count == regs.count, "online (local-equivalent) keeps full list")
+    }
+}
+
+// MARK: - Tick collector (actor — deterministic heartbeat observation)
+
+private actor TickCollector {
+    private(set) var states: [CloudConnectionState] = []
+    var count: Int { states.count }
+
+    func record(_ state: CloudConnectionState) { states.append(state) }
+
+    /// Poll until at least `n` ticks have landed or the timeout elapses.
+    func waitForCount(_ n: Int, timeoutMs: Int) async -> Bool {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000.0)
+        while Date() < deadline {
+            if states.count >= n { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return states.count >= n
+    }
+}

--- a/NotionBridgeTests/EnableCloudAccessFlowTests.swift
+++ b/NotionBridgeTests/EnableCloudAccessFlowTests.swift
@@ -1,0 +1,559 @@
+// EnableCloudAccessFlowTests.swift — WS-F (Bridge Cloud Access · Enable flow)
+// NotionBridge · Tests (custom harness — no XCTest; see main.swift)
+//
+// Drives the WS-F Enable flow end-to-end against fakes — NO NSWorkspace, NO
+// Keychain prompt, NO cloudflared, NO live WorkOS network, NO real clock.
+// Full live end-to-end QA is gated on PKT-810 (operator WorkOS tenant) +
+// WS-A (live Worker); this suite covers every transition + edge against the
+// configurable base URL + mock seams the packet mandates.
+//
+// Coverage (DoD / QA checklist):
+//   • bridge-auth:// callback URL parse (code / wrong-scheme / wrong-host /
+//     missing-code / workos-error).
+//   • WorkOS auth URL builder (env-configurable client id + redirect, query
+//     shape) + config resolution / placeholder fallback.
+//   • CloudAuthCallbackHandler: parse → exchange (mock) → persist (mock) →
+//     posts .cloudAuthCallbackReceived (success + failure userInfo).
+//   • Flow state machine all paths: idle→checkingAccount→signingIn→
+//     provisioning→connected; token-present skip-to-provisioning;
+//     auth-callback success/failure; auth cancellation timeout (120s) →
+//     .failed(.authCancelled) + toggle reverts; provision timeout (30s) →
+//     .failed(.provisionTimeout); provision failure; cancel().
+//   • ProvisioningPresentation mapping for every state.
+
+import Foundation
+import NotionBridgeLib
+
+// MARK: - Fakes (deterministic seams)
+
+private final class FakeTokenStore: CloudTokenStore, @unchecked Sendable {
+    let token: String?
+    init(token: String?) { self.token = token }
+}
+
+private final class RecordingBrowser: AuthBrowserOpening, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _opened: [URL] = []
+    var opened: [URL] { lock.lock(); defer { lock.unlock() }; return _opened }
+    @discardableResult
+    func open(_ url: URL) -> Bool {
+        lock.lock(); _opened.append(url); lock.unlock(); return true
+    }
+}
+
+private final class FakeFlowDefaults: CloudFlowDefaults, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _enabled = true        // toggle starts ON (user flipped it on)
+    private var _hostname: String?
+    var cloudAccessEnabled: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _enabled }
+        set { lock.lock(); _enabled = newValue; lock.unlock() }
+    }
+    var cloudTunnelHostname: String? {
+        get { lock.lock(); defer { lock.unlock() }; return _hostname }
+        set { lock.lock(); _hostname = newValue; lock.unlock() }
+    }
+}
+
+/// Provisioner mock: scripts provision()/startTunnel() success/throw, and can
+/// hang forever (to trigger the 30s guard) via `neverReturns`.
+private final class FakeProvisioner: CloudProvisioning, @unchecked Sendable {
+    let hostname: String
+    let provisionThrows: Bool
+    let tunnelThrows: Bool
+    let neverReturns: Bool
+    init(hostname: String = "device-A.bridge.kup.solutions",
+         provisionThrows: Bool = false,
+         tunnelThrows: Bool = false,
+         neverReturns: Bool = false) {
+        self.hostname = hostname
+        self.provisionThrows = provisionThrows
+        self.tunnelThrows = tunnelThrows
+        self.neverReturns = neverReturns
+    }
+    func provision(baseURL: String) async throws -> String {
+        if neverReturns {
+            // Park until cancelled (the 30s guard wins the race).
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        }
+        if provisionThrows { throw CloudError.provisionFailed }
+        return hostname
+    }
+    func startTunnel() async throws {
+        if tunnelThrows { throw CloudError.provisionFailed }
+    }
+}
+
+/// Clock whose `sleep(seconds:)` never resolves on its own — so a timeout
+/// only fires when the test explicitly `fire()`s it. Lets the 120s / 30s
+/// guards be exercised deterministically without real time.
+private final class ManualClock: CloudClock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [UUID: CheckedContinuation<Void, Error>] = [:]
+    /// A pending sleep that never resolves on its own — but IS cancellation
+    /// aware (a real `Task.sleep`-backed clock throws `CancellationError` on
+    /// cancel, so the fake must too, or a losing timeout-guard task would
+    /// never terminate and the enclosing task group would hang).
+    func sleep(seconds: Double) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                lock.lock()
+                if Task.isCancelled {
+                    lock.unlock()
+                    cont.resume(throwing: CancellationError())
+                } else {
+                    continuations[id] = cont
+                    lock.unlock()
+                }
+            }
+        } onCancel: {
+            lock.lock(); let c = continuations.removeValue(forKey: id); lock.unlock()
+            c?.resume(throwing: CancellationError())
+        }
+    }
+    /// Resolve all pending sleeps (i.e. fire the timeout).
+    func fire() {
+        lock.lock(); let conts = Array(continuations.values); continuations = [:]; lock.unlock()
+        for c in conts { c.resume() }
+    }
+}
+
+/// Clock that resolves every sleep immediately — used where we want the
+/// timeout guard to lose the race (it fires instantly but the work already
+/// completed) OR to drive an instant-timeout case.
+private final class ImmediateClock: CloudClock, @unchecked Sendable {
+    func sleep(seconds: Double) async throws { /* return at once */ }
+}
+
+private final class FakeTokenExchange: CloudTokenExchanging, @unchecked Sendable {
+    let token: String
+    let throwsError: Bool
+    init(token: String = "tok_live_fake", throwsError: Bool = false) {
+        self.token = token; self.throwsError = throwsError
+    }
+    func exchange(code: String, config: WorkOSConfig) async throws -> String {
+        if throwsError { throw CloudError.tokenExchangeFailed }
+        return token
+    }
+}
+
+private final class FakePersister: CloudTokenPersisting, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _persisted: [String] = []
+    let succeeds: Bool
+    init(succeeds: Bool = true) { self.succeeds = succeeds }
+    var persisted: [String] { lock.lock(); defer { lock.unlock() }; return _persisted }
+    @discardableResult
+    func persist(token: String) -> Bool {
+        lock.lock(); _persisted.append(token); lock.unlock(); return succeeds
+    }
+}
+
+// MARK: - Helpers
+
+/// Poll the @MainActor flow's state until `predicate` holds or a bounded
+/// number of yields elapse (deterministic — fakes resolve fast). Avoids any
+/// real wall-clock sleep.
+@MainActor
+private func waitFor(
+    _ flow: EnableCloudAccessFlow,
+    _ predicate: @escaping (EnableCloudAccessState) -> Bool,
+    maxYields: Int = 2000
+) async -> Bool {
+    var i = 0
+    while i < maxYields {
+        if predicate(flow.state) { return true }
+        await Task.yield()
+        i += 1
+    }
+    return predicate(flow.state)
+}
+
+private let wsfConfig = WorkOSConfig(
+    baseURL: "https://api.workos.com",
+    clientID: "client_test",
+    redirectURI: "bridge-auth://callback"
+)
+
+func runEnableCloudAccessFlowTests() async {
+    print("\n\u{2601} EnableCloudAccessFlow / WS-F Enable-flow Tests")
+
+    // MARK: - Callback URL parsing
+
+    await test("WS-F parse: valid bridge-auth://callback?code=… → .code") {
+        let url = URL(string: "bridge-auth://callback?code=abc123")!
+        try expect(CloudAuthCallback.parse(url) == .code("abc123"),
+                   "expected .code(abc123), got \(CloudAuthCallback.parse(url))")
+    }
+
+    await test("WS-F parse: wrong scheme → .invalid") {
+        let url = URL(string: "https://callback?code=abc")!
+        if case .invalid = CloudAuthCallback.parse(url) {} else {
+            throw TestError.assertion("expected .invalid for non-bridge-auth scheme")
+        }
+    }
+
+    await test("WS-F parse: wrong host → .invalid") {
+        let url = URL(string: "bridge-auth://wrong?code=abc")!
+        if case .invalid = CloudAuthCallback.parse(url) {} else {
+            throw TestError.assertion("expected .invalid for wrong host")
+        }
+    }
+
+    await test("WS-F parse: missing code → .invalid") {
+        let url = URL(string: "bridge-auth://callback")!
+        if case .invalid = CloudAuthCallback.parse(url) {} else {
+            throw TestError.assertion("expected .invalid for missing code")
+        }
+    }
+
+    await test("WS-F parse: workos error param → .invalid") {
+        let url = URL(string: "bridge-auth://callback?error=access_denied")!
+        if case .invalid = CloudAuthCallback.parse(url) {} else {
+            throw TestError.assertion("expected .invalid for error param")
+        }
+    }
+
+    // MARK: - Auth URL builder + config
+
+    await test("WS-F authURL: query carries client_id + redirect_uri + code response") {
+        let url = WorkOSAuthURLBuilder.authorizationURL(for: wsfConfig)
+        guard let url else { throw TestError.assertion("authorizationURL was nil") }
+        let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let items = comps?.queryItems ?? []
+        func val(_ n: String) -> String? { items.first { $0.name == n }?.value }
+        try expect(val("client_id") == "client_test", "client_id missing/wrong")
+        try expect(val("redirect_uri") == "bridge-auth://callback", "redirect_uri missing/wrong")
+        try expect(val("response_type") == "code", "response_type must be code")
+        try expect(url.path.hasSuffix("/user_management/authorize"),
+                   "unexpected auth path: \(url.path)")
+    }
+
+    await test("WS-F config: env override wins; absent falls back to placeholder") {
+        let resolved = WorkOSConfig.resolved(environment: [
+            "WORKOS_CLIENT_ID": "client_env",
+        ])
+        try expect(resolved.clientID == "client_env", "env client id should win")
+        try expect(resolved.baseURL == WorkOSConfig.placeholder.baseURL,
+                   "absent base URL should fall back to placeholder")
+        let empty = WorkOSConfig.resolved(environment: [:])
+        try expect(empty == .placeholder, "empty env should equal placeholder")
+    }
+
+    // MARK: - CloudAuthCallbackHandler
+
+    await test("WS-F handler: valid code → exchanges, persists, posts success") {
+        let center = NotificationCenter()
+        let persister = FakePersister(succeeds: true)
+        let handler = CloudAuthCallbackHandler(
+            config: wsfConfig,
+            exchange: FakeTokenExchange(token: "tok_X"),
+            persister: persister,
+            notificationCenter: center
+        )
+        let box = NotificationBox()
+        let obs = center.addObserver(forName: .cloudAuthCallbackReceived, object: nil, queue: nil) { note in
+            box.record(note.userInfo?[cloudAuthSuccessKey] as? Bool)
+        }
+        defer { center.removeObserver(obs) }
+
+        let owned = handler.handle(URL(string: "bridge-auth://callback?code=c1")!)
+        try expect(owned, "handler should own a bridge-auth callback URL")
+        // Drive the async exchange to completion.
+        var i = 0
+        while box.value == nil && i < 2000 { await Task.yield(); i += 1 }
+        try expect(box.value == true, "expected success=true notification, got \(String(describing: box.value))")
+        try expect(persister.persisted == ["tok_X"], "token should be persisted exactly once")
+    }
+
+    await test("WS-F handler: exchange failure → posts success=false, persists nothing") {
+        let center = NotificationCenter()
+        let persister = FakePersister()
+        let handler = CloudAuthCallbackHandler(
+            config: wsfConfig,
+            exchange: FakeTokenExchange(throwsError: true),
+            persister: persister,
+            notificationCenter: center
+        )
+        let box = NotificationBox()
+        let obs = center.addObserver(forName: .cloudAuthCallbackReceived, object: nil, queue: nil) { note in
+            box.record(note.userInfo?[cloudAuthSuccessKey] as? Bool)
+        }
+        defer { center.removeObserver(obs) }
+
+        _ = handler.handle(URL(string: "bridge-auth://callback?code=c1")!)
+        var i = 0
+        while box.value == nil && i < 2000 { await Task.yield(); i += 1 }
+        try expect(box.value == false, "expected success=false on exchange failure")
+        try expect(persister.persisted.isEmpty, "no token should be persisted on failure")
+    }
+
+    await test("WS-F handler: non-bridge-auth URL is not owned") {
+        let handler = CloudAuthCallbackHandler(exchange: FakeTokenExchange())
+        let owned = handler.handle(URL(string: "https://example.com/callback?code=c1")!)
+        try expect(!owned, "handler must not claim a non-bridge-auth URL")
+    }
+
+    await test("WS-F handler: malformed bridge-auth URL is owned + posts failure") {
+        let center = NotificationCenter()
+        let handler = CloudAuthCallbackHandler(
+            config: wsfConfig, exchange: FakeTokenExchange(), notificationCenter: center
+        )
+        let box = NotificationBox()
+        let obs = center.addObserver(forName: .cloudAuthCallbackReceived, object: nil, queue: nil) { note in
+            box.record(note.userInfo?[cloudAuthSuccessKey] as? Bool)
+        }
+        defer { center.removeObserver(obs) }
+        let owned = handler.handle(URL(string: "bridge-auth://callback")!) // no code
+        try expect(owned, "a bridge-auth URL (even malformed) is owned")
+        var i = 0
+        while box.value == nil && i < 2000 { await Task.yield(); i += 1 }
+        try expect(box.value == false, "malformed callback posts success=false")
+    }
+
+    // MARK: - State machine: token-present skip-to-provisioning
+
+    await test("WS-F flow: Keychain token present → skips sign-in → .connected (no browser)") {
+        await MainActor.run {} // hop on
+        let browser = RecordingBrowser()
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: "existing"),
+                browser: browser,
+                provisioner: FakeProvisioner(hostname: "host-1"),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ImmediateClock()
+            )
+        }
+        await MainActor.run { flow.start() }
+        let ok = await waitFor(flow) { $0 == .connected }
+        try expect(ok, "expected .connected; got \(await MainActor.run { flow.state })")
+        try expect(browser.opened.isEmpty, "browser must NOT open when a token is present")
+        try expect(defaults.cloudTunnelHostname == "host-1", "hostname should be persisted on success")
+        try expect(defaults.cloudAccessEnabled == true, "toggle stays ON on success")
+    }
+
+    // MARK: - State machine: full sign-in path
+
+    await test("WS-F flow: no token → opens browser → .signingIn; callback → .provisioning → .connected") {
+        let center = NotificationCenter()
+        let browser = RecordingBrowser()
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: nil),
+                browser: browser,
+                provisioner: FakeProvisioner(hostname: "host-2"),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ManualClock(),   // never auto-times-out
+                notificationCenter: center
+            )
+        }
+        await MainActor.run { flow.start() }
+        let signing = await waitFor(flow) { $0 == .signingIn }
+        try expect(signing, "expected .signingIn after start with no token")
+        try expect(browser.opened.count == 1, "browser should open exactly once")
+        // Simulate the AppDelegate callback (token already written).
+        center.post(name: .cloudAuthCallbackReceived, object: nil,
+                    userInfo: [cloudAuthSuccessKey: true])
+        let connected = await waitFor(flow) { $0 == .connected }
+        try expect(connected, "expected .connected after successful callback")
+        try expect(defaults.cloudTunnelHostname == "host-2", "hostname persisted")
+    }
+
+    await test("WS-F flow: callback failure → .failed(.authFailed) → toggle reverts") {
+        let center = NotificationCenter()
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: nil),
+                browser: RecordingBrowser(),
+                provisioner: FakeProvisioner(),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ManualClock(),
+                notificationCenter: center
+            )
+        }
+        await MainActor.run { flow.start() }
+        _ = await waitFor(flow) { $0 == .signingIn }
+        center.post(name: .cloudAuthCallbackReceived, object: nil,
+                    userInfo: [cloudAuthSuccessKey: false])
+        let failed = await waitFor(flow) { $0 == .failed(.authFailed) }
+        try expect(failed, "expected .failed(.authFailed)")
+        try expect(defaults.cloudAccessEnabled == false, "toggle must revert to OFF on failure")
+    }
+
+    // MARK: - Auth cancellation timeout (120s)
+
+    await test("WS-F flow: auth timeout (120s) → .failed(.authCancelled) → toggle reverts") {
+        let clock = ManualClock()
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: nil),
+                browser: RecordingBrowser(),
+                provisioner: FakeProvisioner(),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: clock,
+                notificationCenter: NotificationCenter()
+            )
+        }
+        await MainActor.run { flow.start() }
+        _ = await waitFor(flow) { $0 == .signingIn }
+        clock.fire()  // the 120s guard elapses with no callback
+        let failed = await waitFor(flow) { $0 == .failed(.authCancelled) }
+        try expect(failed, "expected .failed(.authCancelled) on auth timeout")
+        try expect(defaults.cloudAccessEnabled == false, "toggle reverts on auth timeout")
+    }
+
+    // MARK: - Provision timeout (30s)
+
+    await test("WS-F flow: provision timeout (30s) → .failed(.provisionTimeout)") {
+        let clock = ManualClock()
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: "existing"),  // straight to provisioning
+                browser: RecordingBrowser(),
+                provisioner: FakeProvisioner(neverReturns: true),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: clock
+            )
+        }
+        await MainActor.run { flow.start() }
+        let provisioning = await waitFor(flow) { $0 == .provisioning }
+        try expect(provisioning, "expected .provisioning (token present)")
+        clock.fire()  // the 30s provision guard elapses
+        let failed = await waitFor(flow) { $0 == .failed(.provisionTimeout) }
+        try expect(failed, "expected .failed(.provisionTimeout)")
+        try expect(defaults.cloudAccessEnabled == false, "toggle reverts on provision timeout")
+    }
+
+    await test("WS-F flow: provision() throws → .failed(.provisionFailed)") {
+        let defaults = FakeFlowDefaults()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: "existing"),
+                browser: RecordingBrowser(),
+                provisioner: FakeProvisioner(provisionThrows: true),
+                defaults: defaults,
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ManualClock()  // guard never fires; the throw wins
+            )
+        }
+        await MainActor.run { flow.start() }
+        let failed = await waitFor(flow) { if case .failed = $0 { return true }; return false }
+        try expect(failed, "expected .failed when provision throws")
+        let state = await MainActor.run { flow.state }
+        try expect(state == .failed(.provisionFailed), "expected .provisionFailed, got \(state)")
+    }
+
+    // MARK: - cancel() (toggle OFF mid-flow)
+
+    await test("WS-F flow: cancel() during sign-in → back to .idle, no .failed") {
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: nil),
+                browser: RecordingBrowser(),
+                provisioner: FakeProvisioner(),
+                defaults: FakeFlowDefaults(),
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ManualClock(),
+                notificationCenter: NotificationCenter()
+            )
+        }
+        await MainActor.run { flow.start() }
+        _ = await waitFor(flow) { $0 == .signingIn }
+        await MainActor.run { flow.cancel() }
+        let idle = await MainActor.run { flow.state == .idle }
+        try expect(idle, "cancel() should return the flow to .idle")
+    }
+
+    await test("WS-F flow: start() is idempotent while signing in (no second browser open)") {
+        let browser = RecordingBrowser()
+        let flow = await MainActor.run {
+            EnableCloudAccessFlow(
+                tokenStore: FakeTokenStore(token: nil),
+                browser: browser,
+                provisioner: FakeProvisioner(),
+                defaults: FakeFlowDefaults(),
+                config: wsfConfig,
+                provisionBaseURL: "https://mock.local",
+                clock: ManualClock(),
+                notificationCenter: NotificationCenter()
+            )
+        }
+        await MainActor.run { flow.start() }
+        _ = await waitFor(flow) { $0 == .signingIn }
+        await MainActor.run { flow.start() }  // second call — should be ignored
+        try expect(browser.opened.count == 1, "second start() must not reopen the browser")
+        await MainActor.run { flow.cancel() }  // tear down the in-flight auth wait
+    }
+
+    // MARK: - ProvisioningPresentation mapping
+
+    await test("WS-F presentation: every state maps to the spec'd UI") {
+        let idle = ProvisioningPresentation.make(for: .idle)
+        try expect(idle.indicator == .none && !idle.showsRetry && !idle.showsURL,
+                   ".idle should show nothing")
+
+        let checking = ProvisioningPresentation.make(for: .checkingAccount)
+        try expect(checking.indicator == .spinner, ".checkingAccount → spinner")
+
+        let signing = ProvisioningPresentation.make(for: .signingIn)
+        try expect(signing.indicator == .browser && signing.title.contains("browser"),
+                   ".signingIn → browser affordance + copy")
+
+        let prov = ProvisioningPresentation.make(for: .provisioning)
+        try expect(prov.indicator == .spinner && prov.title.contains("Setting up"),
+                   ".provisioning → spinner + 'Setting up your Bridge…'")
+
+        let connected = ProvisioningPresentation.make(for: .connected)
+        try expect(connected.indicator == .success && connected.showsURL && connected.title == "Connected",
+                   ".connected → checkmark + URL + 'Connected'")
+
+        let failed = ProvisioningPresentation.make(for: .failed(.provisionTimeout))
+        try expect(failed.indicator == .failure && failed.showsRetry,
+                   ".failed → error glyph + Retry")
+        try expect(failed.title == CloudError.provisionTimeout.userMessage,
+                   ".failed title should surface the error message")
+    }
+
+    // MARK: - BridgeCloudManager provisioning seam
+
+    await test("WS-F manager: provision() returns a hostname; startTunnel() brings state online") {
+        let mgr = BridgeCloudManager(
+            tunnel: FakeTunnelProcess(startSucceeds: true, health: .healthy),
+            passkeyGate: FakePasskeyGate(outcome: .approved),
+            node: LocalNodeContext(ownerID: "owner-1", deviceID: "device-A")
+        )
+        let host = try await mgr.provision(baseURL: "https://mock.local")
+        try expect(host.contains("device-A"), "hostname should derive from the node device id: \(host)")
+        try await mgr.startTunnel()
+        let state = await mgr.state
+        try expect(state == .online, "startTunnel() with a healthy fake tunnel → .online, got \(state)")
+    }
+}
+
+/// Thread-safe one-shot box for capturing a notification payload from a
+/// non-main observer queue.
+private final class NotificationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Bool?
+    var value: Bool? { lock.lock(); defer { lock.unlock() }; return _value }
+    func record(_ v: Bool?) { lock.lock(); if _value == nil { _value = v }; lock.unlock() }
+}

--- a/NotionBridgeTests/EnableCloudAccessFlowTests.swift
+++ b/NotionBridgeTests/EnableCloudAccessFlowTests.swift
@@ -153,8 +153,15 @@ private final class FakePersister: CloudTokenPersisting, @unchecked Sendable {
 // MARK: - Helpers
 
 /// Poll the @MainActor flow's state until `predicate` holds or a bounded
-/// number of yields elapse (deterministic — fakes resolve fast). Avoids any
-/// real wall-clock sleep.
+/// number of poll cycles elapse. The fast path is cooperative `Task.yield()`
+/// (fakes resolve in a few turns); but a transition that resolves a
+/// timeout-guard via a background-executor continuation + a `withTaskGroup`
+/// cancellation hop (the provision-timeout path) can need more scheduler
+/// progress than pure yields guarantee under load. So after a short burst of
+/// yields each cycle interleaves a tiny real sleep — guaranteeing wall-clock
+/// progress for the off-actor continuation — which removes the load-sensitive
+/// flake without weakening any assertion. Total worst-case wait stays well
+/// under a second.
 @MainActor
 private func waitFor(
     _ flow: EnableCloudAccessFlow,
@@ -164,7 +171,13 @@ private func waitFor(
     var i = 0
     while i < maxYields {
         if predicate(flow.state) { return true }
-        await Task.yield()
+        if i < 64 {
+            await Task.yield()
+        } else {
+            // ~0.5ms per cycle — guarantees the off-actor continuation/cancel
+            // hop gets real time even when the executor is saturated.
+            try? await Task.sleep(nanoseconds: 500_000)
+        }
         i += 1
     }
     return predicate(flow.state)

--- a/NotionBridgeTests/MailModuleTests.swift
+++ b/NotionBridgeTests/MailModuleTests.swift
@@ -1,0 +1,277 @@
+// MailModuleTests.swift – v3.7·H (PKT-961) MailModule Tests
+// NotionBridge · Tests
+//
+// Exercises the MailModule tools against an INJECTABLE mock AppleScript seam
+// (`MockMailScriptRunner`) — no Mail.app is launched and NO mail is ever sent.
+// The mock records every script it is handed so we can assert the send-guard
+// REFUSED a no-confirm send WITHOUT ever invoking the seam.
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+// MARK: - Mock AppleScript Seam
+
+/// Deterministic, side-effect-free MailScriptRunner. Records each script and
+/// returns a canned result (default success). A class (reference type) so the
+/// recorded scripts are observable after dispatch despite the `Sendable` seam.
+final class MockMailScriptRunner: MailScriptRunner, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _scripts: [String] = []
+    private let result: MailScriptResult
+
+    init(result: MailScriptResult = .success("")) {
+        self.result = result
+    }
+
+    var scripts: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _scripts
+    }
+
+    var runCount: Int { scripts.count }
+
+    func run(_ script: String) -> MailScriptResult {
+        lock.lock(); _scripts.append(script); lock.unlock()
+        return result
+    }
+}
+
+// MARK: - MailModule Tests
+
+func runMailModuleTests() async {
+    print("\n\u{1F4E7} MailModule Tests (PKT-961 · v3.7·H)")
+
+    // Each test installs a fresh mock seam; restore the production runner after.
+    func withMock(_ mock: MockMailScriptRunner, _ body: () async throws -> Void) async rethrows {
+        let prior = MailModule.scriptRunner
+        MailModule.scriptRunner = mock
+        defer { MailModule.scriptRunner = prior }
+        try await body()
+    }
+
+    func makeRouter() async -> ToolRouter {
+        let gate = SecurityGate()
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: gate, auditLog: log)
+        await MailModule.register(on: router)
+        return router
+    }
+
+    // 1. Registration — exactly the 5 mail_* tools.
+    await test("MailModule registers 5 tools") {
+        let router = await makeRouter()
+        let tools = await router.registrations(forModule: "mail")
+        try expect(tools.count == 5, "Expected 5 mail tools, got \(tools.count)")
+        let names = Set(tools.map(\.name))
+        for n in ["mail_list", "mail_read", "mail_search", "mail_draft", "mail_send"] {
+            try expect(names.contains(n), "Missing \(n)")
+        }
+    }
+
+    // 2. Tiering — list/read/search .open, draft .notify, send .request.
+    await test("mail tiers: list/read/search=.open, draft=.notify, send=.request") {
+        let router = await makeRouter()
+        let tools = await router.registrations(forModule: "mail")
+        func tier(_ name: String) throws -> SecurityTier {
+            guard let t = tools.first(where: { $0.name == name }) else {
+                throw TestError.assertion("missing \(name)")
+            }
+            return t.tier
+        }
+        try expect(try tier("mail_list") == .open, "mail_list must be .open")
+        try expect(try tier("mail_read") == .open, "mail_read must be .open")
+        try expect(try tier("mail_search") == .open, "mail_search must be .open")
+        try expect(try tier("mail_draft") == .notify, "mail_draft must be .notify")
+        try expect(try tier("mail_send") == .request, "mail_send must be .request")
+    }
+
+    // 3. mail_list — parses tab/newline rows from the seam.
+    await test("mail_list returns parsed rows from the seam") {
+        let fixture = "101\ttrue\tMon\talice@example.com\tHello\n102\tfalse\tTue\tbob@example.com\tRe: Hello"
+        let mock = MockMailScriptRunner(result: .success(fixture))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_list", arguments: .object(["limit": .int(10)]))
+            guard case .object(let dict) = result,
+                  case .int(let count) = dict["count"],
+                  case .array(let rows) = dict["rows"] else {
+                throw TestError.assertion("Expected {count, rows} object, got \(result)")
+            }
+            try expect(count == 2, "Expected 2 rows, got \(count)")
+            guard case .object(let r0) = rows[0], case .string(let id0) = r0["id"],
+                  case .string(let subj0) = r0["subject"] else {
+                throw TestError.assertion("row0 missing id/subject")
+            }
+            try expect(id0 == "101", "Expected id 101, got \(id0)")
+            try expect(subj0 == "Hello", "Expected subject 'Hello', got \(subj0)")
+        }
+    }
+
+    // 4. mail_read — parses header/body split from the seam.
+    await test("mail_read returns subject/sender/date/body") {
+        let fixture = "Project Update\nalice@example.com\nMon Jun 2\n---\nThe body line one.\nLine two."
+        let mock = MockMailScriptRunner(result: .success(fixture))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_read", arguments: .object(["messageId": .string("101")]))
+            guard case .object(let dict) = result,
+                  case .string(let subject) = dict["subject"],
+                  case .string(let body) = dict["body"] else {
+                throw TestError.assertion("Expected subject/body, got \(result)")
+            }
+            try expect(subject == "Project Update", "Expected subject, got \(subject)")
+            try expect(body.contains("body line one"), "Expected body content, got \(body)")
+        }
+    }
+
+    // 5. mail_search — keyword query parses matching rows.
+    await test("mail_search returns matching rows") {
+        let fixture = "201\tfalse\tWed\tcarol@example.com\tInvoice March"
+        let mock = MockMailScriptRunner(result: .success(fixture))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_search", arguments: .object(["query": .string("Invoice")]))
+            guard case .object(let dict) = result, case .int(let count) = dict["count"] else {
+                throw TestError.assertion("Expected count, got \(result)")
+            }
+            try expect(count == 1, "Expected 1 hit, got \(count)")
+            // The query keyword must have been escaped into the script.
+            try expect(mock.scripts.first?.contains("Invoice") == true, "search script should contain the query")
+        }
+    }
+
+    // 6. mail_draft — creates an UNSENT draft; the script must NOT send.
+    await test("mail_draft creates an unsent draft (no send command)") {
+        let mock = MockMailScriptRunner(result: .success("draft-42"))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_draft", arguments: .object([
+                "to": .string("alice@example.com"),
+                "subject": .string("Hi"),
+                "body": .string("Body text")
+            ]))
+            guard case .object(let dict) = result,
+                  case .bool(let drafted) = dict["drafted"],
+                  case .bool(let sent) = dict["sent"] else {
+                throw TestError.assertion("Expected drafted/sent flags, got \(result)")
+            }
+            try expect(drafted == true, "Expected drafted=true")
+            try expect(sent == false, "Expected sent=false for a draft")
+            // The draft script must never contain a `send` command.
+            let script = mock.scripts.first ?? ""
+            try expect(!script.contains("send newMsg"), "draft script must NOT send")
+            try expect(script.contains("save newMsg"), "draft script must save the message")
+        }
+    }
+
+    // 7. SEND-GUARD — mail_send WITHOUT the confirm token is REFUSED and
+    //    NEVER invokes the AppleScript seam (no mail sent).
+    await test("SEND-GUARD: mail_send WITHOUT confirm='SEND' is refused (seam never runs)") {
+        let mock = MockMailScriptRunner(result: .success("sent"))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_send", arguments: .object([
+                "to": .string("alice@example.com"),
+                "subject": .string("Should not send"),
+                "body": .string("nope"),
+                "confirm": .string("nope")   // wrong token
+            ]))
+            guard case .object(let dict) = result, case .bool(let sent) = dict["sent"] else {
+                throw TestError.assertion("Expected sent flag, got \(result)")
+            }
+            try expect(sent == false, "Expected sent=false without confirm='SEND'")
+            // The guard returns BEFORE building/running any script.
+            try expect(mock.runCount == 0, "send-guard MUST short-circuit before the AppleScript seam runs (runCount=\(mock.runCount))")
+        }
+    }
+
+    // 8. SEND-GUARD: a missing confirm token also refuses (still never sends).
+    await test("SEND-GUARD: mail_send with NO confirm key is rejected before the seam") {
+        let mock = MockMailScriptRunner(result: .success("sent"))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            do {
+                _ = try await router.dispatch(toolName: "mail_send", arguments: .object([
+                    "to": .string("alice@example.com"),
+                    "subject": .string("x"),
+                    "body": .string("y")
+                    // confirm absent → invalidArguments
+                ]))
+                throw TestError.assertion("Expected error for missing confirm")
+            } catch is ToolRouterError {
+                // Expected — missing required param.
+            }
+            try expect(mock.runCount == 0, "no-confirm send must not touch the seam")
+        }
+    }
+
+    // 9. mail_send WITH the exact confirm token sends through the (mock) seam.
+    await test("mail_send WITH confirm='SEND' sends through the seam") {
+        let mock = MockMailScriptRunner(result: .success("sent"))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_send", arguments: .object([
+                "to": .string("alice@example.com"),
+                "subject": .string("Approved"),
+                "body": .string("Go ahead"),
+                "confirm": .string("SEND")
+            ]))
+            guard case .object(let dict) = result, case .bool(let sent) = dict["sent"] else {
+                throw TestError.assertion("Expected sent flag, got \(result)")
+            }
+            try expect(sent == true, "Expected sent=true with confirm='SEND'")
+            try expect(mock.runCount == 1, "send should invoke the seam exactly once")
+            try expect(mock.scripts.first?.contains("send newMsg") == true, "send script must contain the send command")
+        }
+    }
+
+    // 10. Error path — a seam failure (e.g. TCC denial -1743) surfaces as a
+    //     structured error with guidance, not a crash.
+    await test("mail_list surfaces a seam failure as a structured error (TCC -1743)") {
+        let mock = MockMailScriptRunner(result: .failure(message: "Not authorized to send Apple events to Mail.", number: -1743))
+        try await withMock(mock) {
+            let router = await makeRouter()
+            let result = try await router.dispatch(toolName: "mail_list", arguments: .object([:]))
+            guard case .object(let dict) = result,
+                  case .string = dict["error"],
+                  case .int(let num) = dict["errorNumber"] else {
+                throw TestError.assertion("Expected structured error, got \(result)")
+            }
+            try expect(num == -1743, "Expected errorNumber -1743, got \(num)")
+            try expect(dict["tccDenied"] != nil, "Expected tccDenied guidance on -1743")
+        }
+    }
+
+    // 11. Argument validation — required params enforced for read/search/draft.
+    await test("mail_read / mail_search / mail_draft reject missing required params") {
+        let mock = MockMailScriptRunner()
+        try await withMock(mock) {
+            let router = await makeRouter()
+            for (tool, args) in [
+                ("mail_read", Value.object([:])),
+                ("mail_search", Value.object([:])),
+                ("mail_draft", Value.object(["to": .string("a@b.com")]))  // missing subject/body
+            ] {
+                do {
+                    _ = try await router.dispatch(toolName: tool, arguments: args)
+                    throw TestError.assertion("Expected error for \(tool) with missing params")
+                } catch is ToolRouterError {
+                    // Expected
+                }
+            }
+        }
+    }
+
+    // 12. Annotation catalog mirror — mail_send confirms, reads don't.
+    await test("mail annotations mirror the security model (send confirms, reads don't)") {
+        let send = ToolAnnotationCatalog.annotations(for: "mail_send")
+        try expect(send?.requiresConfirmation == true, "mail_send must require confirmation")
+        try expect(send?.readOnlyHint == false, "mail_send is not read-only")
+        let list = ToolAnnotationCatalog.annotations(for: "mail_list")
+        try expect(list?.readOnlyHint == true && list?.requiresConfirmation == false,
+                   "mail_list must be read-only, no confirm")
+        let draft = ToolAnnotationCatalog.annotations(for: "mail_draft")
+        try expect(draft?.requiresConfirmation == false, "mail_draft (.notify) must not require confirmation")
+    }
+}

--- a/NotionBridgeTests/NotesModuleTests.swift
+++ b/NotionBridgeTests/NotesModuleTests.swift
@@ -1,0 +1,445 @@
+// NotesModuleTests.swift – v3.7·G  NotesModule tests
+// NotionBridge · Tests
+//
+// Exercises the full notes_* surface against the INJECTABLE AppleScript
+// seam — zero contact with live Notes.app. Covers registration + tiers,
+// CRUD (create/read/update/delete), search, the AppleScript-error path
+// (incl. the -1743 Automation TCC guidance), id-vs-name addressing, and
+// missing-parameter rejection, plus the pure script-builder / escaping /
+// record-parsing helpers.
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+// MARK: - Mock runner
+
+/// A deterministic, recording AppleScript seam. Captures every script it
+/// was handed and returns a scripted response (default `.ok("")`). Tests
+/// drive the entire module without touching Notes.app.
+private final class MockNotesRunner: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _scripts: [String] = []
+    private var _response: NotesScriptResult
+
+    init(_ response: NotesScriptResult = .ok("")) {
+        self._response = response
+    }
+
+    var scripts: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _scripts
+    }
+
+    var lastScript: String { scripts.last ?? "" }
+
+    func setResponse(_ r: NotesScriptResult) {
+        lock.lock(); defer { lock.unlock() }
+        _response = r
+    }
+
+    /// The `NotesScriptRunner` closure to inject.
+    func runner() -> NotesScriptRunner {
+        return { [self] source in
+            lock.lock()
+            _scripts.append(source)
+            let r = _response
+            lock.unlock()
+            return r
+        }
+    }
+}
+
+private func makeRouter(_ runner: MockNotesRunner) async -> ToolRouter {
+    let gate = SecurityGate()
+    let log = AuditLog()
+    let router = ToolRouter(securityGate: gate, auditLog: log)
+    await NotesModule.register(on: router, runner: runner.runner())
+    return router
+}
+
+// Build a list/search record string with the module's framing.
+private func makeRecords(_ rows: [(String, String, String, String)]) -> String {
+    let fs = NotesModule.fieldSep
+    let rs = NotesModule.recordSep
+    return rows.map { "\($0.0)\(fs)\($0.1)\(fs)\($0.2)\(fs)\($0.3)" }.joined(separator: rs) + rs
+}
+
+func runNotesModuleTests() async {
+    print("\n🗒️  NotesModule Tests (v3.7·G)")
+
+    // ----------------------------------------------------------------
+    // Registration + tiers
+    // ----------------------------------------------------------------
+
+    await test("NotesModule registers exactly 6 tools") {
+        let router = await makeRouter(MockNotesRunner())
+        let tools = await router.registrations(forModule: "notes")
+        try expect(tools.count == 6, "Expected 6 notes tools, got \(tools.count)")
+        let names = Set(tools.map(\.name))
+        for n in ["notes_list", "notes_read", "notes_create", "notes_update", "notes_delete", "notes_search"] {
+            try expect(names.contains(n), "Missing \(n)")
+        }
+    }
+
+    await test("notes_* tiers: list/read/search=open, create/update=notify, delete=request") {
+        let router = await makeRouter(MockNotesRunner())
+        let tools = await router.registrations(forModule: "notes")
+        func tier(_ name: String) -> SecurityTier? { tools.first { $0.name == name }?.tier }
+        try expect(tier("notes_list") == .open, "list tier \(String(describing: tier("notes_list")))")
+        try expect(tier("notes_read") == .open, "read tier")
+        try expect(tier("notes_search") == .open, "search tier")
+        try expect(tier("notes_create") == .notify, "create tier")
+        try expect(tier("notes_update") == .notify, "update tier")
+        try expect(tier("notes_delete") == .request, "delete tier")
+    }
+
+    await test("every notes tool inputSchema property key is camelCase") {
+        let router = await makeRouter(MockNotesRunner())
+        var violations: [String] = []
+        for reg in await router.registrations(forModule: "notes") {
+            guard case .object(let top) = reg.inputSchema,
+                  case .object(let props)? = top["properties"] else { continue }
+            for key in props.keys {
+                let ok = key.first?.isLowercase == true && key.allSatisfy { $0.isLetter || $0.isNumber }
+                if !ok { violations.append("\(reg.name).\(key)") }
+            }
+        }
+        try expect(violations.isEmpty, "non-camelCase notes schema keys: \(violations.sorted())")
+    }
+
+    // ----------------------------------------------------------------
+    // notes_list
+    // ----------------------------------------------------------------
+
+    await test("notes_list parses framed records into rows") {
+        let runner = MockNotesRunner(.ok(makeRecords([
+            ("id://a", "Groceries", "Shopping", "2026-06-01"),
+            ("id://b", "Ideas", "Notes", "2026-05-30")
+        ])))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(toolName: "notes_list", arguments: .object([:]))
+        guard case .object(let dict) = result,
+              case .int(let count)? = dict["count"],
+              case .array(let rows)? = dict["notes"] else {
+            throw TestError.assertion("expected notes/count, got \(result)")
+        }
+        try expect(count == 2, "expected 2 notes, got \(count)")
+        guard case .object(let first) = rows[0], case .string(let name)? = first["name"] else {
+            throw TestError.assertion("row 0 malformed")
+        }
+        try expect(name == "Groceries", "first name \(name)")
+    }
+
+    await test("notes_list scopes to a folder when provided") {
+        let runner = MockNotesRunner(.ok(""))
+        let router = await makeRouter(runner)
+        _ = try await router.dispatch(toolName: "notes_list", arguments: .object(["folder": .string("Work")]))
+        try expect(runner.lastScript.contains("notes of folder \"Work\""),
+                   "folder not scoped in script: \(runner.lastScript)")
+    }
+
+    await test("notes_list respects limit") {
+        let runner = MockNotesRunner(.ok(makeRecords([
+            ("1", "a", "f", "d"), ("2", "b", "f", "d"), ("3", "c", "f", "d")
+        ])))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_list", arguments: .object(["limit": .int(2)]))
+        guard case .object(let dict) = result, case .int(let count)? = dict["count"] else {
+            throw TestError.assertion("expected count")
+        }
+        try expect(count == 2, "limit not applied, got \(count)")
+    }
+
+    // ----------------------------------------------------------------
+    // notes_read
+    // ----------------------------------------------------------------
+
+    await test("notes_read returns found note by id with body + html") {
+        let fs = NotesModule.fieldSep
+        let payload = "id://x\(fs)My Note\(fs)Notes\(fs)plain body text\(fs)<div>plain body text</div>"
+        let runner = MockNotesRunner(.ok(payload))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_read", arguments: .object(["noteId": .string("id://x")]))
+        guard case .object(let dict) = result,
+              case .bool(let found)? = dict["found"],
+              case .string(let body)? = dict["body"],
+              case .string(let html)? = dict["html"] else {
+            throw TestError.assertion("expected found/body/html, got \(result)")
+        }
+        try expect(found == true, "should be found")
+        try expect(body == "plain body text", "body \(body)")
+        try expect(html == "<div>plain body text</div>", "html \(html)")
+        // Reading by id must emit a `note id "…"` resolve clause.
+        try expect(runner.lastScript.contains("note id \"id://x\""),
+                   "id resolve clause missing: \(runner.lastScript)")
+    }
+
+    await test("notes_read by name emits case-insensitive name resolve clause") {
+        let runner = MockNotesRunner(.ok(""))
+        let router = await makeRouter(runner)
+        _ = try await router.dispatch(
+            toolName: "notes_read", arguments: .object(["noteName": .string("Groceries")]))
+        try expect(runner.lastScript.contains("ignoring case"), "no ignoring-case clause")
+        try expect(runner.lastScript.contains("set wanted to \"Groceries\""), "name not bound")
+    }
+
+    await test("notes_read returns found=false on empty (no-match) output") {
+        let runner = MockNotesRunner(.ok(""))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_read", arguments: .object(["noteId": .string("id://missing")]))
+        guard case .object(let dict) = result, case .bool(let found)? = dict["found"] else {
+            throw TestError.assertion("expected found flag")
+        }
+        try expect(found == false, "expected not found")
+    }
+
+    await test("notes_read rejects when neither noteId nor noteName given") {
+        let router = await makeRouter(MockNotesRunner())
+        do {
+            _ = try await router.dispatch(toolName: "notes_read", arguments: .object([:]))
+            throw TestError.assertion("expected rejection")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // notes_create
+    // ----------------------------------------------------------------
+
+    await test("notes_create returns created id and embeds title/body in script") {
+        let runner = MockNotesRunner(.ok("x-coredata://NEW-NOTE"))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_create",
+            arguments: .object(["title": .string("Trip"), "body": .string("pack bags")]))
+        guard case .object(let dict) = result,
+              case .bool(let created)? = dict["created"],
+              case .string(let id)? = dict["id"] else {
+            throw TestError.assertion("expected created/id, got \(result)")
+        }
+        try expect(created == true, "not created")
+        try expect(id == "x-coredata://NEW-NOTE", "id \(id)")
+        try expect(runner.lastScript.contains("Trip") && runner.lastScript.contains("pack bags"),
+                   "title/body not in create script")
+        try expect(runner.lastScript.contains("make new note"), "no make-new-note verb")
+    }
+
+    await test("notes_create places note in folder when provided") {
+        let runner = MockNotesRunner(.ok("id://1"))
+        let router = await makeRouter(runner)
+        _ = try await router.dispatch(
+            toolName: "notes_create",
+            arguments: .object(["title": .string("T"), "folder": .string("Work")]))
+        try expect(runner.lastScript.contains("folder \"Work\""), "folder not targeted")
+        try expect(runner.lastScript.contains("make new note at theFolder"), "not created at folder")
+    }
+
+    await test("notes_create rejects missing title") {
+        let router = await makeRouter(MockNotesRunner())
+        do {
+            _ = try await router.dispatch(toolName: "notes_create", arguments: .object(["body": .string("x")]))
+            throw TestError.assertion("expected rejection for missing title")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // notes_update
+    // ----------------------------------------------------------------
+
+    await test("notes_update returns updated=true with note id") {
+        let runner = MockNotesRunner(.ok("id://u1"))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_update",
+            arguments: .object(["noteId": .string("id://u1"), "body": .string("new content")]))
+        guard case .object(let dict) = result,
+              case .bool(let updated)? = dict["updated"],
+              case .string(let id)? = dict["id"] else {
+            throw TestError.assertion("expected updated/id, got \(result)")
+        }
+        try expect(updated == true, "not updated")
+        try expect(id == "id://u1", "id \(id)")
+        try expect(runner.lastScript.contains("set body of theNote"), "no body-set verb")
+        try expect(runner.lastScript.contains("new content"), "body content missing")
+    }
+
+    await test("notes_update returns updated=false when no note matched") {
+        let runner = MockNotesRunner(.ok(""))   // empty id ⇒ no match
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_update",
+            arguments: .object(["noteName": .string("Ghost"), "body": .string("x")]))
+        guard case .object(let dict) = result, case .bool(let updated)? = dict["updated"] else {
+            throw TestError.assertion("expected updated flag")
+        }
+        try expect(updated == false, "should not be updated")
+    }
+
+    await test("notes_update rejects missing body") {
+        let router = await makeRouter(MockNotesRunner())
+        do {
+            _ = try await router.dispatch(
+                toolName: "notes_update", arguments: .object(["noteId": .string("id://1")]))
+            throw TestError.assertion("expected rejection for missing body")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // notes_delete
+    // ----------------------------------------------------------------
+
+    await test("notes_delete requires confirm='DELETE'") {
+        let runner = MockNotesRunner(.ok("id://d1"))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_delete",
+            arguments: .object(["noteId": .string("id://d1"), "confirm": .string("nope")]))
+        guard case .object(let dict) = result, case .bool(let deleted)? = dict["deleted"] else {
+            throw TestError.assertion("expected deleted flag")
+        }
+        try expect(deleted == false, "must not delete without DELETE confirm")
+        // The runner must not have been invoked (gated before scripting).
+        try expect(runner.scripts.isEmpty, "delete script ran despite bad confirm")
+    }
+
+    await test("notes_delete with confirm='DELETE' deletes and returns id") {
+        let runner = MockNotesRunner(.ok("id://d2"))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_delete",
+            arguments: .object(["noteId": .string("id://d2"), "confirm": .string("DELETE")]))
+        guard case .object(let dict) = result,
+              case .bool(let deleted)? = dict["deleted"],
+              case .string(let id)? = dict["id"] else {
+            throw TestError.assertion("expected deleted/id, got \(result)")
+        }
+        try expect(deleted == true, "not deleted")
+        try expect(id == "id://d2", "id \(id)")
+        try expect(runner.lastScript.contains("delete theNote"), "no delete verb")
+    }
+
+    await test("notes_delete rejects missing confirm") {
+        let router = await makeRouter(MockNotesRunner())
+        do {
+            _ = try await router.dispatch(
+                toolName: "notes_delete", arguments: .object(["noteId": .string("id://1")]))
+            throw TestError.assertion("expected rejection for missing confirm")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // notes_search
+    // ----------------------------------------------------------------
+
+    await test("notes_search parses matches and embeds the query") {
+        let runner = MockNotesRunner(.ok(makeRecords([
+            ("id://s1", "Recipe", "Food", "2026-06-01")
+        ])))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_search", arguments: .object(["query": .string("flour")]))
+        guard case .object(let dict) = result,
+              case .int(let count)? = dict["count"] else {
+            throw TestError.assertion("expected count, got \(result)")
+        }
+        try expect(count == 1, "expected 1 match, got \(count)")
+        try expect(runner.lastScript.contains("set q to \"flour\""), "query not embedded")
+        try expect(runner.lastScript.contains("ignoring case"), "search not case-insensitive")
+    }
+
+    await test("notes_search rejects missing query") {
+        let router = await makeRouter(MockNotesRunner())
+        do {
+            _ = try await router.dispatch(toolName: "notes_search", arguments: .object([:]))
+            throw TestError.assertion("expected rejection for missing query")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // AppleScript error path  (the seam's failure branch)
+    // ----------------------------------------------------------------
+
+    await test("AppleScript error surfaces as structured error on a read") {
+        let runner = MockNotesRunner(.failure(message: "Notes got an error: boom", code: -2700))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_list", arguments: .object([:]))
+        guard case .object(let dict) = result,
+              case .string(let err)? = dict["error"],
+              case .int(let code)? = dict["errorNumber"] else {
+            throw TestError.assertion("expected error/errorNumber, got \(result)")
+        }
+        try expect(err.contains("boom"), "error message lost: \(err)")
+        try expect(code == -2700, "code \(code)")
+        try expect(dict["tccDenied"] == nil, "non-TCC error should not flag tccDenied")
+    }
+
+    await test("AppleScript -1743 (Automation denied) yields TCC guidance") {
+        let runner = MockNotesRunner(.failure(message: "Not authorized to send Apple events to Notes.", code: -1743))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_create",
+            arguments: .object(["title": .string("X")]))
+        guard case .object(let dict) = result,
+              case .bool(let tcc)? = dict["tccDenied"],
+              case .string(let guidance)? = dict["guidance"] else {
+            throw TestError.assertion("expected tccDenied/guidance, got \(result)")
+        }
+        try expect(tcc == true, "tccDenied should be true")
+        try expect(guidance.localizedCaseInsensitiveContains("Automation"), "guidance missing Automation hint")
+    }
+
+    // ----------------------------------------------------------------
+    // Pure helpers: escaping / selector / record parsing / scripts
+    // ----------------------------------------------------------------
+
+    await test("escapeAS escapes backslash then quote (order-correct)") {
+        try expect(NotesModule.escapeAS(#"a"b"#) == #"a\"b"#, "quote escape")
+        try expect(NotesModule.escapeAS(#"a\b"#) == #"a\\b"#, "backslash escape")
+        // A pre-escaped-looking input must not be mangled into a valid escape.
+        try expect(NotesModule.escapeAS(#"\""#) == #"\\\""#, "combined escape")
+    }
+
+    await test("noteSelector prefers noteId over noteName") {
+        let sel = NotesModule.noteSelector(["noteId": .string("ID"), "noteName": .string("NAME")])
+        try expect(sel == .id("ID"), "id should win, got \(String(describing: sel))")
+        let sel2 = NotesModule.noteSelector(["noteName": .string("NAME")])
+        try expect(sel2 == .name("NAME"), "name fallback")
+        let sel3 = NotesModule.noteSelector([:])
+        try expect(sel3 == nil, "nil when neither present")
+    }
+
+    await test("parseNoteRecords skips short/blank records") {
+        let fs = NotesModule.fieldSep
+        let rs = NotesModule.recordSep
+        let raw = "a\(fs)b\(fs)c\(fs)d\(rs)\(rs)tooShort\(rs)e\(fs)f\(fs)g\(fs)h\(rs)"
+        let recs = NotesModule.parseNoteRecords(raw)
+        try expect(recs.count == 2, "expected 2 valid records, got \(recs.count)")
+        try expect(recs[0] == NotesModule.NoteRecord(id: "a", name: "b", folder: "c", modified: "d"),
+                   "rec0 \(recs[0])")
+    }
+
+    await test("Scripts.list/search/create use the framing + Apple-events verbs") {
+        let listScript = NotesModule.Scripts.list(folder: nil)
+        try expect(listScript.contains("tell application \"Notes\""), "list not a Notes tell")
+        try expect(listScript.contains("ASCII character 31") && listScript.contains("ASCII character 30"),
+                   "list missing separator literals")
+        let createScript = NotesModule.Scripts.create(title: "T", body: "B", folder: nil)
+        try expect(createScript.contains("make new note"), "create verb missing")
+        let delScript = NotesModule.Scripts.delete(selector: .id("z"))
+        try expect(delScript.contains("delete theNote"), "delete verb missing")
+    }
+}

--- a/NotionBridgeTests/ReadOnlyTierAuditTests.swift
+++ b/NotionBridgeTests/ReadOnlyTierAuditTests.swift
@@ -41,6 +41,12 @@ func runReadOnlyTierAuditTests() async {
         // tools (see GitModule.swift header). `git_worktree_list` is the only
         // read-only-named member and inherits that deliberate policy.
         "git_worktree_list",
+        // standing_orders_* (PKT-931) are operator-curated config. The packet
+        // DoD mandates tier .notify for ALL FOUR tools (config must not change
+        // silently). list/read are read-only-named but intentionally .notify,
+        // mirroring the credential_read / credential_list precedent above.
+        "standing_orders_list",
+        "standing_orders_read",
     ]
 
     func matchesReadOnlyPattern(_ name: String) -> Bool {

--- a/NotionBridgeTests/RemindersModuleTests.swift
+++ b/NotionBridgeTests/RemindersModuleTests.swift
@@ -1,0 +1,350 @@
+// RemindersModuleTests.swift
+// NotionBridge · Tests
+//
+// PKT-957 (v3.7·D): unit tests for the reminders_* tool family against the
+// injectable `RemindersStoring` seam — no live EventKit / TCC. Covers tool
+// registration + tiering, CRUD round-trips, completion idempotency, and the
+// access-denied path. Handlers are invoked directly off their
+// `ToolRegistration` so dispatch (security gate / license / UserDefaults)
+// stays out of the unit boundary — the seam is what's under test.
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+// MARK: - In-memory mock seam
+
+/// Deterministic in-memory `RemindersStoring` for tests. `authStatus` drives
+/// the access-denied branch; the dictionaries model lists + reminders.
+final class MockRemindersStore: RemindersStoring, @unchecked Sendable {
+    var authStatus: RemindersAuthStatus
+    private(set) var lists_: [ReminderList]
+    private(set) var items: [String: ReminderItem] = [:]
+    private var seq = 0
+
+    init(authStatus: RemindersAuthStatus = .authorized, lists: [ReminderList]? = nil) {
+        self.authStatus = authStatus
+        self.lists_ = lists ?? [
+            ReminderList(id: "list-default", title: "Reminders", isDefault: true, allowsModify: true),
+            ReminderList(id: "list-work", title: "Work", isDefault: false, allowsModify: true)
+        ]
+    }
+
+    func authorizationStatus() -> RemindersAuthStatus { authStatus }
+
+    func ensureAccess() async throws {
+        switch authStatus {
+        case .authorized: return
+        case .notDetermined, .denied, .restricted:
+            throw RemindersModuleError.accessDenied
+        }
+    }
+
+    func lists() async throws -> [ReminderList] {
+        try await ensureAccess()
+        return lists_
+    }
+
+    private func listTitle(_ id: String) -> String {
+        lists_.first(where: { $0.id == id })?.title ?? ""
+    }
+
+    func fetch(_ query: ReminderQuery) async throws -> [ReminderItem] {
+        try await ensureAccess()
+        var out = Array(items.values)
+        if let listId = query.listId {
+            guard lists_.contains(where: { $0.id == listId }) else {
+                throw RemindersModuleError.listNotFound(listId)
+            }
+            out = out.filter { $0.listId == listId }
+        }
+        if !query.includeCompleted { out = out.filter { !$0.completed } }
+        if let before = query.dueBefore {
+            out = out.filter { ($0.due.map { $0 < before }) ?? false }
+        }
+        if let after = query.dueAfter {
+            out = out.filter { ($0.due.map { $0 > after }) ?? false }
+        }
+        return out.sorted { $0.id < $1.id }
+    }
+
+    func create(_ draft: ReminderDraft) async throws -> ReminderItem {
+        try await ensureAccess()
+        let listId = draft.listId ?? "list-default"
+        guard lists_.contains(where: { $0.id == listId }) else {
+            throw RemindersModuleError.listNotFound(listId)
+        }
+        seq += 1
+        let id = "rem-\(seq)"
+        let item = ReminderItem(
+            id: id,
+            title: draft.title ?? "",
+            due: (draft.due?.isEmpty == false) ? draft.due : nil,
+            listId: listId,
+            listTitle: listTitle(listId),
+            completed: false,
+            notes: draft.notes,
+            priority: draft.priority ?? 0
+        )
+        items[id] = item
+        return item
+    }
+
+    func update(id: String, _ draft: ReminderDraft) async throws -> ReminderItem {
+        try await ensureAccess()
+        guard var item = items[id] else { throw RemindersModuleError.notFound(id) }
+        if let t = draft.title { item.title = t }
+        if draft.clearDue { item.due = nil }
+        else if let d = draft.due, !d.isEmpty { item.due = d }
+        if let n = draft.notes { item.notes = n }
+        if let p = draft.priority { item.priority = p }
+        if let l = draft.listId {
+            guard lists_.contains(where: { $0.id == l }) else {
+                throw RemindersModuleError.listNotFound(l)
+            }
+            item.listId = l
+            item.listTitle = listTitle(l)
+        }
+        items[id] = item
+        return item
+    }
+
+    func setCompleted(id: String, completed: Bool) async throws -> ReminderItem {
+        try await ensureAccess()
+        guard var item = items[id] else { throw RemindersModuleError.notFound(id) }
+        item.completed = completed
+        items[id] = item
+        return item
+    }
+
+    func delete(id: String) async throws {
+        try await ensureAccess()
+        guard items[id] != nil else { throw RemindersModuleError.notFound(id) }
+        items[id] = nil
+    }
+}
+
+// MARK: - Test helpers
+
+private func makeRouter(_ store: RemindersStoring) async -> ToolRouter {
+    let gate = SecurityGate()
+    let log = AuditLog()
+    let router = ToolRouter(securityGate: gate, auditLog: log)
+    await RemindersModule.register(on: router, store: store)
+    return router
+}
+
+/// Invoke a tool's handler directly (bypasses dispatch gating — the seam is
+/// the unit under test).
+private func callHandler(_ router: ToolRouter, _ name: String, _ args: Value) async throws -> Value {
+    let regs = await router.registrations(forModule: "reminders")
+    guard let reg = regs.first(where: { $0.name == name }) else {
+        throw TestError.assertion("tool \(name) not registered")
+    }
+    return try await reg.handler(args)
+}
+
+private func objField(_ v: Value, _ key: String) -> Value? {
+    if case .object(let d) = v { return d[key] }
+    return nil
+}
+
+func runRemindersModuleTests() async {
+    print("\n\u{23F0} RemindersModule Tests (PKT-957 · v3.7·D)")
+
+    // MARK: registration + tiering
+
+    await test("RemindersModule registers exactly 6 tools") {
+        let router = await makeRouter(MockRemindersStore())
+        let tools = await router.registrations(forModule: "reminders")
+        try expect(tools.count == 6, "expected 6 reminders tools, got \(tools.count)")
+    }
+
+    await test("reminders tiering matches ReadOnlyTierAudit policy") {
+        let router = await makeRouter(MockRemindersStore())
+        let tools = await router.registrations(forModule: "reminders")
+        let byName = Dictionary(tools.map { ($0.name, $0) }, uniquingKeysWith: { a, _ in a })
+        try expect(byName["reminders_lists"]?.tier == .open, "lists must be .open")
+        try expect(byName["reminders_list"]?.tier == .open, "list must be .open")
+        try expect(byName["reminders_create"]?.tier == .notify, "create must be .notify")
+        try expect(byName["reminders_update"]?.tier == .notify, "update must be .notify")
+        try expect(byName["reminders_complete"]?.tier == .notify, "complete must be .notify")
+        try expect(byName["reminders_delete"]?.tier == .request, "delete must be .request")
+    }
+
+    // MARK: reminders_lists
+
+    await test("reminders_lists returns the seeded lists with default flag") {
+        let router = await makeRouter(MockRemindersStore())
+        let result = try await callHandler(router, "reminders_lists", .object([:]))
+        guard case .int(let count)? = objField(result, "count") else {
+            throw TestError.assertion("missing count")
+        }
+        try expect(count == 2, "expected 2 lists, got \(count)")
+        guard case .array(let arr)? = objField(result, "lists") else {
+            throw TestError.assertion("missing lists array")
+        }
+        let defaults = arr.filter { objField($0, "isDefault") == .bool(true) }
+        try expect(defaults.count == 1, "exactly one default list expected")
+    }
+
+    // MARK: CRUD round-trip
+
+    await test("reminders_create returns a new id + record") {
+        let router = await makeRouter(MockRemindersStore())
+        let result = try await callHandler(router, "reminders_create", .object([
+            "title": .string("Buy milk"),
+            "due": .string("2026-06-05T17:00:00Z"),
+            "priority": .int(1)
+        ]))
+        guard case .string(let id)? = objField(result, "id") else {
+            throw TestError.assertion("create returned no id")
+        }
+        try expect(!id.isEmpty, "empty id")
+        let rec = objField(result, "reminder")
+        try expect(objField(rec!, "title") == .string("Buy milk"), "title mismatch")
+        try expect(objField(rec!, "priority") == .int(1), "priority mismatch")
+        try expect(objField(rec!, "due") == .string("2026-06-05T17:00:00Z"), "due mismatch")
+    }
+
+    await test("reminders_create requires title") {
+        let router = await makeRouter(MockRemindersStore())
+        do {
+            _ = try await callHandler(router, "reminders_create", .object(["notes": .string("x")]))
+            throw TestError.assertion("expected invalidArguments for missing title")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    await test("reminders_list reflects a created reminder; reminders_update mutates it") {
+        let store = MockRemindersStore()
+        let router = await makeRouter(store)
+        let created = try await callHandler(router, "reminders_create", .object(["title": .string("Draft report")]))
+        guard case .string(let id)? = objField(created, "id") else {
+            throw TestError.assertion("no id")
+        }
+
+        // list shows it (incomplete, default filter)
+        let listed = try await callHandler(router, "reminders_list", .object([:]))
+        guard case .int(let n)? = objField(listed, "count") else { throw TestError.assertion("no count") }
+        try expect(n == 1, "expected 1 active reminder, got \(n)")
+
+        // update title + due + priority
+        let updated = try await callHandler(router, "reminders_update", .object([
+            "id": .string(id),
+            "title": .string("Draft Q2 report"),
+            "due": .string("2026-07-01T09:00:00Z"),
+            "priority": .int(5)
+        ]))
+        let rec = objField(updated, "reminder")!
+        try expect(objField(rec, "title") == .string("Draft Q2 report"), "title not updated")
+        try expect(objField(rec, "due") == .string("2026-07-01T09:00:00Z"), "due not updated")
+        try expect(objField(rec, "priority") == .int(5), "priority not updated")
+    }
+
+    await test("reminders_update with empty due clears the due date") {
+        let router = await makeRouter(MockRemindersStore())
+        let created = try await callHandler(router, "reminders_create", .object([
+            "title": .string("Dated"), "due": .string("2026-06-09T12:00:00Z")
+        ]))
+        guard case .string(let id)? = objField(created, "id") else { throw TestError.assertion("no id") }
+        let updated = try await callHandler(router, "reminders_update", .object([
+            "id": .string(id), "due": .string("")
+        ]))
+        try expect(objField(objField(updated, "reminder")!, "due") == .null, "due not cleared")
+    }
+
+    // MARK: completion idempotency
+
+    await test("reminders_complete is idempotent (repeat → same completed state)") {
+        let router = await makeRouter(MockRemindersStore())
+        let created = try await callHandler(router, "reminders_create", .object(["title": .string("Submit")]))
+        guard case .string(let id)? = objField(created, "id") else { throw TestError.assertion("no id") }
+
+        let first = try await callHandler(router, "reminders_complete", .object(["id": .string(id)]))
+        try expect(objField(first, "completed") == .bool(true), "first complete should be true")
+
+        let second = try await callHandler(router, "reminders_complete", .object([
+            "id": .string(id), "completed": .bool(true)
+        ]))
+        try expect(objField(second, "completed") == .bool(true), "idempotent complete must stay true")
+
+        // re-open
+        let reopened = try await callHandler(router, "reminders_complete", .object([
+            "id": .string(id), "completed": .bool(false)
+        ]))
+        try expect(objField(reopened, "completed") == .bool(false), "should be re-opened")
+    }
+
+    await test("completed reminders are hidden by default, shown with includeCompleted") {
+        let router = await makeRouter(MockRemindersStore())
+        let created = try await callHandler(router, "reminders_create", .object(["title": .string("Done soon")]))
+        guard case .string(let id)? = objField(created, "id") else { throw TestError.assertion("no id") }
+        _ = try await callHandler(router, "reminders_complete", .object(["id": .string(id)]))
+
+        let hidden = try await callHandler(router, "reminders_list", .object([:]))
+        try expect(objField(hidden, "count") == .int(0), "completed reminder must be hidden by default")
+
+        let shown = try await callHandler(router, "reminders_list", .object(["includeCompleted": .bool(true)]))
+        try expect(objField(shown, "count") == .int(1), "completed reminder must show with includeCompleted")
+    }
+
+    // MARK: delete
+
+    await test("reminders_delete removes the reminder (idempotency: re-delete throws notFound)") {
+        let router = await makeRouter(MockRemindersStore())
+        let created = try await callHandler(router, "reminders_create", .object(["title": .string("Temp")]))
+        guard case .string(let id)? = objField(created, "id") else { throw TestError.assertion("no id") }
+
+        let del = try await callHandler(router, "reminders_delete", .object(["id": .string(id)]))
+        try expect(objField(del, "deleted") == .bool(true), "delete should report true")
+
+        // gone from listing
+        let listed = try await callHandler(router, "reminders_list", .object([:]))
+        try expect(objField(listed, "count") == .int(0), "deleted reminder still listed")
+
+        // re-delete surfaces a notFound (no silent success on a missing id)
+        do {
+            _ = try await callHandler(router, "reminders_delete", .object(["id": .string(id)]))
+            throw TestError.assertion("expected notFound on re-delete")
+        } catch let e as RemindersModuleError {
+            try expect(e == .notFound(id), "expected notFound, got \(e)")
+        }
+    }
+
+    // MARK: access-denied path
+
+    await test("access-denied: every mutating + reading tool surfaces accessDenied") {
+        let store = MockRemindersStore(authStatus: .denied)
+        let router = await makeRouter(store)
+
+        func expectDenied(_ name: String, _ args: Value) async {
+            await test("  \(name) → accessDenied when TCC denied") {
+                do {
+                    _ = try await callHandler(router, name, args)
+                    throw TestError.assertion("expected accessDenied")
+                } catch let e as RemindersModuleError {
+                    try expect(e == .accessDenied, "expected accessDenied, got \(e)")
+                }
+            }
+        }
+
+        await expectDenied("reminders_lists", .object([:]))
+        await expectDenied("reminders_list", .object([:]))
+        await expectDenied("reminders_create", .object(["title": .string("x")]))
+        await expectDenied("reminders_update", .object(["id": .string("rem-1"), "title": .string("y")]))
+        await expectDenied("reminders_complete", .object(["id": .string("rem-1")]))
+        await expectDenied("reminders_delete", .object(["id": .string("rem-1")]))
+    }
+
+    await test("notDetermined status also throws accessDenied (no live TCC prompt in tests)") {
+        let router = await makeRouter(MockRemindersStore(authStatus: .notDetermined))
+        do {
+            _ = try await callHandler(router, "reminders_lists", .object([:]))
+            throw TestError.assertion("expected accessDenied for notDetermined")
+        } catch let e as RemindersModuleError {
+            try expect(e == .accessDenied)
+        }
+    }
+}

--- a/NotionBridgeTests/ScreenModuleTests.swift
+++ b/NotionBridgeTests/ScreenModuleTests.swift
@@ -127,4 +127,28 @@ func runScreenModuleTests() async {
         try expect(ScreenModule.moduleName == "screen",
                    "Expected 'screen', got '\(ScreenModule.moduleName)'")
     }
+
+    // --- SCK off-main-actor continuation-leak regression guard ---
+    // Before the SCKBoundary fix, dispatching an SCK-backed tool from a
+    // nonisolated / off-main-actor context (`Task.detached`) leaked the
+    // ScreenCaptureKit checked continuation and HUNG FOREVER ("SWIFT TASK
+    // CONTINUATION MISUSE"). The fix routes the SCK call onto the main actor
+    // and guards it with a libdispatch watchdog, so the call must now RETURN
+    // or THROW promptly. We only assert "did not hang" — content depends on
+    // live TCC/display/Chrome state, which we do not gate on here.
+    await test("screen_capture from a detached (off-main) task returns promptly, never hangs") {
+        let result = await Task.detached {
+            try? await router.dispatch(toolName: "screen_capture", arguments: .object([:]))
+        }.value
+        try expect(result != nil, "screen_capture dispatch should produce a value off-main, not hang")
+    }
+
+    await test("chrome_tabs from a detached (off-main) task returns promptly, never hangs") {
+        let chromeRouter = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        await ChromeModule.register(on: chromeRouter)
+        let result = await Task.detached {
+            try? await chromeRouter.dispatch(toolName: "chrome_tabs", arguments: .object([:]))
+        }.value
+        try expect(result != nil, "chrome_tabs dispatch should produce a value off-main, not hang")
+    }
 }

--- a/NotionBridgeTests/ShortcutsModuleTests.swift
+++ b/NotionBridgeTests/ShortcutsModuleTests.swift
@@ -1,0 +1,250 @@
+// ShortcutsModuleTests.swift
+// NotionBridge · Tests
+//
+// PKT-959 (v3.7·F): unit tests for the shortcuts_* tool family against the
+// injectable `ShortcutsRunning` CLI seam — NO live /usr/bin/shortcuts. The
+// mock records the argv it was handed and replays a scripted result, so we
+// assert both the command construction (list flags, run name, --input-path,
+// --output-path -) and the parsed envelopes (list parsing, output capture,
+// failure surfacing, capability-missing short-circuit).
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+// MARK: - In-memory mock seam
+
+/// Deterministic in-memory `ShortcutsRunning`. `available` drives the
+/// capability_missing branch; `result` is the canned invocation result;
+/// `lastArgs` captures the argv the module built so tests can assert it.
+final class MockShortcutsRunner: ShortcutsRunning, @unchecked Sendable {
+    var available: Bool
+    var result: ShortcutsInvocationResult
+    private(set) var lastArgs: [String] = []
+    private(set) var callCount = 0
+
+    init(available: Bool = true,
+         result: ShortcutsInvocationResult = ShortcutsInvocationResult(exitCode: 0, stdout: "", stderr: "")) {
+        self.available = available
+        self.result = result
+    }
+
+    var path: String? { get async { available ? "/usr/bin/shortcuts" : nil } }
+
+    func run(_ args: [String]) async throws -> ShortcutsInvocationResult {
+        callCount += 1
+        lastArgs = args
+        if !available { throw ShortcutsError.capabilityMissing("shortcuts CLI not on PATH") }
+        return result
+    }
+}
+
+func runShortcutsModuleTests() async {
+    print("\n\u{1F500} ShortcutsModule Tests (PKT-959 v3.7·F)")
+
+    // Helper: build a router with the two tools registered over a mock runner.
+    func makeRouter(_ runner: ShortcutsRunning) async -> ToolRouter {
+        let gate = SecurityGate()
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: gate, auditLog: log)
+        await ShortcutsModule.register(on: router, runner: runner)
+        return router
+    }
+
+    // ------------------------------------------------------------------
+    // 1) Registration + tier policy
+    // ------------------------------------------------------------------
+    await test("ShortcutsModule registers 2 tools under module=\"shortcuts\" with correct tiers") {
+        let router = await makeRouter(MockShortcutsRunner())
+        let regs = await router.registrations(forModule: "shortcuts")
+        let byName = Dictionary(uniqueKeysWithValues: regs.map { ($0.name, $0) })
+        try expect(regs.count == 2, "expected 2 shortcuts_* tools, got \(regs.count)")
+        guard let list = byName["shortcuts_list"], let run = byName["shortcuts_run"] else {
+            throw TestError.assertion("missing shortcuts_list / shortcuts_run — got \(byName.keys.sorted())")
+        }
+        try expect(list.tier == .open, "shortcuts_list tier expected .open, got \(list.tier.rawValue)")
+        try expect(run.tier == .notify, "shortcuts_run tier expected .notify, got \(run.tier.rawValue)")
+    }
+
+    await test("shortcuts_run schema declares name required; shortcuts_list none") {
+        let router = await makeRouter(MockShortcutsRunner())
+        let regs = await router.registrations(forModule: "shortcuts")
+        guard let run = regs.first(where: { $0.name == "shortcuts_run" }),
+              case .object(let runSchema) = run.inputSchema,
+              case .array(let runReq) = runSchema["required"] else {
+            throw TestError.assertion("missing shortcuts_run required[]")
+        }
+        let runNames = runReq.compactMap { v -> String? in if case .string(let s) = v { return s }; return nil }
+        try expect(runNames == ["name"], "shortcuts_run required expected [name], got \(runNames)")
+
+        guard let list = regs.first(where: { $0.name == "shortcuts_list" }),
+              case .object(let listSchema) = list.inputSchema,
+              case .array(let listReq) = listSchema["required"] else {
+            throw TestError.assertion("missing shortcuts_list required[]")
+        }
+        try expect(listReq.isEmpty, "shortcuts_list should have no required fields")
+    }
+
+    // ------------------------------------------------------------------
+    // 2) shortcuts_list — parses one-name-per-line stdout + builds argv
+    // ------------------------------------------------------------------
+    await test("shortcuts_list parses names and builds `list` argv") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(
+            exitCode: 0,
+            stdout: "Send iMessage to Contact\nTurn Text Into Audio\n  Start Pomodoro  \n\n",
+            stderr: ""
+        ))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(toolName: "shortcuts_list", arguments: .object([:]))
+        guard case .object(let dict) = result else { throw TestError.assertion("expected object") }
+        if case .bool(let ok) = dict["ok"] { try expect(ok == true) } else { throw TestError.assertion("missing ok") }
+        if case .int(let n) = dict["count"] { try expect(n == 3, "expected 3 names, got \(n)") }
+        else { throw TestError.assertion("missing count") }
+        guard case .array(let names) = dict["shortcuts"] else { throw TestError.assertion("missing shortcuts[]") }
+        let strs = names.compactMap { v -> String? in if case .string(let s) = v { return s }; return nil }
+        try expect(strs == ["Send iMessage to Contact", "Turn Text Into Audio", "Start Pomodoro"],
+            "trimmed/non-empty parse expected, got \(strs)")
+        try expect(runner.lastArgs == ["list"], "argv expected [list], got \(runner.lastArgs)")
+    }
+
+    await test("shortcuts_list folders:true uses --folders and returns folders[]") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(
+            exitCode: 0, stdout: "Personal\nWork\n", stderr: ""
+        ))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "shortcuts_list",
+            arguments: .object(["folders": .bool(true)])
+        )
+        guard case .object(let dict) = result else { throw TestError.assertion("expected object") }
+        try expect(runner.lastArgs == ["list", "--folders"], "argv expected [list, --folders], got \(runner.lastArgs)")
+        guard case .array(let folders) = dict["folders"] else { throw TestError.assertion("missing folders[]") }
+        try expect(folders.count == 2, "expected 2 folders")
+        // The shortcuts key must NOT be present when listing folders.
+        try expect(dict["shortcuts"] == nil, "folders listing should not carry shortcuts[]")
+    }
+
+    await test("shortcuts_list folderName forwards --folder-name") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(exitCode: 0, stdout: "A\n", stderr: ""))
+        let router = await makeRouter(runner)
+        _ = try await router.dispatch(
+            toolName: "shortcuts_list",
+            arguments: .object(["folderName": .string("Work")])
+        )
+        try expect(runner.lastArgs == ["list", "--folder-name", "Work"],
+            "argv expected [list, --folder-name, Work], got \(runner.lastArgs)")
+    }
+
+    // ------------------------------------------------------------------
+    // 3) shortcuts_run — output capture + argv (run <name> --output-path -)
+    // ------------------------------------------------------------------
+    await test("shortcuts_run captures stdout output and builds run argv") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(
+            exitCode: 0, stdout: "Hello from the shortcut", stderr: ""
+        ))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "shortcuts_run",
+            arguments: .object(["name": .string("My Shortcut")])
+        )
+        guard case .object(let dict) = result else { throw TestError.assertion("expected object") }
+        if case .bool(let ok) = dict["ok"] { try expect(ok == true) } else { throw TestError.assertion("missing ok") }
+        if case .string(let out) = dict["output"] {
+            try expect(out == "Hello from the shortcut", "output capture mismatch: \(out)")
+        } else { throw TestError.assertion("missing output") }
+        // No input → argv is run <name> --output-path -
+        try expect(runner.lastArgs == ["run", "My Shortcut", "--output-path", "-"],
+            "argv mismatch: \(runner.lastArgs)")
+    }
+
+    // ------------------------------------------------------------------
+    // 4) shortcuts_run — input passing via temp file (--input-path)
+    // ------------------------------------------------------------------
+    await test("shortcuts_run passes input via --input-path temp file (then cleans up)") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(exitCode: 0, stdout: "ok", stderr: ""))
+        let router = await makeRouter(runner)
+        _ = try await router.dispatch(
+            toolName: "shortcuts_run",
+            arguments: .object(["name": .string("Echo"), "input": .string("payload-123")])
+        )
+        // argv: run Echo --input-path <tmp> --output-path -
+        let a = runner.lastArgs
+        try expect(a.count == 6, "expected 6 argv tokens, got \(a)")
+        try expect(a[0] == "run" && a[1] == "Echo", "head argv mismatch: \(a)")
+        try expect(a[2] == "--input-path", "expected --input-path at [2], got \(a)")
+        let tmpPath = a[3]
+        try expect(tmpPath.contains("bridge-shortcut-input-"), "temp input path expected, got \(tmpPath)")
+        try expect(a[4] == "--output-path" && a[5] == "-", "expected trailing --output-path -, got \(a)")
+        // The temp file is removed via defer after the run returns.
+        try expect(!FileManager.default.fileExists(atPath: tmpPath),
+            "input temp file should be cleaned up, still present at \(tmpPath)")
+    }
+
+    // ------------------------------------------------------------------
+    // 5) shortcuts_run — run-failure surfaces a structured failed envelope
+    // ------------------------------------------------------------------
+    await test("shortcuts_run non-zero exit returns failed envelope with stderr") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(
+            exitCode: 1, stdout: "", stderr: "Couldn't find shortcut named \"Nope\""
+        ))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "shortcuts_run",
+            arguments: .object(["name": .string("Nope")])
+        )
+        guard case .object(let dict) = result else { throw TestError.assertion("expected object") }
+        if case .bool(let ok) = dict["ok"] { try expect(ok == false, "expected ok=false") }
+        else { throw TestError.assertion("missing ok") }
+        if case .string(let status) = dict["status"] {
+            try expect(status == "failed", "expected status=failed, got \(status)")
+        } else { throw TestError.assertion("missing status") }
+        if case .string(let err) = dict["error"] {
+            try expect(err.contains("Couldn't find shortcut"), "error should carry stderr, got \(err)")
+        } else { throw TestError.assertion("missing error") }
+    }
+
+    await test("shortcuts_run missing name returns invalid_argument (no CLI call)") {
+        let runner = MockShortcutsRunner()
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(toolName: "shortcuts_run", arguments: .object([:]))
+        guard case .object(let dict) = result, case .string(let status) = dict["status"] else {
+            throw TestError.assertion("expected status field")
+        }
+        try expect(status == "invalid_argument", "expected invalid_argument, got \(status)")
+        try expect(runner.callCount == 0, "invalid args must short-circuit before any CLI call")
+    }
+
+    // ------------------------------------------------------------------
+    // 6) capability_missing short-circuit (CLI unavailable)
+    // ------------------------------------------------------------------
+    await test("capability_missing when shortcuts CLI is unavailable") {
+        let runner = MockShortcutsRunner(available: false)
+        let router = await makeRouter(runner)
+        // list
+        let listResult = try await router.dispatch(toolName: "shortcuts_list", arguments: .object([:]))
+        guard case .object(let l) = listResult, case .string(let lStatus) = l["status"] else {
+            throw TestError.assertion("expected status on list")
+        }
+        try expect(lStatus == "capability_missing", "list expected capability_missing, got \(lStatus)")
+        // run
+        let runResult = try await router.dispatch(
+            toolName: "shortcuts_run", arguments: .object(["name": .string("X")])
+        )
+        guard case .object(let r) = runResult, case .string(let rStatus) = r["status"] else {
+            throw TestError.assertion("expected status on run")
+        }
+        try expect(rStatus == "capability_missing", "run expected capability_missing, got \(rStatus)")
+        // Capability check happens before invocation → no CLI run attempted.
+        try expect(runner.callCount == 0, "capability_missing must short-circuit before run()")
+    }
+
+    // ------------------------------------------------------------------
+    // 7) parseLines pure helper
+    // ------------------------------------------------------------------
+    await test("parseLines trims, drops empties, preserves order") {
+        let parsed = ShortcutsModule.parseLines("  One \n\nTwo\n   \nThree\n")
+        try expect(parsed == ["One", "Two", "Three"], "got \(parsed)")
+        try expect(ShortcutsModule.parseLines("").isEmpty, "empty stdout → no names")
+        try expect(ShortcutsModule.parseLines("\n  \n").isEmpty, "whitespace-only → no names")
+    }
+}

--- a/NotionBridgeTests/StandingOrdersModuleTests.swift
+++ b/NotionBridgeTests/StandingOrdersModuleTests.swift
@@ -1,0 +1,233 @@
+// StandingOrdersModuleTests.swift — PKT-931 (v3.7·B)
+// Covers StandingOrdersRecordStore + StandingOrdersModule: registration/tier,
+// CRUD round-trip, idempotent upsert (no duplicate), soft-delete + archive,
+// list archived exclusion / includeArchived opt-in, read 404 on soft-deleted,
+// concurrent-save serialization (no last-write-wins race), and atomic-write
+// persistence across a reload.
+
+import Foundation
+import MCP
+import NotionBridgeLib
+
+func runStandingOrdersModuleTests() async {
+    print("\n\u{1F4DC} StandingOrdersModule Tests (PKT-931 · v3.7·B)")
+
+    func tmpURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("nb-so-\(UUID().uuidString).json")
+    }
+
+    func freshStore() -> StandingOrdersRecordStore {
+        StandingOrdersRecordStore(storeURL: tmpURL())
+    }
+
+    // Pull the saved order id out of a standing_orders_save tool result.
+    func savedID(_ result: Value) -> String? {
+        guard case .object(let r) = result, case .object(let o)? = r["order"],
+              case .string(let id)? = o["id"] else { return nil }
+        return id
+    }
+
+    // ── registration / shape ──────────────────────────────────────────
+    let gate = SecurityGate()
+    let log = AuditLog()
+    let router = ToolRouter(securityGate: gate, auditLog: log)
+    await StandingOrdersModule.register(on: router, store: freshStore())
+
+    await test("StandingOrdersModule registers 4 tools under module=\"standing_orders\"") {
+        let regs = await router.registrations(forModule: "standing_orders")
+        let names = Set(regs.map(\.name))
+        let expected: Set<String> = [
+            "standing_orders_list", "standing_orders_read",
+            "standing_orders_save", "standing_orders_delete"
+        ]
+        try expect(expected.isSubset(of: names), "missing — got \(names.sorted())")
+        try expect(regs.count == 4, "expected 4, got \(regs.count)")
+    }
+
+    await test("all 4 standing_orders tools are tier .notify (writes must not auto-execute)") {
+        let regs = await router.registrations(forModule: "standing_orders")
+        for r in regs {
+            try expect(r.tier == .notify, "\(r.name) must be .notify, got \(r.tier.rawValue)")
+        }
+    }
+
+    await test("standing_orders_delete carries neverAutoApprove (destructive consent)") {
+        let regs = await router.registrations(forModule: "standing_orders")
+        let del = regs.first { $0.name == "standing_orders_delete" }
+        try expect(del?.neverAutoApprove == true, "standing_orders_delete must require confirmation")
+    }
+
+    // ── store: CRUD round-trip ────────────────────────────────────────
+    await test("store: create → read → list → update → delete round-trip") {
+        let store = freshStore()
+        let created = try await store.save(title: "Be terse", body: "Skip filler.", scope: .global)
+        try expect(!created.id.isEmpty, "create should mint an id")
+
+        let read = await store.read(id: created.id)
+        try expect(read?.title == "Be terse", "read title mismatch")
+        try expect(read?.body == "Skip filler.", "read body mismatch")
+        try expect(read?.scope == .global, "read scope mismatch")
+
+        let listed = await store.list()
+        try expect(listed.count == 1, "expected 1 listed, got \(listed.count)")
+        try expect(listed.first?.id == created.id, "listed id mismatch")
+
+        let updated = try await store.save(id: created.id, title: "Be terse v2", body: "Skip all filler.", scope: .perSkill)
+        try expect(updated.id == created.id, "update must keep the same id")
+        try expect(updated.title == "Be terse v2", "update title not applied")
+        try expect(updated.scope == .perSkill, "update scope not applied")
+
+        let archived = try await store.delete(id: created.id)
+        try expect(archived.archived, "delete should set archived=true")
+        try expect(archived.archivedAt != nil, "delete should stamp archivedAt")
+    }
+
+    // ── store: idempotent upsert (no duplicate) ───────────────────────
+    await test("store: save with same id is idempotent (no duplicate rows)") {
+        let store = freshStore()
+        let first = try await store.save(title: "Rule", body: "v1", scope: .global)
+        _ = try await store.save(id: first.id, title: "Rule", body: "v2", scope: .global)
+        _ = try await store.save(id: first.id, title: "Rule", body: "v3", scope: .global)
+        let all = await store.list()
+        try expect(all.count == 1, "expected 1 row after repeated upsert, got \(all.count)")
+        let read = await store.read(id: first.id)
+        try expect(read?.body == "v3", "last upsert body should win, got \(read?.body ?? "nil")")
+    }
+
+    // ── store: list metadata-only, no body leak ───────────────────────
+    await test("store: list returns metadata only (no body field on summary)") {
+        let store = freshStore()
+        _ = try await store.save(title: "T", body: "SECRET-BODY", scope: .global)
+        let summaries = await store.list()
+        // StandingOrderSummary has no body property by type — assert the
+        // metadata fields are present and well-formed instead.
+        try expect(summaries.count == 1, "expected 1 summary")
+        try expect(summaries.first?.title == "T", "summary title mismatch")
+    }
+
+    // ── store: soft-delete excluded from list by default, opt-in returns it ──
+    await test("store: list excludes archived by default; includeArchived returns them") {
+        let store = freshStore()
+        let a = try await store.save(title: "Keep", body: "x", scope: .global)
+        let b = try await store.save(title: "Drop", body: "y", scope: .global)
+        _ = try await store.delete(id: b.id)
+
+        let visible = await store.list()
+        try expect(visible.count == 1, "expected 1 visible, got \(visible.count)")
+        try expect(visible.first?.id == a.id, "visible should be the non-archived row")
+
+        let withArchived = await store.list(includeArchived: true)
+        try expect(withArchived.count == 2, "expected 2 with archived, got \(withArchived.count)")
+    }
+
+    // ── store: read of soft-deleted returns nil (→ 404) ───────────────
+    await test("store: read of soft-deleted order returns nil (maps to 404)") {
+        let store = freshStore()
+        let o = try await store.save(title: "Gone", body: "z", scope: .global)
+        _ = try await store.delete(id: o.id)
+        let read = await store.read(id: o.id)
+        try expect(read == nil, "soft-deleted read should be nil")
+        let forced = await store.read(id: o.id, includeArchived: true)
+        try expect(forced != nil, "includeArchived read should surface the archived row")
+        try expect(forced?.archived == true, "forced read should still be archived")
+    }
+
+    // ── store: delete is idempotent + un-archive on re-save ───────────
+    await test("store: delete is idempotent; re-save un-archives") {
+        let store = freshStore()
+        let o = try await store.save(title: "Toggle", body: "a", scope: .global)
+        _ = try await store.delete(id: o.id)
+        _ = try await store.delete(id: o.id)   // second delete: no-op success
+        let stillOne = await store.list(includeArchived: true)
+        try expect(stillOne.count == 1, "double-delete must not duplicate, got \(stillOne.count)")
+
+        let revived = try await store.save(id: o.id, title: "Toggle", body: "b", scope: .global)
+        try expect(!revived.archived, "re-save should un-archive")
+        let visible = await store.list()
+        try expect(visible.count == 1, "revived order should be visible again")
+    }
+
+    await test("store: delete of unknown id throws notFound") {
+        let store = freshStore()
+        do {
+            _ = try await store.delete(id: "no-such-id")
+            try expect(false, "expected notFound throw")
+        } catch StandingOrdersRecordError.notFound {
+            // expected
+        }
+    }
+
+    // ── store: concurrent saves serialized by the actor (no race) ─────
+    await test("store: concurrent saves serialized via actor (no last-write-wins race)") {
+        let store = freshStore()
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<50 {
+                group.addTask {
+                    _ = try? await store.save(title: "concurrent-\(i)", body: "b\(i)", scope: .global)
+                }
+            }
+        }
+        let all = await store.list()
+        try expect(all.count == 50, "expected 50 distinct rows from concurrent saves, got \(all.count)")
+    }
+
+    // ── store: atomic persistence survives a reload from disk ─────────
+    await test("store: saved orders persist atomically across a reload") {
+        let url = tmpURL()
+        let store = StandingOrdersRecordStore(storeURL: url)
+        let o = try await store.save(title: "Persist", body: "durable", scope: .perTool)
+        _ = try await store.delete(id: o.id)
+
+        // Fresh store over the same URL = re-read the on-disk JSON.
+        let reopened = StandingOrdersRecordStore(storeURL: url)
+        let visible = await reopened.list()
+        try expect(visible.isEmpty, "archived order should not be visible after reload")
+        let archived = await reopened.list(includeArchived: true)
+        try expect(archived.count == 1, "row should persist on disk (soft-delete, not purge)")
+        try expect(archived.first?.scope == .perTool, "scope should survive the round-trip")
+    }
+
+    // ── tool layer: save → read → delete via MCP handlers ─────────────
+    await test("tool: standing_orders_save then _read returns full body via handler") {
+        let r = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        await StandingOrdersModule.register(on: r, store: freshStore())
+
+        let saveResult = try await r.dispatch(toolName: 
+            "standing_orders_save",
+            arguments: .object(["title": .string("Hello"), "body": .string("World body"), "scope": .string("per-context")])
+        )
+        guard let id = savedID(saveResult) else { try expect(false, "save did not return an id"); return }
+
+        let readResult = try await r.dispatch(toolName: "standing_orders_read", arguments: .object(["id": .string(id)]))
+        guard case .object(let rr) = readResult, case .object(let order)? = rr["order"],
+              case .string(let body)? = order["body"], case .string(let scope)? = order["scope"] else {
+            try expect(false, "read result missing order/body"); return
+        }
+        try expect(body == "World body", "read body mismatch: \(body)")
+        try expect(scope == "per-context", "read scope mismatch: \(scope)")
+    }
+
+    await test("tool: standing_orders_read of unknown id returns not_found envelope") {
+        let r = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        await StandingOrdersModule.register(on: r, store: freshStore())
+        let res = try await r.dispatch(toolName: "standing_orders_read", arguments: .object(["id": .string("nope")]))
+        guard case .object(let o) = res, case .string(let code)? = o["error"] else {
+            try expect(false, "expected error envelope"); return
+        }
+        try expect(code == "not_found", "expected not_found, got \(code)")
+    }
+
+    await test("tool: standing_orders_save rejects an invalid scope") {
+        let r = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        await StandingOrdersModule.register(on: r, store: freshStore())
+        let res = try await r.dispatch(toolName: 
+            "standing_orders_save",
+            arguments: .object(["title": .string("X"), "body": .string("Y"), "scope": .string("bogus")])
+        )
+        guard case .object(let o) = res, case .string(let code)? = o["error"] else {
+            try expect(false, "expected error envelope"); return
+        }
+        try expect(code == "invalid_scope", "expected invalid_scope, got \(code)")
+    }
+}

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -621,6 +621,7 @@ await runMailModuleTests()           // PKT-961 (v3.7·H): mail_* Apple Mail mod
 await runNotesModuleTests()
 await runSystemModuleTests()
 await runRemindersModuleTests()   // PKT-957 (v3.7·D): reminders_* EventKit module (mock seam)
+await runCalendarModuleTests()    // PKT-962 (v3.7·I): calendar_* EventKit module (mock seam; reuses v3.7·D store + entitlement)
 await runNotionModuleTests()
 await runAccessibilityModuleTests()
 await runScreenModuleTests()

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -1,8 +1,23 @@
-// main.swift – V1-06 Test Runner
+// TestRunner.swift – V1-06 Test Runner
 // NotionBridge · Tests (standalone executable — no XCTest needed)
 //
 // Runs: SecurityGate, ToolRouter, AuditLog, Module tests, Integration/E2E tests
 // PKT-376: SecurityGate tests updated for 3-tier model
+//
+// MAIN-ACTOR REENTRANCY FIX (summary; full reasoning at the @main entry point
+// below): the UI/contract tests hop to the main actor via
+// `await MainActor.run { ... }` (55 call sites across 11 files). If the driver
+// itself runs ON the main actor those hops are reentrant self-calls that
+// nondeterministically deadlock (the suite froze at 0% progress on ~50% of
+// runs, always GREEN when it finished). The driver MUST run off the main actor.
+// This file used to be a `main.swift` (top-level code → implicitly main-actor)
+// and the deadlock was endemic. It is now `TestRunner.swift` with a `@main`
+// struct whose SYNCHRONOUS `main()` runs the whole sequence on a `Task.detached`
+// (off the main actor) while pumping the main run loop with `RunLoop.main.run()`.
+// (A `main.swift` file and a `@main` attribute are mutually exclusive in one
+// target, hence the rename.) The shared harness primitives (`test`, `expect`,
+// `TestError`, `passed`, `failed`) stay at file scope because the other test
+// files call them as free functions.
 
 import Foundation
 
@@ -10,37 +25,30 @@ import Foundation
 import MCP
 import NotionBridgeLib
 
-// Line-buffer stdout. When this runner's output is a pipe (CI: `… | tee`),
-// stdout defaults to FULL buffering, so on an intermittent hang the buffered
-// tail never flushes and the CI log's last line is NOT where it actually hung —
-// it just shows the last flushed block. Line buffering flushes on every newline
-// (negligible overhead: ~one flush per test line, unlike per-byte unbuffered),
-// so the CI log always pinpoints the hanging test. Distinct from the summary
-// teardown race, which is handled by the atexit summary handler below.
-setvbuf(stdout, nil, _IOLBF, 0)
-
-// HERMETIC TEST ISOLATION (v3.6.1): point ConfigManager at a throwaway temp
-// config file BEFORE any test (or ConfigManager.shared) touches it. Without
-// this, ConfigManagerTests read and mutate the user's real
-// ~/.config/.../config.json — non-hermetic, order-dependent, destructive.
-// Seeds a minimal valid config so first reads succeed.
-if ProcessInfo.processInfo.environment["BRIDGE_CONFIG_PATH"] == nil {
-    let tmpConfig = FileManager.default.temporaryDirectory
-        .appendingPathComponent("bridge-test-config-\(ProcessInfo.processInfo.processIdentifier).json")
-    setenv("BRIDGE_CONFIG_PATH", tmpConfig.path, 1)
-    let seed = #"{"sensitivePaths":["~/.ssh","~/.aws","~/.gnupg","~/.config","~/Library/Keychains"]}"#
-    try? seed.data(using: .utf8)?.write(to: tmpConfig, options: .atomic)
-}
-
-// Credential / payment MCP tests assume the Keychain credentials feature is enabled.
-UserDefaults.standard.set(true, forKey: CredentialsFeature.userDefaultsKey)
-
-// MARK: - Test Harness
+// MARK: - Test Harness (file scope — other test files call these as free functions)
 
 nonisolated(unsafe) var passed = 0
 nonisolated(unsafe) var failed = 0
 
-func test(_ name: String, _ body: () async throws -> Void) async {
+// Process exit code, set by the detached run task when the suite finishes and
+// read by `main()` after the main run loop stops. The detached task no longer
+// calls `exit()` itself (see the entry-point note) — it hands the code back to
+// the MAIN thread, which exits cleanly there.
+nonisolated(unsafe) var exitCode: Int32 = 0
+
+// Set true (on the main thread) when the suite has finished and the main loop
+// should stop pumping. `main()` drives the run loop in a `while !suiteFinished`
+// loop and checks this after each iteration, so a stop returns control to it
+// (a bare `RunLoop.main.run()` re-enters its inner mode loop forever after a
+// CFRunLoopStop and never returns — that re-entry was the residual teardown hang).
+nonisolated(unsafe) var suiteFinished = false
+
+// `body` is `sending`: the driver now runs OFF the main actor (see the @main
+// note above), so each test closure is created in the driver's isolation domain
+// and handed to `test()` — marking it `sending` lets ownership transfer across
+// that boundary without a Sendable conformance, which is safe because the
+// closure is used exactly once and never escapes.
+func test(_ name: String, _ body: sending () async throws -> Void) async {
     do {
         try await body()
         passed += 1
@@ -62,29 +70,184 @@ enum TestError: Error, LocalizedError {
     }
 }
 
-// Emit the final summary from an atexit handler so it is GUARANTEED to print.
-// With top-level `await`, the synchronous continuation after the final
-// suspension point intermittently loses a race with process teardown and is
-// skipped entirely (the binary still exits 0 and every test ran) — which
-// dropped the `Results:` line the floor gate parses. atexit handlers run during
-// any normal process exit, after all top-level code, so the summary is
-// deterministic regardless of that race or of stdout buffering mode. The
-// closure references only globals, so it captures nothing (@convention(c)-safe).
-atexit {
-    print("\n" + String(repeating: "=", count: 50))
-    print("Results: \(passed) passed, \(failed) failed, \(passed + failed) total")
-    print(String(repeating: "=", count: 50))
-    print(failed > 0 ? "\u{274C} TESTS FAILED" : "\u{2705} ALL TESTS PASSED")
-    fflush(stdout)
+// AuditLog test fixture. Hoisted to file scope (was a local func inside the
+// driver) so the off-main-actor `sending` test closures can call it without
+// crossing an actor boundary; `nonisolated` because AuditEntry is a plain value.
+nonisolated func makeSampleEntry(
+    toolName: String = "test_tool",
+    tier: SecurityTier = .open,
+    status: ApprovalStatus = .approved
+) -> AuditEntry {
+    AuditEntry(
+        timestamp: Date(), toolName: toolName, tier: tier,
+        inputSummary: "test input", outputSummary: "test output",
+        durationMs: 42.0, approvalStatus: status
+    )
 }
 
-// ============================================================
-// MARK: - SecurityGate Tests (v3: 3-tier model)
-// ============================================================
+// MARK: - Entry point
 
-print("\n\u{1F512} SecurityGate Tests (v3)")
+@main
+struct NotionBridgeTestRunner {
+    // MAIN-ACTOR REENTRANCY FIX (corrected). Symptom: the suite froze at 0%
+    // forward progress on ~50% of local runs, at varying points, always GREEN
+    // when it did finish — a nondeterministic deadlock on the main actor.
+    //
+    // Root cause: the UI/contract tests hop to the main actor via
+    // `await MainActor.run { ... }` (55 call sites across 11 files) to touch
+    // @MainActor types (SwiftUI views, @Observable controllers, AppKit). If the
+    // DRIVER itself runs ON the main actor, those hops are REENTRANT self-calls on
+    // the same actor, which nondeterministically deadlock.
+    //
+    // The original driver was a `main.swift` whose top-level code is implicitly
+    // @MainActor-isolated → on the main actor → deadlock. Renaming it to an
+    // `async @main` did NOT fix it: under swift-tools-version 6.2 ("approachable
+    // concurrency") the `async static func main()` of a `@main` type is INFERRED
+    // @MainActor-isolated, so it STILL ran on the main actor (verified
+    // empirically: `main()`'s body and its nested `MainActor.run` bodies both ran
+    // on the main thread → still reentrant → still deadlocked). A bare
+    // `Task.detached` wrapper with `await runner.value` ALSO failed: while `main()`
+    // was suspended the main run loop was not pumped, so SCK/AppKit replies and
+    // MainActor scheduling stalled → intermittent hangs AND a teardown SIGTRAP.
+    //
+    // FIX: a SYNCHRONOUS `main()` (synchronous → NOT an async main-actor task; it
+    // is the plain process entry on the main thread). It spawns the whole test
+    // sequence on a `Task.detached`, which runs OFF the main actor, then PUMPS the
+    // main run loop (a `while !suiteFinished { CFRunLoopRunInMode(.defaultMode…) }`
+    // drive — see the entry-point body for why a bare `RunLoop.main.run()` cannot
+    // be cleanly stopped). Result: the driver body runs off the main actor (every
+    // `MainActor.run` is now a REAL cross-actor hop, not a reentrant self-call — no
+    // deadlock), and the live main run loop keeps the main actor serviced AND
+    // services CFRunLoop-dependent system callbacks (ScreenCaptureKit / AppKit).
+    // When the suite finishes, the detached task hands the exit code back to the
+    // MAIN thread (via a main-queue enqueue that stops the loop); `main()` then
+    // exits cleanly THERE — no more `exit()` from the detached task out from under
+    // a live run loop (that was the teardown SIGTRAP / hang). `runAllTests()` is
+    // `nonisolated` so its body inherits the detached (non-main) executor.
+    static func main() {
+        // Line-buffer stdout. When this runner's output is a pipe (CI: `… | tee`),
+        // stdout defaults to FULL buffering, so on an intermittent hang the buffered
+        // tail never flushes and the CI log's last line is NOT where it actually hung —
+        // it just shows the last flushed block. Line buffering flushes on every newline
+        // (negligible overhead: ~one flush per test line, unlike per-byte unbuffered),
+        // so the CI log always pinpoints the hanging test. Distinct from the summary
+        // teardown race, which is handled by the atexit summary handler below.
+        setvbuf(stdout, nil, _IOLBF, 0)
 
-let gate = SecurityGate()
+        // HERMETIC TEST ISOLATION (v3.6.1): point ConfigManager at a throwaway temp
+        // config file BEFORE any test (or ConfigManager.shared) touches it. Without
+        // this, ConfigManagerTests read and mutate the user's real
+        // ~/.config/.../config.json — non-hermetic, order-dependent, destructive.
+        // Seeds a minimal valid config so first reads succeed.
+        if ProcessInfo.processInfo.environment["BRIDGE_CONFIG_PATH"] == nil {
+            let tmpConfig = FileManager.default.temporaryDirectory
+                .appendingPathComponent("bridge-test-config-\(ProcessInfo.processInfo.processIdentifier).json")
+            setenv("BRIDGE_CONFIG_PATH", tmpConfig.path, 1)
+            let seed = #"{"sensitivePaths":["~/.ssh","~/.aws","~/.gnupg","~/.config","~/Library/Keychains"]}"#
+            try? seed.data(using: .utf8)?.write(to: tmpConfig, options: .atomic)
+        }
+
+        // Credential / payment MCP tests assume the Keychain credentials feature is enabled.
+        UserDefaults.standard.set(true, forKey: CredentialsFeature.userDefaultsKey)
+
+        // Emit the final summary from an atexit handler so it is GUARANTEED to print.
+        // The synchronous continuation after the final suspension point can
+        // intermittently lose a race with process teardown and be skipped entirely
+        // (the binary still exits 0 and every test ran) — which dropped the
+        // `Results:` line the floor gate parses. atexit handlers run during any
+        // normal process exit, after all code, so the summary is deterministic
+        // regardless of that race or of stdout buffering mode. The closure
+        // references only globals, so it captures nothing (@convention(c)-safe).
+        atexit {
+            print("\n" + String(repeating: "=", count: 50))
+            print("Results: \(passed) passed, \(failed) failed, \(passed + failed) total")
+            print(String(repeating: "=", count: 50))
+            print(failed > 0 ? "\u{274C} TESTS FAILED" : "\u{2705} ALL TESTS PASSED")
+            fflush(stdout)
+        }
+
+        // Run the test sequence OFF the main actor (see the entry-point note),
+        // then pump the main run loop so the (now real) MainActor.run hops and any
+        // CFRunLoop-dependent system callbacks (ScreenCaptureKit / AppKit) are
+        // serviced while the suite runs.
+        //
+        // CLEAN MAIN-THREAD SHUTDOWN (teardown-SIGTRAP fix). The driver used to
+        // call `exit()` from INSIDE the detached task while the main thread was
+        // blocked in `RunLoop.main.run()`. That tore the process down from under a
+        // live CFRunLoop mid-iteration: the C++/Swift-runtime teardown ran while
+        // the run loop was still servicing the main dispatch queue, which
+        // intermittently SIGTRAP'd during teardown BEFORE the atexit summary
+        // handler could print the `Results:` line — so a run that passed every
+        // test exited with no summary (and the operator's truncated-count race has
+        // the same root cause). It could also HANG: if an arming subsystem (e.g. a
+        // test that constructs a real AppDelegate → Sparkle auto-updater) had
+        // scheduled main-queue work, the still-pumping run loop would service it
+        // and present a modal `NSAlert`, wedging the main thread forever.
+        //
+        // FIX: when the suite finishes, the detached task records the exit code and
+        // enqueues a MAIN-QUEUE work item (DispatchQueue.main.async) that sets the
+        // `suiteFinished` flag and stops the loop. The main thread drives the run
+        // loop in a `while !suiteFinished` loop using CFRunLoopRunInMode, then falls
+        // through and exits ON the main thread. Why each piece is the robust form:
+        //   • Hand-off via the main queue (not exit() / CFRunLoopStop from the
+        //     task's own thread): CFRunLoopStop from a FOREIGN thread races an idle
+        //     main loop — it sets the stop flag but the loop only notices on wake,
+        //     and a loop parked in mach_msg with no pending source can miss the
+        //     wakeup and sleep forever. A main-queue enqueue is itself a source the
+        //     main loop always services, so it reliably WAKES the loop and the block
+        //     runs ON the main thread, where the stop is race-free.
+        //   • A `while !suiteFinished { CFRunLoopRunInMode(...) }` drive instead of
+        //     `RunLoop.main.run()`: NSRunLoop.run() runs the loop "permanently" by
+        //     re-entering its inner runMode loop after every return, so a
+        //     CFRunLoopStop breaks ONE inner iteration and run() immediately
+        //     re-enters — it never hands control back (observed: every test printed,
+        //     then a permanent hang in RunLoop.main.run()). Driving the mode
+        //     ourselves and re-checking the flag each iteration makes the stop
+        //     actually return to us. We pump in .defaultMode, which is what
+        //     RunLoop.main.run() used and what services MainActor + the
+        //     CFRunLoop-dependent SCK/AppKit callbacks the suite relies on.
+        // Net: exit() runs on the main thread with the loop torn down in an orderly
+        // way; the atexit summary handler fires on that clean exit, so the
+        // `Results:` summary is emitted deterministically with the full count, every
+        // run.
+        Task.detached(priority: .userInitiated) {
+            await runAllTests()
+            exitCode = failed > 0 ? 1 : 0
+            DispatchQueue.main.async {
+                suiteFinished = true
+                CFRunLoopStop(CFRunLoopGetMain())
+            }
+        }
+        while !suiteFinished {
+            // Block until a source fires (test-driven MainActor hops, SCK/AppKit
+            // callbacks, or the shutdown enqueue), then re-check the flag. Result
+            // handling: .stopped/.handledSource → just loop and re-check. .finished
+            // means the mode momentarily had NO sources/timers and returned at once;
+            // re-running immediately would busy-spin, so back off briefly. In
+            // practice the main dispatch-queue port keeps the mode non-empty for the
+            // whole suite, so .finished is a defensive guard, not the steady state.
+            let result = CFRunLoopRunInMode(.defaultMode, 0.1, false)
+            if result == .finished {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+        }
+
+        // Reached only after the shutdown block set the flag + stopped the loop.
+        // Exit on the MAIN thread with the suite's code; the atexit handler prints
+        // the summary.
+        exit(exitCode)
+    }
+
+    // The full test sequence. `nonisolated` so it runs on whatever (non-main)
+    // executor the detached task provides, NOT the main actor.
+    nonisolated static func runAllTests() async {
+        // ============================================================
+        // MARK: - SecurityGate Tests (v3: 3-tier model)
+        // ============================================================
+
+        print("\n\u{1F512} SecurityGate Tests (v3)")
+
+        let gate = SecurityGate()
 
 await test("Open tier allows immediately") {
     let d = await gate.enforce(toolName: "read_file", tier: .open, arguments: .object(["path": .string("/tmp/test.txt")]))
@@ -352,18 +515,6 @@ await test("Dispatch returns handoff for fork-bomb commands") {
 
 print("\n\u{1F4CB} AuditLog Tests")
 
-func makeSampleEntry(
-    toolName: String = "test_tool",
-    tier: SecurityTier = .open,
-    status: ApprovalStatus = .approved
-) -> AuditEntry {
-    AuditEntry(
-        timestamp: Date(), toolName: toolName, tier: tier,
-        inputSummary: "test input", outputSummary: "test output",
-        durationMs: 42.0, approvalStatus: status
-    )
-}
-
 await test("Append adds entry to in-memory log") {
     let log = AuditLog()
     await log.append(makeSampleEntry())
@@ -596,9 +747,11 @@ await runBridgeCloudManagerTests()
 // MARK: - Summary
 // ============================================================
 
-// Summary is emitted by the atexit handler registered at startup (reliable even
-// if this top-level continuation is skipped by the teardown race). This exit is
-// best-effort: when it runs it sets the proper code AND triggers the atexit
-// summary; if the race skips it, the implicit exit(0) still fires the atexit
-// summary and the floor gate derives pass/fail from the `Results:` count.
-exit(failed > 0 ? 1 : 0)
+// Summary is emitted by the atexit handler registered at startup, which fires on
+// the clean main-thread exit() that `main()` performs after this task stops the
+// run loop. This function NO LONGER calls exit() itself: exiting from here (off
+// the main thread, mid-RunLoop) is exactly the teardown-SIGTRAP this fix removes.
+// The exit code + CFRunLoopStop are handled by the detached-task wrapper in
+// main(); when control returns there, main() exits on the main thread.
+    } // static func runAllTests()
+} // @main struct NotionBridgeTestRunner

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -611,6 +611,7 @@ await runFileModuleTests()
 await runSessionModuleTests()
 await runMessagesModuleTests()
 await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
+await runMailModuleTests()           // PKT-961 (v3.7·H): mail_* Apple Mail module (mock seam; send-guard)
 await runSystemModuleTests()
 await runRemindersModuleTests()   // PKT-957 (v3.7·D): reminders_* EventKit module (mock seam)
 await runNotionModuleTests()

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -767,6 +767,15 @@ await runBridgeCloudManagerTests()
 // rename.)
 await runEnableCloudAccessFlowTests()
 
+// WS-G (PKT-923 · Bridge Cloud Access · terminal UI packet): the one-time
+// FirstRunCloudAccessModal gate (Q2: shown once, BridgeDefaults flag), the
+// Add-to-Claude.ai MCP-URL derivation + query-value percent-encoding contract
+// + Q3 copy+hint shipped mode, and the Disable flow (confirmationDialog →
+// EnableCloudAccessFlow.disable() → CloudTeardown seam + cleared toggle/host;
+// live BridgeCloudManager.disable() → .disabled). All against fakes (no
+// SwiftUI render / WindowServer / cloudflared / network).
+await runCloudAccessWSGTests()
+
 // ============================================================
 // MARK: - Summary
 // ============================================================

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -656,6 +656,7 @@ await runLspModuleRenameRefsLiveTests()
 await runWSHMenuBarTests()        // PKT-804 (v2.3): menu-bar quick-page
 await runSnippetsModuleTests()    // PKT-2135a9e9 (v2.3 · WS-D): snippets module
 await runStandingOrdersModuleTests() // PKT-931 (v3.7·B): standing_orders_* MCP tools
+await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)
 await runFetchSkillMarkdownTests() // cmd-w4: fetch_skill /markdown + shared MentionResolver
 await runFetchSkillPropertiesTests() // cu-sa: fetch_skill simplified `properties` map (additive)

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -767,6 +767,16 @@ await runBridgeCloudManagerTests()
 // rename.)
 await runEnableCloudAccessFlowTests()
 
+// WS-D (PKT-921, Bridge Cloud Access): heartbeat loop over the WS-C
+// BridgeCloudManager (start/stop on toggle, idempotent start), the
+// cloud-gated `bridge_status` MCP tool (gated registration + canonical
+// state-derived payload, NOT in the static feature-module count), and the
+// ServerManager tools/list cloud conditional (CLOUD+offline/disabled → only
+// bridge_status; CLOUD+online/degraded → full; local request never filtered).
+// All against the in-memory WS-C fakes — no cloudflared, no network, no 30s
+// waits (the heartbeat interval is shrunk + ticks observed via onTick).
+await runCloudStatusModuleTests()
+
 // ============================================================
 // MARK: - Summary
 // ============================================================

--- a/NotionBridgeTests/ToolAnnotationAuditTests.swift
+++ b/NotionBridgeTests/ToolAnnotationAuditTests.swift
@@ -35,12 +35,17 @@ func runToolAnnotationAuditTests() async {
         try expect(!regs.isEmpty, "router registered no tools")
     }
 
-    await test("annotation catalog has no stale entries (catalog ⊆ live ∪ {stripe_reconnect})") {
+    await test("annotation catalog has no stale entries (catalog ⊆ live ∪ {stripe_reconnect, bridge_status})") {
         // Tools registered outside the module surface this static router
         // builds: stripe_reconnect (StripeMcpModule — network-dependent).
         // Sprint A · mcp-builder #8: `echo` removed from this allowlist
         // along with the builtin registration in ServerManager.setup().
-        let allowedDynamic: Set<String> = ["stripe_reconnect"]
+        // WS-D (PKT-921): bridge_status is registered ONLY when
+        // BridgeDefaults.cloudAccessEnabled (via registerCloudStatusTool, NOT
+        // the static surface), so it carries a catalog annotation without
+        // appearing in this cloud-off static router — same shape as
+        // stripe_reconnect's network-gated exclusion.
+        let allowedDynamic: Set<String> = ["stripe_reconnect", "bridge_status"]
         let stale = Set(ToolAnnotationCatalog.entries.keys)
             .subtracting(liveNames)
             .subtracting(allowedDynamic)

--- a/NotionBridgeTests/main.swift
+++ b/NotionBridgeTests/main.swift
@@ -460,6 +460,7 @@ await runFileModuleTests()
 await runSessionModuleTests()
 await runMessagesModuleTests()
 await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
+await runNotesModuleTests()          // v3.7·G: Apple Notes (notes_*) over injectable AppleScript seam
 await runSystemModuleTests()
 await runNotionModuleTests()
 await runAccessibilityModuleTests()

--- a/NotionBridgeTests/main.swift
+++ b/NotionBridgeTests/main.swift
@@ -461,6 +461,7 @@ await runSessionModuleTests()
 await runMessagesModuleTests()
 await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
 await runSystemModuleTests()
+await runRemindersModuleTests()   // PKT-957 (v3.7·D): reminders_* EventKit module (mock seam)
 await runNotionModuleTests()
 await runAccessibilityModuleTests()
 await runScreenModuleTests()

--- a/NotionBridgeTests/main.swift
+++ b/NotionBridgeTests/main.swift
@@ -592,6 +592,15 @@ await runSkillsCacheTests()
 // no-raw-credential invariant) + Remote Access settings section/sidebar.
 await runBridgeCloudManagerTests()
 
+// WS-F (Bridge Cloud Access · Enable flow): the EnableCloudAccessFlow
+// @Observable state machine (idle→checkingAccount→signingIn→provisioning→
+// connected|failed), WorkOS sign-in URL builder + bridge-auth:// callback
+// parse/exchange/persist/notify, 120s auth + 30s provision timeouts, toggle
+// revert on failure, and the ProvisioningProgressView state mapping — all
+// against mocks (no NSWorkspace / Keychain prompt / cloudflared / live
+// WorkOS). Live end-to-end QA is gated on PKT-810 + WS-A.
+await runEnableCloudAccessFlowTests()
+
 // ============================================================
 // MARK: - Summary
 // ============================================================

--- a/NotionBridgeTests/main.swift
+++ b/NotionBridgeTests/main.swift
@@ -503,6 +503,7 @@ await runLspModuleTests()
 await runLspModuleRenameRefsLiveTests()
 await runWSHMenuBarTests()        // PKT-804 (v2.3): menu-bar quick-page
 await runSnippetsModuleTests()    // PKT-2135a9e9 (v2.3 · WS-D): snippets module
+await runStandingOrdersModuleTests() // PKT-931 (v3.7·B): standing_orders_* MCP tools
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)
 await runFetchSkillMarkdownTests() // cmd-w4: fetch_skill /markdown + shared MentionResolver
 await runFetchSkillPropertiesTests() // cu-sa: fetch_skill simplified `properties` map (additive)

--- a/docs/test-infra/defect2-mainactor-harness-candidate.swift.txt
+++ b/docs/test-infra/defect2-mainactor-harness-candidate.swift.txt
@@ -1,0 +1,679 @@
+// TestRunner.swift – V1-06 Test Runner
+// NotionBridge · Tests (standalone executable — no XCTest needed)
+//
+// Runs: SecurityGate, ToolRouter, AuditLog, Module tests, Integration/E2E tests
+// PKT-376: SecurityGate tests updated for 3-tier model
+//
+// MAIN-ACTOR REENTRANCY FIX (summary; full reasoning at the @main entry point
+// below): the UI/contract tests hop to the main actor via
+// `await MainActor.run { ... }` (55 call sites across 11 files). If the driver
+// itself runs ON the main actor those hops are reentrant self-calls that
+// nondeterministically deadlock (the suite froze at 0% progress on ~50% of
+// runs, always GREEN when it finished). The driver MUST run off the main actor.
+// This file used to be a `main.swift` (top-level code → implicitly main-actor)
+// and the deadlock was endemic. It is now `TestRunner.swift` with a `@main`
+// struct whose SYNCHRONOUS `main()` runs the whole sequence on a `Task.detached`
+// (off the main actor) while pumping the main run loop with `RunLoop.main.run()`.
+// (A `main.swift` file and a `@main` attribute are mutually exclusive in one
+// target, hence the rename.) The shared harness primitives (`test`, `expect`,
+// `TestError`, `passed`, `failed`) stay at file scope because the other test
+// files call them as free functions.
+
+import Foundation
+
+
+import MCP
+import NotionBridgeLib
+
+// MARK: - Test Harness (file scope — other test files call these as free functions)
+
+nonisolated(unsafe) var passed = 0
+nonisolated(unsafe) var failed = 0
+
+// `body` is `sending`: the driver now runs OFF the main actor (see the @main
+// note above), so each test closure is created in the driver's isolation domain
+// and handed to `test()` — marking it `sending` lets ownership transfer across
+// that boundary without a Sendable conformance, which is safe because the
+// closure is used exactly once and never escapes.
+func test(_ name: String, _ body: sending () async throws -> Void) async {
+    do {
+        try await body()
+        passed += 1
+        print("  \u{2705} \(name)")
+    } catch {
+        failed += 1
+        print("  \u{274C} \(name): \(error)")
+    }
+}
+
+func expect(_ condition: Bool, _ msg: String = "Assertion failed", file: String = #file, line: Int = #line) throws {
+    guard condition else { throw TestError.assertion("\(msg) at \(file):\(line)") }
+}
+
+enum TestError: Error, LocalizedError {
+    case assertion(String)
+    var errorDescription: String? {
+        switch self { case .assertion(let m): return m }
+    }
+}
+
+// AuditLog test fixture. Hoisted to file scope (was a local func inside the
+// driver) so the off-main-actor `sending` test closures can call it without
+// crossing an actor boundary; `nonisolated` because AuditEntry is a plain value.
+nonisolated func makeSampleEntry(
+    toolName: String = "test_tool",
+    tier: SecurityTier = .open,
+    status: ApprovalStatus = .approved
+) -> AuditEntry {
+    AuditEntry(
+        timestamp: Date(), toolName: toolName, tier: tier,
+        inputSummary: "test input", outputSummary: "test output",
+        durationMs: 42.0, approvalStatus: status
+    )
+}
+
+// MARK: - Entry point
+
+@main
+struct NotionBridgeTestRunner {
+    // MAIN-ACTOR REENTRANCY FIX (corrected). Symptom: the suite froze at 0%
+    // forward progress on ~50% of local runs, at varying points, always GREEN
+    // when it did finish — a nondeterministic deadlock on the main actor.
+    //
+    // Root cause: the UI/contract tests hop to the main actor via
+    // `await MainActor.run { ... }` (55 call sites across 11 files) to touch
+    // @MainActor types (SwiftUI views, @Observable controllers, AppKit). If the
+    // DRIVER itself runs ON the main actor, those hops are REENTRANT self-calls on
+    // the same actor, which nondeterministically deadlock.
+    //
+    // The original driver was a `main.swift` whose top-level code is implicitly
+    // @MainActor-isolated → on the main actor → deadlock. Renaming it to an
+    // `async @main` did NOT fix it: under swift-tools-version 6.2 ("approachable
+    // concurrency") the `async static func main()` of a `@main` type is INFERRED
+    // @MainActor-isolated, so it STILL ran on the main actor (verified
+    // empirically: `main()`'s body and its nested `MainActor.run` bodies both ran
+    // on the main thread → still reentrant → still deadlocked). A bare
+    // `Task.detached` wrapper with `await runner.value` ALSO failed: while `main()`
+    // was suspended the main run loop was not pumped, so SCK/AppKit replies and
+    // MainActor scheduling stalled → intermittent hangs AND a teardown SIGTRAP.
+    //
+    // FIX: a SYNCHRONOUS `main()` (synchronous → NOT an async main-actor task; it
+    // is the plain process entry on the main thread). It spawns the whole test
+    // sequence on a `Task.detached`, which runs OFF the main actor, then pumps the
+    // main run loop via `RunLoop.main.run()`. Result: the driver body runs off the
+    // main actor (every `MainActor.run` is now a REAL cross-actor hop, not a
+    // reentrant self-call — no deadlock), and the live main run loop keeps the
+    // main actor serviced AND services CFRunLoop-dependent system callbacks
+    // (ScreenCaptureKit / AppKit). `runAllTests()` calls `exit()` when done, which
+    // tears the process down out from under the run loop. `runAllTests()` is
+    // `nonisolated` so its body inherits the detached (non-main) executor.
+    static func main() {
+        // Line-buffer stdout. When this runner's output is a pipe (CI: `… | tee`),
+        // stdout defaults to FULL buffering, so on an intermittent hang the buffered
+        // tail never flushes and the CI log's last line is NOT where it actually hung —
+        // it just shows the last flushed block. Line buffering flushes on every newline
+        // (negligible overhead: ~one flush per test line, unlike per-byte unbuffered),
+        // so the CI log always pinpoints the hanging test. Distinct from the summary
+        // teardown race, which is handled by the atexit summary handler below.
+        setvbuf(stdout, nil, _IOLBF, 0)
+
+        // HERMETIC TEST ISOLATION (v3.6.1): point ConfigManager at a throwaway temp
+        // config file BEFORE any test (or ConfigManager.shared) touches it. Without
+        // this, ConfigManagerTests read and mutate the user's real
+        // ~/.config/.../config.json — non-hermetic, order-dependent, destructive.
+        // Seeds a minimal valid config so first reads succeed.
+        if ProcessInfo.processInfo.environment["BRIDGE_CONFIG_PATH"] == nil {
+            let tmpConfig = FileManager.default.temporaryDirectory
+                .appendingPathComponent("bridge-test-config-\(ProcessInfo.processInfo.processIdentifier).json")
+            setenv("BRIDGE_CONFIG_PATH", tmpConfig.path, 1)
+            let seed = #"{"sensitivePaths":["~/.ssh","~/.aws","~/.gnupg","~/.config","~/Library/Keychains"]}"#
+            try? seed.data(using: .utf8)?.write(to: tmpConfig, options: .atomic)
+        }
+
+        // Credential / payment MCP tests assume the Keychain credentials feature is enabled.
+        UserDefaults.standard.set(true, forKey: CredentialsFeature.userDefaultsKey)
+
+        // Emit the final summary from an atexit handler so it is GUARANTEED to print.
+        // The synchronous continuation after the final suspension point can
+        // intermittently lose a race with process teardown and be skipped entirely
+        // (the binary still exits 0 and every test ran) — which dropped the
+        // `Results:` line the floor gate parses. atexit handlers run during any
+        // normal process exit, after all code, so the summary is deterministic
+        // regardless of that race or of stdout buffering mode. The closure
+        // references only globals, so it captures nothing (@convention(c)-safe).
+        atexit {
+            print("\n" + String(repeating: "=", count: 50))
+            print("Results: \(passed) passed, \(failed) failed, \(passed + failed) total")
+            print(String(repeating: "=", count: 50))
+            print(failed > 0 ? "\u{274C} TESTS FAILED" : "\u{2705} ALL TESTS PASSED")
+            fflush(stdout)
+        }
+
+        // Run the test sequence OFF the main actor (see the entry-point note),
+        // then pump the main run loop so the (now real) MainActor.run hops and any
+        // CFRunLoop-dependent system callbacks are serviced. The detached task
+        // calls exit() when the suite finishes, so RunLoop.main.run() never
+        // returns normally — the process is torn down from under it.
+        Task.detached(priority: .userInitiated) {
+            await runAllTests()
+        }
+        RunLoop.main.run()
+    }
+
+    // The full test sequence. `nonisolated` so it runs on whatever (non-main)
+    // executor the detached task provides, NOT the main actor.
+    nonisolated static func runAllTests() async {
+        // ============================================================
+        // MARK: - SecurityGate Tests (v3: 3-tier model)
+        // ============================================================
+
+        print("\n\u{1F512} SecurityGate Tests (v3)")
+
+        let gate = SecurityGate()
+
+await test("Open tier allows immediately") {
+    let d = await gate.enforce(toolName: "read_file", tier: .open, arguments: .object(["path": .string("/tmp/test.txt")]))
+    if case .allow = d { } else { throw TestError.assertion("Expected .allow for open tier") }
+}
+
+await test("Open tier allows with safe content") {
+    let d = await gate.enforce(toolName: "write_file", tier: .open, arguments: .object(["path": .string("/tmp/out.txt")]))
+    if case .allow = d { } else { throw TestError.assertion("Expected .allow for open tier write") }
+}
+
+await test("SecurityTier has exactly 3 cases") {
+    try expect(SecurityTier.allCases.count == 3, "Expected 3 tiers, got \(SecurityTier.allCases.count)")
+    try expect(SecurityTier.allCases.contains(.open))
+    try expect(SecurityTier.allCases.contains(.notify))
+    try expect(SecurityTier.allCases.contains(.request))
+}
+
+await test("SecurityTier raw values are correct") {
+    try expect(SecurityTier.open.rawValue == "open")
+    try expect(SecurityTier.notify.rawValue == "notify")
+    try expect(SecurityTier.request.rawValue == "request")
+}
+
+await test("SecurityTier is Codable (JSON round-trip)") {
+    let encoder = JSONEncoder()
+    let data = try encoder.encode(SecurityTier.open)
+    let decoder = JSONDecoder()
+    let decoded = try decoder.decode(SecurityTier.self, from: data)
+    try expect(decoded == .open, "Expected .open after decode")
+}
+
+// Nuclear pattern tests — fork bomb only
+let forkBomb = ":(){ :|:" + "& };:"
+
+await test("Nuclear handoff: fork bomb") {
+    let d = await gate.checkNuclearPattern(forkBomb.lowercased(), raw: forkBomb)
+    guard let decision = d else { throw TestError.assertion("Expected non-nil for fork bomb") }
+    if case .handoff = decision { } else { throw TestError.assertion("Expected .handoff") }
+}
+
+await test("Diskutil is not nuclear anymore") {
+    let cmd = "diskutil erasedisk JHFS+ Untitled /dev/disk2"
+    let d = await gate.checkNuclearPattern(cmd.lowercased(), raw: cmd)
+    try expect(d == nil, "Expected nil for diskutil")
+}
+
+await test("sudo is not nuclear anymore") {
+    let cmd = "sudo -n true"
+    let d = await gate.checkNuclearPattern(cmd.lowercased(), raw: cmd)
+    try expect(d == nil, "Expected nil for sudo")
+}
+
+await test("Nuclear handoff returns command in decision") {
+    let d = await gate.checkNuclearPattern(forkBomb.lowercased(), raw: forkBomb)
+    if case .handoff(let cmd, let explanation, let warning) = d {
+        try expect(!cmd.isEmpty, "Command should not be empty")
+        try expect(!explanation.isEmpty, "Explanation should not be empty")
+        try expect(!warning.isEmpty, "Warning should not be empty")
+    } else {
+        throw TestError.assertion("Expected .handoff with all fields")
+    }
+}
+
+// Sensitive path tests — checkSensitivePaths is async and triggers notifications.
+// For unit tests, we test that the method exists and can detect sensitive paths
+// by checking session/permanent allow behavior.
+
+await test("Session permissions start empty and can be cleared") {
+    await gate.clearSessionPermissions()
+    // After clearing, no paths should be session-allowed
+    // (We can't easily test the notification flow in unit tests)
+}
+
+await test("NotionPageRef normalizes dashed UUID and notion.so URL") {
+    let id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    switch NotionPageRef.normalizedPageId(from: id) {
+    case .success(let n):
+        try expect(n.contains("-"), "Expected dashed UUID form")
+        try expect(n.replacingOccurrences(of: "-", with: "").count == 32, "Expected 32 hex")
+    case .failure(let err):
+        throw TestError.assertion("Expected valid page id: \(err.message)")
+    }
+    let url = "https://www.notion.so/w/Test-a1b2c3d4e5f67890abcdef1234567890"
+    switch NotionPageRef.normalizedPageId(from: url) {
+    case .success(let n):
+        try expect(n.lowercased().contains("a1b2c3d4"), "Expected id from URL")
+    case .failure(let err):
+        throw TestError.assertion("Expected URL parse: \(err.message)")
+    }
+}
+
+await test("NotionPageRef rejects non-Notion URL") {
+    switch NotionPageRef.normalizedPageId(from: "https://example.com/page") {
+    case .success:
+        throw TestError.assertion("Expected failure for non-Notion URL")
+    case .failure(let err):
+        try expect(!err.message.isEmpty, "Expected error message")
+    }
+}
+
+await test("Permanent access can be granted and revoked") {
+    // Test isolation (flake fix): grant/revokePermanentAccess mutate
+    // process-global UserDefaults.standard under a key derived purely from
+    // the path. A hardcoded shared path ("~/.ssh") made this key collide
+    // with the sibling "permanent allow passes through" test, so concurrent
+    // or order-dependent suite execution raced on the same global key and
+    // produced nondeterministic pass/fail. This test only needs a
+    // round-trip on the raw key, so use a per-test UNIQUE path → unique key
+    // that can never collide with any other test or the seeded defaults.
+    // Belt-and-suspenders: snapshot & restore the exact key so neither
+    // direction of contamination is possible regardless of harness order.
+    let testPath = "~/.notionbridge-test-permaccess-\(UUID().uuidString)"
+    let key = "com.notionbridge.security.pathAllow." + testPath
+    let saved = UserDefaults.standard.object(forKey: key)
+    defer {
+        if let saved { UserDefaults.standard.set(saved, forKey: key) }
+        else { UserDefaults.standard.removeObject(forKey: key) }
+    }
+    await gate.grantPermanentAccess(path: testPath)
+    try expect(UserDefaults.standard.bool(forKey: key) == true, "Expected permanent access granted")
+    await gate.revokePermanentAccess(path: testPath)
+    try expect(UserDefaults.standard.bool(forKey: key) == false, "Expected permanent access revoked")
+}
+
+await test("Sensitive path with permanent allow passes through") {
+    // Test isolation (flake fix): this test MUST use a real configured
+    // sensitive path ("~/.ssh" — a ConfigManager default) because
+    // checkSensitivePaths only honors the permanent key when the path
+    // matches the sensitive-paths list, so a UUID path cannot exercise it.
+    // The shared global key is therefore structurally unavoidable here;
+    // serialize safety by snapshotting the exact key, force-clearing it to
+    // a known state before the grant, and restoring the original value in a
+    // guaranteed cleanup that runs on BOTH the success and failure path so
+    // this test can neither be contaminated by nor leak into any sibling.
+    let testPath = "~/.ssh"
+    let key = "com.notionbridge.security.pathAllow." + testPath
+    let saved = UserDefaults.standard.object(forKey: key)
+    defer {
+        if let saved { UserDefaults.standard.set(saved, forKey: key) }
+        else { UserDefaults.standard.removeObject(forKey: key) }
+    }
+    UserDefaults.standard.removeObject(forKey: key)
+    await gate.grantPermanentAccess(path: testPath)
+    // With permanent allow, checkSensitivePaths should return nil (allow)
+    let result = await gate.checkSensitivePaths(["~/.ssh/id_rsa"], toolName: "file_read")
+    try expect(result == nil, "Expected nil (allow) for permanently allowed path")
+    await gate.revokePermanentAccess(path: testPath)
+}
+
+await test("GateDecision.handoff is not allow or reject") {
+    let d = await gate.checkNuclearPattern(forkBomb.lowercased(), raw: forkBomb)
+    if case .allow = d { throw TestError.assertion("Nuclear should not be .allow") }
+    if case .reject = d { throw TestError.assertion("Nuclear should not be .reject") }
+    if case .handoff = d { /* expected */ } else { throw TestError.assertion("Expected .handoff") }
+}
+
+// ============================================================
+// MARK: - ToolRouter Tests
+// ============================================================
+
+print("\n\u{1F500} ToolRouter Tests")
+
+let routerGate = SecurityGate()
+let routerLog = AuditLog()
+let router = ToolRouter(securityGate: routerGate, auditLog: routerLog)
+
+await test("Tool registration stores and retrieves tools") {
+    await router.register(ToolRegistration(
+        name: "test_tool", module: "test", tier: .open,
+        description: "A test tool",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in .string("ok") }
+    ))
+    let all = await router.allRegistrations()
+    try expect(all.count >= 1, "Expected at least 1 registration")
+    try expect(all.contains(where: { $0.name == "test_tool" }), "Expected test_tool in registry")
+}
+
+await test("Registration overwrites existing tool with same name") {
+    await router.register(ToolRegistration(
+        name: "overwrite_test", module: "mod1", tier: .open,
+        description: "Version 1", inputSchema: .object([:]),
+        handler: { _ in .string("v1") }
+    ))
+    await router.register(ToolRegistration(
+        name: "overwrite_test", module: "mod1", tier: .open,
+        description: "Version 2", inputSchema: .object([:]),
+        handler: { _ in .string("v2") }
+    ))
+    let all = await router.allRegistrations()
+    let match = all.first(where: { $0.name == "overwrite_test" })
+    try expect(match?.description == "Version 2", "Expected Version 2")
+}
+
+await test("Registrations can be filtered by module") {
+    await router.register(ToolRegistration(
+        name: "alpha_tool", module: "alpha", tier: .open,
+        description: "A", inputSchema: .object([:]),
+        handler: { _ in .null }
+    ))
+    let alpha = await router.registrations(forModule: "alpha")
+    try expect(alpha.count >= 1)
+    try expect(alpha[0].name == "alpha_tool")
+}
+
+await test("Dispatch routes to correct handler") {
+    await router.register(ToolRegistration(
+        name: "echo_test", module: "builtin", tier: .open,
+        description: "Echo test", inputSchema: .object([:]),
+        handler: { args in
+            if case .object(let dict) = args,
+               case .string(let msg) = dict["message"] {
+                return .string("echo: \(msg)")
+            }
+            return .string("no message")
+        }
+    ))
+    let result = try await router.dispatch(
+        toolName: "echo_test",
+        arguments: .object(["message": .string("hello")])
+    )
+    if case .string(let s) = result {
+        try expect(s == "echo: hello", "Expected 'echo: hello' got '\(s)'")
+    } else {
+        throw TestError.assertion("Expected string result")
+    }
+}
+
+await test("Dispatch throws for unknown tool") {
+    do {
+        _ = try await router.dispatch(toolName: "nonexistent_xyz", arguments: .object([:]))
+        throw TestError.assertion("Expected error for unknown tool")
+    } catch is ToolRouterError {
+        // Expected
+    }
+}
+
+await test("Dispatch returns handoff for fork-bomb commands") {
+    await router.register(ToolRegistration(
+        name: "nuclear_test", module: "test", tier: .open,
+        description: "Test", inputSchema: .object([:]),
+        handler: { _ in .string("should not reach") }
+    ))
+    let result = try await router.dispatch(
+        toolName: "nuclear_test",
+        arguments: .object(["command": .string(forkBomb)])
+    )
+    if case .object(let dict) = result {
+        if case .string(let status) = dict["status"] {
+            try expect(status == "handoff", "Expected status=handoff, got \(status)")
+        } else {
+            throw TestError.assertion("Expected status key in handoff response")
+        }
+    } else {
+        throw TestError.assertion("Expected object result for fork-bomb handoff")
+    }
+}
+
+// PKT-373 P1-5: batchGate tests removed (dead code removed)
+
+// ============================================================
+// MARK: - AuditLog Tests
+// ============================================================
+
+print("\n\u{1F4CB} AuditLog Tests")
+
+await test("Append adds entry to in-memory log") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry())
+    let count = await log.count()
+    try expect(count == 1, "Expected count 1, got \(count)")
+}
+
+await test("Multiple appends accumulate") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry(toolName: "tool_a"))
+    await log.append(makeSampleEntry(toolName: "tool_b"))
+    await log.append(makeSampleEntry(toolName: "tool_c"))
+    let count = await log.count()
+    try expect(count == 3, "Expected count 3, got \(count)")
+}
+
+await test("All entries returns complete log") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry(toolName: "alpha"))
+    await log.append(makeSampleEntry(toolName: "beta"))
+    let entries = await log.allEntries()
+    try expect(entries.count == 2)
+    try expect(entries[0].toolName == "alpha")
+    try expect(entries[1].toolName == "beta")
+}
+
+await test("Filter by tool name") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry(toolName: "echo"))
+    await log.append(makeSampleEntry(toolName: "tools_list"))
+    await log.append(makeSampleEntry(toolName: "echo"))
+    let echoEntries = await log.entries(forTool: "echo")
+    try expect(echoEntries.count == 2)
+}
+
+await test("Filter by tier") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry(tier: .open))
+    await log.append(makeSampleEntry(tier: .notify))
+    await log.append(makeSampleEntry(tier: .open))
+    let openEntries = await log.entries(forTier: .open)
+    try expect(openEntries.count == 2)
+}
+
+await test("Filter by approval status") {
+    let log = AuditLog()
+    await log.append(makeSampleEntry(status: .approved))
+    await log.append(makeSampleEntry(status: .rejected))
+    await log.append(makeSampleEntry(status: .approved))
+    let rejected = await log.entries(withStatus: .rejected)
+    try expect(rejected.count == 1)
+}
+
+await test("Entry contains all required fields") {
+    let log = AuditLog()
+    let entry = AuditEntry(
+        timestamp: Date(), toolName: "test", tier: .open,
+        inputSummary: "input", outputSummary: "output",
+        durationMs: 100.5, approvalStatus: .approved
+    )
+    await log.append(entry)
+    let entries = await log.allEntries()
+    let first = entries[0]
+    try expect(first.toolName == "test")
+    try expect(first.tier == .open)
+    try expect(first.inputSummary == "input")
+    try expect(first.outputSummary == "output")
+    try expect(first.durationMs == 100.5)
+    try expect(first.approvalStatus == .approved)
+}
+
+await test("AuditEntry is Codable (JSON round-trip)") {
+    let entry = makeSampleEntry()
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(entry)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let decoded = try decoder.decode(AuditEntry.self, from: data)
+    try expect(decoded.toolName == entry.toolName)
+    try expect(decoded.tier == entry.tier)
+    try expect(decoded.approvalStatus == entry.approvalStatus)
+}
+
+// ============================================================
+// MARK: - V1-04/V1-05 Module Tests
+// ============================================================
+
+// SKIPPED: checkAll() hangs in CLI — NSAppleScript probes need AppKit run loop
+// await runPermissionManagerTests()
+await runShellModuleTests()
+await runLspModuleTests()
+await runFileModuleTests()
+await runSessionModuleTests()
+await runMessagesModuleTests()
+await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
+await runSystemModuleTests()
+await runNotionModuleTests()
+await runAccessibilityModuleTests()
+await runScreenModuleTests()
+await runAppleScriptModuleTests()
+await runBuiltinModuleTests()
+await runConfigManagerTests()
+await runMCPHTTPValidationTests()
+await runDesktopOrganizationScenarioTests()
+await runChromeModuleTests()
+await runSkillsModuleTests()
+await runCredentialManagerTests()
+await runCredentialModuleTests()
+await runStripeClientTests()
+await runPaymentModuleTests()
+await runConnectionsModuleTests()
+await runStripeTokenizationTests()
+await runSecurityAuditTests()
+await runReadOnlyTierAuditTests()
+
+
+// ============================================================
+// MARK: - V1-06 Integration / End-to-End Tests
+// ============================================================
+
+await runCodeEditModuleTests()
+await runDevModuleTests()              // dev-suite audit: dev_module_info coverage
+await runDevSuiteAuditTests()          // dev-suite audit: cross-tool invariants
+await runDevSuiteEdgeTests()           // dev-suite audit: edge / attack surface
+await runSpotlightModuleTests()        // PKT-747 (v2.2 · 3.3)
+await runSyntheticInputModuleTests()   // PKT-747 (v2.2 · 3.3)
+await runMouseClickModuleTests()        // PKT-765 (v2.2 · 3.3.1)
+await runCGEventModuleTests()           // PKT-765 (v2.2 · 3.3.1)
+await runPasteboardHistoryModuleTests() // PKT-765 (v2.2 · 3.3.1)
+await runJobsModuleTests()
+await runBgProcessModuleTests()
+await runDevServerModuleTests()
+await runGhModuleTests()
+await runGitModuleTests()
+await runLspModuleTests()
+await runLspModuleRenameRefsLiveTests()
+await runWSHMenuBarTests()        // PKT-804 (v2.3): menu-bar quick-page
+await runSnippetsModuleTests()    // PKT-2135a9e9 (v2.3 · WS-D): snippets module
+await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)
+await runFetchSkillMarkdownTests() // cmd-w4: fetch_skill /markdown + shared MentionResolver
+await runFetchSkillPropertiesTests() // cu-sa: fetch_skill simplified `properties` map (additive)
+await runCommandBoxSpikeTests()   // cmd-w1 spike (imported): GUI-free command-box units + cmd-ux recorder/persist
+await runCommandPaletteTests()    // cmd-w3: palette search + gate + AppDelegate gating + coordinator
+await runSkillVsCommandSplitTests() // cmd-ux: LOCK the skill-vs-command body/properties split
+await runCommandsControllerTests()  // cmd-ux W1/W2: CommandsController observable state machine + status/focus model
+await runCommandBridgeControllerTests()  // PKT-878 v3.6.3: SwiftUI Command Bridge popup — placement/recents/anim/builders
+await runCommandVisibilityTests()   // cmd-ux W3: .command visibility axis — Codable, palette filter, picker write-back, empty-state
+await runFlagVisibilityMigrationTests()  // cmd-ux W4 (3.4.1): flag-based visibility SSOT — enum↔flags, decode/encode migration, RegistrySkillsCommandProvider flag filter, mutator parity
+await runW4ComponentAndStorageTests()    // cmd-ux W4 (3.4.1): kbd-chip splitter + per-path file-source flag storage + effective routing/palette resolution
+await runSkillsMCPFlagRoundTripTests()    // 3.4.2 W3 H1 fix: SkillConfig MCP reconstruction preserves combined-state flag pair
+await runHotkeyRecorderFocusTests()        // 3.4.2 W4 H5 fix: RecorderFocusModel contract locks the button-binding focus path
+await runFrontmatterParserTests()   // W2 D8: SKILL.md YAML frontmatter parser
+await runSkillSourceTests()         // W2 D2: SkillSource enum + legacy notionPageId backward-compat
+await runFilesystemSkillIndexTests() // W2 D3: SKILL.md filesystem index actor
+await runFetchSkillFileSourceTests() // W2 D5: file-source fetch_skill envelope shape
+await runListRoutingSkillsMergeTests() // W2 D6: merged routing-skills listing
+await runSkillPathResolverTests()      // PKT-907: fetch_skill orchestrator (path / intent / file specialist / W3 summary)
+await runToolAnnotationAuditTests() // PKT-803 (v2.3 · WS-B): annotation coverage audit
+await runTransportRouterTests()     // PKT-803 (v2.3 · WS-B): transport router default/env
+await runRemoteOAuthHTTPTests()     // PKT-800 (S1): RFC 9728 PRM + transport gating + route
+await runRemoteOAuthBearerTests()   // PKT-800 (S2): JWTKit bearer + ScopeGate + 401/WWW-Auth
+await runRemoteOAuthHardeningTests() // PKT-800 (S3): step-up + confused-deputy + leak-sweep + gating
+await runRemoteOAuthHardeningS4Tests() // PKT-800 (S4): contacts.read split + TransportRouter seam + step-up scope-only
+await runBridgeFeatureFlagsTests()  // PKT-798 (v2.3 · WS-C): fail-closed capability gates
+await runBridgeModuleRegistryTests() // PKT v3.0·0.4: single-source module registrar
+await runMCPToolFactoryTests()       // PKT v3.0·0.5: metadata contract + unified Tool factory
+await runToolConventionTests()       // PKT v3.0·0.5: P0 — aliases + key convention + dispatch contract
+await runToolMetadataAuthoringTests() // PKT v3.0·0.5: P1 — projection + authored-metadata render
+await runPlaywrightModuleTests()  // PKT-781 (v2.2 · 3.2a)
+await runVitestModuleTests()      // PKT-781 (v2.2 · 3.2a)
+await runLighthouseModuleTests()  // PKT-781 (v2.2 · 3.2a)
+await runArtifactModuleTests()    // PKT-743 (v2.2 · 3.1)
+await runRunnerParsersTests()      // PKT-782 (v2.2 · 3.2b)
+await runCronHumanizerTests()
+
+await runStripeDeprecationShimTests()
+await runEndToEndTests()
+await runWranglerModuleTests() // PKT-757 (v2.2 · 0.2.2)
+
+// PKT-1 (v3.5): rename migration + canonical paths.
+await runPathMigrationTests()
+
+// PKT-9 (v3.5): Standing Orders + Routing Index.
+await runStandingOrdersTests()
+
+// PKT-6 (v3.5): CommandStore (markdown-per-command + index.json).
+await runCommandStoreTests()
+
+// PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
+await runSettingsSectionsLGTests()
+
+// PKT-877 (Bridge v3.6·2): ModuleGroup + dispatch fail-closed SAFETY CONTRACT.
+await runModuleGroupTests()
+await runToolRouterFailClosedTests()
+
+// PKT-879 (v3.6.4): Dashboard / Onboarding / icon picker reskin.
+await runPKT879DashboardTests()
+await runPKT879OnboardingTests()
+await runPKT879IconPickerTests()
+
+// v3.6.0 D1: Credentials scope filter regression guard.
+await runCredentialsScopeFilterTests()
+
+// v3.6.0 D6: ModuleGroupCard expand-state persistence contract.
+await runModuleGroupExpandPersistenceTests()
+
+// v3.6·6: CommandStore security audit (slug sanitization defense-in-depth).
+await runCommandStoreSecurityTests()
+
+// PKT-909 (Sell/Distribute v3 · 1): License-key system + 30-day trial gate.
+await runLicenseTokenTests()
+await runLicenseManagerTests()
+await runLicenseToolErrorTests()
+await runLicenseUITests()
+await runLicenseRevocationTests()
+await runLicenseDispatchGateTests()
+
+// v3.7·A: SkillsCacheReader/Writer pipeline — Notion-source eager
+// enumeration carve-out closure (PKT-907) + StandingOrders cached
+// routing-skills backing (v3.6·5 TODO closure).
+await runSkillsCacheTests()
+
+// WS-C + WS-E (Mac-side cloud access): BridgeCloudManager state machine +
+// NL-3 auth-passdown (capability validation + mandatory passkey gate +
+// no-raw-credential invariant) + Remote Access settings section/sidebar.
+await runBridgeCloudManagerTests()
+
+// ============================================================
+// MARK: - Summary
+// ============================================================
+
+// Summary is emitted by the atexit handler registered at startup (reliable even
+// if this final continuation is skipped by the teardown race). This exit is
+// best-effort: when it runs it sets the proper code AND triggers the atexit
+// summary; if the race skips it, the implicit exit(0) still fires the atexit
+// summary and the floor gate derives pass/fail from the `Results:` count.
+        exit(failed > 0 ? 1 : 0)
+    } // static func runAllTests()
+} // @main struct NotionBridgeTestRunner

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -615,7 +615,20 @@ set -euo pipefail
 # MCPToolFactory/EndToEnd count assertions move with the constants).
 # Floor recomputed from the merged suite's measured green (see value below),
 # per the order-inversion rule — never lowered.
-FLOOR="${BRIDGE_TEST_FLOOR:-1607}"
+#
+# v3.7·I (PKT-962): CalendarModule (native EventKit `.event` entities over an
+# INJECTABLE `CalendarStoring` seam — production EventKitCalendarStore mirrors
+# v3.7·D's EventKitRemindersStore + REUSES the same calendars entitlement; tests
+# inject MockCalendarStore) added 5 MCP tools (calendar_list/events/create/
+# update/delete) + CalendarModuleTests (+18 measured test() blocks: registration,
+# tiering open/notify/request, list, CRUD round-trip, required-field validation,
+# notFound, date-range overlap filter, calendar-scoped filter, delete + re-delete
+# notFound, access-denied across all 5 tools + notDetermined). All against the
+# mock seam; NO live EventKit / TCC. calendar_list/events are .open (read-only),
+# create/update .notify, delete .request. Tool count 195 + 5 = 200; family count
+# 24 + 1 = 25 (the strict count assertions move with the constants). Floor raised
+# to the merged suite's measured green per the order-inversion rule — never lowered.
+FLOOR="${BRIDGE_TEST_FLOOR:-1625}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -522,7 +522,11 @@ set -euo pipefail
 # "datasource_update succeeds with API key" test moved into the hasAPIKey
 # branch and renamed to datasource_get. Hermetic base was 1467; WS-C/E adds
 # the BridgeCloudManager suite. Floor recomputed from the post-merge gate run.
-FLOOR="${BRIDGE_TEST_FLOOR:-1501}"
+FLOOR="${BRIDGE_TEST_FLOOR:-1503}"
+# fix/sck-continuation-leak (2026-06-02): +2 SCK off-main-actor
+# continuation-leak regression guards in ScreenModuleTests (screen_capture +
+# chrome_tabs dispatched from a Task.detached must return/throw promptly, not
+# hang). Floor raised 1501 → 1503 to match the added passing tests.
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -630,30 +630,60 @@ swift build -c debug
 LOG="$(mktemp -t bridge-test-floor.XXXXXX)"
 trap 'rm -f "$LOG"' EXIT
 
-# Watchdog: cap the test binary at 25 minutes (local run is ~5 min,
-# CI macos-26 is ~3x slower). If the binary hangs (e.g. a test waiting
-# on a process that won't exit on a headless runner), perl's SIGALRM
-# kills it and the workflow step still surfaces the last test that
-# logged — so future hangs are diagnosable instead of opaque 6h cancels.
-# perl is always present on macOS; no brew install needed.
+# Watchdog: cap the test binary at DEADLINE seconds (default 1500 = 25 min;
+# local run is ~5 min, CI macos-26 is ~3x slower). Override with
+# TEST_WATCHDOG_SECONDS — a short value (e.g. 5) makes the watchdog testable.
 #
-# Bounded retry on the harness teardown flake: the runner emits its summary
-# from a top-level-`await` tail that, on a fully-completed suite, intermittently
-# loses a race with process teardown and drops the final `Results:` line — the
-# binary still exits 0 and every test ran (the per-test ✅ lines are all
-# present). That is NOT a test failure, so re-run up to ATTEMPTS times until the
-# summary is captured. A real hang (watchdog) or a genuine non-zero exit fails
-# immediately with no retry, and the floor/failure checks below are unchanged.
+# This is a REAL EXTERNAL watchdog, not `perl -e 'alarm N; exec'`. On macOS the
+# SIGALRM timer set by alarm() is CLEARED by exec() (the new image starts with no
+# pending alarm), so the old pattern never actually killed a hung binary — it ran
+# until the CI step/job timeout. Instead we now: launch the binary in the
+# background, capture its PID, start a separate killer subshell that SIGKILLs that
+# PID after DEADLINE, and `wait` on the binary. On normal completion we KILL THE
+# KILLER so a finished run leaves no stray `sleep` and the script never blocks on
+# it. On a watchdog kill we FAIL FAST with the last logged test line so the hang
+# is diagnosable instead of an opaque multi-hour cancel.
+DEADLINE="${TEST_WATCHDOG_SECONDS:-1500}"
+#
+# Bounded retry on the harness teardown flake: the runner emits its summary from
+# a tail that, on a fully-completed suite, can intermittently lose a race with
+# process teardown and drop the final `Results:` line — the binary still exits 0
+# and every test ran (the per-test ✅ lines are all present). That is NOT a test
+# failure, so re-run up to ATTEMPTS times until the summary is captured. A real
+# hang (watchdog) or a genuine non-zero exit fails immediately with no retry, and
+# the floor/failure checks below are unchanged.
 ATTEMPTS=3
 LINE=""
 for attempt in $(seq 1 "$ATTEMPTS"); do
   set +e
-  perl -e 'alarm 1500; exec @ARGV' "$BIN" | tee "$LOG"
-  RC=${PIPESTATUS[0]}
+  # Run the binary in the background, tee'ing its combined output to the log so
+  # the timeout path can print the last test line. `$!` is the binary's PID.
+  "$BIN" > >(tee "$LOG") 2>&1 &
+  BIN_PID=$!
+
+  # External killer: SIGKILL the binary if it outlives DEADLINE. Captured PID so
+  # we can cancel it on a clean finish.
+  ( sleep "$DEADLINE"; kill -9 "$BIN_PID" 2>/dev/null ) &
+  KILLER_PID=$!
+
+  # Block until the binary exits (normally, or via the killer's SIGKILL).
+  wait "$BIN_PID"
+  RC=$?
+
+  # Cleanup: cancel + reap the killer so a completed run leaves no stray sleep
+  # and the script doesn't block waiting on it. Kill the killer's `sleep` CHILD
+  # first (while the subshell is still alive so `pkill -P` can resolve it),
+  # otherwise killing only the subshell orphans the `sleep` and it keeps running
+  # for the full DEADLINE. Then kill + reap the subshell itself.
+  pkill -P "$KILLER_PID" 2>/dev/null
+  kill "$KILLER_PID" 2>/dev/null
+  wait "$KILLER_PID" 2>/dev/null
   set -e
 
-  if [ "$RC" -eq 142 ] || [ "$RC" -eq 14 ]; then
-    echo "::error::test-floor-gate: test binary exceeded 1500s watchdog and was killed"
+  # SIGKILL from the watchdog surfaces as 137 (128+9). (128+SIGALRM=142 / 14 are
+  # kept as a defensive fallback in case a future change reintroduces an alarm.)
+  if [ "$RC" -eq 137 ] || [ "$RC" -eq 142 ] || [ "$RC" -eq 14 ]; then
+    echo "::error::test-floor-gate: test binary exceeded ${DEADLINE}s watchdog and was killed"
     echo "--- last 60 lines of test output (so you can see which test hung) ---"
     tail -60 "$LOG" || true
     echo "--- end of test output tail ---"

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -522,7 +522,14 @@ set -euo pipefail
 # "datasource_update succeeds with API key" test moved into the hasAPIKey
 # branch and renamed to datasource_get. Hermetic base was 1467; WS-C/E adds
 # the BridgeCloudManager suite. Floor recomputed from the post-merge gate run.
-FLOOR="${BRIDGE_TEST_FLOOR:-1501}"
+# v3.7·B (PKT-931, 2026-06-01): standing_orders_* MCP tools (list/read/save/
+# delete) landed — new StandingOrdersRecordStore actor + 4-tool module.
+# +15 StandingOrdersModuleTests (registration/tier, CRUD round-trip, idempotent
+# upsert, soft-delete+archive, list archived exclusion/opt-in, read 404 on
+# soft-deleted, concurrent-save actor serialization, atomic persistence,
+# handler-level save/read/invalid-scope). 1501 → 1515. Tool count 172 → 176,
+# family count 19 → 20. Measured on the worktree gate run, 0 failures.
+FLOOR="${BRIDGE_TEST_FLOOR:-1515}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -615,7 +615,21 @@ set -euo pipefail
 # MCPToolFactory/EndToEnd count assertions move with the constants).
 # Floor recomputed from the merged suite's measured green (see value below),
 # per the order-inversion rule — never lowered.
-FLOOR="${BRIDGE_TEST_FLOOR:-1607}"
+FLOOR="${BRIDGE_TEST_FLOOR:-1618}"
+# WS-G (PKT-923, 2026-06-02 · Bridge Cloud Access · terminal UI packet):
+# CloudAccessWSGTests added +11 test() blocks for the first-run modal gate
+# (Q2 one-time, BridgeDefaults.hasSeenCloudAccessFirstRun), the Add-to-
+# Claude.ai MCP-URL derivation + query-value percent-encoding contract +
+# Q3 copy+hint shipped mode, and the Disable flow (EnableCloudAccessFlow.
+# disable() → CloudTeardown seam + cleared toggle/host; live BridgeCloudManager.
+# disable() → .disabled; cancel = no side effects). All against fakes (no
+# SwiftUI render / WindowServer / cloudflared / network). Also hardened the
+# WS-F `waitFor` test helper to interleave a tiny real sleep once cooperative
+# yields are exhausted — removes a pre-existing load-sensitive flake on the
+# provision-timeout test (off-actor continuation + withTaskGroup cancel hop)
+# without weakening any assertion. Floor 1607 → 1618 (+11) per the
+# order-inversion rule — never lowered.
+#
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -522,7 +522,23 @@ set -euo pipefail
 # "datasource_update succeeds with API key" test moved into the hasAPIKey
 # branch and renamed to datasource_get. Hermetic base was 1467; WS-C/E adds
 # the BridgeCloudManager suite. Floor recomputed from the post-merge gate run.
-FLOOR="${BRIDGE_TEST_FLOOR:-1501}"
+# v3.7·G (PKT-960, 2026-06-02): notes_* MCP tools (Apple Notes via AppleScript).
+# New NotesModule over an INJECTABLE NotesScriptRunner seam (NSAppleScript in
+# production; a recording mock in tests — zero contact with live Notes.app).
+# Six tools registered: notes_list/read/search (.open), notes_create/update
+# (.notify), notes_delete (.request + confirm:'DELETE'). Wired into
+# BridgeModuleRegistry; ToolAnnotationCatalog gained 6 explicit entries
+# (tier↔requiresConfirmation coherent); ModuleGroup gained a first-class
+# `notes` case + prefix + Automation dependency chip; staticFeatureModuleToolCount
+# 172→178 (+6) and family count 19→20 (+1). New NotesModuleTests.swift adds 27
+# harness test() blocks (registration + tier matrix + camelCase schema-key guard
+# + CRUD via the mock seam + search + AppleScript-error path incl. -1743 TCC
+# guidance + id-vs-name addressing + missing-param rejection + pure escaping/
+# selector/record-parse/script-builder checks). Measured 1528 passed, 0 failed.
+# Floor raised 1501 -> 1528 per the order-inversion rule. The Notes per-app
+# Automation TCC grant is a macOS operator first-use prompt (no entitlement
+# change — uses the existing apple-events automation entitlement).
+FLOOR="${BRIDGE_TEST_FLOOR:-1528}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -515,6 +515,17 @@
 # the order-inversion rule.
 set -euo pipefail
 
+# PKT-957 / v3.7·D (2026-06-01): reminders_* MCP tool family over EventKit
+# (RemindersModule + injectable RemindersStoring seam). New
+# RemindersModuleTests contributes 17 harness `test()` blocks (6 top-level
+# + 6 nested access-denied sub-tests + 5 CRUD/idempotency/listing blocks)
+# against the in-memory mock seam — no live EventKit/TCC. Also bumped
+# staticFeatureModuleToolCount 172 -> 178 and family count 19 -> 20
+# (registry-count / E2E family assertions move with the constants). Measured
+# 1518 passed, 0 failed. Floor raised 1501 -> 1518 per the order-inversion
+# rule. (Known ScreenModuleTests/screen_record_stop sandbox hang handled by
+# the watchdog/retry below — unaffected.)
+
 # v3.6.1 (2026-05-31): hermetic-test remediation + WS-C/E (Mac-side cloud
 # access: BridgeCloudManager + NL-3 auth-passdown + Remote Access settings)
 # merged in. ConfigManagerTests no longer read/mutate the user's live config
@@ -522,7 +533,7 @@ set -euo pipefail
 # "datasource_update succeeds with API key" test moved into the hasAPIKey
 # branch and renamed to datasource_get. Hermetic base was 1467; WS-C/E adds
 # the BridgeCloudManager suite. Floor recomputed from the post-merge gate run.
-FLOOR="${BRIDGE_TEST_FLOOR:-1501}"
+FLOOR="${BRIDGE_TEST_FLOOR:-1518}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -615,7 +615,16 @@ set -euo pipefail
 # MCPToolFactory/EndToEnd count assertions move with the constants).
 # Floor recomputed from the merged suite's measured green (see value below),
 # per the order-inversion rule — never lowered.
-FLOOR="${BRIDGE_TEST_FLOOR:-1607}"
+#
+# WS-D (PKT-921, 2026-06-02): Bridge Cloud Access heartbeat wiring +
+# cloud-gated bridge_status MCP tool + ServerManager tools/list cloud
+# conditional. +12 CloudStatusModuleTests (heartbeat start/stop/idempotent,
+# bridge_status gated registration + canonical payload + NOT-in-static-count,
+# tools/list CLOUD+offline/disabled→only bridge_status, CLOUD+online/degraded→
+# full, local-never-filtered). Independently measured green = 1618 (1606 +12).
+# FLOOR raised 1607 → 1618 per the order-inversion rule. Static module count
+# UNCHANGED at 195 (bridge_status is cloud-gated, not static).
+FLOOR="${BRIDGE_TEST_FLOOR:-1618}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -580,7 +580,19 @@ set -euo pipefail
 # TestRunner (runEnableCloudAccessFlowTests) — it did NOT auto-merge across the
 # main.swift→TestRunner.swift rename, so the test file would otherwise have
 # compiled but never run. Measured 1557/0 on every one of 5 gate runs.
-FLOOR="${BRIDGE_TEST_FLOOR:-1557}"
+#
+# v3.7·H (PKT-961, 2026-06-02): MailModule (Apple Mail over an INJECTABLE
+# AppleScript seam) added 5 MCP tools (mail_list/read/search/draft/send) +
+# MailModuleTests (+12 test() blocks: registration, tiering, list/read/search/
+# draft, the send-guard proved 3 ways — wrong token refused, missing-key
+# rejected, seam never invoked — confirmed send, TCC -1743 error path,
+# validation, annotation mirror). All against the mock seam; NO live mail.
+# Reconciled tool count 182 + 5 = 187; family count 21 + 1 (mail) = 22 (the
+# strict BridgeModuleRegistry/MCPToolFactory/EndToEnd == 187 + family == 22
+# assertions pass green). Integrated green measured 1557 + 12 = 1569 passed /
+# 0 failed, twice on the watchdog-protected gate. FLOOR raised to the measured
+# integrated count (1569) per the order-inversion rule.
+FLOOR="${BRIDGE_TEST_FLOOR:-1569}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -650,10 +650,12 @@ set -euo pipefail
 # without weakening any assertion.
 #
 # v3.7 Wave-2 integration (2026-06-02): FLOOR recomputed from the MERGED suite's
-# measured green across 5 clean runs (Calendar +18, WS-D +12, WS-G +11 on the
-# Wave-1 base of 1607), per the order-inversion rule — derived from the ACTUAL
-# reconciled count, never lowered, never trusting per-branch numbers.
-FLOOR="${BRIDGE_TEST_FLOOR:-1648}"
+# measured green across 5 clean runs, per the order-inversion rule — derived from
+# the ACTUAL reconciled count (1647), never lowered, never trusting per-branch
+# numbers. Note: the naive per-branch sum (1607 +18 calendar +12 WS-D +11 WS-G =
+# 1648) over-counts by one against the merged suite; the honest measured green is
+# 1647/1647 (0 failed), so the floor is set to that, not the arithmetic estimate.
+FLOOR="${BRIDGE_TEST_FLOOR:-1647}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -580,7 +580,22 @@ set -euo pipefail
 # TestRunner (runEnableCloudAccessFlowTests) — it did NOT auto-merge across the
 # main.swift→TestRunner.swift rename, so the test file would otherwise have
 # compiled but never run. Measured 1557/0 on every one of 5 gate runs.
-FLOOR="${BRIDGE_TEST_FLOOR:-1557}"
+#
+# v3.7·F (PKT-959, 2026-06-02): shortcuts_* MCP tool family over the
+# /usr/bin/shortcuts CLI (NO entitlement) — ShortcutsModule + injectable
+# `ShortcutsRunning` process seam (production CLIShortcutsRunner spawns the
+# CLI; tests inject MockShortcutsRunner). Two tools: shortcuts_list (.open,
+# read-only enumeration) + shortcuts_run (.notify — a Shortcut can do anything,
+# so it never auto-executes silently). New ShortcutsModuleTests contributes +11
+# harness test() blocks against the mock seam (registration/tier, list parse +
+# argv, folders + folderName argv, run output-capture + argv, input-passing via
+# --input-path temp file + cleanup, run-failure envelope, invalid-arg
+# short-circuit, capability_missing short-circuit, parseLines pure helper) — no
+# live CLI. Also bumped staticFeatureModuleToolCount 182 -> 184 and family count
+# 21 -> 22 (the strict BridgeModuleRegistry/MCPToolFactory/E2E count assertions
+# move with the constants). Measured 1568 passed, 0 failed. Floor raised
+# 1557 -> 1568 per the order-inversion rule.
+FLOOR="${BRIDGE_TEST_FLOOR:-1568}"
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the
 # PKT-907 Notion-source eager-enumeration carve-out and the v3.6·5


### PR DESCRIPTION
## Summary

The **v3.7 build-out** for Bridge MCP, in one release branch: a test-infra reliability rescue that makes the suite deterministic, the v3.7 platform-tail tool families, the full Mac/iCloud tool sprint, and the Mac-side of Cloud Access. **53 files, +9,626 / −110.** Test floor **1501 → 1647**, suite green **5/5 deterministically**.

## What changed

### Test-infra reliability (the foundation everything else rode on)
- **Real external watchdog** in `scripts/test-floor-gate.sh` — the old `perl -e 'alarm N; exec'` never killed a hung suite on macOS (`exec` clears the SIGALRM timer); replaced with a background-PID + killer that fails fast at the deadline.
- **ScreenCaptureKit off-main-actor boundary** (`NotionBridge/Modules/ScreenCaptureKitBoundary.swift`) — `SCShareableContent` / `SCScreenshotManager` leaked their continuation and hung forever when called off the main actor. This is a **real product bug** (affects `screen_capture` / `chrome_tabs` from any nonisolated async caller), not just tests.
- **Custom test-harness fix** — `NotionBridgeTests/main.swift` → `TestRunner.swift` with a clean main-thread shutdown (`CFRunLoopRunInMode` loop) so `MainActor.run` in UI tests is actually serviced; Sparkle's auto-updater is disarmed in the test process (it was presenting a modal that wedged the run loop). Eliminates the ~1-in-3 nondeterministic hang and the truncated-summary race.

### v3.7 platform tail
- `standing_orders_*` MCP tools (list / read / save / delete).
- UI polish round (spacing, sidebar tint, Skills/Jobs/Credentials surfaces).
- `reminders_*` MCP tools (EventKit).

### Mac/iCloud tool families (new)
- `shortcuts_*` — Apple Shortcuts via `/usr/bin/shortcuts` (no entitlement).
- `notes_*` — Apple Notes via AppleScript.
- `mail_*` — Apple Mail via AppleScript. **Drafts by default; `mail_send` is guarded behind an explicit `confirm:'SEND'` token** (mirrors `messages_send`) — an unconfirmed send provably cannot reach Mail.app.
- `calendar_*` — EventKit; shares the EventKit store + `calendars` entitlement with `reminders_*` (no duplication).

### Cloud Access (Mac-side, end-to-end)
- `BridgeCloudManager` — cloudflared tunnel lifecycle + NL-3 auth-passdown enforcement [WS-C]; Remote Access settings section [WS-E]; Enable flow + WorkOS sign-in + `bridge-auth://` callback [WS-F].
- `bridge_status` cloud-gated MCP tool + heartbeat (`refreshHealth` timer) + conditional `tools/list` (omits Mac tools when the cloud channel is offline) [WS-D].
- First-run modal + Disable flow + Add-to-Claude.ai (copy + hint fallback) [WS-G].

## Counts
- `staticFeatureModuleToolCount` **172 → 200**; families **19 → 25**. `bridge_status` is cloud-gated and intentionally **off** the static count (registered dynamically).
- Test floor **1501 → 1647**.

## Test plan
`scripts/test-floor-gate.sh` run 5×: **1647 passed / 0 failed every run**, 0 hangs, summary printed each run. `swift build` clean (only pre-existing `try?`-unused warnings in unrelated test files).

## Reviewer notes & operator follow-ups (NOT in this PR)
- **Live cloud E2E is gated on external infra** not in this repo: the KUP `bridge-worker` Cloudflare Worker (provision / heartbeat / multi-tenant routing) + a WorkOS tenant + a CF Tunnel. The Mac-side is unit-tested against mock seams — no live tunnel or WorkOS calls.
- **First-use TCC grants** are required at runtime for Reminders / Notes / Mail / Calendar (per-app Automation/privacy prompts). The `calendars` EventKit entitlement is declared but should be **notarize-validated on a signed Developer-ID build** — a prior `keychain-access-groups` entitlement was refused by the provisioning profile (see the comment in `NotionBridge.entitlements`).
- **Sparkle grandfather check** remains a manual QA step (confirm no trial-countdown leak for v3.4.x → current upgraders).
- **History is merge-heavy** — assembled from worktree-isolated executor branches via integration branches. Review the **net diff**, not per-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
