### PR TITLE
test(wsf): latch ManualClock to kill the provision-timeout CI flake

### DIFF
--- a/NotionBridgeTests/EnableCloudAccessFlowTests.swift
+++ b/NotionBridgeTests/EnableCloudAccessFlowTests.swift
@@ -90,6 +90,16 @@ private final class FakeProvisioner: CloudProvisioning, @unchecked Sendable {
 private final class ManualClock: CloudClock, @unchecked Sendable {
     private let lock = NSLock()
     private var continuations: [UUID: CheckedContinuation<Void, Error>] = [:]
+    /// Edge-pending latch. A `fire()` that arrives BEFORE any `sleep` has
+    /// registered its continuation is remembered here, so the next `sleep`
+    /// resolves immediately instead of hanging forever. The flow arms its
+    /// timeout guard via `clock.sleep(...)` on a background task inside a
+    /// `withTaskGroup`, so a test that `fire()`s right after observing a state
+    /// transition can race ahead of that registration. Latching makes the
+    /// timeout fire deterministically regardless of which side lands first —
+    /// removing the load-sensitive ordering flake without touching the WS-F
+    /// flow's production behavior.
+    private var pendingFires = 0
     /// A pending sleep that never resolves on its own — but IS cancellation
     /// aware (a real `Task.sleep`-backed clock throws `CancellationError` on
     /// cancel, so the fake must too, or a losing timeout-guard task would
@@ -102,6 +112,12 @@ private final class ManualClock: CloudClock, @unchecked Sendable {
                 if Task.isCancelled {
                     lock.unlock()
                     cont.resume(throwing: CancellationError())
+                } else if pendingFires > 0 {
+                    // A fire() already arrived for this sleep — consume the
+                    // latch and resolve at once (the timeout has elapsed).
+                    pendingFires -= 1
+                    lock.unlock()
+                    cont.resume()
                 } else {
                     continuations[id] = cont
                     lock.unlock()
@@ -112,9 +128,15 @@ private final class ManualClock: CloudClock, @unchecked Sendable {
             c?.resume(throwing: CancellationError())
         }
     }
-    /// Resolve all pending sleeps (i.e. fire the timeout).
+    /// Resolve all pending sleeps (i.e. fire the timeout). If no sleep has
+    /// registered yet, latch the fire so the NEXT `sleep` resolves at once —
+    /// closing the fire()-before-sleep() ordering race.
     func fire() {
-        lock.lock(); let conts = Array(continuations.values); continuations = [:]; lock.unlock()
+        lock.lock()
+        let conts = Array(continuations.values)
+        continuations = [:]
+        if conts.isEmpty { pendingFires += 1 }
+        lock.unlock()
         for c in conts { c.resume() }
     }
 }


### PR DESCRIPTION
## Kills the `WS-F provision timeout (30s)` CI flake

**Root cause (ordering race, not wall-clock):** the flow arms its timeout via `clock.sleep(...)` on a background task inside a `withTaskGroup` (`EnableCloudAccessFlow.swift:332`). A test calling `clock.fire()` right after a state transition can race **ahead** of that continuation registering, so the fire resolves nothing, the sleep hangs, and `waitFor` times out.

**Fix (test-infra only):** edge-pending latch on `ManualClock` — a `fire()` with no waiters increments `pendingFires`; the next `sleep` consumes it and resolves immediately. Timeout now fires deterministically regardless of `fire()`/`sleep()` ordering. Covers both the provision-timeout and auth-timeout tests (same clock). **No change to `EnableCloudAccessFlow` production behavior.**

**Verified:** clean build + `make test-floor` **×5 consecutive, all green** (1727 ≥ floor 1725, 0 failed); provision-timeout + auth-timeout tests pass every run.

Improves CI reliability for all PRs. Composes cleanly into v3.7.6 (disjoint from the theme/routing changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)