### PR TITLE
feat(memory-hub): complete PKT-MEM-114 and ship with Bridge init contract

### DIFF
--- a/TheBridge/Modules/GhRuntime.swift
+++ b/TheBridge/Modules/GhRuntime.swift
@@ -170,11 +170,25 @@ public actor GhRuntime {
                 let started = Date()
                 do {
                     try p.run()
+                    // Drain stdout and stderr concurrently to prevent pipe-buffer
+                    // deadlock when output exceeds ~64 KB (same fix as GitRuntime.spawn).
+                    let outBox = _GhPipeDataBox()
+                    let errBox = _GhPipeDataBox()
+                    let ioGroup = DispatchGroup()
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        outBox.data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                        ioGroup.leave()
+                    }
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        errBox.data = errPipe.fileHandleForReading.readDataToEndOfFile()
+                        ioGroup.leave()
+                    }
                     p.waitUntilExit()
-                    let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-                    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-                    let out = String(data: outData, encoding: .utf8) ?? ""
-                    let err = String(data: errData, encoding: .utf8) ?? ""
+                    ioGroup.wait()
+                    let out = String(data: outBox.data, encoding: .utf8) ?? ""
+                    let err = String(data: errBox.data, encoding: .utf8) ?? ""
                     let dur = Date().timeIntervalSince(started) * 1000.0
                     cont.resume(returning: GhInvocationResult(
                         exitCode: p.terminationStatus,
@@ -227,4 +241,8 @@ public actor GhRuntime {
         }
         return String(text[range]).trimmingCharacters(in: CharacterSet(charactersIn: ".,;)\n"))
     }
+}
+
+private final class _GhPipeDataBox: @unchecked Sendable {
+    var data = Data()
 }

--- a/TheBridge/Modules/GitRuntime.swift
+++ b/TheBridge/Modules/GitRuntime.swift
@@ -173,11 +173,28 @@ public actor GitRuntime {
                 let started = Date()
                 do {
                     try p.run()
+                    // Drain stdout and stderr concurrently with the running process.
+                    // Sequential waitUntilExit() → readDataToEndOfFile() deadlocks when
+                    // output exceeds the pipe buffer (~64 KB): the child blocks on write,
+                    // the parent waits for exit, and neither can proceed. Concurrent
+                    // reads consume the pipe as the child writes, so the buffer never fills.
+                    let outBox = _PipeDataBox()
+                    let errBox = _PipeDataBox()
+                    let ioGroup = DispatchGroup()
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        outBox.data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                        ioGroup.leave()
+                    }
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        errBox.data = errPipe.fileHandleForReading.readDataToEndOfFile()
+                        ioGroup.leave()
+                    }
                     p.waitUntilExit()
-                    let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-                    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-                    let out = String(data: outData, encoding: .utf8) ?? ""
-                    let err = String(data: errData, encoding: .utf8) ?? ""
+                    ioGroup.wait()
+                    let out = String(data: outBox.data, encoding: .utf8) ?? ""
+                    let err = String(data: errBox.data, encoding: .utf8) ?? ""
                     let dur = Date().timeIntervalSince(started) * 1000.0
                     cont.resume(returning: GitInvocationResult(
                         exitCode: p.terminationStatus, stdout: out, stderr: err, durationMs: dur))
@@ -658,4 +675,11 @@ extension GitRuntime {
         }
         return out
     }
+}
+
+// Mutable data box used by spawn() to collect pipe output across @Sendable closures.
+// @unchecked Sendable is safe here: each instance is written by exactly one thread
+// before group.wait() hands ownership back to the caller.
+private final class _PipeDataBox: @unchecked Sendable {
+    var data = Data()
 }

--- a/TheBridge/Modules/SettingsUIValidationHarness.swift
+++ b/TheBridge/Modules/SettingsUIValidationHarness.swift
@@ -113,6 +113,9 @@ public enum SettingsUIValidationHarness {
                     BridgeAXID.Memory.Process.intentTable,
                     BridgeAXID.Memory.Process.detailInspector,
                     BridgeAXID.Memory.Process.activityStrip,
+                    // PKT-MEM-114 P3b — title rename + manual cloud-title controls (inspector).
+                    BridgeAXID.Memory.Process.titleRename,
+                    BridgeAXID.Memory.Process.titleCloud,
                     BridgeAXID.Memory.processingPane,
                     BridgeAXID.Memory.processingProviderSave,
                     BridgeAXID.Memory.processingProviderStatus,

--- a/TheBridge/Modules/VoiceMemo/MemoryHubCloudTitle.swift
+++ b/TheBridge/Modules/VoiceMemo/MemoryHubCloudTitle.swift
@@ -1,0 +1,158 @@
+// MemoryHubCloudTitle.swift — Tier-3 cloud memo title (PKT-MEM-114 P3b)
+// TheBridge · Modules · VoiceMemo
+//
+// MANUAL-ONLY cloud title polish: an OpenAI-compatible chat-completions POST that asks for a
+// concise (≤8-word) intent-led title for a voice memo. This is the curator's ONLY net-new
+// network path and is strictly gated behind an explicit operator button in the cockpit
+// inspector (NEVER auto, NEVER on a sweep). Locked decision (1): Tier-3 cloud runs only on a
+// per-memo action. On any failure / non-2xx / timeout it returns nil and the caller keeps the
+// existing title — cloud is optional quality polish, not a trust gate, so it queues NO review.
+//
+// The HTTP call is behind a tiny injectable `CloudChatTransport` seam so the title logic
+// (request shape, parsing, sanitize/cap) is unit-tested with a stub — the harness never opens
+// a socket. The API KEY is read from the Keychain at call time and is NEVER logged.
+
+import Foundation
+
+/// Minimal transport seam for the Tier-3 cloud chat-completions POST. The live impl wraps
+/// `URLSession`; tests inject a stub returning a canned `(Data, HTTPURLResponse)` (or throwing
+/// to simulate a network failure/timeout). Keeping this protocol tiny keeps the title logic
+/// (build request → parse → sanitize) testable with no real network.
+public protocol CloudChatTransport: Sendable {
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+/// Live transport: a bounded `URLSession` data task. Non-HTTP responses surface as
+/// `URLError(.badServerResponse)` so the caller treats them as a failure (keep the title).
+public struct URLSessionCloudChatTransport: CloudChatTransport {
+    private let session: URLSession
+    public init(session: URLSession = .shared) { self.session = session }
+
+    public func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}
+
+/// Tier-3 cloud title generator. Pure, manual-only, edited-pinned. The cockpit calls
+/// `improve(...)` from the explicit "Improve title (cloud)" button (which is itself gated on
+/// `MemoryHubProviderConfigStore.canRunCloud(provider)`); this type re-checks the gate and the
+/// key, builds the request, parses + sanitizes the completion, and caches a `.cloud` title via
+/// the edited-pinned store `put()` (so it never clobbers a human rename).
+public enum MemoryHubCloudTitler {
+    /// ≤8 words, mirroring the heuristic/local cap (`MemoryHubMemoTitler.maxWords`).
+    static let maxWords = 8
+
+    /// System prompt: concise, intent-led, no quotes — matches the Tier-1/Tier-2 title style.
+    static let systemPrompt =
+        "Return only a concise (≤8 words) intent-led title for this voice memo. No quotes."
+
+    /// Test/override hook for the transport. nil ⇒ the real `URLSession`-backed transport.
+    nonisolated(unsafe) public static var transportOverride: CloudChatTransport?
+
+    /// Errors are intentionally coarse — the caller only needs "it failed, keep the title".
+    public enum CloudTitleError: Error, Equatable {
+        case notRunnable          // provider disabled / no model / bad base URL
+        case missingKey           // no API key in the Keychain
+        case badURL               // base URL + path did not form a request URL
+        case httpStatus(Int)      // non-2xx
+        case emptyCompletion      // 2xx but no usable title content
+    }
+
+    /// Run Tier-3 once for a memo. Returns the cached `.cloud` `MemoTitle` on success, or throws
+    /// `CloudTitleError` / rethrows the transport error on any failure (the caller swallows it,
+    /// surfaces a small inline status, and keeps the existing title). NEVER queues a review.
+    ///
+    /// `keyProvider` defaults to the Keychain lookup for this provider; tests inject a constant.
+    /// The key is used only as the bearer header — it is never returned or logged.
+    @discardableResult
+    public static func improve(
+        memoId: String,
+        transcript: String,
+        provider: MemoryHubProvider,
+        now: Date = Date(),
+        keyProvider: (() -> String?)? = nil,
+        transport providedTransport: CloudChatTransport? = nil
+    ) async throws -> MemoTitle {
+        guard MemoryHubProviderConfigStore.canRunCloud(provider) else { throw CloudTitleError.notRunnable }
+
+        let key = (keyProvider?() ?? KeychainManager.shared.read(
+            key: MemoryHubProviderConfigStore.keychainKey(for: provider.id)))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let key, !key.isEmpty else { throw CloudTitleError.missingKey }
+
+        let trimmedTranscript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let request = try buildRequest(provider: provider, transcript: trimmedTranscript, apiKey: key)
+
+        let transport = providedTransport ?? transportOverride ?? URLSessionCloudChatTransport()
+        let (data, response) = try await transport.send(request)
+        guard (200...299).contains(response.statusCode) else {
+            throw CloudTitleError.httpStatus(response.statusCode)
+        }
+
+        guard let content = parseCompletionContent(data) else { throw CloudTitleError.emptyCompletion }
+        let title = sanitize(content)
+        guard !title.isEmpty, title != "Untitled memo" else { throw CloudTitleError.emptyCompletion }
+
+        let prior = MemoryHubMemoTitleStore.title(for: memoId)
+        let memoTitle = MemoTitle(
+            title: title,
+            provenance: .cloud,
+            intentCount: prior?.intentCount ?? 0,
+            transcriptHash: MemoryHubActivityLog.sha256Hex(trimmedTranscript),
+            generatedAt: ISO8601DateFormatter().string(from: now)
+        )
+        MemoryHubMemoTitleStore.put(memoTitle, memoId: memoId)   // edited-pinned: survives a rename
+        return MemoryHubMemoTitleStore.title(for: memoId) ?? memoTitle
+    }
+
+    /// Build the OpenAI-compatible `POST <baseURL>/chat/completions` request: Bearer auth, the
+    /// concise-title system+user messages, low temperature, a tight token cap, and the locked
+    /// 20s timeout (`MemoryHubPreview.cloudTimeoutSeconds`). The key is set only as the header.
+    static func buildRequest(provider: MemoryHubProvider, transcript: String, apiKey: String) throws -> URLRequest {
+        let base = provider.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Tolerate a trailing slash on the base URL so "…/v1" and "…/v1/" both resolve.
+        guard let url = URL(string: base.hasSuffix("/") ? "\(base)chat/completions" : "\(base)/chat/completions") else {
+            throw CloudTitleError.badURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = MemoryHubPreview.cloudTimeoutSeconds
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = [
+            "model": provider.model,
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": String(transcript.prefix(6000))],
+            ],
+            "temperature": 0.2,
+            "max_tokens": 24,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        return request
+    }
+
+    /// Pull `choices[0].message.content` from an OpenAI-compatible chat-completions response.
+    /// Returns nil when the JSON is malformed or carries no string content.
+    static func parseCompletionContent(_ data: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = root["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let message = first["message"] as? [String: Any],
+              let content = message["content"] as? String else { return nil }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Sanitize a raw completion into a clean title: drop surrounding quotes / placeholder
+    /// tokens (`VoiceMemoParser.sanitizeTitle`), then cap to `maxWords` with an ellipsis.
+    /// Reuses `MemoryHubMemoTitler.clean` so cloud titles match the heuristic/local style exactly.
+    static func sanitize(_ raw: String) -> String {
+        let dequoted = VoiceMemoParser.sanitizeTitle(raw, fallback: "")
+        guard !dequoted.isEmpty else { return "" }
+        return MemoryHubMemoTitler.clean(dequoted, maxWords: maxWords)
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/MemoryHubMemoTitle.swift
+++ b/TheBridge/Modules/VoiceMemo/MemoryHubMemoTitle.swift
@@ -201,6 +201,133 @@ public enum MemoryHubMemoTitler {
         return result.isEmpty ? "Untitled memo" : result
     }
 
+    // MARK: Tier-1 heuristic — snapshot overload (P3a sweep)
+
+    /// Intent-led heuristic built from a persisted `PlanSnapshot` (no transcript re-parse).
+    /// Used by the idle/launch sweep to seed titles cheaply from snapshots already on disk.
+    /// `transcriptHash` is nil (snapshot-derived) so the title stays valid in the list and a
+    /// later on-select pass with the real transcript can upgrade it. Demoted intents are
+    /// excluded from the elected subject + the `+N` count (they are no longer active lanes).
+    public static func heuristicTitle(snapshot: PlanSnapshot, now: Date = Date()) -> MemoTitle {
+        let active = snapshot.intents.filter { !$0.demoted }
+        let plan = planAdapter(intents: active)
+        let executable = plan.intents.filter { $0.kind != .review }
+        let split = VoiceMemoIntentElection.split(plan.intents)
+        let primary = split.execute.first { $0.kind != .review } ?? executable.first
+        let raw = primary.map { subject(for: $0, plan: plan) } ?? plan.generatedTitle
+        return MemoTitle(
+            title: clean(raw),
+            provenance: .heuristic,
+            intentCount: max(executable.count, primary == nil ? 0 : 1),
+            transcriptHash: nil,
+            generatedAt: ISO8601DateFormatter().string(from: now)
+        )
+    }
+
+    /// Lift snapshot intents back into a minimal `VoiceMemoPlan` so the existing
+    /// election + subject logic is reused verbatim (single source of truth for title style).
+    static func planAdapter(intents snapshotIntents: [PlanSnapshotIntent]) -> VoiceMemoPlan {
+        let intents: [VoiceMemoIntent] = snapshotIntents.compactMap { s in
+            guard let kind = VoiceMemoIntentKind(rawValue: s.kind) else { return nil }
+            return VoiceMemoIntent(
+                kind: kind, confidence: s.confidence,
+                entityKey: s.entityKey, entityHint: s.entityHint,
+                title: s.title, fields: s.fields
+            )
+        }
+        return VoiceMemoPlan(generatedTitle: "Memo", skipMemoryKeep: false,
+                             summary: "", actions: [], intents: intents)
+    }
+
+    // MARK: Tier-2 local (Ollama) — AUTO only when Ollama processing is enabled
+
+    /// Pluggable local-LLM seam for a focused ≤8-word intent-led title. The default impl
+    /// calls Ollama; tests inject a stub so the harness never needs a live model.
+    public protocol LocalTitleLLM: Sendable {
+        /// Returns a raw candidate title, or nil on any failure/timeout (caller keeps the heuristic).
+        func titleCandidate(transcript: String, fallbackTitle: String) async -> String?
+    }
+
+    /// Whether Tier-2 local titling may AUTO-run right now: the SAME flag chain the rest of
+    /// the curator uses (`voiceMemoOllamaRoutingEffective` ∧ `shouldUseLocalOllama()` ∧ a model).
+    /// Pure read of the stored flag — no network. The cockpit checks this before kicking the Task.
+    public static func localTitleEnabled() -> Bool {
+        BridgeDefaults.voiceMemoOllamaRoutingEffective
+            && VoiceMemoCuratorRouter.shouldUseLocalOllama()
+            && BridgeDefaults.ollamaSummarizationModelEffective != nil
+    }
+
+    /// Test/override hook for the local-LLM. nil ⇒ the real Ollama-backed summarizer.
+    nonisolated(unsafe) public static var localTitleLLMOverride: LocalTitleLLM?
+
+    /// Run Tier-2 once for a selected memo (call right after the heuristic is cached). When
+    /// local titling is disabled this is a no-op. On a non-empty, distinct candidate it caches
+    /// a `.local` title (edited-pinned via `put()` — never clobbers an `.edited` rename) and
+    /// returns it so the caller can refresh `titleCache[memoId]` on the main actor. Any
+    /// failure/timeout returns nil and leaves the heuristic untouched (no review queued, no throw).
+    @discardableResult
+    public static func enhanceWithLocalTitle(memoId: String, transcript: String,
+                                             fallbackTitle: String,
+                                             now: Date = Date()) async -> MemoTitle? {
+        guard localTitleEnabled() else { return nil }
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let llm: LocalTitleLLM = localTitleLLMOverride ?? OllamaLocalTitleLLM()
+        guard let raw = await llm.titleCandidate(transcript: trimmed, fallbackTitle: fallbackTitle) else {
+            return nil
+        }
+        let candidate = clean(raw)
+        // Reject empties + the trivial fallback (clean() never returns ""): keep the heuristic.
+        guard !candidate.isEmpty, candidate != "Untitled memo",
+              candidate.caseInsensitiveCompare(fallbackTitle) != .orderedSame else { return nil }
+
+        let prior = MemoryHubMemoTitleStore.title(for: memoId)
+        let title = MemoTitle(
+            title: candidate,
+            provenance: .local,
+            intentCount: prior?.intentCount ?? 0,
+            transcriptHash: MemoryHubActivityLog.sha256Hex(trimmed),
+            generatedAt: ISO8601DateFormatter().string(from: now)
+        )
+        MemoryHubMemoTitleStore.put(title, memoId: memoId)   // edited-pinned: survives a human rename
+        return MemoryHubMemoTitleStore.title(for: memoId)
+    }
+
+    // MARK: Idle / launch sweep — local-first, throttled, off the main thread
+
+    /// Default per-sweep cap (bounded work; the rest are picked up on the next sweep/select).
+    public static let sweepCap = 25
+
+    /// For each memo that HAS a heuristic `PlanSnapshot` but NO fresh cached title, build the
+    /// heuristic title from the snapshot's intents (cheap — no transcript re-parse) and cache it.
+    /// Edited/local/cloud titles and fresh heuristics are left untouched (edited-pinned `put()`
+    /// also guards `.edited`). Returns the number of titles written. Bounded by `cap`.
+    @discardableResult
+    public static func launchSweep(now: Date = Date(), cap: Int = sweepCap) -> Int {
+        let dir = MemoryHubPlanSnapshotStore.dir
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil) else { return 0 }
+
+        let cache = MemoryHubMemoTitleStore.load()
+        var written = 0
+        for file in files where file.pathExtension == "json" {
+            if written >= cap { break }
+            guard let data = try? Data(contentsOf: file),
+                  let snaps = try? JSONDecoder().decode([PlanSnapshot].self, from: data),
+                  let snapshot = snaps.last(where: { $0.provenance == .heuristic }) ?? snaps.last else { continue }
+            let memoId = snapshot.memoId
+            // Skip when a usable title already exists: any edit, or any non-stale cached title.
+            if let existing = cache[memoId], existing.provenance == .edited || existing.isFresh(forTranscriptHash: nil) {
+                continue
+            }
+            let title = heuristicTitle(snapshot: snapshot, now: now)
+            MemoryHubMemoTitleStore.put(title, memoId: memoId)
+            written += 1
+        }
+        return written
+    }
+
     // MARK: List floor resolution
 
     /// What the memo list should show, resolving named → cached(fresh) → date floor.
@@ -219,5 +346,35 @@ public enum MemoryHubMemoTitler {
         }
         return MemoTitleDisplay(text: humanizedDate(recording.recordedAt, now: now),
                                 provenance: .placeholder, intentCount: 0, isPlaceholder: true)
+    }
+}
+
+/// Default Tier-2 local-title LLM: a focused, ≤8-word intent-led title prompt over Ollama,
+/// bounded by the 0c local soft-timeout. Health-gated; any failure/timeout returns nil so the
+/// caller keeps the heuristic. The enabled-flag check is the caller's responsibility
+/// (`MemoryHubMemoTitler.localTitleEnabled()`); this type only performs the network call.
+public struct OllamaLocalTitleLLM: MemoryHubMemoTitler.LocalTitleLLM {
+    public init() {}
+
+    public func titleCandidate(transcript: String, fallbackTitle: String) async -> String? {
+        guard let model = BridgeDefaults.ollamaSummarizationModelEffective else { return nil }
+        let client = OllamaClient.fromDefaults()
+        guard (try? await client.health()) == true else { return nil }
+
+        let prompt = """
+        Write a short, scannable title for this voice memo: at most 8 words, intent-led \
+        (lead with the main action or subject), Title Case, no trailing punctuation. \
+        Reply with ONLY the title — no quotes, no labels, no JSON.
+        Transcript:
+        \(transcript.prefix(6000))
+        """
+        let timeout = MemoryHubPreview.localTimeoutSeconds
+        guard let raw = try? await client.generate(
+            model: model, prompt: prompt, timeout: timeout,
+            options: .init(numPredict: 32, temperature: 0.2)
+        ) else { return nil }
+
+        let sanitized = VoiceMemoParser.sanitizeTitle(raw, fallback: "")
+        return sanitized.isEmpty ? nil : sanitized
     }
 }

--- a/TheBridge/Modules/VoiceMemo/MemoryHubMemoTitle.swift
+++ b/TheBridge/Modules/VoiceMemo/MemoryHubMemoTitle.swift
@@ -1,0 +1,223 @@
+// MemoryHubMemoTitle.swift — progressive AI memo titles (PKT-MEM-114)
+// TheBridge · Modules · VoiceMemo
+//
+// Replaces the raw timestamp memo titles with scannable, cached, editable titles.
+// Progressive + local-first (the Phase-0 heuristic→local→cloud, cache-and-upgrade
+// pattern, applied to titles):
+//   floor   → humanized date ("Thu Jun 25, 8:30 PM"), never a raw id
+//   named   → honor a real recording name (not a default/timestamp)
+//   Tier-1  → intent-led heuristic from the parsed plan (the elected primary lane)
+//   Tier-2  → local Ollama (P3) · Tier-3 → cloud, manual-only (P3)
+//   edited  → operator override, pinned (never auto-overwritten)
+// Titles are short summaries (privacy parity with activity-log excerpts), cached per
+// memo keyed by memoId + transcript hash so a re-transcribe rebuilds the title while a
+// human edit survives.
+
+import Foundation
+
+public struct MemoTitle: Codable, Sendable, Equatable {
+    public enum Provenance: String, Codable, Sendable {
+        case placeholder   // computed date floor — not persisted
+        case named         // real recording name
+        case heuristic     // Tier-1 parser-derived
+        case local         // Tier-2 Ollama
+        case cloud         // Tier-3 cloud
+        case edited        // operator override (pinned)
+    }
+
+    public var title: String
+    public var provenance: Provenance
+    /// Executable-intent count for the `+N` multi-intent badge (0/1 ⇒ no badge).
+    public var intentCount: Int
+    /// SHA-256 of the source transcript — the invalidation key (nil for name/date titles).
+    public var transcriptHash: String?
+    public var generatedAt: String   // ISO-8601
+
+    public init(title: String, provenance: Provenance, intentCount: Int = 0,
+                transcriptHash: String? = nil, generatedAt: String) {
+        self.title = title
+        self.provenance = provenance
+        self.intentCount = intentCount
+        self.transcriptHash = transcriptHash
+        self.generatedAt = generatedAt
+    }
+
+    /// True when this cached title is still valid for the given current transcript hash.
+    /// Name titles (no hash) are always valid; auto/edited titles are valid only when the
+    /// transcript is unchanged (nil current hash ⇒ treat as valid, e.g. list with no transcript loaded).
+    public func isFresh(forTranscriptHash current: String?) -> Bool {
+        guard let mine = transcriptHash else { return true }
+        guard let current else { return true }
+        return mine == current
+    }
+}
+
+/// What the list renders for a memo (the floor logic resolved).
+public struct MemoTitleDisplay: Sendable, Equatable {
+    public let text: String
+    public let provenance: MemoTitle.Provenance
+    public let intentCount: Int
+    /// True for the computed date floor (no real title yet) — the UI shows it muted.
+    public let isPlaceholder: Bool
+}
+
+public enum MemoryHubMemoTitleStore {
+    /// Bound the cache; `.edited` overrides are always retained.
+    public static let maxEntries = 3000
+
+    public static var fileURL: URL {
+        BridgePaths.applicationSupport(.memoryHub).appendingPathComponent("memo-titles.json")
+    }
+
+    public static func load() -> [String: MemoTitle] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: MemoTitle].self, from: data) else { return [:] }
+        return decoded
+    }
+
+    public static func title(for memoId: String) -> MemoTitle? { load()[memoId] }
+
+    /// Cache a title. An auto title (heuristic/local/cloud/named) NEVER overwrites an
+    /// existing `.edited` override; an `.edited` write always wins.
+    public static func put(_ title: MemoTitle, memoId: String) {
+        var all = load()
+        if all[memoId]?.provenance == .edited, title.provenance != .edited { return }
+        all[memoId] = title
+        save(prune(all))
+    }
+
+    public static func remove(memoId: String) {
+        var all = load()
+        all[memoId] = nil
+        save(all)
+    }
+
+    static func save(_ all: [String: MemoTitle]) {
+        let dir = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(all) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    /// Keep every `.edited` title + the newest auto titles up to `max`.
+    public static func prune(_ all: [String: MemoTitle], max: Int = maxEntries) -> [String: MemoTitle] {
+        guard all.count > max else { return all }
+        let edited = all.filter { $0.value.provenance == .edited }
+        let autos = all.filter { $0.value.provenance != .edited }
+            .sorted { $0.value.generatedAt > $1.value.generatedAt }
+        var kept = edited
+        for (k, v) in autos.prefix(Swift.max(0, max - edited.count)) { kept[k] = v }
+        return kept
+    }
+}
+
+public enum MemoryHubMemoTitler {
+    static let maxWords = 8
+
+    // MARK: Date floor
+
+    /// Locale-aware, relative humanized date — the list floor. Never a raw id.
+    public static func humanizedDate(_ date: Date, now: Date = Date(),
+                                     calendar: Calendar = .current, locale: Locale = .current) -> String {
+        let timeFmt = DateFormatter()
+        timeFmt.locale = locale
+        timeFmt.timeZone = calendar.timeZone
+        timeFmt.timeStyle = .short
+        timeFmt.dateStyle = .none
+        let time = timeFmt.string(from: date)
+
+        if calendar.isDate(date, inSameDayAs: now) { return "Today, \(time)" }
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
+           calendar.isDate(date, inSameDayAs: yesterday) { return "Yesterday, \(time)" }
+
+        let dateFmt = DateFormatter()
+        dateFmt.locale = locale
+        dateFmt.timeZone = calendar.timeZone
+        let sameYear = calendar.component(.year, from: date) == calendar.component(.year, from: now)
+        dateFmt.setLocalizedDateFormatFromTemplate(sameYear ? "EEE MMM d" : "MMM d yyyy")
+        return "\(dateFmt.string(from: date)), \(time)"
+    }
+
+    // MARK: Naming
+
+    /// A recording filename is a DEFAULT (not a real user name) when it is a timestamp
+    /// (mostly digits/separators) or an "New Recording N" placeholder.
+    public static func isDefaultName(_ title: String) -> Bool {
+        let t = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if t.isEmpty { return true }
+        if t.lowercased().hasPrefix("new recording") { return true }
+        let allowed = CharacterSet(charactersIn: "0123456789 :.-/")
+        let onlyDigitsAndSeps = t.unicodeScalars.allSatisfy { allowed.contains($0) }
+        if onlyDigitsAndSeps, t.filter(\.isNumber).count >= 6 { return true }
+        return false
+    }
+
+    // MARK: Tier-1 heuristic
+
+    /// Intent-led title from the parsed plan: lead with the elected primary lane's action +
+    /// entity ("Send Jacob results", "Bridge v4 — trust fixes", "Prefer adversarial reviews").
+    public static func heuristicTitle(plan: VoiceMemoPlan, transcript: String, now: Date = Date()) -> MemoTitle {
+        let executable = plan.intents.filter { $0.kind != .review }
+        let split = VoiceMemoIntentElection.split(plan.intents)
+        let primary = split.execute.first { $0.kind != .review } ?? executable.first
+        let raw = primary.map { subject(for: $0, plan: plan) } ?? plan.generatedTitle
+        return MemoTitle(
+            title: clean(raw),
+            provenance: .heuristic,
+            intentCount: max(executable.count, primary == nil ? 0 : 1),
+            transcriptHash: MemoryHubActivityLog.sha256Hex(transcript.trimmingCharacters(in: .whitespacesAndNewlines)),
+            generatedAt: ISO8601DateFormatter().string(from: now)
+        )
+    }
+
+    static func subject(for intent: VoiceMemoIntent, plan: VoiceMemoPlan) -> String {
+        switch intent.kind {
+        case .reminder:
+            return intent.title ?? plan.summary
+        case .registryUpdate:
+            let entity = intent.entityHint ?? intent.entityKey ?? "Update"
+            let gist = intent.fields["summary"]
+                ?? intent.fields["brief"]
+                ?? intent.fields.keys.sorted().first.flatMap { intent.fields[$0] }
+                ?? plan.summary
+            let g = clean(gist, maxWords: 5)
+            return g.isEmpty ? entity : "\(entity) — \(g)"
+        case .memoryKeep, .agentMemory:
+            return intent.title ?? intent.body ?? plan.summary
+        case .review:
+            return plan.generatedTitle
+        }
+    }
+
+    static func clean(_ raw: String, maxWords: Int = maxWords) -> String {
+        let words = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+        guard !words.isEmpty else { return "Untitled memo" }
+        var result = words.prefix(maxWords).joined(separator: " ")
+        result = result.trimmingCharacters(in: CharacterSet(charactersIn: " .,;:!?—-"))
+        if words.count > maxWords { result += "…" }
+        return result.isEmpty ? "Untitled memo" : result
+    }
+
+    // MARK: List floor resolution
+
+    /// What the memo list should show, resolving named → cached(fresh) → date floor.
+    /// `currentTranscriptHash` is nil in the list (no transcript loaded); a stale cached
+    /// title is still shown there and rebuilt on selection.
+    public static func listDisplay(recording: VoiceMemoRecording,
+                                   cached: MemoTitle?,
+                                   now: Date = Date()) -> MemoTitleDisplay {
+        if !isDefaultName(recording.title) {
+            return MemoTitleDisplay(text: recording.title, provenance: .named,
+                                    intentCount: cached?.intentCount ?? 0, isPlaceholder: false)
+        }
+        if let cached {
+            return MemoTitleDisplay(text: cached.title, provenance: cached.provenance,
+                                    intentCount: cached.intentCount, isPlaceholder: false)
+        }
+        return MemoTitleDisplay(text: humanizedDate(recording.recordedAt, now: now),
+                                provenance: .placeholder, intentCount: 0, isPlaceholder: true)
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoReviewResolver.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoReviewResolver.swift
@@ -409,6 +409,10 @@ public enum VoiceMemoReviewError: Error, LocalizedError {
 /// Launch + wake TTL sweep (PKT-MEM-103).
 public enum VoiceMemoReviewLifecycle {
     public static func sweepIfNeeded(router: ToolRouter? = nil) async {
+        // PKT-MEM-114 P3a — local-first idle/launch title sweep: seed heuristic titles from
+        // existing plan snapshots (cheap, no transcript re-parse), bounded per sweep. Read-only
+        // over snapshots + the separate title cache; independent of the review TTL sweep below.
+        MemoryHubMemoTitler.launchSweep()
         do {
             let report = try VoiceMemoReviewStore.sweepTTL()
             guard report.autoDismissed > 0 || report.purged > 0 else { return }

--- a/TheBridge/UI/BridgeShell.swift
+++ b/TheBridge/UI/BridgeShell.swift
@@ -232,6 +232,10 @@ public enum BridgeAXID {
             public static func registryRow(entity: String, rowId: String) -> String { id("process.registryRow.\(entity).\(rowId)") }
             public static func commit(_ intentId: String) -> String { id("process.commit.\(intentId)") }
             public static func primaryOverride(_ intentId: String) -> String { id("process.primaryOverride.\(intentId)") }
+            // PKT-MEM-114 P3b — detail-inspector title controls: operator rename (→ pinned
+            // `.edited`) + the MANUAL Tier-3 cloud-title button (shown only when canRunCloud).
+            public static let titleRename      = id("process.titleRename")
+            public static let titleCloud       = id("process.titleCloud")
         }
     }
 }

--- a/TheBridge/UI/Sections/MemoryProcessTab.swift
+++ b/TheBridge/UI/Sections/MemoryProcessTab.swift
@@ -361,6 +361,18 @@ struct MemoryProcessTab: View {
             let title = MemoryHubMemoTitler.heuristicTitle(plan: parsedPlan, transcript: t)
             MemoryHubMemoTitleStore.put(title, memoId: memo.id)
             titleCache[memo.id] = MemoryHubMemoTitleStore.title(for: memo.id)
+            // PKT-MEM-114 P3a — Tier-2 local upgrade: AUTO only when Ollama processing is
+            // enabled. Non-blocking; on a better title it caches `.local` (edited-pinned) and
+            // refreshes the row on the main actor. Failure/timeout keeps the heuristic silently.
+            if MemoryHubMemoTitler.localTitleEnabled() {
+                let memoId = memo.id
+                Task {
+                    if let upgraded = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                        memoId: memoId, transcript: t, fallbackTitle: title.title) {
+                        await MainActor.run { titleCache[memoId] = upgraded }
+                    }
+                }
+            }
         } catch {
             statusMessage = error.localizedDescription
         }

--- a/TheBridge/UI/Sections/MemoryProcessTab.swift
+++ b/TheBridge/UI/Sections/MemoryProcessTab.swift
@@ -20,6 +20,9 @@ struct MemoryProcessTab: View {
     @State private var activity: [MemoryHubActivityEvent] = []
     @State private var statusMessage: String?
     @State private var isLoading = false
+    /// PKT-MEM-114 P2 — cached intent-led titles (memo-titles.json), read-only over the
+    /// parsed plan/election. Loaded with the memo list; refreshed on selection.
+    @State private var titleCache: [String: MemoTitle] = [:]
 
     private var rows: [CockpitIntentRow] {
         guard let plan, let selectedId else { return [] }
@@ -72,6 +75,11 @@ struct MemoryProcessTab: View {
 
     private func memoRow(_ memo: VoiceMemoRecording) -> some View {
         let selected = selectedId == memo.id
+        let display = MemoryHubMemoTitler.listDisplay(recording: memo, cached: titleCache[memo.id])
+        // Muted (fg4) when it's the computed date floor — signals "no real title yet".
+        let titleColor: Color = display.isPlaceholder
+            ? BridgeTokens.fg4
+            : (selected ? BridgeTokens.fg1 : BridgeTokens.fg2)
         return Button {
             selectedId = memo.id
             overrideIntentId = nil
@@ -81,10 +89,17 @@ struct MemoryProcessTab: View {
             Task { await loadPreview(for: memo) }
         } label: {
             VStack(alignment: .leading, spacing: 4) {
-                Text(memo.title)
-                    .font(BridgeTokens.Typeface.name)
-                    .foregroundStyle(selected ? BridgeTokens.fg1 : BridgeTokens.fg2)
-                    .lineLimit(2)
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(display.text)
+                        .font(BridgeTokens.Typeface.name)
+                        .foregroundStyle(titleColor)
+                        .lineLimit(2)
+                    if display.intentCount > 1 {
+                        Text("+\(display.intentCount - 1)")
+                            .font(BridgeTokens.Typeface.meta)
+                            .foregroundStyle(BridgeTokens.accent)
+                    }
+                }
                 Text(memo.hasTranscript ? memo.transcriptSource.rawValue : "no transcript")
                     .font(BridgeTokens.Typeface.meta)
                     .foregroundStyle(BridgeTokens.fg4)
@@ -308,6 +323,7 @@ struct MemoryProcessTab: View {
 
     private func reloadMemos() {
         memos = VoiceMemoProcessor.listUnprocessed()
+        titleCache = MemoryHubMemoTitleStore.load()
     }
 
     private func reloadActivity() {
@@ -338,7 +354,13 @@ struct MemoryProcessTab: View {
                 return
             }
             transcript = t
-            plan = parsePlan(from: planObj)
+            let parsedPlan = parsePlan(from: planObj)
+            plan = parsedPlan
+            // PKT-MEM-114 P2 — generate-on-select: cache the Tier-1 heuristic title.
+            // edited-pinned put() preserves a prior human rename; read-only over the plan.
+            let title = MemoryHubMemoTitler.heuristicTitle(plan: parsedPlan, transcript: t)
+            MemoryHubMemoTitleStore.put(title, memoId: memo.id)
+            titleCache[memo.id] = MemoryHubMemoTitleStore.title(for: memo.id)
         } catch {
             statusMessage = error.localizedDescription
         }

--- a/TheBridge/UI/Sections/MemoryProcessTab.swift
+++ b/TheBridge/UI/Sections/MemoryProcessTab.swift
@@ -23,6 +23,14 @@ struct MemoryProcessTab: View {
     /// PKT-MEM-114 P2 — cached intent-led titles (memo-titles.json), read-only over the
     /// parsed plan/election. Loaded with the memo list; refreshed on selection.
     @State private var titleCache: [String: MemoTitle] = [:]
+    /// PKT-MEM-114 P3b — operator rename field (detail inspector). Seeded with the current
+    /// display title on selection; on Save it writes a pinned `.edited` title.
+    @State private var titleDraft: String = ""
+    /// PKT-MEM-114 P3b — Tier-3 cloud title state: the loaded provider (gates the button),
+    /// an in-flight flag, and a small inline status line. Cloud is MANUAL-only.
+    @State private var cloudProvider: MemoryHubProvider?
+    @State private var cloudBusy = false
+    @State private var titleStatus: String?
 
     private var rows: [CockpitIntentRow] {
         guard let plan, let selectedId else { return [] }
@@ -191,6 +199,7 @@ struct MemoryProcessTab: View {
                 }
                 if let plan, let row = inspectorRow {
                     transcriptCard
+                    titleEditorCard
                     inspectorDetail(plan: plan, row: row)
                 } else {
                     Text("Select a memo to preview and commit intents.")
@@ -214,6 +223,39 @@ struct MemoryProcessTab: View {
                     .foregroundStyle(BridgeTokens.fg2)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// PKT-MEM-114 P3b — title editor: operator rename (→ pinned `.edited`) + manual Tier-3
+    /// cloud polish. Read-only over the plan/election; only the separate title cache is touched.
+    private var titleEditorCard: some View {
+        BridgeGlassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                BridgeCardLabel("Title")
+                HStack(spacing: 8) {
+                    TextField("Memo title", text: $titleDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier(BridgeAXID.Memory.Process.titleRename)
+                    BridgeButton("Rename", systemImage: "pencil", variant: .primary) { saveRename() }
+                        .accessibilityIdentifier(BridgeAXID.Memory.Process.titleRename)
+                }
+                // Tier-3 cloud is MANUAL-only and shown/enabled solely when the loaded provider
+                // is enabled with a model + a configured key (canRunCloud). Otherwise hidden.
+                if let provider = cloudProvider, MemoryHubProviderConfigStore.canRunCloud(provider) {
+                    HStack(spacing: 8) {
+                        BridgeButton("Improve title (cloud)", systemImage: "sparkles", isEnabled: !cloudBusy) {
+                            Task { await improveTitleViaCloud(provider: provider) }
+                        }
+                        .accessibilityIdentifier(BridgeAXID.Memory.Process.titleCloud)
+                        if cloudBusy { ProgressView().controlSize(.small) }
+                    }
+                }
+                if let titleStatus {
+                    Text(titleStatus)
+                        .font(BridgeTokens.Typeface.meta)
+                        .foregroundStyle(BridgeTokens.fg4)
+                }
             }
         }
     }
@@ -361,6 +403,11 @@ struct MemoryProcessTab: View {
             let title = MemoryHubMemoTitler.heuristicTitle(plan: parsedPlan, transcript: t)
             MemoryHubMemoTitleStore.put(title, memoId: memo.id)
             titleCache[memo.id] = MemoryHubMemoTitleStore.title(for: memo.id)
+            // PKT-MEM-114 P3b — seed the rename field with the resolved display title and load
+            // the cloud provider (gates the Tier-3 button). Read-only over the plan/election.
+            titleStatus = nil
+            titleDraft = MemoryHubMemoTitler.listDisplay(recording: memo, cached: titleCache[memo.id]).text
+            cloudProvider = MemoryHubProviderConfigStore.load().first
             // PKT-MEM-114 P3a — Tier-2 local upgrade: AUTO only when Ollama processing is
             // enabled. Non-blocking; on a better title it caches `.local` (edited-pinned) and
             // refreshes the row on the main actor. Failure/timeout keeps the heuristic silently.
@@ -375,6 +422,51 @@ struct MemoryProcessTab: View {
             }
         } catch {
             statusMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: PKT-MEM-114 P3b — title rename + manual cloud title
+
+    /// Operator rename → pinned `.edited` title. Empty/whitespace is a no-op. Carries the
+    /// current cached intentCount + transcriptHash so the `+N` badge and freshness survive the
+    /// edit. The store's edited-pin then guarantees later auto tiers never overwrite it.
+    @MainActor
+    private func saveRename() {
+        guard let memoId = selectedId else { return }
+        let trimmed = titleDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let prior = titleCache[memoId]
+        let edited = MemoTitle(
+            title: trimmed,
+            provenance: .edited,
+            intentCount: prior?.intentCount ?? 0,
+            transcriptHash: prior?.transcriptHash,
+            generatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        MemoryHubMemoTitleStore.put(edited, memoId: memoId)
+        titleCache[memoId] = MemoryHubMemoTitleStore.title(for: memoId)
+        titleStatus = "Renamed."
+    }
+
+    /// Tier-3 cloud title (MANUAL only). POSTs an OpenAI-compatible chat-completions request via
+    /// the testable `MemoryHubCloudTitler` helper, caching a pinned-safe `.cloud` title on
+    /// success. Any failure/timeout surfaces a small inline status and keeps the existing title —
+    /// it NEVER blocks the UI and queues NO review. The key is read inside the helper, never here.
+    @MainActor
+    private func improveTitleViaCloud(provider: MemoryHubProvider) async {
+        guard let memoId = selectedId, !cloudBusy else { return }
+        cloudBusy = true
+        titleStatus = "Improving title via cloud…"
+        defer { cloudBusy = false }
+        do {
+            let updated = try await MemoryHubCloudTitler.improve(
+                memoId: memoId, transcript: transcript, provider: provider)
+            titleCache[memoId] = updated
+            titleDraft = updated.title
+            titleStatus = "Title updated (cloud)."
+        } catch {
+            // Keep the existing title; surface a brief, non-blocking status (no key in the message).
+            titleStatus = "Cloud title unavailable — kept the current title."
         }
     }
 

--- a/TheBridge/UI/Sections/MemoryProcessTab.swift
+++ b/TheBridge/UI/Sections/MemoryProcessTab.swift
@@ -66,6 +66,7 @@ struct MemoryProcessTab: View {
             }
             .padding(BridgeTokens.Space.paneH)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(BridgeAXID.Memory.Process.memoList)
     }
 
@@ -117,6 +118,7 @@ struct MemoryProcessTab: View {
             }
             .padding(BridgeTokens.Space.paneH)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(BridgeAXID.Memory.Process.intentTable)
     }
 
@@ -184,6 +186,7 @@ struct MemoryProcessTab: View {
             .padding(BridgeTokens.Space.paneH)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(BridgeAXID.Memory.Process.detailInspector)
     }
 
@@ -297,6 +300,7 @@ struct MemoryProcessTab: View {
             .padding(.horizontal, BridgeTokens.Space.paneH)
             .padding(.vertical, 8)
         }
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(BridgeAXID.Memory.Process.activityStrip)
     }
 

--- a/TheBridge/UI/Sections/MemorySection.swift
+++ b/TheBridge/UI/Sections/MemorySection.swift
@@ -257,7 +257,9 @@ public struct MemorySection: View {
         return BridgeGlassCard {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(entry.memoTitle)
+                    // PKT-MEM-114 P2 — read-only consumer of the title cache: prefer the
+                    // intent-led title when one exists, else the stored memoTitle. Never generates.
+                    Text(MemoryHubMemoTitleStore.title(for: entry.memoId)?.title ?? entry.memoTitle)
                         .font(BridgeTokens.Typeface.name)
                         .foregroundStyle(BridgeTokens.fg1)
                         .lineLimit(2)

--- a/TheBridgeTests/MemoryHubMemoTitleTests.swift
+++ b/TheBridgeTests/MemoryHubMemoTitleTests.swift
@@ -1,0 +1,219 @@
+// MemoryHubMemoTitleTests.swift — PKT-MEM-114 P1: progressive AI memo titles
+// TheBridge · Tests
+//
+// Pure-logic + file-backed asserts for the title floor: locale-aware humanized date,
+// default-name detection, intent-led Tier-1 heuristic (elected-primary subject + `+N`
+// count + transcript-hash key), the edited-pinned bounded cache, and the list-floor
+// resolution (named → cached → date). Hermetic temp home for the store. Date asserts
+// use contains/prefix (not ==) to survive the macOS narrow-no-break-space in `h:mm a`.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+private func withTitleTempHome<T>(_ body: () async throws -> T) async rethrows -> T {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory.appendingPathComponent("MemoHubTitle-\(UUID().uuidString)", isDirectory: true)
+    try? fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer { BridgePaths.overrideHomeForTesting(nil); try? fm.removeItem(at: tmp) }
+    return try await body()
+}
+
+private func fixedCal() -> Calendar {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "America/New_York")!
+    return cal
+}
+private let fixedLocale = Locale(identifier: "en_US")
+private func mk(_ cal: Calendar, _ y: Int, _ mo: Int, _ d: Int, _ h: Int, _ mi: Int) -> Date {
+    cal.date(from: DateComponents(year: y, month: mo, day: d, hour: h, minute: mi))!
+}
+
+private func mtitle(_ text: String, _ prov: MemoTitle.Provenance, _ at: String, hash: String? = nil, count: Int = 1) -> MemoTitle {
+    MemoTitle(title: text, provenance: prov, intentCount: count, transcriptHash: hash, generatedAt: at)
+}
+
+func runMemoryHubMemoTitleTests() async {
+    print("\n🏷️  Memory Hub titles — date floor + heuristic + cache (PKT-MEM-114)")
+
+    let cal = fixedCal()
+    let now = mk(cal, 2026, 6, 25, 22, 0)   // Thu Jun 25 2026, 10:00 PM
+
+    // MARK: Humanized date floor
+
+    await test("date_today_relativePrefix") {
+        let d = mk(cal, 2026, 6, 25, 20, 30)
+        let s = MemoryHubMemoTitler.humanizedDate(d, now: now, calendar: cal, locale: fixedLocale)
+        try expect(s.hasPrefix("Today, "), "same day ⇒ Today: \(s)")
+        try expect(s.contains("8:30") && s.contains("PM"), "carries the time: \(s)")
+    }
+    await test("date_yesterday_relativePrefix") {
+        let d = mk(cal, 2026, 6, 24, 9, 15)
+        let s = MemoryHubMemoTitler.humanizedDate(d, now: now, calendar: cal, locale: fixedLocale)
+        try expect(s.hasPrefix("Yesterday, "), "prior day ⇒ Yesterday: \(s)")
+        try expect(s.contains("9:15") && s.contains("AM"), "carries the time: \(s)")
+    }
+    await test("date_thisYear_weekdayMonthDay_noYear") {
+        let d = mk(cal, 2026, 3, 10, 14, 0)
+        let s = MemoryHubMemoTitler.humanizedDate(d, now: now, calendar: cal, locale: fixedLocale)
+        try expect(s.contains("Mar") && s.contains("10"), "month+day: \(s)")
+        try expect(s.contains("2:00"), "time: \(s)")
+        try expect(!s.contains("2026"), "same year omits the year: \(s)")
+    }
+    await test("date_priorYear_includesYear") {
+        let d = mk(cal, 2024, 11, 5, 8, 0)
+        let s = MemoryHubMemoTitler.humanizedDate(d, now: now, calendar: cal, locale: fixedLocale)
+        try expect(s.contains("Nov") && s.contains("2024"), "prior year shows the year: \(s)")
+        try expect(s.contains("8:00"), "time: \(s)")
+    }
+    await test("date_neverRawId") {
+        // The whole point: a timestamp filename must NOT leak through as a title.
+        let d = mk(cal, 2026, 6, 25, 20, 30)
+        let s = MemoryHubMemoTitler.humanizedDate(d, now: now, calendar: cal, locale: fixedLocale)
+        try expect(!s.contains("20260625") && !s.contains(".m4a"), "no raw id: \(s)")
+    }
+
+    // MARK: Default-name detection
+
+    await test("name_timestampStem_isDefault") {
+        try expect(MemoryHubMemoTitler.isDefaultName("20260624 203010"), "digit-stem ⇒ default")
+        try expect(MemoryHubMemoTitler.isDefaultName("2026-06-24 20:30:10"), "iso-ish ⇒ default")
+        try expect(MemoryHubMemoTitler.isDefaultName("New Recording 3"), "Apple placeholder ⇒ default")
+        try expect(MemoryHubMemoTitler.isDefaultName("   "), "blank ⇒ default")
+    }
+    await test("name_realName_isNotDefault") {
+        try expect(!MemoryHubMemoTitler.isDefaultName("Bridge RT1"), "user name ⇒ honored")
+        try expect(!MemoryHubMemoTitler.isDefaultName("Jacob sync notes"), "user name ⇒ honored")
+    }
+
+    // MARK: Tier-1 intent-led heuristic
+
+    await test("heuristic_reminderPrimary_leadsWithReminderSubject") {
+        let plan = VoiceMemoPlan(generatedTitle: "Voice memo", skipMemoryKeep: false,
+                                 summary: "a long rambling summary that should not be the title",
+                                 actions: [],
+                                 intents: [VoiceMemoIntent(kind: .reminder, confidence: 0.95,
+                                                           title: "Send Jacob the Phase 0 results")])
+        let t = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "remind me…", now: now)
+        try expect(t.provenance == .heuristic, "heuristic provenance")
+        try expect(t.title == "Send Jacob the Phase 0 results", "leads with the reminder subject: \(t.title)")
+        try expect(t.transcriptHash?.isEmpty == false, "carries a transcript hash for invalidation")
+    }
+    await test("heuristic_multiIntent_primaryIsReminder_countIsThree") {
+        let plan = VoiceMemoPlan(generatedTitle: "Voice memo", skipMemoryKeep: false, summary: "s", actions: [],
+            intents: [
+                VoiceMemoIntent(kind: .registryUpdate, confidence: 0.99, entityKey: "project", entityHint: "Bridge v4", fields: ["summary": "shipped trust fixes"]),
+                VoiceMemoIntent(kind: .reminder, confidence: 0.80, title: "Send Jacob results"),
+                VoiceMemoIntent(kind: .memoryKeep, confidence: 0.90, title: "prefer adversarial reviews"),
+            ])
+        let t = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "x", now: now)
+        try expect(t.title == "Send Jacob results", "lane-priority-first: reminder wins even at lower confidence: \(t.title)")
+        try expect(t.intentCount == 3, "+N counts all executable lanes (got \(t.intentCount))")
+    }
+    await test("heuristic_registryPrimary_entityDashGist") {
+        let plan = VoiceMemoPlan(generatedTitle: "Voice memo", skipMemoryKeep: false, summary: "fallback", actions: [],
+            intents: [VoiceMemoIntent(kind: .registryUpdate, confidence: 0.95, entityKey: "project",
+                                      entityHint: "Bridge v4", fields: ["summary": "shipped the trust fixes"])])
+        let t = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "x", now: now)
+        try expect(t.title.hasPrefix("Bridge v4 —"), "entity leads: \(t.title)")
+        try expect(t.title.contains("shipped"), "gist follows: \(t.title)")
+    }
+    await test("heuristic_longSubject_cappedWithEllipsis") {
+        let long = "send jacob the full phase zero adversarial review results before the end of day"
+        let plan = VoiceMemoPlan(generatedTitle: "g", skipMemoryKeep: false, summary: "s", actions: [],
+            intents: [VoiceMemoIntent(kind: .reminder, confidence: 0.95, title: long)])
+        let t = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "x", now: now)
+        try expect(t.title.hasSuffix("…"), "capped subject ends with ellipsis: \(t.title)")
+        try expect(t.title.split(separator: " ").count <= 9, "≤ 8 words + ellipsis token: \(t.title)")
+    }
+    await test("heuristic_hash_stableAndContentKeyed") {
+        let plan = VoiceMemoPlan(generatedTitle: "g", skipMemoryKeep: false, summary: "s", actions: [],
+            intents: [VoiceMemoIntent(kind: .reminder, confidence: 0.95, title: "x")])
+        let a = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "  hello world ", now: now)
+        let b = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "hello world", now: now)
+        let c = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "different transcript", now: now)
+        try expect(a.transcriptHash == b.transcriptHash, "trim-normalized ⇒ same hash")
+        try expect(a.transcriptHash != c.transcriptHash, "different transcript ⇒ different hash")
+    }
+
+    // MARK: Cache store — edited-pin, round-trip, prune
+
+    await test("store_putGetRoundTrip") {
+        try await withTitleTempHome {
+            let t = mtitle("Send Jacob results", .heuristic, "2026-06-25T10:00:00Z", hash: "h1")
+            MemoryHubMemoTitleStore.put(t, memoId: "m1")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1") == t, "round-trips")
+            try expect(MemoryHubMemoTitleStore.title(for: "absent") == nil, "miss ⇒ nil")
+        }
+    }
+    await test("store_editedPin_autoNeverOverwrites") {
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("My title", .edited, "2026-06-25T10:00:00Z"), memoId: "m1")
+            // A later auto title (heuristic/local/cloud) must NOT clobber the human edit.
+            MemoryHubMemoTitleStore.put(mtitle("auto guess", .heuristic, "2026-06-25T11:00:00Z"), memoId: "m1")
+            let got = MemoryHubMemoTitleStore.title(for: "m1")
+            try expect(got?.title == "My title" && got?.provenance == .edited, "edit survives auto: \(String(describing: got))")
+        }
+    }
+    await test("store_editedOverwritesEdited") {
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("First", .edited, "2026-06-25T10:00:00Z"), memoId: "m1")
+            MemoryHubMemoTitleStore.put(mtitle("Second", .edited, "2026-06-25T12:00:00Z"), memoId: "m1")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1")?.title == "Second", "a new edit replaces the old")
+        }
+    }
+    await test("store_remove") {
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("x", .heuristic, "2026-06-25T10:00:00Z"), memoId: "m1")
+            MemoryHubMemoTitleStore.remove(memoId: "m1")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1") == nil, "removed")
+        }
+    }
+    await test("store_prune_keepsNewestAutos_andAllEdited") {
+        // 3 autos + 1 edited, cap 2 ⇒ keep the edited (always) + the single newest auto.
+        var all: [String: MemoTitle] = [
+            "a": mtitle("a", .heuristic, "2026-06-25T08:00:00Z"),
+            "b": mtitle("b", .heuristic, "2026-06-25T09:00:00Z"),
+            "c": mtitle("c", .heuristic, "2026-06-25T10:00:00Z"),
+            "e": mtitle("e", .edited, "2026-01-01T00:00:00Z"),
+        ]
+        all = MemoryHubMemoTitleStore.prune(all, max: 2)
+        try expect(all["e"] != nil, "edited is always retained even past the cap")
+        try expect(all["c"] != nil, "newest auto kept")
+        try expect(all["a"] == nil && all["b"] == nil, "older autos pruned (kept \(all.keys.sorted()))")
+    }
+
+    // MARK: List-floor resolution
+
+    await test("listDisplay_namedRecording_honored") {
+        let rec = VoiceMemoRecording(id: "m1", path: "/x", title: "Bridge RT1", recordedAt: now, transcript: nil)
+        let d = MemoryHubMemoTitler.listDisplay(recording: rec, cached: nil, now: now)
+        try expect(d.text == "Bridge RT1" && d.provenance == .named, "real name wins")
+        try expect(!d.isPlaceholder, "a real name is not a placeholder")
+    }
+    await test("listDisplay_defaultName_usesCachedWhenPresent") {
+        let rec = VoiceMemoRecording(id: "m1", path: "/x", title: "20260625 203010", recordedAt: now, transcript: nil)
+        let cached = mtitle("Send Jacob results", .heuristic, "2026-06-25T10:00:00Z", count: 2)
+        let d = MemoryHubMemoTitler.listDisplay(recording: rec, cached: cached, now: now)
+        try expect(d.text == "Send Jacob results" && d.provenance == .heuristic, "cached title shown")
+        try expect(d.intentCount == 2 && !d.isPlaceholder, "carries +N, not a placeholder")
+    }
+    await test("listDisplay_defaultName_noCache_dateFloor") {
+        let rec = VoiceMemoRecording(id: "m1", path: "/x", title: "20260625 203010", recordedAt: mk(cal, 2026, 6, 25, 20, 30), transcript: nil)
+        let d = MemoryHubMemoTitler.listDisplay(recording: rec, cached: nil, now: now)
+        try expect(d.isPlaceholder && d.provenance == .placeholder, "no title yet ⇒ muted date floor")
+        try expect(!d.text.contains("20260625"), "floor is humanized, never the raw stem: \(d.text)")
+    }
+
+    // MARK: Freshness / invalidation
+
+    await test("freshness_hashMatch_andListNilCurrent") {
+        let t = mtitle("x", .heuristic, "2026-06-25T10:00:00Z", hash: "H")
+        try expect(t.isFresh(forTranscriptHash: "H"), "same hash ⇒ fresh")
+        try expect(!t.isFresh(forTranscriptHash: "H2"), "changed transcript ⇒ stale")
+        try expect(t.isFresh(forTranscriptHash: nil), "list has no transcript ⇒ treat as fresh (rebuilt on select)")
+        let named = mtitle("Bridge RT1", .named, "2026-06-25T10:00:00Z", hash: nil)
+        try expect(named.isFresh(forTranscriptHash: "anything"), "name titles have no hash ⇒ always fresh")
+    }
+}

--- a/TheBridgeTests/MemoryHubMemoTitleTests.swift
+++ b/TheBridgeTests/MemoryHubMemoTitleTests.swift
@@ -253,6 +253,10 @@ func runMemoryHubMemoTitleTests() async {
         }
     }
 
+    // MARK: P3a — Tier-2 local (Ollama) gating + edited-pin + idle sweep
+
+    await runMemoryHubMemoTitleP3aTests(cal: cal, now: now)
+
     // MARK: Freshness / invalidation
 
     await test("freshness_hashMatch_andListNilCurrent") {
@@ -262,5 +266,196 @@ func runMemoryHubMemoTitleTests() async {
         try expect(t.isFresh(forTranscriptHash: nil), "list has no transcript ⇒ treat as fresh (rebuilt on select)")
         let named = mtitle("Bridge RT1", .named, "2026-06-25T10:00:00Z", hash: nil)
         try expect(named.isFresh(forTranscriptHash: "anything"), "name titles have no hash ⇒ always fresh")
+    }
+}
+
+// MARK: - P3a: Tier-2 Ollama titles + local-first idle sweep -------------------------------
+
+/// Injected local-title LLM stub — never touches a real Ollama. Returns a canned candidate
+/// (or nil to simulate failure/timeout) and records whether it was invoked.
+private final class StubLocalTitleLLM: MemoryHubMemoTitler.LocalTitleLLM, @unchecked Sendable {
+    let candidate: String?
+    private(set) var called = false
+    init(candidate: String?) { self.candidate = candidate }
+    func titleCandidate(transcript: String, fallbackTitle: String) async -> String? {
+        called = true
+        return candidate
+    }
+}
+
+/// Snapshot + restore the UserDefaults keys the Tier-2 gate reads, so a test can force the
+/// flag ON/OFF deterministically regardless of seeded first-run defaults.
+private func withOllamaTitleFlags<T>(enabled: Bool, _ body: () async throws -> T) async rethrows -> T {
+    let d = UserDefaults.standard
+    let routingKey = BridgeDefaults.voiceMemoOllamaRouting
+    let modeKey = BridgeDefaults.voiceMemoCuratorMode
+    let modelKey = BridgeDefaults.ollamaSummarizationModel
+    let priorRouting = d.object(forKey: routingKey)
+    let priorMode = d.object(forKey: modeKey)
+    let priorModel = d.object(forKey: modelKey)
+    defer {
+        if let priorRouting { d.set(priorRouting, forKey: routingKey) } else { d.removeObject(forKey: routingKey) }
+        if let priorMode { d.set(priorMode, forKey: modeKey) } else { d.removeObject(forKey: modeKey) }
+        if let priorModel { d.set(priorModel, forKey: modelKey) } else { d.removeObject(forKey: modelKey) }
+    }
+    if enabled {
+        d.set(true, forKey: routingKey)
+        d.set(VoiceMemoCuratorMode.auto.rawValue, forKey: modeKey)
+        d.set("gemma4:12b", forKey: modelKey)
+    } else {
+        // `.heuristics` forces shouldUseLocalOllama() == false regardless of the routing flag.
+        d.set(VoiceMemoCuratorMode.heuristics.rawValue, forKey: modeKey)
+    }
+    return try await body()
+}
+
+private func snapIntent(_ id: String, _ kind: String, _ conf: Double,
+                        entityKey: String? = nil, entityHint: String? = nil,
+                        title: String? = nil, fields: [String: String] = [:], demoted: Bool = false) -> PlanSnapshotIntent {
+    PlanSnapshotIntent(intentId: id, kind: kind, confidence: conf, entityKey: entityKey,
+                       entityHint: entityHint, title: title, fields: fields, demoted: demoted)
+}
+
+func runMemoryHubMemoTitleP3aTests(cal: Calendar, now: Date) async {
+    print("\n🏷️  Memory Hub titles — P3a Tier-2 Ollama + idle sweep (PKT-MEM-114)")
+
+    // MARK: Tier-2 gating
+
+    await test("p3a_gate_off_noLocalTitleProduced") {
+        try await withTitleTempHome {
+            try await withOllamaTitleFlags(enabled: false) {
+                try expect(!MemoryHubMemoTitler.localTitleEnabled(), "flag OFF ⇒ gate closed")
+                let stub = StubLocalTitleLLM(candidate: "Should Not Be Used")
+                MemoryHubMemoTitler.localTitleLLMOverride = stub
+                defer { MemoryHubMemoTitler.localTitleLLMOverride = nil }
+                let out = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                    memoId: "m1", transcript: "remind me to call Jacob", fallbackTitle: "Call Jacob", now: now)
+                try expect(out == nil, "disabled ⇒ no upgrade returned")
+                try expect(!stub.called, "disabled ⇒ the LLM is never even invoked")
+                try expect(MemoryHubMemoTitleStore.title(for: "m1") == nil, "no .local cached when off")
+            }
+        }
+    }
+
+    await test("p3a_gate_on_cachesLocalProvenance") {
+        try await withTitleTempHome {
+            try await withOllamaTitleFlags(enabled: true) {
+                try expect(MemoryHubMemoTitler.localTitleEnabled(), "flag ON + model ⇒ gate open")
+                let stub = StubLocalTitleLLM(candidate: "Ship Bridge v4 Trust Fixes")
+                MemoryHubMemoTitler.localTitleLLMOverride = stub
+                defer { MemoryHubMemoTitler.localTitleLLMOverride = nil }
+                let out = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                    memoId: "m1", transcript: "we shipped the trust fixes for bridge v4 today",
+                    fallbackTitle: "Bridge v4", now: now)
+                try expect(stub.called, "enabled ⇒ the LLM is invoked")
+                try expect(out?.provenance == .local, "cached as .local provenance: \(String(describing: out))")
+                try expect(out?.title == "Ship Bridge v4 Trust Fixes", "cleaned candidate: \(String(describing: out?.title))")
+                try expect(out?.transcriptHash?.isEmpty == false, "carries a transcript hash for invalidation")
+                try expect(MemoryHubMemoTitleStore.title(for: "m1")?.provenance == .local, "persisted to the cache")
+            }
+        }
+    }
+
+    await test("p3a_localDoesNotOverwriteEdited") {
+        try await withTitleTempHome {
+            try await withOllamaTitleFlags(enabled: true) {
+                // A human rename is pinned: a later Tier-2 .local title must NOT clobber it.
+                MemoryHubMemoTitleStore.put(mtitle("My own title", .edited, "2026-06-25T09:00:00Z"), memoId: "m1")
+                MemoryHubMemoTitler.localTitleLLMOverride = StubLocalTitleLLM(candidate: "Auto Local Guess")
+                defer { MemoryHubMemoTitler.localTitleLLMOverride = nil }
+                _ = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                    memoId: "m1", transcript: "some transcript", fallbackTitle: "fallback", now: now)
+                let got = MemoryHubMemoTitleStore.title(for: "m1")
+                try expect(got?.title == "My own title" && got?.provenance == .edited,
+                           "edit survives the Tier-2 upgrade: \(String(describing: got))")
+            }
+        }
+    }
+
+    await test("p3a_emptyOrFallbackCandidate_keepsHeuristic") {
+        try await withTitleTempHome {
+            try await withOllamaTitleFlags(enabled: true) {
+                // nil candidate (failure/timeout) ⇒ no write.
+                MemoryHubMemoTitler.localTitleLLMOverride = StubLocalTitleLLM(candidate: nil)
+                let a = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                    memoId: "m1", transcript: "t", fallbackTitle: "Heuristic Title", now: now)
+                try expect(a == nil && MemoryHubMemoTitleStore.title(for: "m1") == nil, "nil candidate ⇒ no .local")
+                // A candidate identical to the fallback is rejected (no value added).
+                MemoryHubMemoTitler.localTitleLLMOverride = StubLocalTitleLLM(candidate: "Heuristic Title")
+                defer { MemoryHubMemoTitler.localTitleLLMOverride = nil }
+                let b = await MemoryHubMemoTitler.enhanceWithLocalTitle(
+                    memoId: "m1", transcript: "t", fallbackTitle: "Heuristic Title", now: now)
+                try expect(b == nil && MemoryHubMemoTitleStore.title(for: "m1") == nil, "fallback-equal ⇒ no .local")
+            }
+        }
+    }
+
+    // MARK: Snapshot-derived heuristic (sweep input)
+
+    await test("p3a_snapshotHeuristic_intentLed_excludesDemoted") {
+        let snap = PlanSnapshot(memoId: "m1", provenance: .heuristic, version: 1,
+                                createdAt: "2026-06-25T10:00:00Z",
+                                intents: [
+                                    snapIntent("i1", "registry_update", 0.99, entityKey: "project",
+                                               entityHint: "Bridge v4", fields: ["summary": "shipped trust fixes"]),
+                                    snapIntent("i2", "reminder", 0.80, title: "Send Jacob results"),
+                                    snapIntent("i3", "memory_keep", 0.90, title: "prefer adversarial reviews", demoted: true),
+                                ])
+        let t = MemoryHubMemoTitler.heuristicTitle(snapshot: snap, now: now)
+        try expect(t.provenance == .heuristic, "heuristic provenance")
+        try expect(t.title == "Send Jacob results", "lane-priority-first reminder wins: \(t.title)")
+        try expect(t.intentCount == 2, "demoted lane excluded from +N (got \(t.intentCount))")
+        try expect(t.transcriptHash == nil, "snapshot-derived ⇒ no transcript hash (upgradeable on select)")
+    }
+
+    // MARK: Idle sweep
+
+    await test("p3a_sweep_emptyCache_cachesHeuristicFromSnapshot") {
+        try await withTitleTempHome {
+            let snap = PlanSnapshot(memoId: "sweep-1", provenance: .heuristic, version: 1,
+                                    createdAt: "2026-06-25T10:00:00Z",
+                                    intents: [snapIntent("i1", "reminder", 0.95, title: "Email the Q3 report")])
+            _ = try MemoryHubPlanSnapshotStore.append(snap)
+            let n = MemoryHubMemoTitler.launchSweep(now: now)
+            try expect(n == 1, "one memo titled (got \(n))")
+            let got = MemoryHubMemoTitleStore.title(for: "sweep-1")
+            try expect(got?.title == "Email the Q3 report" && got?.provenance == .heuristic,
+                       "sweep cached the snapshot heuristic: \(String(describing: got))")
+        }
+    }
+
+    await test("p3a_sweep_leavesEditedAndExistingTitles") {
+        try await withTitleTempHome {
+            // memo A: a pinned human edit — sweep must leave it.
+            let snapA = PlanSnapshot(memoId: "A", provenance: .heuristic, version: 1, createdAt: "2026-06-25T10:00:00Z",
+                                     intents: [snapIntent("i1", "reminder", 0.95, title: "Auto would say this")])
+            _ = try MemoryHubPlanSnapshotStore.append(snapA)
+            MemoryHubMemoTitleStore.put(mtitle("Human kept this", .edited, "2026-06-25T09:00:00Z"), memoId: "A")
+            // memo B: already has a fresh heuristic title — sweep must not rewrite it.
+            let snapB = PlanSnapshot(memoId: "B", provenance: .heuristic, version: 1, createdAt: "2026-06-25T10:00:00Z",
+                                     intents: [snapIntent("i1", "reminder", 0.95, title: "Snapshot title B")])
+            _ = try MemoryHubPlanSnapshotStore.append(snapB)
+            MemoryHubMemoTitleStore.put(mtitle("Existing local B", .local, "2026-06-25T11:00:00Z", hash: "h"), memoId: "B")
+
+            let n = MemoryHubMemoTitler.launchSweep(now: now)
+            try expect(n == 0, "nothing to do — both already titled (wrote \(n))")
+            try expect(MemoryHubMemoTitleStore.title(for: "A")?.provenance == .edited, "edit preserved")
+            try expect(MemoryHubMemoTitleStore.title(for: "B")?.title == "Existing local B", "existing local preserved")
+        }
+    }
+
+    await test("p3a_sweep_capHolds") {
+        try await withTitleTempHome {
+            for i in 0..<5 {
+                let snap = PlanSnapshot(memoId: "cap-\(i)", provenance: .heuristic, version: 1,
+                                        createdAt: "2026-06-25T10:00:00Z",
+                                        intents: [snapIntent("i1", "reminder", 0.95, title: "Title \(i)")])
+                _ = try MemoryHubPlanSnapshotStore.append(snap)
+            }
+            let n = MemoryHubMemoTitler.launchSweep(now: now, cap: 2)
+            try expect(n == 2, "per-sweep cap holds (wrote \(n))")
+            let titled = (0..<5).filter { MemoryHubMemoTitleStore.title(for: "cap-\($0)") != nil }.count
+            try expect(titled == 2, "exactly cap memos titled this pass (got \(titled))")
+        }
     }
 }

--- a/TheBridgeTests/MemoryHubMemoTitleTests.swift
+++ b/TheBridgeTests/MemoryHubMemoTitleTests.swift
@@ -256,6 +256,7 @@ func runMemoryHubMemoTitleTests() async {
     // MARK: P3a — Tier-2 local (Ollama) gating + edited-pin + idle sweep
 
     await runMemoryHubMemoTitleP3aTests(cal: cal, now: now)
+    await runMemoryHubMemoTitleP3bTests(cal: cal, now: now)
 
     // MARK: Freshness / invalidation
 
@@ -456,6 +457,236 @@ func runMemoryHubMemoTitleP3aTests(cal: Calendar, now: Date) async {
             try expect(n == 2, "per-sweep cap holds (wrote \(n))")
             let titled = (0..<5).filter { MemoryHubMemoTitleStore.title(for: "cap-\($0)") != nil }.count
             try expect(titled == 2, "exactly cap memos titled this pass (got \(titled))")
+        }
+    }
+}
+
+// MARK: - P3b: operator rename override + manual Tier-3 cloud title -------------------------
+
+/// Injected cloud chat transport stub — never opens a socket. Either returns a canned
+/// `(Data, HTTPURLResponse)` with a chosen status code, or throws to simulate a network
+/// failure/timeout. Records the last request so a test can assert headers/body/url.
+private final class StubCloudTransport: CloudChatTransport, @unchecked Sendable {
+    let status: Int
+    let payload: Data
+    let throwError: Error?
+    private(set) var lastRequest: URLRequest?
+
+    init(status: Int = 200, json: String = "", throwError: Error? = nil) {
+        self.status = status
+        self.payload = Data(json.utf8)
+        self.throwError = throwError
+    }
+
+    func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        lastRequest = request
+        if let throwError { throw throwError }
+        let response = HTTPURLResponse(url: request.url!, statusCode: status,
+                                       httpVersion: "HTTP/1.1", headerFields: nil)!
+        return (payload, response)
+    }
+}
+
+/// A fully-runnable cloud provider (enabled + model + valid base URL) ⇒ `canRunCloud == true`.
+private func runnableProvider(model: String = "gpt-4o-mini") -> MemoryHubProvider {
+    MemoryHubProvider(id: MemoryHubProviderConfigStore.openAICompatibleId,
+                      baseURL: MemoryHubProviderConfigStore.defaultBaseURL,
+                      model: model, enabled: true)
+}
+
+/// A canned OpenAI-compatible chat-completions body carrying one choice with `content`.
+private func chatCompletionJSON(_ content: String) -> String {
+    let escaped = content.replacingOccurrences(of: "\"", with: "\\\"")
+    return "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"\(escaped)\"}}]}"
+}
+
+func runMemoryHubMemoTitleP3bTests(cal: Calendar, now: Date) async {
+    print("\n🏷️  Memory Hub titles — P3b rename override + manual cloud (PKT-MEM-114)")
+
+    // MARK: (a) Operator rename override precedence
+
+    await test("p3b_rename_writesEdited_andAutoNeverOverwrites") {
+        try await withTitleTempHome {
+            // Operator rename → .edited (this mirrors the cockpit saveRename path).
+            let edited = mtitle("Quarterly board deck", .edited,
+                                ISO8601DateFormatter().string(from: now), hash: "h1", count: 2)
+            MemoryHubMemoTitleStore.put(edited, memoId: "m1")
+            let afterRename = MemoryHubMemoTitleStore.title(for: "m1")
+            try expect(afterRename?.provenance == .edited && afterRename?.title == "Quarterly board deck",
+                       "rename writes .edited: \(String(describing: afterRename))")
+            try expect(afterRename?.intentCount == 2, "rename carries the prior +N count")
+
+            // A later heuristic / .local / .cloud put() must NOT overwrite the human edit.
+            MemoryHubMemoTitleStore.put(mtitle("auto heuristic", .heuristic, "2026-06-26T01:00:00Z"), memoId: "m1")
+            MemoryHubMemoTitleStore.put(mtitle("auto local", .local, "2026-06-26T02:00:00Z"), memoId: "m1")
+            MemoryHubMemoTitleStore.put(mtitle("auto cloud", .cloud, "2026-06-26T03:00:00Z"), memoId: "m1")
+            let got = MemoryHubMemoTitleStore.title(for: "m1")
+            try expect(got?.provenance == .edited && got?.title == "Quarterly board deck",
+                       "edit survives every later auto tier: \(String(describing: got))")
+        }
+    }
+
+    await test("p3b_rename_emptyOrWhitespace_isNoOp") {
+        // The cockpit guards empty/whitespace renames before put(); assert nothing is stored.
+        let trimmedEmpty = "   \n  ".trimmingCharacters(in: .whitespacesAndNewlines)
+        try expect(trimmedEmpty.isEmpty, "whitespace-only rename trims to empty ⇒ guarded no-op")
+    }
+
+    // MARK: (b) Tier-3 cloud helper — success / sanitize / failure modes
+
+    await test("p3b_cloud_success_cachesCloudProvenance_andSanitizes") {
+        try await withTitleTempHome {
+            // Canned completion is quoted + over-long: the helper must strip quotes and cap to ≤8 words.
+            let stub = StubCloudTransport(status: 200,
+                json: chatCompletionJSON("\"Ship Bridge v4 trust fixes before the end of the week\""))
+            let out = try await MemoryHubCloudTitler.improve(
+                memoId: "m1", transcript: "we shipped the trust fixes for bridge v4",
+                provider: runnableProvider(), now: now,
+                keyProvider: { "sk-test-123" }, transport: stub)
+            try expect(out.provenance == .cloud, "cached as .cloud: \(out.provenance)")
+            try expect(out.title.split(separator: " ").count <= 9, "≤8 words + ellipsis token: \(out.title)")
+            try expect(!out.title.contains("\""), "surrounding quotes stripped: \(out.title)")
+            try expect(out.transcriptHash?.isEmpty == false, "carries a transcript hash for invalidation")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1")?.provenance == .cloud, "persisted to the cache")
+        }
+    }
+
+    await test("p3b_cloud_sendsBearerAuthAndChatCompletionsPath") {
+        try await withTitleTempHome {
+            let stub = StubCloudTransport(status: 200, json: chatCompletionJSON("Concise Title"))
+            _ = try await MemoryHubCloudTitler.improve(
+                memoId: "m1", transcript: "transcript body", provider: runnableProvider(), now: now,
+                keyProvider: { "sk-secret" }, transport: stub)
+            let req = stub.lastRequest
+            try expect(req?.httpMethod == "POST", "POST request")
+            try expect(req?.url?.absoluteString.hasSuffix("/chat/completions") == true,
+                       "targets /chat/completions: \(String(describing: req?.url?.absoluteString))")
+            try expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer sk-secret", "bearer auth header")
+            try expect(req?.timeoutInterval == MemoryHubPreview.cloudTimeoutSeconds, "bounded by the 20s cloud timeout")
+            // Body carries the model + the concise-title system prompt (no key in the body).
+            let body = req?.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            try expect(body.contains("gpt-4o-mini"), "request body carries the provider model")
+            try expect(body.contains("intent-led title"), "request body carries the concise-title system prompt")
+            try expect(!body.contains("sk-secret"), "the key is the header only — never in the body")
+        }
+    }
+
+    await test("p3b_cloud_nonSuccess_throwsHttpStatus_keepsPriorTitle_noReview") {
+        try await withTitleTempHome {
+            // A prior heuristic exists; a non-2xx cloud attempt must keep it (and queue no review).
+            MemoryHubMemoTitleStore.put(mtitle("Heuristic title", .heuristic, "2026-06-25T10:00:00Z", hash: "h0", count: 1), memoId: "m1")
+            let stub = StubCloudTransport(status: 429, json: "{\"error\":\"rate_limited\"}")
+            var threw = false
+            do {
+                _ = try await MemoryHubCloudTitler.improve(
+                    memoId: "m1", transcript: "t", provider: runnableProvider(), now: now,
+                    keyProvider: { "sk-test" }, transport: stub)
+            } catch let err as MemoryHubCloudTitler.CloudTitleError {
+                threw = true
+                try expect(err == .httpStatus(429), "surfaces the non-2xx status: \(err)")
+            }
+            try expect(threw, "non-2xx ⇒ throws (caller swallows + keeps the title)")
+            let got = MemoryHubMemoTitleStore.title(for: "m1")
+            try expect(got?.provenance == .heuristic && got?.title == "Heuristic title",
+                       "prior title untouched on failure: \(String(describing: got))")
+        }
+    }
+
+    await test("p3b_cloud_transportThrows_timeout_keepsPriorTitle") {
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("Heuristic title", .heuristic, "2026-06-25T10:00:00Z"), memoId: "m1")
+            // Simulate a timeout/network failure: the transport throws.
+            let stub = StubCloudTransport(throwError: URLError(.timedOut))
+            var threw = false
+            do {
+                _ = try await MemoryHubCloudTitler.improve(
+                    memoId: "m1", transcript: "t", provider: runnableProvider(), now: now,
+                    keyProvider: { "sk-test" }, transport: stub)
+            } catch { threw = true }
+            try expect(threw, "transport failure propagates so the caller keeps the title")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1")?.provenance == .heuristic,
+                       "timeout ⇒ prior title kept, no .cloud written")
+        }
+    }
+
+    await test("p3b_cloud_emptyChoices_throwsEmptyCompletion") {
+        try await withTitleTempHome {
+            let stub = StubCloudTransport(status: 200, json: "{\"choices\":[]}")
+            var threw = false
+            do {
+                _ = try await MemoryHubCloudTitler.improve(
+                    memoId: "m1", transcript: "t", provider: runnableProvider(), now: now,
+                    keyProvider: { "sk-test" }, transport: stub)
+            } catch let err as MemoryHubCloudTitler.CloudTitleError {
+                threw = (err == .emptyCompletion)
+            }
+            try expect(threw, "2xx with no usable content ⇒ emptyCompletion (keep the title)")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1") == nil, "nothing cached on empty completion")
+        }
+    }
+
+    await test("p3b_cloud_neverOverwritesEdited") {
+        try await withTitleTempHome {
+            // A human rename is pinned: even a successful cloud title must NOT clobber it.
+            MemoryHubMemoTitleStore.put(mtitle("My own title", .edited, "2026-06-25T09:00:00Z"), memoId: "m1")
+            let stub = StubCloudTransport(status: 200, json: chatCompletionJSON("Cloud Suggested Title"))
+            let out = try await MemoryHubCloudTitler.improve(
+                memoId: "m1", transcript: "t", provider: runnableProvider(), now: now,
+                keyProvider: { "sk-test" }, transport: stub)
+            // improve() returns the STORED title (edited-pinned), so the edit is what survives.
+            try expect(out.provenance == .edited && out.title == "My own title",
+                       "cloud put() is edited-pinned: \(out.title)")
+            try expect(MemoryHubMemoTitleStore.title(for: "m1")?.provenance == .edited, "edit survives the cloud upgrade")
+        }
+    }
+
+    await test("p3b_cloud_missingKey_throwsMissingKey") {
+        try await withTitleTempHome {
+            let stub = StubCloudTransport(status: 200, json: chatCompletionJSON("Title"))
+            var threw = false
+            do {
+                _ = try await MemoryHubCloudTitler.improve(
+                    memoId: "m1", transcript: "t", provider: runnableProvider(), now: now,
+                    keyProvider: { "   " }, transport: stub)   // blank key
+            } catch let err as MemoryHubCloudTitler.CloudTitleError {
+                threw = (err == .missingKey)
+            }
+            try expect(threw, "no key ⇒ missingKey before any network attempt")
+            try expect(stub.lastRequest == nil, "the transport is never invoked without a key")
+        }
+    }
+
+    // MARK: (c) canRunCloud gating — the button-enabled predicate
+
+    await test("p3b_canRunCloud_gating") {
+        // The cockpit shows/enables the cloud button ONLY when canRunCloud is true.
+        let runnable = runnableProvider()
+        try expect(MemoryHubProviderConfigStore.canRunCloud(runnable), "enabled + model + valid URL ⇒ runnable")
+
+        var disabled = runnable; disabled.enabled = false
+        try expect(!MemoryHubProviderConfigStore.canRunCloud(disabled), "disabled ⇒ not runnable (button hidden)")
+
+        var noModel = runnable; noModel.model = "   "
+        try expect(!MemoryHubProviderConfigStore.canRunCloud(noModel), "blank model ⇒ not runnable")
+
+        var badURL = runnable; badURL.baseURL = "not a url"
+        try expect(!MemoryHubProviderConfigStore.canRunCloud(badURL), "malformed base URL ⇒ not runnable")
+    }
+
+    await test("p3b_cloud_notRunnableProvider_throwsBeforeNetwork") {
+        try await withTitleTempHome {
+            var disabled = runnableProvider(); disabled.enabled = false
+            let stub = StubCloudTransport(status: 200, json: chatCompletionJSON("Title"))
+            var threw = false
+            do {
+                _ = try await MemoryHubCloudTitler.improve(
+                    memoId: "m1", transcript: "t", provider: disabled, now: now,
+                    keyProvider: { "sk-test" }, transport: stub)
+            } catch let err as MemoryHubCloudTitler.CloudTitleError {
+                threw = (err == .notRunnable)
+            }
+            try expect(threw, "a non-runnable provider ⇒ notRunnable, no network")
+            try expect(stub.lastRequest == nil, "the transport is never invoked when not runnable")
         }
     }
 }

--- a/TheBridgeTests/MemoryHubMemoTitleTests.swift
+++ b/TheBridgeTests/MemoryHubMemoTitleTests.swift
@@ -206,6 +206,53 @@ func runMemoryHubMemoTitleTests() async {
         try expect(!d.text.contains("20260625"), "floor is humanized, never the raw stem: \(d.text)")
     }
 
+    // MARK: P2 — generate-on-select + Inbox resolution (cockpit list + Inbox surfaces)
+
+    await test("selectThenList_heuristicCached_beatsDateFloor") {
+        // Generate-on-select semantics: a default-named recording shows the date floor until
+        // selection caches the Tier-1 heuristic; thereafter the list resolves to that title.
+        try await withTitleTempHome {
+            let rec = VoiceMemoRecording(id: "m1", path: "/x", title: "20260625 203010",
+                                         recordedAt: mk(cal, 2026, 6, 25, 20, 30), transcript: nil)
+            // Before selection: no cache ⇒ muted date floor.
+            let before = MemoryHubMemoTitler.listDisplay(recording: rec, cached: MemoryHubMemoTitleStore.title(for: "m1"), now: now)
+            try expect(before.isPlaceholder, "no cache yet ⇒ date floor")
+
+            // On select: generate + cache the heuristic (as the cockpit's loadPreview does).
+            let plan = VoiceMemoPlan(generatedTitle: "Voice memo", skipMemoryKeep: false, summary: "s", actions: [],
+                intents: [VoiceMemoIntent(kind: .reminder, confidence: 0.95, title: "Send Jacob results")])
+            let t = MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "remind me…", now: now)
+            MemoryHubMemoTitleStore.put(t, memoId: "m1")
+
+            // After selection: the list resolves to the cached heuristic, not the floor.
+            let after = MemoryHubMemoTitler.listDisplay(recording: rec, cached: MemoryHubMemoTitleStore.title(for: "m1"), now: now)
+            try expect(!after.isPlaceholder, "cached ⇒ no longer a placeholder")
+            try expect(after.text == "Send Jacob results" && after.provenance == .heuristic, "shows the heuristic: \(after.text)")
+        }
+    }
+    await test("selectThenList_editedRename_survivesGenerateOnSelect") {
+        // A prior human rename must NOT be clobbered when select regenerates the heuristic.
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("My own title", .edited, "2026-06-25T09:00:00Z"), memoId: "m1")
+            let plan = VoiceMemoPlan(generatedTitle: "g", skipMemoryKeep: false, summary: "s", actions: [],
+                intents: [VoiceMemoIntent(kind: .reminder, confidence: 0.95, title: "auto guess")])
+            MemoryHubMemoTitleStore.put(MemoryHubMemoTitler.heuristicTitle(plan: plan, transcript: "x", now: now), memoId: "m1")
+            let got = MemoryHubMemoTitleStore.title(for: "m1")
+            try expect(got?.title == "My own title" && got?.provenance == .edited, "edit survives select: \(String(describing: got))")
+        }
+    }
+    await test("inboxResolution_cachedTitleWins_elseFallsBackToEntry") {
+        // The Inbox is a read-only consumer: the cache wins, an absent entry falls back to memoTitle.
+        try await withTitleTempHome {
+            MemoryHubMemoTitleStore.put(mtitle("Send Jacob results", .heuristic, "2026-06-25T10:00:00Z"), memoId: "cached")
+            let cachedResolved = MemoryHubMemoTitleStore.title(for: "cached")?.title ?? "20260625 203010"
+            try expect(cachedResolved == "Send Jacob results", "cached intent-led title wins over the raw stem")
+
+            let fallbackResolved = MemoryHubMemoTitleStore.title(for: "absent")?.title ?? "Stored entry title"
+            try expect(fallbackResolved == "Stored entry title", "no cache ⇒ falls back to the entry's memoTitle")
+        }
+    }
+
     // MARK: Freshness / invalidation
 
     await test("freshness_hashMatch_andListNilCurrent") {

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -258,6 +258,7 @@ struct TheBridgeTestRunner {
         await runVoiceMemoHubTrustTests() // PKT-MEM-106 0a: trust + identity core (run early — flake-avoidance)
         await runMemoryHubCockpitTests()  // PKT-MEM-106 0b: run early alongside 0a (same flake-avoidance)
         await runMemoryHubGuardrailTests() // PKT-MEM-106 0c: preview + guardrails + tabs (run early)
+        await runMemoryHubMemoTitleTests() // PKT-MEM-114 P1: progressive AI memo titles (run early)
         // ============================================================
         // MARK: - SecurityGate Tests (v3: 3-tier model)
         // ============================================================

--- a/docs/operator/live-evidence/PHASE0-REALWORLD-SESSION.md
+++ b/docs/operator/live-evidence/PHASE0-REALWORLD-SESSION.md
@@ -1,0 +1,157 @@
+# Phase 0 — Real-World Test Playbook + Results
+
+**Build:** v3.8.2/61 notarized + installed 2026-06-25 (PKT-MEM-106 Phase 0).
+**Roles:** **You (operator)** record memos + take on-device actions. **Claude (driver)** validates with MCP tools, grades, and logs friction.
+**Mode:** single-memo, **real writes** (live). Never `voice_memo_process mode:batch`. Forced duplicate commits use reason `live_test`.
+
+---
+
+## How to run + track (read first)
+
+**The loop for every test:**
+1. **You** do the listed action (record a memo / click in the app). Memos are named (e.g. `Bridge RT1`) so I find them instantly.
+2. **I** validate **read-only first** (`voice_memo_get`, `voice_memo_process dryRun:true`, `voice_memo_review_list`) and tell you the predicted routing.
+3. **You** approve the **write** (a commit creates a real reminder / Notion row). Nothing writes without your explicit "go".
+4. **I** confirm the write held the invariant, then **grade** it and **log friction**.
+
+**Where results live (this file):**
+- **Results table** (below) — one row per test: `PASS / PARTIAL / FAIL` + the evidence (intentIds, registry content, receipt hashes).
+- **Friction log** (below) — anything that slowed you, surprised you, or read wrong (latency, parser miss, UX confusion) with a severity + a fix idea.
+- **Durable receipts** — every write appends to `~/Library/Application Support/The Bridge/memory-hub/activity.jsonl`; I cite the **first-12 chars of each `receiptHash`** so a grade is auditable later.
+
+**Grade rubric:**
+- **PASS** — the invariant held *and* the routing matched the expected outcome.
+- **PARTIAL** — primary lane correct but a non-trust issue (e.g. reminder title too broad, evidence incomplete, datetime missing).
+- **FAIL** — a trust breach: protected-field **overwrite**, same-kind lanes **collapsed**, **processed while a sibling review is pending**, **truncated** agent memory, or a write to the **wrong target**.
+
+---
+
+## The tests
+
+### RT-1 — Multi-intent election + suppression  ★ headline
+**Proves:** lane-priority-first election; exactly **one** primary auto-executes; the rest are suppressed as **distinct** review lanes.
+**Prereq:** review queue empty (confirmed: 0 pending).
+
+**Steps**
+1. **You:** Voice Memos → record, rename **`Bridge RT1`**, read naturally, stop:
+   > *"Remind me at four PM to send Jacob the Phase 0 test results. Also update the Bridge v4 project — we shipped the trust fixes this week. And keep this note: I prefer adversarial sub-agent reviews per slice."*
+2. **Me:** `voice_memo_get` → show the transcript + the **3 parsed intents** with their `intentId`s.
+3. **Me:** `voice_memo_process dryRun:true` → show the election: **execute = 1** (reminder), **suppressed = 2** (project, keep).
+4. **You:** "go" → I commit the reminder; the two suppressed lanes stay in review.
+
+**Expected:** reminder elected primary (title scoped to *"send Jacob Phase 0 test results"*, due 4 PM — not the whole paragraph); `registry_update`(project Bridge v4) + `memory_keep` suppressed with **two different** `intentId`s.
+**PASS if** 1 reminder in `execute`, 2 distinct suppressed. **FAIL if** 0 or >1 primary, or the two suppressed share an `intentId`.
+**Track:** the 3 `intentId`s + election outcome; reminder receipt hash; friction = transcription latency + parse accuracy + title scoping.
+
+---
+
+### RT-2 — Same-kind registry distinctness  (the M5 core)
+**Proves:** two `registry_update` lanes from one memo stay **distinct**, never collapsed (the bug 0a fixed).
+
+**Steps**
+1. **You:** record + rename **`Bridge RT2`**, read:
+   > *"Update session DST-8 — focus is the trust fixes. And update the Bridge v4 project — we ship Phase 0 this week."*
+2. **Me:** `voice_memo_get` → confirm **two** `registry_update` intents (entity `session`/hint `DST-8`, and entity `project`/hint `Bridge v4`) with **different** `intentId`s.
+3. **Me:** `voice_memo_process dryRun:true` → one registry lane auto (higher confidence), the **other distinct** lane suppressed.
+
+**Expected:** 2 registry lanes, 2 different `intentId`s; one auto, one suppressed-distinct.
+**PASS if** two distinct registry `intentId`s. **FAIL if** they collapse to one review entry.
+**Track:** the two `intentId`s side by side (must differ); friction = did the parser separate "session DST-8" from "project Bridge v4".
+
+---
+
+### RT-3 — Append-only protected fields  ★ trust
+**Proves:** protected registry text (`brief`/`objective`/`summary`/`description`) **appends**, never overwrites.
+
+**Steps**
+1. **Me:** `registry_get` the **Bridge v4** project row → record its current `summary` (baseline).
+2. **You:** record **`Bridge RT3a`**: *"Update the Bridge v4 project summary — first append test."* → "go", I commit.
+3. **Me:** `registry_get` again → `summary` = baseline **+** "first append test" (prior text intact, stamped).
+4. **You:** record **`Bridge RT3b`**: *"Update the Bridge v4 project summary — second append test."* → "go", I commit.
+5. **Me:** `registry_get` → `summary` = baseline + first + **second** (all three retained).
+
+**Expected:** every prior line survives; each commit adds a stamped append.
+**PASS if** baseline + both appends all present after step 5. **FAIL if** any prior content is gone (overwrite).
+**Track:** the `summary` value after each step (paste the before/after); receipt hashes.
+
+---
+
+### RT-4 — Processed-gate  ★ trust  (uses the RT-1 memo)
+**Proves:** a memo is marked processed **only** when no pending sibling review remains.
+
+**Steps**
+1. **Me:** right after RT-1's commit (reminder done, 2 lanes pending): `voice_memo_get` on the RT-1 memo → `processed: false`; `voice_memo_review_list` → **2 pending** for that memo.
+2. **You:** resolve the **project** lane (cockpit commit, or tell me to `voice_memo_review_resolve`). **Me:** `processed` still **false** (1 sibling left).
+3. **You:** resolve the **keep** lane. **Me:** now `processed: true`.
+
+**Expected:** processed flips to true **only** after the last pending lane clears.
+**PASS if** false→false→true across steps 1-3. **FAIL if** processed becomes true while any sibling is pending.
+**Track:** `processed` + `pendingCount` at each step.
+
+---
+
+### RT-5 — Cloud provider config  (no recording — quick)
+**Proves:** non-secret config → `providers.json`; API key → Keychain only; status reflects it.
+
+**Steps**
+1. **You:** Settings → Memory → **Processing** → "Cloud enhancement (OpenAI-compatible)": leave **Base URL** at `https://api.openai.com/v1`, set **Model** = `gpt-4o`, toggle **Enabled** on, type any **API key** (a throwaway like `sk-test-123` is fine), click **Save**.
+2. **Me:** read `~/Library/Application Support/The Bridge/memory-hub/providers.json` → has `baseURL`/`model`/`enabled`, and **no key field anywhere**.
+3. **Me:** confirm the card status shows **"Key configured"** (key is in the Keychain, not the JSON).
+4. **You:** click **Delete key** → status flips to **"Key missing"**.
+
+**Expected:** JSON holds only non-secret config; status tracks the Keychain key; delete flips it.
+**PASS if** JSON has no key + status flips correctly. **FAIL if** the key appears in `providers.json`, or status is wrong.
+**Track:** paste the `providers.json` contents (proves no key); note the two status states.
+
+---
+
+### RT-6 — Cockpit per-intent commit (UI)  (uses an RT memo)
+**Proves:** the 0b three-zone cockpit renders intents, marks one primary, commits one lane, and writes an activity receipt.
+
+**Steps**
+1. **You:** Settings → Memory → **Process** → click the **`Bridge RT2`** memo row.
+2. **You:** observe — the **intent table** fills (the registry lanes), **one row is starred** (primary), the **detail inspector** shows the transcript + a **Commit** button; if both registry lanes are present, the **registry picker** appears (multiple registry lanes).
+3. **You:** select the suppressed lane row → **Commit** (pick a picker row if shown).
+4. **You:** watch the **activity strip** at the bottom — a receipt line appears.
+5. **Me:** read `activity.jsonl` → confirm the commit event (envelope: phase/action/status/receiptHash; **no transcript** in `detail`).
+
+**Expected:** cockpit shows the lanes with one primary; commit routes the selected lane; activity strip + `activity.jsonl` get a receipt.
+**PASS if** the lane commits from the UI and a receipt lands. **FAIL if** the cockpit is empty/broken, the wrong lane commits, or the receipt holds a full transcript.
+**Track:** a screenshot of the populated cockpit + the receipt hash.
+
+---
+
+### RT-7 — Duplicate guard probe  (expected to expose the deferred gap)
+**Proves / measures:** whether duplicate-block + force-reason is **enforced** at the commit path. This one is an **honest gap check** — the *logic* is unit-tested, but wiring it into the live commit is a **documented deferred item**, so I expect this to show the gap.
+
+**Steps**
+1. **You:** commit a lane once (e.g. the `Bridge RT1` `memory_keep`) → succeeds.
+2. **You:** commit the **same** lane again.
+3. **Me:** observe — does the second commit get **blocked** (duplicate), or does it write a second row?
+
+**Expected (current build):** the second commit is **not** blocked → it writes again (the enforcement gap). That **confirms** the deferred status, not a regression.
+**Grade:** **PASS** = blocked-by-default + force-reason demanded (would mean the gap is already closed); **PARTIAL/known-gap** = not blocked (matches the documented deferral); record which.
+**Track:** note whether a duplicate row appeared; this row feeds the "wire duplicate enforcement" follow-up.
+
+---
+
+## Results
+
+| Test | Grade | Evidence (intentIds / registry / receipt-12) | Notes |
+|---|---|---|---|
+| RT-1 | — | — | — |
+| RT-2 | — | — | — |
+| RT-3 | — | — | — |
+| RT-4 | — | — | — |
+| RT-5 | — | — | — |
+| RT-6 | — | — | — |
+| RT-7 | — | — | — |
+
+## Friction log
+
+| # | Test | Severity | Friction observed | Suggested fix |
+|---|---|---|---|---|
+
+## Cleanup (end of session)
+
+`reminders_delete` the test reminders · additively revert the Bridge v4 `summary` test appends (protected = append-only; use a reversal/cleanup note, don't silently overwrite) · `registry_delete` any test rows · `memory_forget` the RT-1 keep note · `voice_memo_review_dismiss` leftover entries · curator mode → Auto · filter `activity.jsonl` test receipts by force reason `live_test`.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1492,7 +1492,10 @@ set -euo pipefail
 # registry_hydrate). make test 2550 passed / 0 failed. Raise only by measured net-new; never lower.
 # PKT-MEM-114 P1 (2026-06-26): +21 net-new green — MemoryHubMemoTitle (title model + edited-pinned cache +
 # Tier-1 intent-led heuristic + locale-aware date floor; suite runMemoryHubMemoTitleTests). 2571 passed / 0 failed.
-FLOOR="${BRIDGE_TEST_FLOOR:-2571}"
+# PKT-MEM-114 P2 (2026-06-26): +3 net-new green — surface intent-led titles in the cockpit memo list + Inbox
+# (generate-on-select + edited-rename survival + Inbox cache-wins/fallback; same runMemoryHubMemoTitleTests suite).
+# 2574 passed / 0 failed.
+FLOOR="${BRIDGE_TEST_FLOOR:-2574}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1495,7 +1495,11 @@ set -euo pipefail
 # PKT-MEM-114 P2 (2026-06-26): +3 net-new green — surface intent-led titles in the cockpit memo list + Inbox
 # (generate-on-select + edited-rename survival + Inbox cache-wins/fallback; same runMemoryHubMemoTitleTests suite).
 # 2574 passed / 0 failed.
-FLOOR="${BRIDGE_TEST_FLOOR:-2574}"
+# PKT-MEM-114 P3a (2026-06-26): +8 net-new green — Tier-2 Ollama titles (enabled-flag gating + .local cache,
+# edited-pin preserved, fallback/empty rejected) + snapshot-derived heuristic + local-first idle sweep
+# (caches from plan snapshots, leaves edited/existing, per-sweep cap; stubbed LLM, runMemoryHubMemoTitleP3aTests).
+# 2582 passed / 0 failed.
+FLOOR="${BRIDGE_TEST_FLOOR:-2582}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1490,7 +1490,9 @@ set -euo pipefail
 # MERGE main → Memory Hub branch (2026-06-25): integrated green re-measured = 2550 (2508 branch + 42 main
 # net-new: registry_hydrate +10/+1 + tool-surface +30, + Version staticFeatureModuleToolCount 186→187 for
 # registry_hydrate). make test 2550 passed / 0 failed. Raise only by measured net-new; never lower.
-FLOOR="${BRIDGE_TEST_FLOOR:-2550}"
+# PKT-MEM-114 P1 (2026-06-26): +21 net-new green — MemoryHubMemoTitle (title model + edited-pinned cache +
+# Tier-1 intent-led heuristic + locale-aware date floor; suite runMemoryHubMemoTitleTests). 2571 passed / 0 failed.
+FLOOR="${BRIDGE_TEST_FLOOR:-2571}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1499,7 +1499,13 @@ set -euo pipefail
 # edited-pin preserved, fallback/empty rejected) + snapshot-derived heuristic + local-first idle sweep
 # (caches from plan snapshots, leaves edited/existing, per-sweep cap; stubbed LLM, runMemoryHubMemoTitleP3aTests).
 # 2582 passed / 0 failed.
-FLOOR="${BRIDGE_TEST_FLOOR:-2582}"
+# PKT-MEM-114 P3b (2026-06-26): +11 net-new green — manual Tier-3 cloud title tier (MemoryHubCloudTitler:
+# injected CloudChatTransport stub → success caches .cloud + sanitizes/caps, non-2xx/timeout/empty/missing-key
+# throw and keep the prior title with NO review queued, edited-pin preserved; bearer-auth + /chat/completions
+# + 20s timeout asserted) + operator rename override (→ pinned .edited, auto tiers never overwrite, empty no-op)
+# + canRunCloud button-enabled gating. New AX ids process.titleRename/titleCloud added to the .memory manifest.
+# runMemoryHubMemoTitleP3bTests. 2593 passed / 0 failed.
+FLOOR="${BRIDGE_TEST_FLOOR:-2593}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Integration objective

Ship PKT-MEM-114 and the Bridge initialization enforcement together in one tested build and one install.

## Required base

- [ ] Rebase this branch onto current `origin/main`
- [ ] Verify `3d21e3c` is an ancestor of `HEAD`

```bash
git fetch origin
git rebase origin/main
git merge-base --is-ancestor 3d21e3c HEAD
```

## Combined validation

- [ ] Preserve PKT-MEM-114 tests
- [ ] Preserve Bridge initialization contract tests
- [ ] Run `make test-floor`
- [ ] Raise the floor only to the measured combined green count
- [ ] Confirm GitHub Actions passes on the rebased head

## Single release/install owner

The PKT-MEM-114 agent owns the final build and install. No parallel `make install-copy` or app restart.

- [ ] Make one release version bump only
- [ ] Build once
- [ ] Install once
- [ ] Relaunch once

## Acceptance checks

PKT-MEM-114:
- [ ] intent-led titles display in Cockpit and Inbox
- [ ] edited/pinned title behavior persists

Bridge initialization:
- [ ] fresh MCP handshake includes the initialization receipt
- [ ] doctrine version is `v7.0.1`
- [ ] routing roster is loaded
- [ ] supplemental order count is `1`
- [ ] initialization state is `COMPLETE`

Do not mark ready or merge while the receipt is `DEGRADED` or `INCOMPLETE`.