### PR TITLE
fix(updater): guarantee user feedback on manual Check for Updates

### DIFF
--- a/NotionBridge/App/AppDelegate.swift
+++ b/NotionBridge/App/AppDelegate.swift
@@ -498,9 +498,32 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// log the updater's checkable state so a silent no-op (the historical
     /// PKT-932 bug) is diagnosable in the unified log rather than vanishing.
     public func checkForUpdates() {
+        // LSUIElement (menu-bar) app: become a regular app so Sparkle's update
+        // window/alert can surface as a focused window, then activate.
+        NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
         let u = updaterController.updater
         NSLog("[Bridge][Updater] checkForUpdates tapped — canCheckForUpdates=\(u.canCheckForUpdates) sessionInProgress=\(u.sessionInProgress) feedURL=\(u.feedURL?.absoluteString ?? "nil")")
+        // Guarantee user-visible feedback. Sparkle silently ignores a manual
+        // check when it cannot start one — most commonly because an automatic
+        // download/install session is already in progress (canCheckForUpdates ==
+        // false). Historically that produced a dead button with no UI at all.
+        // Surface an explicit alert in that state instead of no-op'ing.
+        guard u.canCheckForUpdates else {
+            let alert = NSAlert()
+            if u.sessionInProgress {
+                alert.messageText = "An update is already in progress"
+                alert.informativeText = "The Bridge is downloading or preparing an update in the background. Quit and reopen The Bridge to finish installing it."
+            } else {
+                alert.messageText = "Updates are unavailable right now"
+                alert.informativeText = "The updater isn’t ready to check at the moment. Please try again in a few seconds."
+            }
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "OK")
+            NSLog("[Bridge][Updater] manual check unavailable — surfaced alert (sessionInProgress=\(u.sessionInProgress))")
+            alert.runModal()
+            return
+        }
         updaterController.checkForUpdates(nil)
     }
 


### PR DESCRIPTION
## Problem
Connections-tab **Check for Updates** does nothing from a UX standpoint — no dialog at all.

## Root cause
The button IS wired to Sparkle (`ConnectionsSection` -> `AppDelegate.checkForUpdates()` -> `SPUStandardUpdaterController.checkForUpdates`). The engine is healthy, but Sparkle silently ignores a user-initiated check when `canCheckForUpdates == false` — most commonly when an automatic download/install session is already in progress (auto-install is on; an update was available: running 3.7.6/51, signed appcast offers 3.7.7/52). Net: dead button, zero feedback. Forensics: recent `SULastCheckTime` + `SUAutomaticallyUpdate=1` + 3.7.7 available + 0 `[Bridge][Updater]` tap-logs while the app logged normally.

## Fix
`AppDelegate.checkForUpdates()` now guarantees feedback:
- `NSAlert` when `canCheckForUpdates == false`, distinguishing "update already in progress -> quit and reopen to finish installing" from a transient "try again" state.
- `setActivationPolicy(.regular)` before the check so the LSUIElement menu-bar app reliably surfaces Sparkle's window.
- Keeps the diagnostic `NSLog`; adds one for the alert path.

## Verification
- swift build green (incremental) on the main base.
- Operator click-test required before merge: build+install this branch, Connections -> Check for Updates, expect a dialog every time. Not unit-testable (modal UI; the test harness disarms the updater).

## Contingency
If a click with `canCheckForUpdates == true` still shows no window, that's pure Sparkle window-surfacing -> add an `SPUStandardUserDriverDelegate` to force the window front (the `.regular` activation here should already cover it).