### PR TITLE
feat(routing): skip retired specialists by lifecycle status (active-status filter)

### DIFF
--- a/NotionBridge/Modules/SkillPathResolver.swift
+++ b/NotionBridge/Modules/SkillPathResolver.swift
@@ -210,6 +210,100 @@ public enum SpecialistFilter {
         guard sawSpace, idx < lower.endIndex else { return false }
         return lower[idx].isNumber
     }
+
+    // MARK: Active-status guard (v3.7.6 — routing/specialist-active-status)
+
+    /// Lifecycle predicate (fast-follow to v3.7.4's relation source). A
+    /// curated specialist may stay a MEMBER of a parent's `Specialist`
+    /// relation for history even after it is retired (e.g. focus-keepr's
+    /// deprecation-dated `retro`). Routing must never surface such a row.
+    /// `isActiveSpecialist` inspects the specialist PAGE's own properties and
+    /// returns `false` ONLY on a confident inactive signal:
+    ///   • a populated `Deprecation Date` (or common aliases), OR
+    ///   • a lifecycle `Status`/`Lifecycle`/`State`/`Maturity`/`Stage`
+    ///     select/status/multi_select whose value is an inactive token.
+    ///
+    /// It FAILS OPEN: an absent, empty, or unrecognized status leaves the
+    /// specialist ACTIVE, so a missing or oddly-named property can never
+    /// silently empty the routing surface — the same reliability bias as the
+    /// relation reader's "empty → fall back" contract. Pairs with
+    /// `isSpecialist(title:)` as the second hydration-time guard.
+    /// Pure + deterministic; never throws.
+    public static func isActiveSpecialist(properties: [String: Any]) -> Bool {
+        // 1) An explicit deprecation / sunset / retirement DATE retires the row.
+        if hasPopulatedDate(in: properties,
+                            keys: ["Deprecation Date", "Deprecated On", "Deprecated",
+                                   "Sunset Date", "Sunset", "Retired On", "Archived On"]) {
+            return false
+        }
+        // 2) A lifecycle status/select in a known inactive state.
+        for key in ["Status", "Lifecycle", "State", "Maturity", "Stage"] {
+            for token in statusTokens(in: properties, key: key)
+            where inactiveStatusTokens.contains(token) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Lower-cased status values that mark a specialist INACTIVE for routing.
+    /// Conservative on purpose (exact-match, not substring): only unambiguous
+    /// retirement words, so an in-flight status — "Active", "Stable", "Beta",
+    /// "Draft", "Experimental", "Production" — never hides a live specialist.
+    static let inactiveStatusTokens: Set<String> = [
+        "deprecated", "archived", "folded", "retired",
+        "sunset", "sunsetted", "removed", "obsolete", "inactive", "merged"
+    ]
+
+    /// Lower-cased display name(s) of a `status` / `select` / `multi_select`
+    /// property, matched case-insensitively by key. Empty when the property
+    /// is absent or a different type. Pure.
+    static func statusTokens(in properties: [String: Any], key: String) -> [String] {
+        var out: [String] = []
+        for (k, v) in properties where k.caseInsensitiveCompare(key) == .orderedSame {
+            guard let prop = v as? [String: Any],
+                  let type = prop["type"] as? String else { continue }
+            switch type {
+            case "status":
+                if let s = prop["status"] as? [String: Any], let name = s["name"] as? String {
+                    out.append(name.lowercased())
+                }
+            case "select":
+                if let s = prop["select"] as? [String: Any], let name = s["name"] as? String {
+                    out.append(name.lowercased())
+                }
+            case "multi_select":
+                if let arr = prop["multi_select"] as? [[String: Any]] {
+                    for opt in arr {
+                        if let name = opt["name"] as? String {
+                            out.append(name.lowercased())
+                        }
+                    }
+                }
+            default:
+                continue
+            }
+        }
+        return out
+    }
+
+    /// True when any of `keys` resolves to a `date`-typed property whose
+    /// `start` is a non-empty string (Notion's representation of a set date).
+    /// Case-insensitive on the key. Pure.
+    static func hasPopulatedDate(in properties: [String: Any], keys: [String]) -> Bool {
+        for key in keys {
+            for (k, v) in properties where k.caseInsensitiveCompare(key) == .orderedSame {
+                guard let prop = v as? [String: Any],
+                      (prop["type"] as? String) == "date",
+                      let date = prop["date"] as? [String: Any],
+                      let start = date["start"] as? String else { continue }
+                if !start.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return true
+                }
+            }
+        }
+        return false
+    }
 }
 
 // MARK: - SkillIntentScorer

--- a/NotionBridge/Modules/Skills/SkillsCacheWriter.swift
+++ b/NotionBridge/Modules/Skills/SkillsCacheWriter.swift
@@ -228,6 +228,10 @@ extension SkillsCacheWriter.ChildEnumerator {
         for cid in candidateIds {
             var title = ""
             var summary = ""
+            // Fail-open: if the page can't be fetched we don't hide it on
+            // status grounds (the title guard below already drops an
+            // unresolved/empty-title candidate).
+            var isActive = true
             if let pageData = try? await client.getPage(pageId: cid),
                let json = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any],
                let props = json["properties"] as? [String: Any] {
@@ -236,10 +240,14 @@ extension SkillsCacheWriter.ChildEnumerator {
                 // Best-effort one-line summary: prefer the curated `Summary`
                 // rich_text, then `Description`, then any `description` key.
                 summary = firstRichText(props, keys: ["Summary", "Description", "description"])
+                isActive = SpecialistFilter.isActiveSpecialist(properties: props)
             }
-            // Defensive secondary guard: exclude any doc-page that slipped
-            // into the curated relation (or the fallback walk).
-            guard SpecialistFilter.isSpecialist(title: title) else { continue }
+            // Two hydration-time guards (belt + suspenders): drop doc-pages by
+            // title, AND drop a retired specialist by lifecycle status — a
+            // deprecated/archived/folded row (or one with a Deprecation Date)
+            // may linger in the curated relation for history but must never
+            // surface in routing (v3.7.6).
+            guard SpecialistFilter.isSpecialist(title: title), isActive else { continue }
             out.append(CachedSpecialist(
                 id: cid,
                 title: title,

--- a/NotionBridge/Modules/SkillsModule.swift
+++ b/NotionBridge/Modules/SkillsModule.swift
@@ -2681,11 +2681,20 @@ public enum SkillsModule {
                     if !t.isEmpty && t != "Untitled" { resolvedTitle = t }
                 }
             }
-            // Defensive secondary guard: exclude any doc-page (changelogs,
-            // PRDs, §-sections, test matrices, evolution logs, phase/pruning
-            // notes, duplicate stubs) that slipped into the curated relation
-            // or the fallback walk, so the routing surface stays curated.
-            guard SpecialistFilter.isSpecialist(title: resolvedTitle) else { continue }
+            // Two hydration-time guards (belt + suspenders):
+            //  1) exclude any doc-page (changelogs, PRDs, §-sections, test
+            //     matrices, evolution logs, phase/pruning notes, duplicate
+            //     stubs) that slipped into the curated relation or the
+            //     fallback walk, by title; and
+            //  2) exclude a retired specialist by lifecycle status — a
+            //     deprecated/archived/folded row (or one with a Deprecation
+            //     Date) may linger in the curated relation for history but
+            //     must never surface in routing (v3.7.6).
+            // isActiveSpecialist fails open, so an absent/odd Status keeps the
+            // specialist (an empty props from a failed fetch is already
+            // dropped by the title guard above).
+            guard SpecialistFilter.isSpecialist(title: resolvedTitle),
+                  SpecialistFilter.isActiveSpecialist(properties: props) else { continue }
             out.append(NotionChildPageRef(
                 pageId: cid,
                 title: resolvedTitle,

--- a/NotionBridgeTests/SpecialistRelationTests.swift
+++ b/NotionBridgeTests/SpecialistRelationTests.swift
@@ -216,4 +216,108 @@ func runSpecialistRelationTests() async {
         try expect(SpecialistFilter.isSpecialist(title: "bug-report"),
                    "while a real specialist in the same relation is kept")
     }
+
+    // =================================================================
+    // Active-status guard (v3.7.6 — routing/specialist-active-status).
+    // A specialist may remain a MEMBER of the curated `Specialist`
+    // relation after retirement; routing must drop it by lifecycle
+    // status. `isActiveSpecialist` is pure + FAILS OPEN.
+    // =================================================================
+
+    // 10. Fail-open default: no status, empty props, unknown status, and
+    //     non-status property types all leave the specialist ACTIVE — a
+    //     missing/odd property can never silently empty the routing surface.
+    await test("ActiveStatus: fails open (absent / empty / unknown → active)") {
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [:]),
+                   "empty props → active (fail-open)")
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Skill Name": ["type": "title", "title": [["plain_text": "discourse"]]]
+        ]), "no lifecycle property → active")
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Status": ["type": "status", "status": ["name": "Active"]]
+        ]), "an 'Active' status → active")
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Status": ["type": "status", "status": ["name": "Some Future State"]]
+        ]), "an unrecognized status token → active (only confident inactives drop)")
+    }
+
+    // 11. A `status`-typed lifecycle field in a known inactive state retires
+    //     the specialist (case-insensitive on the value).
+    await test("ActiveStatus: deprecated/archived/folded status → inactive") {
+        for value in ["Deprecated", "ARCHIVED", "folded", "Retired", "Obsolete", "Merged"] {
+            let props: [String: Any] = [
+                "Status": ["type": "status", "status": ["name": value]]
+            ]
+            try expect(!SpecialistFilter.isActiveSpecialist(properties: props),
+                       "status '\(value)' must mark the specialist inactive")
+        }
+    }
+
+    // 12. Works across property TYPES (select, multi_select) and ALT keys
+    //     (Maturity / Lifecycle), case-insensitive on the key.
+    await test("ActiveStatus: select / multi_select / alt-key all detected") {
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: [
+            "Maturity": ["type": "select", "select": ["name": "Deprecated"]]
+        ]), "a 'select' Maturity = Deprecated → inactive")
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: [
+            "Lifecycle": ["type": "multi_select",
+                          "multi_select": [["name": "v2"], ["name": "Archived"]]]
+        ]), "a multi_select carrying 'Archived' → inactive")
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: [
+            "status": ["type": "status", "status": ["name": "Sunset"]]  // lower-cased key
+        ]), "case-insensitive key 'status' = Sunset → inactive")
+        // A select in an in-flight state stays active.
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Maturity": ["type": "select", "select": ["name": "Stable"]]
+        ]), "Maturity = Stable → active")
+    }
+
+    // 13. A populated Deprecation Date (or alias) retires the specialist;
+    //     an empty/absent date does not.
+    await test("ActiveStatus: populated Deprecation Date → inactive; empty → active") {
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: [
+            "Deprecation Date": ["type": "date", "date": ["start": "2026-05-30"]]
+        ]), "a set Deprecation Date → inactive")
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: [
+            "Sunset Date": ["type": "date", "date": ["start": "2025-01-01T00:00:00.000Z"]]
+        ]), "a set Sunset Date alias → inactive")
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Deprecation Date": ["type": "date", "date": NSNull()]
+        ]), "a null date → active")
+        try expect(SpecialistFilter.isActiveSpecialist(properties: [
+            "Deprecation Date": ["type": "date", "date": ["start": "   "]]
+        ]), "a whitespace-only date start → active (treated as unset)")
+    }
+
+    // 14. No false positives: in-flight statuses whose names merely resemble
+    //     real lifecycle words stay active (exact-match, not substring).
+    await test("ActiveStatus: in-flight statuses are never hidden") {
+        for value in ["Active", "Beta", "Draft", "Experimental", "Production", "Stable", "Live", "In Review"] {
+            try expect(SpecialistFilter.isActiveSpecialist(properties: [
+                "Status": ["type": "status", "status": ["name": value]]
+            ]), "in-flight status '\(value)' must stay active")
+        }
+    }
+
+    // 15. The two hydration-time guards COMPOSE on the canonical case: a real
+    //     specialist title (passes the title heuristic) that is deprecation-
+    //     dated (fails the status guard) — exactly focus-keepr's `retro`.
+    //     This is what the live enumerators evaluate per candidate page.
+    await test("ActiveStatus: retro-shaped row — kept by title guard, dropped by status guard") {
+        let retroProps: [String: Any] = [
+            "Skill Name": ["type": "title", "title": [["plain_text": "retro"]]],
+            "Status": ["type": "status", "status": ["name": "Deprecated"]],
+            "Deprecation Date": ["type": "date", "date": ["start": "2026-04-01"]]
+        ]
+        // Title heuristic keeps it (it IS a real skill name, not a doc-page)…
+        try expect(SpecialistFilter.isSpecialist(title: "retro"),
+                   "'retro' passes the title heuristic (real specialist name)")
+        // …but the active-status guard drops it (retired). Routing excludes it
+        // only because BOTH guards must pass.
+        try expect(!SpecialistFilter.isActiveSpecialist(properties: retroProps),
+                   "'retro' is dropped by the active-status guard (Deprecated + dated)")
+        let bothPass = SpecialistFilter.isSpecialist(title: "retro")
+            && SpecialistFilter.isActiveSpecialist(properties: retroProps)
+        try expect(!bothPass, "a retired specialist must fail the combined hydration guard")
+    }
 }


### PR DESCRIPTION
## Routing — skip retired specialists by lifecycle status

Fast-follow to **v3.7.4** (routing now sources specialists from a parent's curated `Specialist` relation). A specialist can stay a **member** of that relation after it's retired — e.g. focus-keepr's deprecation-dated `retro` — and routing must never surface it.

### Change
New pure predicate `SpecialistFilter.isActiveSpecialist(properties:)`, wired as the **second hydration-time guard** (beside the existing title heuristic) in both consumers:
- `SkillsModule.listNotionChildPages`
- `SkillsCacheWriter.fetchChildren`

It returns `false` **only on a confident inactive signal**:
- a populated `Deprecation Date` (or aliases: Sunset/Retired/Archived On), or
- a lifecycle `Status`/`Lifecycle`/`State`/`Maturity`/`Stage` (`status`/`select`/`multi_select`) in a known inactive token: `deprecated, archived, folded, retired, sunset, removed, obsolete, inactive, merged`.

**Fail-open by design:** absent / empty / unknown status leaves the specialist **active**, so a missing or oddly-named property can never silently empty the routing surface — the same reliability bias as the relation reader's "empty → fall back" contract. Exact-match (not substring) on tokens so in-flight states ("Active", "Beta", "Stable", "Draft") are never hidden.

### Why this matters beyond `retro`
It converts the audit's `[NOTION]` relation-membership cleanup from a **routing-correctness requirement** into **defense-in-depth** — a deprecated row lingering in a curated relation is now masked at runtime, regardless of when the Notion hygiene happens.

### Tests (+6 hermetic, in `SpecialistRelationTests`)
fail-open default · status/select/multi_select + alt-key detection · Deprecation Date (incl. null/whitespace = unset) · no-false-positives on in-flight statuses · the canonical **`retro` compose case** (kept by title guard, dropped by status guard).

- `make build`: clean (strict concurrency).
- `make test-floor`: **1732 passed**, floor **1725** (no bump — **rides v3.7.6** with the theme PR).
- ⚠️ One suite failure observed locally was the **pre-existing `WS-F provision timeout (30s)` timing flake** (`EnableCloudAccessFlowTests.swift:453`), unrelated to this change — re-run clears it. Flagging separately.

### Risk / rollback
Additive guard on the specialist enumeration; no schema/model change, no version bump. Fail-open means worst case is "shows a stale specialist" (the prior behavior), never "hides a live one." Rollback = revert one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
