### PR TITLE
feat(memory): Wave 2 export/import and consolidation (PKT-977)

### DIFF
--- a/NotionBridge/App/AppDelegate.swift
+++ b/NotionBridge/App/AppDelegate.swift
@@ -255,6 +255,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             print("[PathMigration] WARNING: migration failed: \(error)")
         }
 
+        // PKT-977 Wave 2: demote stale reference memories on launch (best-effort).
+        Task {
+            do {
+                let report = try await MemoryStore.shared.consolidationSweep()
+                if report.referenceDemoted > 0 || report.expiredTombstoned > 0 {
+                    print("[Memory] consolidation: referenceDemoted=\(report.referenceDemoted) expired=\(report.expiredTombstoned)")
+                }
+            } catch {
+                print("[Memory] WARNING: consolidation sweep failed: \(error)")
+            }
+        }
+
         // PKT-909 (Sell/Distribute v3 · 1): bootstrap the licensing gate.
         // MUST come AFTER PathMigration — the grandfather detection looks
         // at PathMigration's sentinel file. First-launch users seed

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -105,7 +105,8 @@ public enum BridgeConstants {
     ///   joins the existing `notion` family) = 208.
     /// fb-permissions: + 1 (permissions_status — unified TCC grant probe, new
     ///   `permissions` family) = 209.
-    public static let staticFeatureModuleToolCount = 209
+    /// Unified Memory Wave 2 (PKT-977): + 2 (memory_export + memory_import) = 211.
+    public static let staticFeatureModuleToolCount = 211
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/NotionBridge/Core/BridgeDefaults.swift
+++ b/NotionBridge/Core/BridgeDefaults.swift
@@ -91,6 +91,15 @@ public enum BridgeDefaults {
     /// `ClientOverlayStore`.
     public static let standingOrdersClientOverlays = "com.notionbridge.standingOrdersClientOverlays"
 
+    /// Wave 2 (PKT-977): when true, append the memory handshake slice to
+    /// `initialize.instructions` for connecting MCP clients. Default OFF —
+    /// memory remains opt-in via `bridge://memory` until the operator enables this.
+    public static let memoryHandshakeAutoInject = "com.notionbridge.memory.handshakeAutoInject"
+
+    public static var memoryHandshakeAutoInjectEffective: Bool {
+        UserDefaults.standard.bool(forKey: memoryHandshakeAutoInject)
+    }
+
     // MARK: - Commands Palette (cmd-ux)
 
     /// Master on/off for the Commands palette (global-hotkey command box).

--- a/NotionBridge/Modules/MemoryModule.swift
+++ b/NotionBridge/Modules/MemoryModule.swift
@@ -1,4 +1,4 @@
-// MemoryModule.swift — Unified Memory MCP tools · FOUNDATION (Wave 1)
+// MemoryModule.swift — Unified Memory MCP tools · Wave 1 + Wave 2
 // NotionBridge · Modules
 //
 // Registers `memory_remember` + `memory_recall` on the ToolRouter so BOTH
@@ -135,6 +135,80 @@ public enum MemoryModule {
                 ])
             }
         ))
+
+        // MARK: 3. memory_export — request (local backup seam)
+        await router.register(ToolRegistration(
+            name: "memory_export",
+            module: moduleName,
+            tier: .request,
+            description: "Export all live memories as a versioned JSON envelope for backup or migration. Local-only; does not include soft-tombstoned rows.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:])
+            ]),
+            metadata: ToolMetadata(
+                title: "Memory Export",
+                whenToUse: ["backup memories before a reinstall", "migrate memory between Macs via export/import"],
+                whenNotToUse: ["reading memories for grounding (use memory_recall)"],
+                relatedTools: ["memory_import", "memory_recall"]
+            ),
+            handler: { _ in
+                let payload = try await store.exportJSON()
+                return .object([
+                    "ok": .bool(true),
+                    "format": .string("json"),
+                    "schemaVersion": .int(MemoryStore.ExportEnvelope.currentSchemaVersion),
+                    "payload": .string(payload)
+                ])
+            }
+        ))
+
+        // MARK: 4. memory_import — request (local restore seam)
+        await router.register(ToolRegistration(
+            name: "memory_import",
+            module: moduleName,
+            tier: .request,
+            description: "Import memories from a `memory_export` JSON envelope. Skips duplicates (same scope+entity+contentHash). Assigns fresh ids to imported rows.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "payload": .object(["type": .string("string"), "description": .string("JSON from memory_export")])
+                ]),
+                "required": .array([.string("payload")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Memory Import",
+                whenToUse: ["restore a memory_export backup on this Mac"],
+                whenNotToUse: ["creating a single new memory (use memory_remember)"],
+                relatedTools: ["memory_export", "memory_remember"]
+            ),
+            handler: { arguments in
+                guard case .object(let obj) = arguments,
+                      case .string(let payload)? = obj["payload"], !payload.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "memory_import", reason: "missing 'payload'")
+                }
+                let result = try await store.importJSON(payload)
+                return .object([
+                    "ok": .bool(true),
+                    "imported": .int(result.imported),
+                    "skipped": .int(result.skipped),
+                    "errors": .array(result.errors.map { .string($0) })
+                ])
+            }
+        ))
+    }
+
+    // MARK: - Client source threading (Wave 2 · Q3)
+
+    /// Inject the live MCP client name as `source` when the caller omitted it.
+    public static func argumentsWithClientSource(_ arguments: Value, clientName: String?) -> Value {
+        guard let name = clientName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+            return arguments
+        }
+        guard case .object(var obj) = arguments else { return arguments }
+        if stringArg(obj, "source") != nil { return arguments }
+        obj["source"] = .string(name)
+        return .object(obj)
     }
 
     // MARK: - Helpers

--- a/NotionBridge/Modules/MemoryStore.swift
+++ b/NotionBridge/Modules/MemoryStore.swift
@@ -408,6 +408,115 @@ public actor MemoryStore {
             .map(\.entry)
     }
 
+    // MARK: Wave 2 — export / import / consolidation
+
+    /// JSON envelope for `memory_export` / `memory_import` (local-only sync seam).
+    public struct ExportEnvelope: Codable, Sendable, Equatable {
+        public static let currentSchemaVersion = 1
+        public var schemaVersion: Int
+        public var exportedAt: Date
+        public var entries: [MemoryEntry]
+
+        public init(exportedAt: Date = Date(), entries: [MemoryEntry]) {
+            self.schemaVersion = Self.currentSchemaVersion
+            self.exportedAt = exportedAt
+            self.entries = entries
+        }
+    }
+
+    public struct ImportResult: Sendable, Equatable {
+        public var imported: Int
+        public var skipped: Int
+        public var errors: [String]
+    }
+
+    public struct ConsolidationReport: Sendable, Equatable {
+        public var referenceDemoted: Int
+        public var expiredTombstoned: Int
+    }
+
+    /// All live rows as JSON (pretty-printed). Does not include tombstoned rows.
+    public func exportJSON() throws -> String {
+        try ensureOpen()
+        let entries = try liveEntries(scope: nil, entity: nil)
+        let envelope = ExportEnvelope(entries: entries)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(envelope),
+              let json = String(data: data, encoding: .utf8) else {
+            throw MemoryStoreError.storageFailure("export encode failed")
+        }
+        return json
+    }
+
+    /// Import from a Wave-2 export envelope. Skips rows whose `contentHash` already
+    /// exists live in the same scope+entity; otherwise inserts with a fresh id.
+    public func importJSON(_ raw: String) throws -> ImportResult {
+        try ensureOpen()
+        guard let data = raw.data(using: .utf8) else {
+            throw MemoryStoreError.invalidArgument("import payload is not valid UTF-8")
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(ExportEnvelope.self, from: data)
+        guard envelope.schemaVersion == ExportEnvelope.currentSchemaVersion else {
+            throw MemoryStoreError.invalidArgument("unsupported export schemaVersion \(envelope.schemaVersion)")
+        }
+        var imported = 0
+        var skipped = 0
+        var errors: [String] = []
+        for entry in envelope.entries {
+            do {
+                if try liveDuplicateExists(scope: entry.scope, entity: entry.entity, hash: entry.contentHash) {
+                    skipped += 1
+                    continue
+                }
+                var row = entry
+                row.id = UUID().uuidString
+                row.supersedesId = nil
+                try insertRow(row)
+                imported += 1
+            } catch {
+                errors.append("\(entry.id): \(error.localizedDescription)")
+            }
+        }
+        return ImportResult(imported: imported, skipped: skipped, errors: errors)
+    }
+
+    /// On-launch catch-up: demote-not-delete stale `reference` rows and tombstone
+    /// any row whose explicit `expiresAt` is in the past. Pinned rows are never swept.
+    public func consolidationSweep(now: Date = Date()) throws -> ConsolidationReport {
+        try ensureOpen()
+        var referenceDemoted = 0
+        var expiredTombstoned = 0
+        let all = try liveEntries(scope: nil, entity: nil)
+        for entry in all where !entry.pinned {
+            if let exp = entry.expiresAt, exp <= now {
+                try tombstone(id: entry.id, at: now)
+                expiredTombstoned += 1
+                continue
+            }
+            if entry.type == .reference {
+                let age = now.timeIntervalSince(entry.lastUsedAt)
+                if age >= Self.referenceStaleSeconds {
+                    try tombstone(id: entry.id, at: now)
+                    referenceDemoted += 1
+                }
+            }
+        }
+        return ConsolidationReport(referenceDemoted: referenceDemoted, expiredTombstoned: expiredTombstoned)
+    }
+
+    /// ~90 days without use: `reference` entries are soft-tombstoned on consolidation.
+    static let referenceStaleSeconds: TimeInterval = 60 * 60 * 24 * 90
+
+    private func liveDuplicateExists(scope: String, entity: String?, hash: String) throws -> Bool {
+        try liveEntry(matchingHash: hash).map { existing in
+            existing.scope == scope && existing.entity == entity
+        } ?? false
+    }
+
     // MARK: - Salience
 
     /// Salience = weighted sum of:

--- a/NotionBridge/Server/DeliveryLog.swift
+++ b/NotionBridge/Server/DeliveryLog.swift
@@ -38,6 +38,8 @@ public enum DeliveryEventKind: String, Sendable, Equatable, CaseIterable {
     /// the skill name/path that was fetched and the intent (when supplied)
     /// so the routing surface can be audited for drift / mis-routes.
     case skillFetched
+    /// A `memory_*` tool call (audit-only — memories surfaced telemetry).
+    case memoryToolCall
 }
 
 /// One immutable telemetry event. `Sendable` so it can be built off-main and
@@ -326,6 +328,23 @@ public final class DeliveryLog {
     /// value for the routing-stability audit. `skill` is the `name` string
     /// (empty when absent); `intent` is the trimmed `intent` string when
     /// non-empty, else nil. Pure + nonisolated — touches only its argument.
+    /// Record a `memory_*` tool call. AUDIT ONLY — never gates dispatch.
+    public nonisolated func recordMemoryToolCall(
+        sessionID: String,
+        clientName: String?,
+        toolName: String,
+        at: Date = Date()
+    ) {
+        let event = DeliveryEvent(
+            sessionID: sessionID,
+            clientName: clientName,
+            kind: .memoryToolCall,
+            uri: toolName,
+            at: at
+        )
+        Task { @MainActor in DeliveryLog.shared.ingest(event) }
+    }
+
     public nonisolated static func skillFetchFields(from arguments: Value?) -> (skill: String, intent: String?) {
         guard case .object(let dict)? = arguments else { return ("", nil) }
         let skill: String = {

--- a/NotionBridge/Server/SSETransport.swift
+++ b/NotionBridge/Server/SSETransport.swift
@@ -856,7 +856,17 @@ public actor SSEServer {
                     intent: intent
                 )
             }
-            let arguments: Value = params.arguments.map { .object($0) } ?? .object([:])
+            if params.name.hasPrefix("memory_") {
+                DeliveryLog.shared.recordMemoryToolCall(
+                    sessionID: resourceSessionID,
+                    clientName: resourceClientName,
+                    toolName: params.name
+                )
+            }
+            var arguments: Value = params.arguments.map { .object($0) } ?? .object([:])
+            if params.name == "memory_remember" {
+                arguments = MemoryModule.argumentsWithClientSource(arguments, clientName: resourceClientName)
+            }
             let (text, isError) = await router.dispatchFormatted(toolName: params.name, arguments: arguments)
             if !isError { await MainActor.run { onToolCall() } }
             return .init(content: [.text(.init(text))], isError: isError)

--- a/NotionBridge/Server/ServerManager.swift
+++ b/NotionBridge/Server/ServerManager.swift
@@ -287,7 +287,17 @@ public actor ServerManager {
                     intent: intent
                 )
             }
-            let arguments: Value = params.arguments.map { .object($0) } ?? .object([:])
+            var arguments: Value = params.arguments.map { .object($0) } ?? .object([:])
+            if params.name == "memory_remember" {
+                arguments = MemoryModule.argumentsWithClientSource(arguments, clientName: "stdio")
+            }
+            if params.name.hasPrefix("memory_") {
+                DeliveryLog.shared.recordMemoryToolCall(
+                    sessionID: Self.stdioSessionID,
+                    clientName: "stdio",
+                    toolName: params.name
+                )
+            }
             let (text, isError) = await router.dispatchFormatted(toolName: params.name, arguments: arguments)
             if !isError { await MainActor.run { onToolCall() } }
             return .init(content: [.text(.init(text))], isError: isError)

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -246,6 +246,8 @@ public enum ToolAnnotationCatalog {
         // false (a closed local store). recall is read-only — recall DOES bump
         // useCount/lastUsedAt (use-promotion), but that is metadata-only and
         // does not mutate content, so readOnlyHint stays true.
+        "memory_export": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
+        "memory_import": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         "memory_recall": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "memory_remember": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "messages_chat": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),

--- a/NotionBridge/UI/Sections/StandingOrdersSection.swift
+++ b/NotionBridge/UI/Sections/StandingOrdersSection.swift
@@ -482,6 +482,7 @@ public struct StandingOrdersSection: View {
         case .resourceRead: return "fetched"
         case .reminderToolCall: return "reminder"
         case .skillFetched: return "skill"
+        case .memoryToolCall: return "memory"
         }
     }
 
@@ -491,6 +492,7 @@ public struct StandingOrdersSection: View {
         case .resourceRead: return BridgeTokens.okText
         case .reminderToolCall: return BridgeTokens.warnText
         case .skillFetched: return BridgeTokens.infoText
+        case .memoryToolCall: return BridgeTokens.infoText
         }
     }
 

--- a/NotionBridgeTests/MemoryModuleTests.swift
+++ b/NotionBridgeTests/MemoryModuleTests.swift
@@ -275,12 +275,12 @@ func runMemoryModuleTests() async {
 
     // MARK: - Module registration + tiering
 
-    await test("MemoryModule registers exactly 2 tools") {
+    await test("MemoryModule registers exactly 4 tools") {
         let (store, url) = makeTempStore()
         defer { Task { await store.close(); cleanup(url) } }
         let router = await makeMemoryRouter(store)
         let tools = await router.registrations(forModule: "memory")
-        try expect(tools.count == 2, "expected 2 memory tools, got \(tools.count)")
+        try expect(tools.count == 4, "expected 4 memory tools, got \(tools.count)")
     }
 
     await test("memory tiering: remember=.notify (write), recall=.open (read-only)") {
@@ -333,5 +333,65 @@ func runMemoryModuleTests() async {
                 throw TestError.assertion("expected invalidArguments, got \(e)")
             }
         }
+    }
+
+    // MARK: - Wave 2: export / import / consolidation / client source
+
+    await test("MemoryStore: exportJSON round-trips through importJSON") {
+        let (store, url) = makeTempStore()
+        defer { Task { await store.close(); cleanup(url) } }
+        _ = try await store.remember(text: "export me", scope: "global", source: "t")
+        let json = try await store.exportJSON()
+        let (store2, url2) = makeTempStore()
+        defer { Task { await store2.close(); cleanup(url2) } }
+        let result = try await store2.importJSON(json)
+        try expect(result.imported == 1 && result.skipped == 0, "import should land one row")
+        let recalled = try await store2.recall(query: "export", scope: "global", entity: nil, limit: 5)
+        try expect(recalled.count == 1, "imported memory must be recallable")
+    }
+
+    await test("MemoryStore: importJSON skips duplicate contentHash in same scope") {
+        let (store, url) = makeTempStore()
+        defer { Task { await store.close(); cleanup(url) } }
+        _ = try await store.remember(text: "dup check", scope: "mac", source: "t")
+        let json = try await store.exportJSON()
+        let result = try await store.importJSON(json)
+        try expect(result.imported == 0 && result.skipped == 1, "duplicate must skip")
+    }
+
+    await test("MemoryStore: consolidationSweep tombstones stale reference rows") {
+        let (store, url) = makeTempStore()
+        defer { Task { await store.close(); cleanup(url) } }
+        let staleSeconds = 60.0 * 60 * 24 * 90 + 3600
+        let staleDate = Date().addingTimeInterval(-staleSeconds)
+        let staleRef = MemoryEntry(
+            scope: "global", text: "old ref link", type: .reference,
+            lastUsedAt: staleDate, source: "test", contentHash: "stale-ref-hash"
+        )
+        let envelope = MemoryStore.ExportEnvelope(entries: [staleRef])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let json = String(data: try encoder.encode(envelope), encoding: .utf8)!
+        _ = try await store.importJSON(json)
+
+        let pinned = try await store.remember(text: "pinned ref", scope: "global", type: .reference, source: "t")
+        try await store.pin(id: pinned.id, true)
+
+        let report = try await store.consolidationSweep(now: Date())
+        try expect(report.referenceDemoted == 1, "stale reference must demote once, got \(report.referenceDemoted)")
+        let gone = try await store.recall(query: "old ref link", scope: "global", entity: nil, limit: 5)
+        try expect(!gone.contains { $0.text == "old ref link" }, "tombstoned reference must not recall")
+        let stillLive = try await store.recall(query: "pinned", scope: "global", entity: nil, limit: 5)
+        try expect(stillLive.contains { $0.id == pinned.id }, "pinned reference must survive sweep")
+    }
+
+    await test("MemoryModule.argumentsWithClientSource injects client when source omitted") {
+        let args = MemoryModule.argumentsWithClientSource(.object(["text": .string("x")]), clientName: "cursor-vscode")
+        try expect(memObjField(args, "source") == .string("cursor-vscode"))
+        let kept = MemoryModule.argumentsWithClientSource(
+            .object(["text": .string("x"), "source": .string("explicit")]),
+            clientName: "cursor-vscode"
+        )
+        try expect(memObjField(kept, "source") == .string("explicit"), "explicit source must win")
     }
 }

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -977,8 +977,8 @@ set -euo pipefail
 # axcrash +8, automation +17, buildtools +22, notionwrite +11, resultsize +17,
 # permissions +13, credentials +27, session +17, sparkle +15 = +173 → 1950.
 # (3 docs-only branches — playbook, design-decouple, operator-runbooks — add 0
-# tests.) Measured integrated green 2014 passed / 0 failed locally across the
-# full suite; FLOOR set to 1950 stays 64 below the measured 2014 so the existing
+# tests.) Measured integrated green 2018 passed / 0 failed locally across the
+# full suite; FLOOR set to 1950 stays 68 below the measured 2018 so the existing
 # GUI/TCC + flake headroom is preserved while none of the +173 new tests can be
 # silently dropped. Never lowered below origin/main's 1777.
 FLOOR="${BRIDGE_TEST_FLOOR:-1950}"


### PR DESCRIPTION
## Summary
- Adds `memory_export` and `memory_import` MCP tools (`.request` tier) for local backup/migration
- Threads MCP client name into `memory_remember` `source` when omitted (HTTP + stdio)
- Runs reference consolidation sweep on app launch (90-day stale `reference` tombstone)
- Records `memory_*` tool calls in DeliveryLog telemetry
- `staticFeatureModuleToolCount` 209 → 211

## Test plan
- [x] `make test` — **2018 passed / 0 failed** (floor 1950)
- [ ] Operator: `memory_export` → `memory_import` round-trip on live MCP
- [ ] Operator: verify consolidation log line on launch when stale references exist
- [ ] Merge after review; bump app version if shipping with v3.7.8

## Packet
PKT-977 — Unified Memory Wave 2 (design ratified; handshake auto-inject flag added but not wired — opt-in via `bridge://memory` remains default)


Made with [Cursor](https://cursor.com)