### PR TITLE
build: harden install/install-copy against the Sparkle auto-update race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,37 @@ check-stale-build:
 		exit 1; \
 	fi
 
+# ── Local-install safety (2026-06-04 incident) ─────────────────────────
+# `install`/`install-copy` write directly into the Sparkle-managed
+# /Applications bundle. If the app is running or Sparkle has a staged update
+# pending, the manual rm-rf+ditto can race Sparkle's installer and leave a
+# corrupted bundle (mixed versions) that crash-loops at launch in
+# Bundle.module / loadMenuBarIcon(). These canned recipes make local installs
+# race-safe: quit the app + clear pending Sparkle staging before writing, and
+# verify bundle consistency after. (The shipped DMG is unaffected — the `app`
+# target packages the SPM resource bundle correctly.)
+define PREINSTALL_SAFETY
+@echo "⏏️  Quitting any running $(APP_NAME) (prevents install/Sparkle race)..."
+@osascript -e 'tell application "The Bridge" to quit' >/dev/null 2>&1 || true
+@pkill -f "The Bridge.app/Contents/MacOS/NotionBridge" 2>/dev/null || true
+@pkill -f "NBJobRunner" 2>/dev/null || true
+@i=0; while pgrep -f "The Bridge.app/Contents/MacOS/NotionBridge" >/dev/null 2>&1 && [ $$i -lt 20 ]; do sleep 0.5; i=$$((i+1)); done
+@echo "🧹 Clearing any pending Sparkle staged update (prevents revert-over-install)..."
+@rm -rf "$$HOME/Library/Caches/$(BUNDLE_ID)/org.sparkle-project.Sparkle/Installation/"* "$$HOME/Library/Caches/$(BUNDLE_ID)/org.sparkle-project.Sparkle/PersistentDownloads/"* 2>/dev/null || true
+endef
+
+define VERIFY_INSTALL
+@SRC_VER=$$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$(APP_BUNDLE)/Contents/Info.plist" 2>/dev/null); \
+	DST_VER=$$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "/Applications/The Bridge.app/Contents/Info.plist" 2>/dev/null); \
+	if [ -z "$$DST_VER" ] || [ "$$SRC_VER" != "$$DST_VER" ]; then \
+		echo "❌ install verify: version mismatch (source '$$SRC_VER' != installed '$$DST_VER') — bundle may be raced/corrupt"; exit 1; \
+	fi; \
+	if [ ! -d "/Applications/The Bridge.app/Contents/Resources/NotionBridge_NotionBridge.bundle" ]; then \
+		echo "❌ install verify: SPM resource bundle missing — app would crash at launch (Bundle.module)"; exit 1; \
+	fi; \
+	echo "✅ install verify: version $$DST_VER + SPM resource bundle present"
+endef
+
 # ── Install ────────────────────────────────────────────────────────────
 # PKT-1 v3.5: destination renamed to "/Applications/The Bridge.app".
 # Cleanup removes the new path AND both legacy variants ("Notion Bridge.app"
@@ -219,21 +250,26 @@ check-stale-build:
 # name installs) so re-installs land cleanly regardless of prior state.
 install: check-stale-build notarize
 	@echo "📲 Installing notarized app to /Applications..."
+	$(PREINSTALL_SAFETY)
 	@rm -rf "/Applications/The Bridge.app" "/Applications/Notion Bridge.app" "/Applications/NotionBridge.app"
 	@ditto "$(APP_BUNDLE)" "/Applications/The Bridge.app"
 	@spctl --assess --verbose "/Applications/The Bridge.app"
 	@echo "🔄 Re-registering with Launch Services..."
 	@/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "/Applications/The Bridge.app"
 	@killall Dock 2>/dev/null || true
+	$(VERIFY_INSTALL)
 	@echo "✅ Installed: /Applications/The Bridge.app"
 
 # v1.7.0: Copy-only install (no notarize dep, no killall) (F3)
 install-copy: check-stale-build sign
+	@echo "⚠️  install-copy replaces the Sparkle-managed /Applications/The Bridge.app — the running app is quit automatically below to avoid an install/Sparkle race."
 	@echo "Installing app to /Applications (copy-only)..."
+	$(PREINSTALL_SAFETY)
 	@rm -rf "/Applications/The Bridge.app" "/Applications/Notion Bridge.app" "/Applications/NotionBridge.app"
 	@ditto "$(APP_BUNDLE)" "/Applications/The Bridge.app"
 	@echo "🔄 Re-registering with Launch Services..."
 	@/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "/Applications/The Bridge.app"
+	$(VERIFY_INSTALL)
 	@echo "Installed: /Applications/The Bridge.app"
 	@echo "Restart The Bridge manually to pick up changes."
 


### PR DESCRIPTION
## Prevents the local install/Sparkle race that took the app down (2026-06-04)

`install`/`install-copy` write directly into the **Sparkle-managed** `/Applications/The Bridge.app`. If the app is running or Sparkle has a staged update pending, the manual `rm -rf`+`ditto` can race Sparkle's installer → a corrupted mixed-version bundle that crash-loops at launch in `Bundle.module`/`loadMenuBarIcon()` (EXC_BREAKPOINT `_assertionFailure`). That's exactly what happened when an `install-copy` of 3.7.6 collided with Sparkle installing the staged 3.7.5.

### Change (Makefile install recipes only)
Two canned recipes, used by **both** `install` and `install-copy`:
- **`PREINSTALL_SAFETY`** — quit the running app (`osascript` quit + `pkill`, wait up to 10s for exit) and clear pending Sparkle staging (`Installation/` + `PersistentDownloads/`) **before** the `rm -rf`+`ditto`, so nothing races the manual write.
- **`VERIFY_INSTALL`** — **after** `ditto`, assert the installed `Info.plist` version matches the source build **and** the SPM resource bundle exists; fail loudly (`exit 1`) otherwise.
- A one-line warning that `install-copy` replaces the Sparkle-managed bundle.

### Not affected
The **shipped DMG is fine** — the `app` target already packages the SPM resource bundle into `Contents/Resources` (Makefile ~115–127). This was strictly a local dev-install race. **Build/dmg/sign targets untouched.**

### Verification
- `make -n install-copy` / `make -n install`: parse clean (RC=0), both canned recipes expand with vars resolved (`The Bridge`, `kup.solutions.notion-bridge`, `.build/NotionBridge.app`).
- `VERIFY_INSTALL` logic: **passes** for a good install (3.7.6 + bundle present), **trips** on a version mismatch.
- Full live `install-copy` run deferred to avoid tearing down the just-restored running app; the path is dry-run-validated + logic-tested. (CI's `make build`/`test-floor` doesn't exercise install targets, so it only confirms the Makefile still builds/tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)