### PR TITLE
v3.8.2 — registry_remove_entity + Data Sources pane Remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.8.2 — Registry entity-management: `registry_remove_entity` + pane Remove
+
+- **`registry_remove_entity` (10th registry tool).** The symmetric counterpart to `registry_add_entity`: forgets an entity's binding + property map and evicts its cached rows. **Does not touch Notion** — the data source and its rows remain; only the Bridge's local binding is removed. Destructive `.request` tier (confirmation-gated). The seeded **Skills** entity is guarded behind an explicit `confirm:true` so an offhand call can't strip the default a fresh install relies on. Symmetric `RegistryConfigStore.removeEntity(key:)` (atomic persist + cache evict).
+- **Settings → Data Sources: a "Remove" affordance** on each entity card, routed through a confirmation dialog with an extra-firm message for the seed. The pane and the MCP tool share the same store + seed guard (BE↔FE alignment).
+- `staticFeatureModuleToolCount` 171 → 172. +6 tests (registration count 9→10, tier, add→remove round-trip, seed-guard refuse/confirm, unknown-entity, pane remove + `isSeed`); floor 2163 → 2169, zero regression.
+
 ## v3.8.1 — Security: close the legacy-route tunnel bypass (+ Data-Source Registry)
 
 - **Security — legacy `/sse` + `/messages` are now loopback-only (PKT-810 R5 hardening).** The legacy SSE transport (PKT-336: `GET /sse` + `POST /messages`) is dispatched in the NIO handler **before** the `/mcp` connector-auth gate, and cloudflared forwards every path to `:9700` (no path scoping) — so a Cloudflare-tunnel caller could open an **unauthenticated** legacy MCP session and drive the full tool surface, bypassing the entire OAuth gate that protects `/mcp`. Tunnel-origin (`Cf-*`) requests to the legacy routes are now refused with **403**; direct loopback (older local SSE clients) is unaffected. A new `SSEServer.isRemoteTunnelRequest(headers:)` mirrors the `/mcp` origin split for the NIO dispatch layer (kept in lockstep with the `HTTPRequest` overload). +5 tests (HTTPHeaders discriminator + real-NIO-decode of tunnel/loopback × `/sse`,`/messages`); floor 2158 → 2163.

--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.1</string>
+	<string>3.8.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>60</string>
+	<string>61</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/NotionBridge/Config/Version.swift
+++ b/NotionBridge/Config/Version.swift
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "3.8.1"
+    public static let marketing = "3.8.2"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -81,7 +81,13 @@ public enum AppVersion {
     ///   loopback (older local SSE clients) is unaffected. Also bundles the
     ///   config-driven Data-Source Registry (9 `registry_*` tools) that landed on
     ///   main post-v3.8.0. test-floor 2158 → 2163, zero regression.
-    public static let build = "60"
+    /// v3.8.2: 60 → 61 — Data-Source Registry entity-management completion:
+    ///   + registry_remove_entity (symmetric to registry_add_entity — forgets a
+    ///   local entity binding + evicts its row cache, no Notion write; .request
+    ///   tier; seeded Skills entity guarded behind explicit confirm) + a "Remove"
+    ///   affordance in the Data Sources pane. staticFeatureModuleToolCount 171 →
+    ///   172. test-floor 2163 → 2169, zero regression.
+    public static let build = "61"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }
@@ -179,7 +185,10 @@ public enum BridgeConstants {
     ///   introspect/list/get/create/update/delete/possess — the new `registry`
     ///   family: one generic CRUD set + entity registration + introspect + possess
     ///   serving every configured entity). 162 + 9 = 171.
-    public static let staticFeatureModuleToolCount = 171
+    /// Registry entity-management completion (2026-06-18): + 1 (registry_remove_entity
+    ///   — the symmetric counterpart to registry_add_entity; drops a local
+    ///   entity binding + evicts its cache, no Notion write). 171 + 1 = 172.
+    public static let staticFeatureModuleToolCount = 172
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/NotionBridge/Modules/Registry/DataSourcesViewModel.swift
+++ b/NotionBridge/Modules/Registry/DataSourcesViewModel.swift
@@ -149,4 +149,26 @@ public final class DataSourcesViewModel: ObservableObject {
         await refreshCacheCounts()
         status = "Cleared cache for \(key)"
     }
+
+    // MARK: - Remove data source
+
+    /// Whether `key` is the seeded Skills entity — the pane requires an extra,
+    /// explicit confirm before removing it (it's the validating fold-in + the
+    /// default a fresh install relies on). Mirrors the `registry_remove_entity`
+    /// tool guard so the UI and the MCP surface agree.
+    public func isSeed(_ key: String) -> Bool { key == RegistryEntity.seedEntityKey }
+
+    /// Remove an entity from the registry (forget its binding + evict its cache)
+    /// and persist. Goes through the SHARED store, so it serializes with the
+    /// registry tools' writes (BE↔FE alignment). Does NOT touch Notion.
+    public func removeEntity(_ key: String) async {
+        busy = true; defer { busy = false }
+        do {
+            _ = try await store().removeEntity(key: key)   // atomic, serialized, evicts cache
+            await load()
+            status = "Removed data source ‘\(key)’"
+        } catch {
+            status = "Could not remove ‘\(key)’: \(error.localizedDescription)"
+        }
+    }
 }

--- a/NotionBridge/Modules/Registry/RegistryConfigStore.swift
+++ b/NotionBridge/Modules/Registry/RegistryConfigStore.swift
@@ -136,4 +136,20 @@ public actor RegistryConfigStore {
         try save(config)
         return config
     }
+
+    /// Remove one entity by key, persist, AND evict its row cache — the
+    /// "forget this data source entirely" operation (symmetric to `upsertEntity`).
+    /// A no-op (returns the current config, no save) if the key isn't present.
+    /// Does NOT touch Notion — only the Bridge's local binding + cache.
+    /// The Skills SEED is removable here like any other entity; the "explicit
+    /// confirm" guard for it lives in the CALLER (the tool / the pane), not the
+    /// store, so a deliberate programmatic removal stays simple.
+    @discardableResult
+    public func removeEntity(key: String) async throws -> RegistryConfig {
+        var config = try load()
+        guard config.removeEntity(key: key) else { return config }   // not present — no-op
+        try save(config)
+        await RegistryRowCache.shared.evictAll(entity: key)
+        return config
+    }
 }

--- a/NotionBridge/Modules/Registry/RegistryModels.swift
+++ b/NotionBridge/Modules/Registry/RegistryModels.swift
@@ -214,6 +214,15 @@ public struct RegistryConfig: Codable, Sendable, Equatable {
             entities.append(entity)
         }
     }
+
+    /// Remove an entity by key. Returns true if one was present and removed
+    /// (false ⇒ no-op, key wasn't configured).
+    @discardableResult
+    public mutating func removeEntity(key: String) -> Bool {
+        guard let i = entities.firstIndex(where: { $0.key == key }) else { return false }
+        entities.remove(at: i)
+        return true
+    }
 }
 
 // MARK: - Default seed (Skills as entity #1 — Decision 7)
@@ -229,6 +238,12 @@ public extension RegistryConfig {
 }
 
 public extension RegistryEntity {
+    /// Canonical key of the seeded Skills entity (entity #1). Special-cased by
+    /// destructive ops — `registry_remove_entity` + the pane guard it behind an
+    /// explicit confirm, since it's the validating fold-in (Decision 7) and the
+    /// default a fresh install relies on.
+    static let seedEntityKey = "skill"
+
     /// Skills as a registry entity. The data source id is the operator's
     /// verified Keepr/Skills source (a portable install rebinds it at setup);
     /// property IDs are unbound (resolved by name against the live schema).
@@ -236,7 +251,7 @@ public extension RegistryEntity {
     /// (the `fetch_skill`/`possess` pattern — Decision 1 / Decision 2).
     static func skillsSeed() -> RegistryEntity {
         RegistryEntity(
-            key: "skill",
+            key: seedEntityKey,
             displayName: "Skills",
             dataSourceId: "b6ff6ea5-3917-4af7-9c36-278dc8bfb21f",
             workspace: nil,

--- a/NotionBridge/Modules/Registry/RegistryModule.swift
+++ b/NotionBridge/Modules/Registry/RegistryModule.swift
@@ -100,6 +100,7 @@ public enum RegistryModule {
     public static func register(on router: ToolRouter) async {
         await router.register(makeEntities())
         await router.register(makeAddEntity())
+        await router.register(makeRemoveEntity())
         await router.register(makeIntrospect())
         await router.register(makeList())
         await router.register(makeGet())
@@ -175,6 +176,41 @@ public enum RegistryModule {
                 // Atomic upsert on the shared actor (serialized).
                 _ = try await configStore().upsertEntity(entity)
                 return .object(["added": .bool(true), "entity": entityValue(entity)])
+            })
+    }
+
+    // MARK: - registry_remove_entity
+
+    public static func makeRemoveEntity() -> ToolRegistration {
+        ToolRegistration(
+            name: "registry_remove_entity", module: moduleName, tier: .request,
+            description: "Remove an entity from the data-source registry: forget its entity→data-source mapping + property map and evict its cached rows. Does NOT touch Notion — the data source and its rows remain; only the Bridge's local binding is removed. Removing the seeded Skills entity requires confirm:true.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "entity": .object(["type": .string("string"), "description": .string("Entity key to remove, e.g. ‘project’.")]),
+                    "confirm": .object(["type": .string("boolean"), "description": .string("Required (true) to remove the seeded Skills entity.")]),
+                ]),
+                "required": .array([.string("entity")]),
+            ]),
+            handler: { args in
+                guard case .object(let a) = args, let key = string(a, "entity") else {
+                    throw ToolRouterError.invalidArguments(toolName: "registry_remove_entity", reason: "missing ‘entity’")
+                }
+                let config = await loadConfig()
+                _ = try requireEntity(key, in: config, tool: "registry_remove_entity")   // 404 on unknown
+                // Guard the seeded Skills entity (entity #1 — the validating
+                // fold-in + the default a fresh install relies on): removing it
+                // needs an explicit confirm so an offhand call can't strip it.
+                var confirm = false
+                if case .bool(let b)? = a["confirm"] { confirm = b }
+                if key == RegistryEntity.seedEntityKey && !confirm {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "registry_remove_entity",
+                        reason: "‘\(key)’ is the seeded Skills entity — pass confirm:true to remove it")
+                }
+                _ = try await configStore().removeEntity(key: key)
+                return .object(["removed": .bool(true), "entity": .string(key)])
             })
     }
 

--- a/NotionBridge/Server/BridgeModuleRegistry.swift
+++ b/NotionBridge/Server/BridgeModuleRegistry.swift
@@ -68,7 +68,7 @@ public enum BridgeModuleRegistry {
         await StandingOrdersModule.register(on: router)
         await ShortcutsModule.register(on: router)
         await MemoryModule.register(on: router)
-        await RegistryModule.register(on: router)          // Data-Source Registry: generic CRUD + add_entity + introspect + possess (9 tools)
+        await RegistryModule.register(on: router)          // Data-Source Registry: generic CRUD + add/remove_entity + introspect + possess (10 tools)
         await BridgeAutomationModule.register(on: router) // FB-AUTOMATION: bridge_settings_navigate
         await PermissionsModule.register(on: router)       // fb-permissions: permissions_status
     }

--- a/NotionBridge/Server/ToolAnnotations.swift
+++ b/NotionBridge/Server/ToolAnnotations.swift
@@ -243,6 +243,9 @@ public enum ToolAnnotationCatalog {
         // config (idempotent). `registry_entities` reads LOCAL config (closed).
         "registry_entities": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "registry_add_entity": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
+        // remove_entity drops a LOCAL binding + evicts its cache (no Notion write
+        // → closed world); destructive + confirmation-gated (.request tier).
+        "registry_remove_entity": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "registry_introspect": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "registry_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "registry_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),

--- a/NotionBridge/UI/Sections/DataSourcesSection.swift
+++ b/NotionBridge/UI/Sections/DataSourcesSection.swift
@@ -31,6 +31,10 @@ import SwiftUI
 
 public struct DataSourcesSection: View {
     @StateObject private var vm = DataSourcesViewModel()
+    /// The entity awaiting a remove confirmation (nil ⇒ no dialog). Removal is
+    /// destructive (forgets the binding + evicts the cache), so it always routes
+    /// through a confirmationDialog — with an extra-firm message for the seed.
+    @State private var removalTarget: RegistryEntity?
 
     public init() {}
 
@@ -55,6 +59,25 @@ public struct DataSourcesSection: View {
         }
         .background(Color.clear)
         .task { await vm.load() }
+        .confirmationDialog(
+            removalTarget.map { "Remove \($0.displayName)?" } ?? "Remove data source?",
+            isPresented: Binding(get: { removalTarget != nil },
+                                 set: { if !$0 { removalTarget = nil } }),
+            presenting: removalTarget
+        ) { entity in
+            Button("Remove \(entity.displayName)", role: .destructive) {
+                let key = entity.key
+                removalTarget = nil
+                Task { await vm.removeEntity(key) }
+            }
+            Button("Cancel", role: .cancel) { removalTarget = nil }
+        } message: { entity in
+            if vm.isSeed(entity.key) {
+                Text("‘\(entity.displayName)’ is the seeded entity The Bridge ships with. Removing it forgets its binding and cached rows — your Notion data source and its rows are NOT touched, and you can re-add it via Introspect. This can’t be undone from here.")
+            } else {
+                Text("Forget this entity’s binding + property map and evict its cached rows. Your Notion data source and its rows are not touched.")
+            }
+        }
     }
 
     // MARK: - Header (what the registry is + a subtle live status)
@@ -167,6 +190,13 @@ public struct DataSourcesSection: View {
                 Task { await vm.clearCache(entity.key) }
             }
             .accessibilityIdentifier(ax("clearCache"))
+
+            BridgeButton("Remove", systemImage: "minus.circle",
+                         variant: .default, isEnabled: !vm.busy) {
+                removalTarget = entity
+            }
+            .help("Remove this data source from the registry (does not touch Notion)")
+            .accessibilityIdentifier(ax("remove"))
 
             Spacer(minLength: 8)
 

--- a/NotionBridgeTests/DataSourcesViewModelTests.swift
+++ b/NotionBridgeTests/DataSourcesViewModelTests.swift
@@ -79,6 +79,36 @@ func runDataSourcesViewModelTests() async {
         }
     }
 
+    // MARK: - Remove data source (pane affordance + seed guard)
+
+    await test("Scenario: remove a non-seed data source via the pane (forgets binding, seed remains)") {
+        try await withVMEnv(VMFakeGateway(schema: fullSkillsSchema())) { vm in
+            // Add a second entity through the SAME shared store the tools use.
+            _ = try await RegistryModule.makeAddEntity().handler(.object([
+                "key": .string("project"),
+                "dataSourceId": .string("f6d6ae1d-bfb4-4494-be18-c46e87dea149"),
+                "properties": .array([
+                    .object(["key": .string("title"), "notionName": .string("Name"), "type": .string("title"), "role": .string("title")]),
+                ]),
+            ]))
+            await vm.load()
+            let before = await MainActor.run { vm.entities.map { $0.key }.sorted() }
+            try expect(before == ["project", "skill"], "pane sees both, got \(before)")
+            await vm.removeEntity("project")
+            let (after, status) = await MainActor.run { (vm.entities.map { $0.key }, vm.status) }
+            try expect(after == ["skill"], "project removed, seed remains, got \(after)")
+            try expect(status.contains("Removed"), "status reflects removal: \(status)")
+        }
+    }
+
+    await test("Scenario: isSeed flags the Skills seed (extra-confirm guard) and not others") {
+        try await withVMEnv(VMFakeGateway(schema: fullSkillsSchema())) { vm in
+            let (seed, notSeed) = await MainActor.run { (vm.isSeed("skill"), vm.isSeed("project")) }
+            try expect(seed, "‘skill’ is the seed (pane shows the firm confirm)")
+            try expect(!notSeed, "‘project’ is not the seed")
+        }
+    }
+
     // MARK: - Propose → review → confirm (Decision 5)
 
     await test("Scenario: propose binding sets a CLEAN proposal but does NOT persist") {

--- a/NotionBridgeTests/RegistryModuleTests.swift
+++ b/NotionBridgeTests/RegistryModuleTests.swift
@@ -84,23 +84,24 @@ func runRegistryModuleTests() async {
 
     // MARK: - Registration
 
-    await test("RegistryModule registers exactly 9 tools with expected names") {
+    await test("RegistryModule registers exactly 10 tools with expected names") {
         let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
         await RegistryModule.register(on: router)
         let tools = await router.registrations(forModule: "registry")
-        try expect(tools.count == 9, "expected 9 registry tools, got \(tools.count)")
+        try expect(tools.count == 10, "expected 10 registry tools, got \(tools.count)")
         let names = Set(tools.map { $0.name })
-        try expect(names == ["registry_entities", "registry_add_entity", "registry_introspect", "registry_list",
-                             "registry_get", "registry_create", "registry_update", "registry_delete", "registry_possess"],
+        try expect(names == ["registry_entities", "registry_add_entity", "registry_remove_entity", "registry_introspect",
+                             "registry_list", "registry_get", "registry_create", "registry_update", "registry_delete", "registry_possess"],
                    "tool names: \(names.sorted())")
     }
 
-    await test("RegistryModule tiers: delete=request, writes=notify, reads=open") {
+    await test("RegistryModule tiers: delete+remove_entity=request, writes=notify, reads=open") {
         let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
         await RegistryModule.register(on: router)
         let tools = await router.registrations(forModule: "registry")
         func tier(_ n: String) -> SecurityTier? { tools.first { $0.name == n }?.tier }
         try expect(tier("registry_delete") == .request, "delete must be .request (confirmation)")
+        try expect(tier("registry_remove_entity") == .request, "remove_entity must be .request (destructive)")
         try expect(tier("registry_create") == .notify && tier("registry_update") == .notify && tier("registry_introspect") == .notify,
                    "writes are .notify")
         try expect(tier("registry_get") == .open && tier("registry_list") == .open && tier("registry_entities") == .open && tier("registry_possess") == .open,
@@ -201,6 +202,60 @@ func runRegistryModuleTests() async {
             guard case .array(let arr)? = obj(after)["entities"] else { throw TestError.assertion("no entities") }
             let keys = arr.compactMap { e -> String? in if case .string(let k)? = obj(e)["key"] { return k } else { return nil } }
             try expect(Set(keys) == ["skill", "project"], "skill + project configured, got \(keys)")
+        }
+    }
+
+    await test("registry_remove_entity removes a non-seed entity (add → remove → gone)") {
+        try await withRegistryModuleEnv(ModFakeGateway(schema: skillsSchema())) {
+            // Add a second entity, then remove it.
+            _ = try await RegistryModule.makeAddEntity().handler(.object([
+                "key": .string("project"),
+                "dataSourceId": .string("f6d6ae1d-bfb4-4494-be18-c46e87dea149"),
+                "properties": .array([
+                    .object(["key": .string("title"), "notionName": .string("Name"), "type": .string("title"), "role": .string("title")]),
+                ]),
+            ]))
+            let out = try await RegistryModule.makeRemoveEntity().handler(.object(["entity": .string("project")]))
+            try expect(obj(out)["removed"] == .bool(true), "removed")
+            // Persisted: registry_entities no longer lists project (skill seed remains).
+            let after = try await RegistryModule.makeEntities().handler(.object([:]))
+            guard case .array(let arr)? = obj(after)["entities"] else { throw TestError.assertion("no entities") }
+            let keys = arr.compactMap { e -> String? in if case .string(let k)? = obj(e)["key"] { return k } else { return nil } }
+            try expect(keys == ["skill"], "only the skill seed remains, got \(keys)")
+        }
+    }
+
+    await test("registry_remove_entity refuses the seeded Skills entity without confirm") {
+        try await withRegistryModuleEnv(ModFakeGateway(schema: skillsSchema())) {
+            var threw = false
+            do { _ = try await RegistryModule.makeRemoveEntity().handler(.object(["entity": .string("skill")])) }
+            catch { threw = true }
+            try expect(threw, "removing the seed without confirm:true must throw")
+            // Still present.
+            let after = try await RegistryModule.makeEntities().handler(.object([:]))
+            if case .array(let arr)? = obj(after)["entities"] {
+                try expect(arr.count == 1, "skill seed must survive a guarded removal attempt")
+            } else { throw TestError.assertion("entities missing") }
+        }
+    }
+
+    await test("registry_remove_entity removes the seed WITH confirm:true") {
+        try await withRegistryModuleEnv(ModFakeGateway(schema: skillsSchema())) {
+            let out = try await RegistryModule.makeRemoveEntity().handler(.object(["entity": .string("skill"), "confirm": .bool(true)]))
+            try expect(obj(out)["removed"] == .bool(true), "seed removed with explicit confirm")
+            let after = try await RegistryModule.makeEntities().handler(.object([:]))
+            if case .array(let arr)? = obj(after)["entities"] {
+                try expect(arr.isEmpty, "registry now empty after confirmed seed removal, got \(arr.count)")
+            } else { throw TestError.assertion("entities missing") }
+        }
+    }
+
+    await test("registry_remove_entity rejects unknown entity") {
+        try await withRegistryModuleEnv(ModFakeGateway(schema: skillsSchema())) {
+            var threw = false
+            do { _ = try await RegistryModule.makeRemoveEntity().handler(.object(["entity": .string("ghost")])) }
+            catch { threw = true }
+            try expect(threw, "removing an unknown entity must throw")
         }
     }
 

--- a/NotionBridgeTests/TestRunner.swift
+++ b/NotionBridgeTests/TestRunner.swift
@@ -627,7 +627,7 @@ await runRegistryConfigTests()       // Data-Source Registry W1: config model + 
 await runRegistryRowCacheTests()     // Data-Source Registry W1: generalized per-entity read-through row cache (stale-while-revalidate + offline)
 await runRegistryPropertyCodecTests() // Data-Source Registry W2: Notion property codec (typed Value ↔ Notion JSON, decode/encode/isWritable)
 await runRegistryDataPathTests()     // Data-Source Registry W2: live data path (schema binder · read-through reader · writer create-then-update · rate limiter)
-await runRegistryModuleTests()       // Data-Source Registry W3: MCP tool surface (8 generic CRUD + introspect + possess tools, registration + handler behavior)
+await runRegistryModuleTests()       // Data-Source Registry W3: MCP tool surface (10 tools: generic CRUD + add/remove_entity + introspect + possess, registration + handler behavior)
 await runDataSourcesViewModelTests() // Data-Source Registry W4: Settings pane scenarios (propose→confirm, TTL, drift, errors) + BE↔FE alignment
 await runRegistryEdgeCaseTests()     // Data-Source Registry: adversarial edge cases (codec chunking, pagination, cache concurrency, config race, writer)
 await runMessagesModuleTests()

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1324,7 +1324,16 @@ set -euo pipefail
 # isRemoteTunnelRequest(headers:) overload mirrors the HTTPRequest one for the
 # NIO dispatch layer. +5 tests (HTTPHeaders discriminator + real-NIO-decode of
 # tunnel/loopback × /sse,/messages). Measured = 2163. FLOOR 2158 -> 2163.
-FLOOR="${BRIDGE_TEST_FLOOR:-2163}"
+#
+# 2026-06-18 Registry entity-management completion: + registry_remove_entity (the
+# symmetric counterpart to registry_add_entity) + a "Remove" affordance in the
+# Data Sources pane. Removes a LOCAL entity binding + evicts its row cache (no
+# Notion write); .request tier; the seeded Skills entity is guarded behind an
+# explicit confirm in BOTH the tool and the pane. staticFeatureModuleToolCount
+# 171 -> 172. +6 tests (4 module: registration count 9->10, tier, add→remove
+# round-trip, seed-guard refuse/confirm, unknown-entity; 2 VM: pane remove +
+# isSeed). Measured = 2169. FLOOR 2163 -> 2169.
+FLOOR="${BRIDGE_TEST_FLOOR:-2169}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
Completes the Data-Source Registry's entity-management surface (deferred from the first slice): a `registry_remove_entity` MCP tool + a matching **Remove** affordance in Settings → Data Sources.

## What
- **`registry_remove_entity`** (10th registry tool) — symmetric to `registry_add_entity`. Forgets an entity's binding + property map and evicts its cached rows. **Does not touch Notion** — only the local binding. `.request` tier (confirmation-gated). The seeded **Skills** entity is guarded behind an explicit `confirm:true`.
- **`RegistryConfigStore.removeEntity(key:)`** — atomic persist + `RegistryRowCache` evict, symmetric to `upsertEntity`.
- **Data Sources pane** — a "Remove" button per entity → `confirmationDialog` with an extra-firm message for the seed. Pane + tool share the store + seed guard (BE↔FE alignment).
- `ToolAnnotationCatalog` entry; `staticFeatureModuleToolCount` 171 → 172.

## Tests
+6 (registration count 9→10, tier, add→remove round-trip, seed-guard refuse/confirm, unknown-entity; pane remove + `isSeed`). Floor **2163 → 2169**, 0 failed.

## Release
**v3.8.2 (build 61)** — Version.swift + root Info.plist bumped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)