### PR TITLE
fix(ui): dashboard — restore the Bridge mark + liquid-glass Restart/Quit pair

### DIFF
--- a/TheBridge/UI/BridgeThemeV2.swift
+++ b/TheBridge/UI/BridgeThemeV2.swift
@@ -486,7 +486,7 @@ private struct BridgeButtonChrome: ViewModifier {
                 .padding(.horizontal, 13)
                 .background(fillView(shape))
                 .overlay(shape.strokeBorder(border, lineWidth: 0.5))
-                .modifier(BevelIf(apply: variant == .default, bevel: BridgeTokens.bevelControl, radius: BridgeTokens.Radius.control))
+                .modifier(BevelIf(apply: variant == .default || variant == .danger, bevel: BridgeTokens.bevelControl, radius: BridgeTokens.Radius.control))
                 .overlay(
                     // focus ring (`--focus`: 0 0 0 3px) — a halo stroke outside the edge.
                     shape.strokeBorder(BridgeTokens.focusRing, lineWidth: focused ? BridgeTokens.focusRingWidth : 0)
@@ -518,8 +518,12 @@ private struct BridgeButtonChrome: ViewModifier {
             shape.fill(BridgeTokens.glassControl)
                 .overlay(shape.fill(BridgeTokens.fg1.opacity(hovering ? 0.08 : 0)))
         case .danger:
-            // Red-tinted fill: rgba(255,90,90,.14) → .22 on hover.
-            shape.fill(Color(red: 1.0, green: 0.353, blue: 0.353).opacity(hovering ? 0.22 : 0.14))
+            // Red-tinted LIQUID GLASS: the neutral control glass carries the depth
+            // (bevel + sheen), a red wash sets the danger tone (brightening on
+            // hover). Matches `.default`'s material so a Restart/Quit pair reads as
+            // one set of controls instead of glass-vs-flat.
+            shape.fill(BridgeTokens.glassControl)
+                .overlay(shape.fill(Color(red: 1.0, green: 0.353, blue: 0.353).opacity(hovering ? 0.26 : 0.16)))
         case .link:
             shape.fill(.clear)
         }
@@ -529,7 +533,7 @@ private struct BridgeButtonChrome: ViewModifier {
         switch variant {
         case .primary: return Color(red: 0.588, green: 0.706, blue: 0.902).opacity(0.40) // rgba(150,180,230,.4)
         case .default: return BridgeTokens.hairlineStrong
-        case .danger:  return Color(red: 1.0, green: 0.353, blue: 0.353).opacity(0.28)   // rgba(255,90,90,.28)
+        case .danger:  return Color(red: 1.0, green: 0.353, blue: 0.353).opacity(0.34)   // red-tinted glass edge
         case .link:    return .clear
         }
     }

--- a/TheBridge/UI/DashboardView.swift
+++ b/TheBridge/UI/DashboardView.swift
@@ -186,8 +186,10 @@ public struct DashboardView: View {
     }
 
     /// `.db-ico` — the 30pt rounded app-icon tile (raised control glass with the
-    /// bridge mark; the design uses the real app icon, here the SF bridge glyph
-    /// on the glass tile so it adapts to both themes).
+    /// real Bridge mark). `MenuBarIcon` is template-rendered so it tints with the
+    /// adaptive foreground (carbon↔titanium); a valid SF glyph is the headless
+    /// fallback. (The prior `bridge.fill` SF Symbol does not exist, so the tile
+    /// rendered empty — this restores the mark.)
     private var appIconTile: some View {
         RoundedRectangle(cornerRadius: 9, style: .continuous)
             .fill(BridgeTokens.glassControl)
@@ -195,12 +197,37 @@ public struct DashboardView: View {
                 RoundedRectangle(cornerRadius: 9, style: .continuous)
                     .strokeBorder(BridgeTokens.hairline, lineWidth: 0.5))
             .frame(width: 30, height: 30)
-            .overlay(
-                Image(systemName: "bridge.fill")
-                    .font(.system(size: 16, weight: .regular))
-                    .foregroundStyle(BridgeTokens.fg1))
+            .overlay(bridgeMark)
             .bridgeBevel(BridgeTokens.bevelControl, radius: 9)
     }
+
+    /// The Bridge brand mark for the header tile — the bundled `MenuBarIcon`
+    /// (the same mark shown in the menu bar), template-tinted to `fg1` so it reads
+    /// on both carbon and titanium. Falls back to an SF connection glyph headlessly.
+    @ViewBuilder
+    private var bridgeMark: some View {
+        if let mark = Self.bridgeMarkImage {
+            Image(nsImage: mark)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 17, height: 17)
+                .foregroundStyle(BridgeTokens.fg1)
+        } else {
+            Image(systemName: "network")
+                .font(.system(size: 15, weight: .regular))
+                .foregroundStyle(BridgeTokens.fg1)
+        }
+    }
+
+    /// `MenuBarIcon` lives in the executable's resource bundle; load it once via
+    /// `Bundle.main` (NEVER the trapping `Bundle.module`), `NSImage(named:)` as the
+    /// fallback. Mirrors `CommandBridge.bridgeMarkImage` (the proven loader).
+    private static let bridgeMarkImage: NSImage? = {
+        let img = Bundle.main.image(forResource: "MenuBarIcon") ?? NSImage(named: "MenuBarIcon")
+        img?.isTemplate = true
+        return img
+    }()
 
     private var versionLine: String {
         if buildNumber.isEmpty {
@@ -523,12 +550,12 @@ public struct DashboardView: View {
         // `.db-foot` — two full-width buttons, gap 7, padding 12/10/13. Restart
         // is the default glass control; Quit carries the danger tone.
         HStack(spacing: 7) {
-            BridgeButton("Restart Bridge", variant: .default) {
+            BridgeButton("Restart Bridge", systemImage: "arrow.clockwise", variant: .default) {
                 NSApp.restartBridge()
             }
             .frame(maxWidth: .infinity)
 
-            BridgeButton("Quit", variant: .danger) {
+            BridgeButton("Quit", systemImage: "power", variant: .danger) {
                 NSApp.terminate(nil)
             }
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Menu-bar dashboard polish

Fixes the two issues with the menu-bar dashboard popover, verified on-device in **both carbon (dark) and titanium (light)**.

### 1 · Missing bridge icon
The header tile rendered **empty** — it used `Image(systemName: "bridge.fill")`, which is not a real SF Symbol. Now renders the bundled **`MenuBarIcon`** Bridge mark (template-tinted `fg1` so it tracks carbon↔titanium; SF `network` fallback headlessly), mirroring CommandBridge's proven loader.

### 2 · Restart / Quit looked unbalanced
The footer was a mismatched pair: `Restart` (`.default`) was raised liquid glass, but `Quit` (`.danger`) was a flat thin-red rectangle (no bevel, no glass depth). Reworked the shared `.danger` variant into **red-tinted liquid glass** (neutral control glass for depth + a red wash for tone + the control bevel + a crisper red hairline) so Quit matches Restart's material; added leading icons (`arrow.clockwise` / `power`). Net win for the Jobs "Delete" button too.

### Verification
- On-device, both themes: the mark renders + adapts; the buttons read as one premium glass set.
- `make build` strict-concurrency clean; floor gate **2250 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)