### PR TITLE
Packet E Wave 3: fail-loud PRM gate + legacy-403 E2E tests (audit #1/#2)

### DIFF
--- a/TheBridge/Modules/Auth/AuthorizationServer.swift
+++ b/TheBridge/Modules/Auth/AuthorizationServer.swift
@@ -215,6 +215,50 @@ public enum ProtectedResourceMetadataProvider {
         encoder.outputFormatting = [.sortedKeys]
         return (try? encoder.encode(doc)) ?? Data("{}".utf8)
     }
+
+    /// Packet E Wave 3 — fail-loud PRM serving decision.
+    ///
+    /// What the `/.well-known/oauth-protected-resource` route should emit:
+    ///   • `.serve(body)` — the build is configured (env / config.json / baked
+    ///     identity present), so advertise the normal RFC 9728 document. The
+    ///     body is exactly `jsonBody(...)`, so a configured deployment is
+    ///     byte-identical to the pre-Wave-3 behaviour (a normal 200 PRM).
+    ///   • `.refuseMisconfigured` — `isMisconfigured()` is true: the resolved
+    ///     issuer is still the fail-closed `auth.example.invalid` placeholder.
+    ///     The caller MUST NOT serve a 200 advertising a placeholder
+    ///     authorization server (a client would be sent into a dead OAuth
+    ///     discovery against a non-resolvable host). Fail loud instead.
+    ///
+    /// Pure + injectable (env / config / baked seams) so the serving-path
+    /// decision is hermetically testable; the live serving path calls it with
+    /// the defaults (real environment, ConfigManager, baked identity), so the
+    /// gate fires off exactly the same signal that `isMisconfigured()` reports.
+    public enum PRMServingDecision: Sendable, Equatable {
+        case serve(Data)
+        case refuseMisconfigured
+    }
+
+    public static func prmServingDecision(
+        resource: String? = nil,
+        port: Int? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        config: (String) -> String? = { ConfigManager.shared.value(forKey: $0) as? String },
+        baked: String? = nil
+    ) -> PRMServingDecision {
+        if isMisconfigured(environment: environment, config: config, baked: baked) {
+            return .refuseMisconfigured
+        }
+        return .serve(jsonBody(resource: resource, port: port, environment: environment))
+    }
+
+    /// Short human-readable error message for the 503 the PRM route returns
+    /// when the build is misconfigured (placeholder issuer). The 503 body
+    /// deliberately advertises NO `authorization_servers` — it signals "remote
+    /// access is not configured" rather than handing out the `.invalid`
+    /// placeholder authorization server.
+    public static let misconfiguredPRMErrorMessage =
+        "remote access not configured: no authorization server is advertised "
+        + "until BRIDGE_OAUTH_ISSUER / config / a baked identity is set"
 }
 
 /// PKCE challenge pair (RFC 7636). `method` is `S256` for OAuth 2.1.

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -412,6 +412,20 @@ public actor SSEServer {
             print("[SSE] Legacy SSE:      GET /sse + POST /messages")
             print("[SSE] Health:          GET /health")
 
+            // Packet E Wave 3 (fail-loud): the connector OAuth gate is live
+            // ONLY when streamableHTTP is active — and `connectorAuth` is
+            // built iff `transportRouter.isActive(.streamableHTTP)` (see
+            // ServerManager.setup), so `connectorAuth != nil` is that signal
+            // here without reaching into ServerManager. If the build is also
+            // misconfigured (resolved issuer is still the fail-closed
+            // placeholder), the PRM route now refuses (503) instead of
+            // advertising `auth.example.invalid`; emit ONE loud line so an
+            // operator sees why remote sign-in will not work.
+            if connectorAuth != nil, ProtectedResourceMetadataProvider.isMisconfigured() {
+                print("[SSE] ⚠️ remote access misconfigured: serving no authorization server "
+                    + "until BRIDGE_OAUTH_ISSUER / config / baked identity is set")
+            }
+
             Task { await sessionCleanupLoop() }
 
             try await channel.closeFuture.get()
@@ -1535,6 +1549,15 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     private let jobsCallbackHandler: @Sendable (String) async -> Data  // PKT-340: POST /jobs/{id}/run
     private let onClientDisconnected: @Sendable (String) async -> Void  // PKT-366 F13
 
+    /// Packet E Wave 3 (test seam ONLY): when non-nil, the PRM serving path
+    /// uses this in place of `ProtectedResourceMetadataProvider.prmServingDecision()`,
+    /// so the serving-path test can drive both the configured (200) and
+    /// misconfigured (503) branches hermetically without mutating the process
+    /// environment or `ConfigManager`. nil in every production code path (the
+    /// `start()` bootstrap never sets it) ⇒ live behaviour is unchanged.
+    private let prmDecisionForTesting:
+        (@Sendable () -> ProtectedResourceMetadataProvider.PRMServingDecision)?
+
     private struct PendingRequest {
         var head: HTTPRequestHead
         var bodyBuffer: ByteBuffer
@@ -1550,7 +1573,9 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         httpRequestHandler: @escaping @Sendable (HTTPRequest) async -> HTTPResponse,
         healthHandler: @escaping @Sendable () async -> Data,
         jobsCallbackHandler: @escaping @Sendable (String) async -> Data = { _ in Data() },
-        onClientDisconnected: @escaping @Sendable (String) async -> Void = { _ in }
+        onClientDisconnected: @escaping @Sendable (String) async -> Void = { _ in },
+        prmDecisionForTesting:
+            (@Sendable () -> ProtectedResourceMetadataProvider.PRMServingDecision)? = nil
     ) {
         self.legacyBridge = legacyBridge
         self.endpoint = endpoint
@@ -1559,6 +1584,7 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         self.healthHandler = healthHandler
         self.jobsCallbackHandler = jobsCallbackHandler
         self.onClientDisconnected = onClientDisconnected
+        self.prmDecisionForTesting = prmDecisionForTesting
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -1606,7 +1632,10 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         context.fireChannelInactive()
     }
 
-    private func processRequest(head: HTTPRequestHead, body: Data?, context: ChannelHandlerContext) async {
+    // `fileprivate` (was `private`) ONLY so the same-file public test seam
+    // `SSEServer.runHTTPHandlerForTesting` can invoke the UNMODIFIED dispatch;
+    // still unreachable outside this file. The body is byte-unchanged.
+    fileprivate func processRequest(head: HTTPRequestHead, body: Data?, context: ChannelHandlerContext) async {
         let fullURI = head.uri
         let path = fullURI.split(separator: "?").first.map(String.init) ?? fullURI
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -1638,9 +1667,32 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             // (BRIDGE_OAUTH_ISSUER) and defaults to a documented
             // placeholder — there is no live authorization server in
             // this slice.
-            let prmData = ProtectedResourceMetadataProvider.jsonBody()
-            logAccess(method: "GET", path: path, sessionID: nil, status: 200, start: startTime)
-            await writeJSONResponse(data: prmData, version: head.version, context: context)
+            //
+            // Packet E Wave 3 (fail-loud): when the build is misconfigured —
+            // the resolved issuer is still the `auth.example.invalid`
+            // placeholder (no env / config / baked identity) — do NOT serve a
+            // 200 advertising that placeholder authorization server. A client
+            // would be pushed into a dead OAuth discovery against a
+            // non-resolvable host. Return 503 with a short error that
+            // advertises NO `authorization_servers` instead. When configured,
+            // `.serve(body)` carries exactly `jsonBody()` → the 200 PRM is
+            // byte-identical to the pre-Wave-3 behaviour.
+            //
+            // `prmDecisionForTesting` is nil in every production path, so the
+            // live decision is always the global `prmServingDecision()`; it is
+            // set ONLY by the hermetic serving-path test seam.
+            switch (prmDecisionForTesting?() ?? ProtectedResourceMetadataProvider.prmServingDecision()) {
+            case .serve(let prmData):
+                logAccess(method: "GET", path: path, sessionID: nil, status: 200, start: startTime)
+                await writeJSONResponse(data: prmData, version: head.version, context: context)
+            case .refuseMisconfigured:
+                logAccess(method: "GET", path: path, sessionID: nil, status: 503, start: startTime)
+                await writeResponse(
+                    .error(statusCode: 503, .internalError(
+                        ProtectedResourceMetadataProvider.misconfiguredPRMErrorMessage)),
+                    version: head.version,
+                    context: context)
+            }
             return
 
         case .legacySSE:
@@ -1898,5 +1950,52 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                 ctx.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
             }
         }
+    }
+}
+
+// MARK: - Public test seam (Packet E Wave 3 / audit #1 + #2)
+//
+// `SSEHTTPHandler` and its `processRequest` are file-private, and the test
+// target imports `TheBridgeLib` WITHOUT `@testable` (custom executable harness),
+// so it can only reach PUBLIC API. To prove the REAL outbound behaviour of the
+// live NIO route classification + origin gate (rather than re-asserting the
+// predicate in isolation), this narrow public seam runs the UNMODIFIED
+// `processRequest` against a caller-supplied `Channel`.
+//
+// The caller-supplied channel keeps `NIOEmbedded` (an `EmbeddedChannel` is a
+// test-only construct) OUT of the production library's dependency graph — the
+// test builds the `EmbeddedChannel`, hands it in as the NIOCore `Channel`
+// protocol, then drains the outbound parts itself. Nothing here touches the
+// origin-decision logic (route classify, `isRemoteTunnelRequest`, the
+// legacy-route loopback-only 403, the loopback `/mcp` split): those run exactly
+// as in production.
+extension SSEServer {
+    /// Run ONE decoded request end-to-end through the live
+    /// `SSEHTTPHandler.processRequest`, writing the outbound response parts to
+    /// `channel`. The caller (test) supplies the channel and reads the outbound
+    /// parts back. `prmDecisionForTesting` is the only injectable seam (used by
+    /// the PRM serving-path test to drive both the configured-200 and the
+    /// misconfigured-503 branches hermetically); every other input flows through
+    /// the unmodified route + gate code.
+    public static func runHTTPHandlerForTesting(
+        on channel: Channel,
+        head: HTTPRequestHead,
+        body: Data? = nil,
+        prmDecisionForTesting:
+            (@Sendable () -> ProtectedResourceMetadataProvider.PRMServingDecision)? = nil
+    ) async throws {
+        let handler = SSEHTTPHandler(
+            legacyBridge: LegacySSEBridge(),
+            endpoint: "/mcp",
+            rpcHandler: { _, _ in nil },
+            httpRequestHandler: { _ in .ok() },
+            healthHandler: { Data("{}".utf8) },
+            jobsCallbackHandler: { _ in Data() },
+            onClientDisconnected: { _ in },
+            prmDecisionForTesting: prmDecisionForTesting
+        )
+        try await channel.pipeline.addHandler(handler).get()
+        let context = try await channel.pipeline.context(handler: handler).get()
+        await handler.processRequest(head: head, body: body, context: context)
     }
 }

--- a/TheBridgeTests/RemoteOAuthOriginGatingTests.swift
+++ b/TheBridgeTests/RemoteOAuthOriginGatingTests.swift
@@ -279,4 +279,159 @@ func runRemoteOAuthOriginGatingTests() async {
         try expect(!SSEServer.isRemoteTunnelRequest(headers: head.headers),
                    "a direct-loopback POST /messages must NOT trip the gate")
     }
+
+    // MARK: - E2E: legacy /sse + /messages 403 OUTBOUND through real dispatch
+    //
+    // The predicate tests above prove the gate's *decision inputs*. These drive
+    // the UNMODIFIED `SSEHTTPHandler.processRequest` (via the public
+    // `runHTTPHandlerForTesting` seam) against a real `EmbeddedChannel` and
+    // assert the OUTBOUND response: a tunnel-origin legacy request must emit a
+    // 403 whose body says loopback-only, and its direct-loopback twin must NOT
+    // be 403 (served normally). cloudflared forwards every path to :9700, so
+    // the server itself is the trust boundary for these legacy routes.
+
+    /// Run one decoded request through the live dispatch and drain the captured
+    /// outbound (status, body) from the embedded channel.
+    func driveOutbound(_ raw: String, body: Data? = nil) async throws -> (status: Int, body: String) {
+        let head = try decodeHead(raw)
+        let channel = EmbeddedChannel()
+        // A fresh loop the handler's `eventLoop.execute` writes will target.
+        try await SSEServer.runHTTPHandlerForTesting(on: channel, head: head, body: body)
+        (channel.eventLoop as! EmbeddedEventLoop).run()
+        var status = -1
+        var text = ""
+        while let out = try? channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch out {
+            case .head(let h): if status == -1 { status = Int(h.status.code) }
+            case .body(let d):
+                if case .byteBuffer(var b) = d, let s = b.readString(length: b.readableBytes) { text += s }
+            case .end: break
+            }
+        }
+        _ = try? channel.finish()
+        return (status, text)
+    }
+
+    await test("OriginGate(legacy E2E): TUNNEL GET /sse ⇒ OUTBOUND 403 loopback-only") {
+        let r = try await driveOutbound("GET /sse HTTP/1.1\r\nHost: 127.0.0.1:9700\r\nCf-Ray: abc-123\r\n\r\n")
+        try expect(r.status == 403, "tunnel GET /sse must emit 403, got \(r.status)")
+        try expect(r.body.lowercased().contains("loopback"),
+                   "403 body must say loopback-only, got: \(r.body)")
+    }
+
+    await test("OriginGate(legacy E2E): LOOPBACK GET /sse ⇒ NOT 403 (served)") {
+        let r = try await driveOutbound("GET /sse HTTP/1.1\r\nHost: 127.0.0.1:9700\r\n\r\n")
+        try expect(r.status != 403, "direct-loopback GET /sse must NOT be 403, got \(r.status)")
+        try expect(r.status == 200, "direct-loopback GET /sse must be served (200 SSE head), got \(r.status)")
+    }
+
+    await test("OriginGate(legacy E2E): TUNNEL POST /messages ⇒ OUTBOUND 403 loopback-only") {
+        let r = try await driveOutbound(
+            "POST /messages?sessionId=x HTTP/1.1\r\nHost: 127.0.0.1:9700\r\nCf-Connecting-Ip: 203.0.113.7\r\nContent-Length: 0\r\n\r\n")
+        try expect(r.status == 403, "tunnel POST /messages must emit 403, got \(r.status)")
+        try expect(r.body.lowercased().contains("loopback"),
+                   "403 body must say loopback-only, got: \(r.body)")
+    }
+
+    await test("OriginGate(legacy E2E): LOOPBACK POST /messages ⇒ NOT 403 (served)") {
+        // A real body so the handler reaches the 202 accept path (a body-less
+        // POST is a legitimate 400 — still NOT the loopback-only 403, which is
+        // the security point). The tunnel twin above 403s BEFORE body handling.
+        let payload = Data(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.utf8)
+        let r = try await driveOutbound(
+            "POST /messages?sessionId=x HTTP/1.1\r\nHost: 127.0.0.1:9700\r\nContent-Length: \(payload.count)\r\n\r\n",
+            body: payload)
+        try expect(r.status != 403, "direct-loopback POST /messages must NOT be 403, got \(r.status)")
+        try expect(r.status == 202, "direct-loopback POST /messages must be accepted (202), got \(r.status)")
+    }
+
+    // Non-regression guard: /health stays tunnel-reachable without auth (it is
+    // dispatched before the gate and carries no secret).
+    await test("OriginGate(legacy E2E): TUNNEL GET /health ⇒ NOT 403 (intentionally reachable)") {
+        let r = try await driveOutbound("GET /health HTTP/1.1\r\nHost: 127.0.0.1:9700\r\nCf-Ray: abc-123\r\n\r\n")
+        try expect(r.status != 403, "tunnel GET /health must NOT be 403, got \(r.status)")
+        try expect(r.status == 200, "GET /health must be served 200 even over the tunnel, got \(r.status)")
+    }
+
+    // MARK: - E2E: PRM fail-loud serving path (Packet E Wave 3 — audit #1)
+    //
+    // The pure `isMisconfigured()` is covered in RemoteAccessIdentityTests; this
+    // proves the SERVING path: when misconfigured the `.well-known/oauth-
+    // protected-resource` route refuses (503, NO placeholder authorization
+    // server in the body), and when a valid identity is injected it serves a
+    // normal 200 PRM (byte-identical to the pre-Wave-3 behaviour). The decision
+    // is injected via the seam so both branches are hermetic (no env / no
+    // ConfigManager mutation).
+
+    func drivePRM(decision: @escaping @Sendable () -> ProtectedResourceMetadataProvider.PRMServingDecision)
+        async throws -> (status: Int, body: String) {
+        let head = try decodeHead("GET /.well-known/oauth-protected-resource HTTP/1.1\r\nHost: 127.0.0.1:9700\r\n\r\n")
+        let channel = EmbeddedChannel()
+        try await SSEServer.runHTTPHandlerForTesting(on: channel, head: head, prmDecisionForTesting: decision)
+        (channel.eventLoop as! EmbeddedEventLoop).run()
+        var status = -1
+        var text = ""
+        while let out = try? channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch out {
+            case .head(let h): if status == -1 { status = Int(h.status.code) }
+            case .body(let d):
+                if case .byteBuffer(var b) = d, let s = b.readString(length: b.readableBytes) { text += s }
+            case .end: break
+            }
+        }
+        _ = try? channel.finish()
+        return (status, text)
+    }
+
+    await test("PRM E2E: misconfigured ⇒ 503 and NO placeholder authorization server advertised") {
+        let r = try await drivePRM { .refuseMisconfigured }
+        try expect(r.status == 503, "misconfigured PRM route must emit 503, got \(r.status)")
+        try expect(!r.body.contains(ProtectedResourceMetadataProvider.defaultIssuer),
+                   "503 body must NOT advertise the auth.example.invalid placeholder, got: \(r.body)")
+        try expect(!r.body.contains("authorization_servers"),
+                   "503 body must NOT carry an authorization_servers list, got: \(r.body)")
+    }
+
+    await test("PRM E2E: configured (valid identity injected) ⇒ normal 200 PRM with that AS") {
+        let goodBody = ProtectedResourceMetadataProvider.jsonBody(
+            resource: "https://mcp.kup.solutions/mcp",
+            environment: ["BRIDGE_OAUTH_ISSUER": "https://real.authkit.app"])
+        let r = try await drivePRM { .serve(goodBody) }
+        try expect(r.status == 200, "configured PRM route must serve 200, got \(r.status)")
+        // JSONEncoder escapes the scheme slashes (https:\/\/…), so match the
+        // host substring rather than the full URL.
+        try expect(r.body.contains("real.authkit.app"),
+                   "200 PRM must advertise the injected authorization server, got: \(r.body)")
+        try expect(r.body.contains("authorization_servers"),
+                   "200 PRM must carry the authorization_servers list, got: \(r.body)")
+        try expect(!r.body.contains("auth.example.invalid"),
+                   "a configured 200 PRM must never contain the placeholder issuer, got: \(r.body)")
+    }
+
+    // The serving path with NO injected decision must agree with the live
+    // `prmServingDecision()` default — proving the gate is actually WIRED to it,
+    // not only reachable via the injected seam. Robust in BOTH a baked and an
+    // unbaked environment: if the real resolver reports misconfigured (the
+    // committed fail-closed default) the route MUST 503; if a real identity is
+    // baked/env-set it MUST serve 200. Either way the wiring is proven.
+    await test("PRM E2E: default decision tracks the live prmServingDecision (gate is wired)") {
+        let head = try decodeHead("GET /.well-known/oauth-protected-resource HTTP/1.1\r\nHost: 127.0.0.1:9700\r\n\r\n")
+        let channel = EmbeddedChannel()
+        // No prmDecisionForTesting ⇒ the live `prmServingDecision()` runs.
+        try await SSEServer.runHTTPHandlerForTesting(on: channel, head: head)
+        (channel.eventLoop as! EmbeddedEventLoop).run()
+        var status = -1
+        while let out = try? channel.readOutbound(as: HTTPServerResponsePart.self) {
+            if case .head(let h) = out { status = Int(h.status.code); break }
+        }
+        _ = try? channel.finish()
+        let misconfigured = ProtectedResourceMetadataProvider.isMisconfigured()
+        if misconfigured {
+            try expect(status == 503,
+                       "misconfigured (placeholder issuer) build must hit the fail-loud 503, got \(status)")
+        } else {
+            try expect(status == 200,
+                       "a configured build must serve a normal 200 PRM, got \(status)")
+        }
+    }
 }

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1412,7 +1412,19 @@ set -euo pipefail
 # still leads a group, so a recycled pid yields ESRCH→already_terminated instead
 # of hitting an unrelated process (covered by the #6 group-kill case). Measured
 # integrated green 2227 → 2242.
-FLOOR="${BRIDGE_TEST_FLOOR:-2242}"
+# Security-audit remediation — auth surface REVIEW-FIRST #1/#2 (PRJCT-2754 ·
+# 2026-06-23): Packet E Wave 3 fail-loud PRM gate + legacy /sse,/messages 403
+# E2E. +8 tests in RemoteOAuthOriginGatingTests (5 legacy-route E2E driving the
+# UNMODIFIED SSEHTTPHandler.processRequest through an EmbeddedChannel: tunnel
+# GET /sse & POST /messages → OUTBOUND 403 loopback-only, their loopback twins
+# → served (200 SSE head / 202 accept), + a /health-stays-tunnel-reachable
+# non-regression; 3 PRM serving-path E2E: misconfigured ⇒ 503 with NO
+# placeholder authorization_servers, a configured identity ⇒ normal 200 PRM,
+# and the default decision tracks the live prmServingDecision so the gate is
+# proven WIRED, not only seam-reachable). The origin-decision logic
+# (isRemoteTunnelRequest, the legacy-route loopback-only 403, the loopback /mcp
+# split) is byte-unchanged. Measured integrated green 2242 → 2250.
+FLOOR="${BRIDGE_TEST_FLOOR:-2250}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Packet E Wave 3 — fail-loud PRM gate (#1) + legacy-403 E2E tests (#2)

Closes the two REVIEW-FIRST items from the v4 security audit (`docs/audits/v4-security-audit-2026-06-23.md`). Verified R5-safe by three independent adversarial reviewers + a manual review; the off-loopback origin gate is **byte-unchanged**.

### #1 — Fail-loud PRM serving gate
`ProtectedResourceMetadataProvider.isMisconfigured()` existed and was unit-tested but had **zero callers**, so a placeholder-issuer build silently advertised `auth.example.invalid` as its authorization server in the RFC 9728 PRM doc.
- New pure/injectable `prmServingDecision()` → `.serve(jsonBody())` when configured (**byte-identical** to the prior 200 PRM) or `.refuseMisconfigured` when `isMisconfigured()`.
- The `/.well-known/oauth-protected-resource` route now returns **503 with no `authorization_servers`** when misconfigured, instead of advertising the placeholder. The PRM endpoint is intentionally unauthenticated (PKT-810 R5), so this only makes an already-public endpoint **more conservative**.
- One loud launch-warning line when `streamableHTTP` is active and the build is misconfigured.

### #2 — Legacy-403 end-to-end tests (was predicate-only)
- 5 tests drive **real dispatch** through the unmodified `processRequest`: tunnel-origin `GET /sse` + `POST /messages` → real outbound **403 loopback-only**; loopback twins → served; tunnel `GET /health` → 200 (intentionally tunnel-reachable). Mutation-tested to confirm they lock behavior, not trivially pass.
- Required a minimal, **production-inert** test seam: `processRequest` `private`→`fileprivate`, a `public runHTTPHandlerForTesting` forwarder, and an optional `prmDecisionForTesting` init param (**nil in every production path**). Not an MCP tool — unreachable by any client; runs the real gate.

### R5 safety (verified)
- Origin gate byte-unchanged: `isRemoteTunnelRequest`, route `classify()`, both legacy-route 403s, the loopback `/mcp` split — all identical pre/post.
- A correctly-configured deployment serves a byte-identical 200 PRM and stays tunnel-reachable; `/health` stays reachable; the 503 fires **only** when `isMisconfigured()`.
- 3/3 adversarial reviewers SAFE (weakening / healthy-regression / test-validity).

### Verification
- `make build` clean (release, `-strict-concurrency=complete`); floor gate **2250 passed / 0 failed** (2242 → 2250, +8 tests).

### Follow-up (separate, pre-existing — NOT in this PR)
- 6 tests in `RemoteOAuthHTTPTests` / `RemoteOAuthBearerTests` assert the placeholder/localhost defaults and fail when `make build` bakes a real identity; they should inject their own identity to stay hermetic. Not in the gate's `swift build` path; pre-dates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
