### PR TITLE
feat(voice-curator): frontier-first parse provider chain + UX remediation

### DIFF
--- a/TheBridge/Modules/VoiceMemo/VoiceMemoModels.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoModels.swift
@@ -85,6 +85,17 @@ public struct VoiceMemoIntent: Sendable, Equatable {
     }
 }
 
+/// Which arm of the FRONTIER-FIRST Understand chain produced a plan's intents.
+/// `agent` is reserved for out-of-process commits by the connected MCP agent;
+/// `cloud` is the frontier API rung; `local` is the in-a-pinch Ollama LLM; and
+/// `heuristic` is the deterministic guaranteed floor (`VoiceMemoParser.parse`).
+public enum ParseProvenance: String, Codable, Sendable {
+    case agent
+    case cloud
+    case local
+    case heuristic
+}
+
 /// Parser output for one memo.
 public struct VoiceMemoPlan: Sendable, Equatable {
     public var generatedTitle: String
@@ -92,19 +103,28 @@ public struct VoiceMemoPlan: Sendable, Equatable {
     public var summary: String
     public var actions: [String]
     public var intents: [VoiceMemoIntent]
+    /// Which Understand-chain arm produced `intents` (FRONTIER-FIRST provenance).
+    public var provenance: ParseProvenance
+    /// True when a higher-preference rung was available by config but returned
+    /// nil at runtime, so the chain fell through to a lower rung (graceful degrade).
+    public var degraded: Bool
 
     public init(
         generatedTitle: String,
         skipMemoryKeep: Bool,
         summary: String,
         actions: [String],
-        intents: [VoiceMemoIntent]
+        intents: [VoiceMemoIntent],
+        provenance: ParseProvenance = .heuristic,
+        degraded: Bool = false
     ) {
         self.generatedTitle = generatedTitle
         self.skipMemoryKeep = skipMemoryKeep
         self.summary = summary
         self.actions = actions
         self.intents = intents
+        self.provenance = provenance
+        self.degraded = degraded
     }
 }
 

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoParseProvider.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoParseProvider.swift
@@ -1,0 +1,109 @@
+// VoiceMemoParseProvider.swift — FRONTIER-FIRST Understand provider chain (Phase 1, W1)
+// TheBridge · Modules · VoiceMemo
+//
+// The curator's Understand step is inverted from local-first to FRONTIER-FIRST:
+// a connected MCP agent (out-of-process) or a cloud API produces the routing
+// intents FIRST (zero marginal cost / best quality); local Ollama + the
+// deterministic heuristic are the in-a-pinch floor. Each rung conforms to
+// `VoiceMemoParseProvider`; `VoiceMemoParseRouter` walks the ordered chain and
+// stamps `plan.provenance` / `plan.degraded`.
+//
+// TRUST INVARIANT: a provider only changes WHO produces the `VoiceMemoPlan`.
+// The produced plan feeds the EXISTING election / guardrails / processed-gate /
+// per-intent commit — all unchanged. The cloud rung is a STUB this wave (W2
+// implements the real OpenAI-compatible call by reusing `CloudChatTransport`).
+
+import Foundation
+
+/// One arm of the Understand chain. `parse` returns nil when the rung is
+/// unavailable or fails at runtime, so the router falls through to the next rung.
+/// `isAvailable()` is the cheap config/precondition check used to decide the
+/// chain shape and the `degraded` flag (an earlier available rung that returns
+/// nil at runtime ⇒ degraded).
+public protocol VoiceMemoParseProvider: Sendable {
+    /// The provenance stamped on a plan this provider produces.
+    var provenance: ParseProvenance { get }
+    /// Cheap precondition gate — true when this rung COULD run for the current
+    /// config (not a guarantee it succeeds; `parse` may still return nil).
+    func isAvailable() -> Bool
+    /// Produce a plan, or nil when unavailable / failed (⇒ fall through).
+    func parse(transcript: String, fallbackTitle: String, recordingPath: String) async -> VoiceMemoPlan?
+}
+
+// MARK: - Cloud (frontier API) — STUB this wave
+
+/// Tier-3 cloud (frontier API) Understand rung. STUB for W1: never available and
+/// always returns nil, so `.auto`/`.cloud` chains fall straight through to the
+/// local/heuristic floor with no behavior change. W2 replaces the body with a
+/// real OpenAI-compatible chat-completions call that reuses the injectable
+/// `CloudChatTransport` seam (see `MemoryHubCloudTitle.swift`) and the
+/// `MemoryHubProviderConfigStore` gate (`canRunCloud` + Keychain key), stamping
+/// `.cloud` provenance. Keeping the rung in the chain now means W2 is a pure
+/// body swap with no router/model churn.
+public struct CloudParseProvider: VoiceMemoParseProvider {
+    public init() {}
+
+    public var provenance: ParseProvenance { .cloud }
+
+    /// STUB: cloud is not wired this wave. W2 returns
+    /// `MemoryHubProviderConfigStore.canRunCloud(provider) && keyConfigured`.
+    public func isAvailable() -> Bool { false }
+
+    /// STUB: W1 never produces a cloud plan. W2 builds + sends the request and
+    /// maps the completion into a `VoiceMemoPlan` (provenance `.cloud`), or nil
+    /// on any non-2xx / timeout / parse failure (⇒ degrade to local/heuristic).
+    public func parse(transcript: String, fallbackTitle: String, recordingPath: String) async -> VoiceMemoPlan? {
+        nil
+    }
+}
+
+// MARK: - Local (Ollama) — in-a-pinch fallback
+
+/// Local Ollama Understand rung. Availability is the EXISTING gate
+/// (`voiceMemoOllamaRoutingEffective ∧ shouldUseLocalOllama() ∧ a routing model`);
+/// `parse` delegates to `VoiceMemoParser.ollamaParse` (the verbatim-extracted
+/// Ollama body), which returns nil on an unhealthy daemon / generation or
+/// JSON-parse failure. The plan is stamped `.local` by `ollamaParse`.
+public struct LocalParseProvider: VoiceMemoParseProvider {
+    public init() {}
+
+    public var provenance: ParseProvenance { .local }
+
+    public func isAvailable() -> Bool {
+        BridgeDefaults.voiceMemoOllamaRoutingEffective
+            && VoiceMemoCuratorRouter.shouldUseLocalOllama()
+            && BridgeDefaults.ollamaRoutingModelEffective != nil
+    }
+
+    public func parse(transcript: String, fallbackTitle: String, recordingPath: String) async -> VoiceMemoPlan? {
+        await VoiceMemoParser.ollamaParse(
+            transcript: transcript,
+            fallbackTitle: fallbackTitle,
+            recordingPath: recordingPath
+        )
+    }
+}
+
+// MARK: - Heuristic — guaranteed floor
+
+/// Deterministic heuristic Understand rung — the GUARANTEED FLOOR. Always
+/// available and NEVER nil: it wraps `VoiceMemoParser.parse` (pure phrase
+/// matching, no network/LLM). Stamps `.heuristic`. Every chain ends here so the
+/// curator always has intents to feed the election.
+public struct HeuristicParseProvider: VoiceMemoParseProvider {
+    public init() {}
+
+    public var provenance: ParseProvenance { .heuristic }
+
+    public func isAvailable() -> Bool { true }
+
+    public func parse(transcript: String, fallbackTitle: String, recordingPath: String) async -> VoiceMemoPlan? {
+        var plan = VoiceMemoParser.parse(
+            transcript: transcript,
+            fallbackTitle: fallbackTitle,
+            recordingPath: recordingPath.isEmpty ? nil : recordingPath
+        )
+        plan.provenance = .heuristic
+        return plan
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoParseRouter.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoParseRouter.swift
@@ -1,0 +1,100 @@
+// VoiceMemoParseRouter.swift — FRONTIER-FIRST Understand chain walk (Phase 1, W1)
+// TheBridge · Modules · VoiceMemo
+//
+// Reads the operator's curator mode and walks an ordered provider chain. The
+// FIRST rung that is `isAvailable()` AND whose `parse()` returns non-nil wins;
+// its `provenance` is stamped onto the plan. The chain is FRONTIER-FIRST: for
+// `.auto` it is [cloud, local, heuristic] so the zero-marginal-cost / best-
+// quality rung is tried first and local Ollama / heuristics are the floor.
+//
+// `degraded` is set true when a HIGHER-preference rung was available by config
+// but returned nil at runtime (so we fell past it). The heuristic floor is
+// always available and never nil, guaranteeing the walk terminates with intents.
+//
+// TRUST INVARIANT: the router only changes WHO produces the plan — the produced
+// plan feeds the EXISTING election / guardrails / processed-gate / commit, all
+// unchanged.
+
+import Foundation
+
+public enum VoiceMemoParseRouter {
+
+    /// Test seam: when set, `parse` uses this provider list instead of
+    /// `providers(for:)`. Lets the harness inject stub rungs (controllable
+    /// availability + canned/nil plans) with NO real network / Ollama / agent.
+    /// nil ⇒ the production `providers(for:)` chain. Matches the
+    /// `transportOverride` injection pattern used elsewhere in the hub.
+    nonisolated(unsafe) public static var providerOverride: (@Sendable (VoiceMemoCuratorMode) -> [VoiceMemoParseProvider])?
+
+    /// The ordered Understand chain for a curator mode (FRONTIER-FIRST):
+    ///   .cloud      → [Cloud, Heuristic]
+    ///   .local      → [Local, Heuristic]
+    ///   .heuristics → [Heuristic]
+    ///   .agent      → [Heuristic]   (the connected agent parses out-of-process;
+    ///                                the in-process preview uses the floor)
+    ///   .auto       → [Cloud, Local, Heuristic]   (frontier-first)
+    /// Heuristic is ALWAYS last so every chain has a guaranteed non-nil floor.
+    public static func providers(for mode: VoiceMemoCuratorMode) -> [VoiceMemoParseProvider] {
+        switch mode {
+        case .cloud:
+            return [CloudParseProvider(), HeuristicParseProvider()]
+        case .local:
+            return [LocalParseProvider(), HeuristicParseProvider()]
+        case .heuristics:
+            return [HeuristicParseProvider()]
+        case .agent:
+            return [HeuristicParseProvider()]
+        case .auto:
+            return [CloudParseProvider(), LocalParseProvider(), HeuristicParseProvider()]
+        }
+    }
+
+    /// Walk the mode-ordered chain and return the winning plan with `provenance`
+    /// stamped (and `degraded` set per the rule above). Reads
+    /// `VoiceMemoCuratorRouter.effectiveMode()`.
+    public static func parse(
+        transcript: String,
+        fallbackTitle: String,
+        recordingPath: String? = nil
+    ) async -> VoiceMemoPlan {
+        let mode = VoiceMemoCuratorRouter.effectiveMode()
+        let chain = (providerOverride ?? { providers(for: $0) })(mode)
+        return await walk(chain, transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath)
+    }
+
+    /// Walk an explicit chain (used by `parse` and directly by tests). The first
+    /// available rung that yields a plan wins; an earlier available rung that
+    /// returned nil marks the result `degraded`.
+    static func walk(
+        _ chain: [VoiceMemoParseProvider],
+        transcript: String,
+        fallbackTitle: String,
+        recordingPath: String?
+    ) async -> VoiceMemoPlan {
+        let path = recordingPath ?? ""
+        var degraded = false
+        for provider in chain {
+            guard provider.isAvailable() else { continue }
+            if var plan = await provider.parse(transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: path) {
+                plan.provenance = provider.provenance
+                plan.degraded = degraded
+                return plan
+            }
+            // Available by config but returned nil at runtime ⇒ we fall PAST a
+            // higher-preference rung: every later winner is a graceful degrade.
+            degraded = true
+        }
+        // Defensive floor: the chain SHOULD always end in HeuristicParseProvider
+        // (always available, never nil), so this is unreachable in practice. If a
+        // caller passes a chain with no terminating floor, synthesize the
+        // heuristic plan directly so the curator never returns without intents.
+        var plan = VoiceMemoParser.parse(
+            transcript: transcript,
+            fallbackTitle: fallbackTitle,
+            recordingPath: path.isEmpty ? nil : path
+        )
+        plan.provenance = .heuristic
+        plan.degraded = degraded
+        return plan
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoParser.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoParser.swift
@@ -124,20 +124,43 @@ public enum VoiceMemoParser {
         )
     }
 
-    /// When Ollama routing is enabled and configured, attempt LLM classification; fall back to heuristics.
+    /// FRONTIER-FIRST shim: delegate the Understand step to `VoiceMemoParseRouter`,
+    /// which walks the mode-ordered provider chain (cloud → local → heuristic for
+    /// `.auto`) and stamps `plan.provenance`. Retained so existing callers
+    /// (`VoiceMemoProcessor.processOne`, `VoiceMemoReviewResolver`) keep compiling;
+    /// the local-Ollama body now lives in `LocalParseProvider` via `ollamaParse`.
     public static func parseWithOptionalOllama(
         transcript: String,
         fallbackTitle: String,
         recordingPath: String? = nil
     ) async -> VoiceMemoPlan {
+        await VoiceMemoParseRouter.parse(
+            transcript: transcript,
+            fallbackTitle: fallbackTitle,
+            recordingPath: recordingPath
+        )
+    }
+
+    /// The local-Ollama Understand arm, extracted verbatim from the old
+    /// `parseWithOptionalOllama`. Returns nil (NOT the heuristic fallback) on a
+    /// missing model / unhealthy daemon / generation or JSON-parse failure — the
+    /// chain router decides the fallback. The returned plan is stamped `.local`.
+    /// The gate (`voiceMemoOllamaRoutingEffective ∧ shouldUseLocalOllama ∧ model`)
+    /// is checked by `LocalParseProvider.isAvailable()`, but re-asserted here so a
+    /// direct call is still safe.
+    public static func ollamaParse(
+        transcript: String,
+        fallbackTitle: String,
+        recordingPath: String? = nil
+    ) async -> VoiceMemoPlan? {
         guard BridgeDefaults.voiceMemoOllamaRoutingEffective,
               VoiceMemoCuratorRouter.shouldUseLocalOllama(),
               let model = BridgeDefaults.ollamaRoutingModelEffective else {
-            return parse(transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath)
+            return nil
         }
         let client = OllamaClient.fromDefaults()
         guard (try? await client.health()) == true else {
-            return parse(transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath)
+            return nil
         }
         let prompt = """
         Classify this voice memo transcript into routing lanes. Reply with ONLY JSON:
@@ -147,9 +170,10 @@ public enum VoiceMemoParser {
         """
         let genOptions = OllamaClient.GenerateOptions(numPredict: 512, temperature: 0.2, think: false)
         guard let raw = try? await client.generate(model: model, prompt: prompt, options: genOptions),
-              let plan = parseOllamaJSON(raw, transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath) else {
-            return parse(transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath)
+              var plan = parseOllamaJSON(raw, transcript: transcript, fallbackTitle: fallbackTitle, recordingPath: recordingPath) else {
+            return nil
         }
+        plan.provenance = .local
         return plan
     }
 

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -746,7 +746,10 @@ public enum VoiceMemoProcessor {
         guard let transcript = resolved.text else {
             throw VoiceMemoError.invalidIntent("no transcript for memo")
         }
-        var plan = await VoiceMemoParser.parseWithOptionalOllama(
+        // FRONTIER-FIRST Understand: walk the curator-mode provider chain
+        // (cloud → local → heuristic for .auto), stamping plan.provenance /
+        // .degraded. The summary step + everything downstream is unchanged.
+        var plan = await VoiceMemoParseRouter.parse(
             transcript: transcript,
             fallbackTitle: recording.title,
             recordingPath: recording.path

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -697,6 +697,7 @@ await runJobsModuleTests()
 await runSchedulerResilienceTests()  // PKT-381: durable backlog + reconciler + serial drain + first job
 await runVoiceMemoModuleTests()        // Voice Memos curator: registry-centric router + 9am job
 await runVoiceMemoLiveRegressionTests() // PKT-MEM-105/106 live fixture regression
+await runVoiceMemoParseChainTests()    // Voice Curator FRONTIER-FIRST (Phase 1 W1): parse provider chain + plan provenance/degraded
 // PKT-MEM-106 0a + 0b run early in runAllTests() (flake-avoidance) — not duplicated here.
 await runMemorySettingsTests()         // PKT-MEM-102: Memory Settings section + Inbox UI
 await runOllamaModuleTests()           // Local Ollama client + module (Wave 2a)

--- a/TheBridgeTests/VoiceMemoParseChainTests.swift
+++ b/TheBridgeTests/VoiceMemoParseChainTests.swift
@@ -1,0 +1,311 @@
+// VoiceMemoParseChainTests.swift — FRONTIER-FIRST Understand chain (Phase 1, W1)
+// TheBridge · Tests
+//
+// Covers the parse provider-chain abstraction + plan provenance:
+//  • providers(for:) chain ORDER + shape per curator mode
+//  • parse() walks the chain: first available rung that yields a plan wins
+//  • .auto is FRONTIER-FIRST (Cloud → Local → Heuristic) by availability
+//  • degraded set IFF an earlier AVAILABLE rung returned nil at runtime
+//  • the heuristic floor is always available and never nil (guaranteed)
+//  • provenance is stamped from the winning rung
+//  • .agent / .heuristics resolve to the floor
+//
+// All rungs are injected STUBS via `VoiceMemoParseRouter.providerOverride` — no
+// real network / Ollama / agent. The real CloudParseProvider is a W1 stub
+// (unavailable), so the production chains are also exercised offline.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+// MARK: - Stub provider (controllable availability + canned/nil plan)
+
+private struct StubParseProvider: VoiceMemoParseProvider {
+    let provenance: ParseProvenance
+    let available: Bool
+    /// nil ⇒ this rung fails at runtime (returns nil from parse) even if available.
+    let yieldsPlan: Bool
+    /// Records that parse() was actually invoked (to assert short-circuit).
+    let onParse: (@Sendable () -> Void)?
+
+    init(
+        provenance: ParseProvenance,
+        available: Bool,
+        yieldsPlan: Bool,
+        onParse: (@Sendable () -> Void)? = nil
+    ) {
+        self.provenance = provenance
+        self.available = available
+        self.yieldsPlan = yieldsPlan
+        self.onParse = onParse
+    }
+
+    func isAvailable() -> Bool { available }
+
+    func parse(transcript: String, fallbackTitle: String, recordingPath: String) async -> VoiceMemoPlan? {
+        onParse?()
+        guard yieldsPlan else { return nil }
+        // Provenance is (re)stamped by the router from `self.provenance`; seed a
+        // distinct sentinel title so we can also confirm the winning rung's plan
+        // is the one returned.
+        return VoiceMemoPlan(
+            generatedTitle: "stub-\(provenance.rawValue)",
+            skipMemoryKeep: false,
+            summary: "s",
+            actions: [],
+            intents: [VoiceMemoIntent(kind: .review, confidence: 0.5)],
+            provenance: provenance,
+            degraded: false
+        )
+    }
+}
+
+/// A thread-safe invocation flag for short-circuit assertions.
+private final class InvocationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hit = false
+    func mark() { lock.lock(); hit = true; lock.unlock() }
+    var wasHit: Bool { lock.lock(); defer { lock.unlock() }; return hit }
+}
+
+// MARK: - Mode helper
+
+/// Set the curator mode in UserDefaults for the duration of `body`, then restore.
+/// Also force the local-Ollama routing flag OFF (and restore it) so the REAL
+/// production chain's `LocalParseProvider.isAvailable()` is deterministic
+/// regardless of suite order (an earlier suite that flipped the flag on must not
+/// leak into these tests). Stub-injected tests bypass `providers(for:)` so this
+/// is a no-op for them; real-chain tests rely on it.
+private func withCuratorMode(_ mode: VoiceMemoCuratorMode, _ body: () async -> Void) async {
+    let modeKey = BridgeDefaults.voiceMemoCuratorMode
+    let ollamaKey = BridgeDefaults.voiceMemoOllamaRouting
+    let priorMode = UserDefaults.standard.string(forKey: modeKey)
+    let priorOllama = UserDefaults.standard.object(forKey: ollamaKey)
+    UserDefaults.standard.set(mode.rawValue, forKey: modeKey)
+    UserDefaults.standard.set(false, forKey: ollamaKey)
+    defer {
+        if let priorMode { UserDefaults.standard.set(priorMode, forKey: modeKey) }
+        else { UserDefaults.standard.removeObject(forKey: modeKey) }
+        if let priorOllama { UserDefaults.standard.set(priorOllama, forKey: ollamaKey) }
+        else { UserDefaults.standard.removeObject(forKey: ollamaKey) }
+    }
+    await body()
+}
+
+func runVoiceMemoParseChainTests() async {
+    print("\n\u{1F3D4}\u{FE0F} Voice Memo Parse Chain Tests (FRONTIER-FIRST W1)")
+
+    // Always clear the override after each test block so production chains aren't
+    // affected by a leaked stub.
+    defer { VoiceMemoParseRouter.providerOverride = nil }
+
+    // ── providers(for:) chain order + shape per mode ──────────────────────────
+
+    await test("providers(.auto) is frontier-first: cloud → local → heuristic") {
+        let chain = VoiceMemoParseRouter.providers(for: .auto)
+        try expect(chain.map { $0.provenance } == [.cloud, .local, .heuristic],
+                   "auto chain must be [cloud, local, heuristic], got \(chain.map { $0.provenance })")
+    }
+
+    await test("providers(.cloud) is [cloud, heuristic]") {
+        let chain = VoiceMemoParseRouter.providers(for: .cloud)
+        try expect(chain.map { $0.provenance } == [.cloud, .heuristic],
+                   "cloud chain must be [cloud, heuristic], got \(chain.map { $0.provenance })")
+    }
+
+    await test("providers(.local) is [local, heuristic]") {
+        let chain = VoiceMemoParseRouter.providers(for: .local)
+        try expect(chain.map { $0.provenance } == [.local, .heuristic])
+    }
+
+    await test("providers(.heuristics) is [heuristic] only") {
+        let chain = VoiceMemoParseRouter.providers(for: .heuristics)
+        try expect(chain.map { $0.provenance } == [.heuristic])
+    }
+
+    await test("providers(.agent) is [heuristic] floor (agent parses out-of-process)") {
+        let chain = VoiceMemoParseRouter.providers(for: .agent)
+        try expect(chain.map { $0.provenance } == [.heuristic])
+    }
+
+    await test("every mode's chain ends in the heuristic floor") {
+        for mode in VoiceMemoCuratorMode.allCases {
+            let chain = VoiceMemoParseRouter.providers(for: mode)
+            try expect(chain.last?.provenance == .heuristic,
+                       "mode \(mode) chain must end in heuristic")
+        }
+    }
+
+    // ── parse(): winner selection + provenance stamp ──────────────────────────
+
+    await test(".auto picks Cloud when cloud is available + yields") {
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: true, yieldsPlan: true),
+            StubParseProvider(provenance: .local, available: true, yieldsPlan: true),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true),
+        ] }
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "hello", fallbackTitle: "F")
+            // Note: assertions inside an async closure can't `throw` out to `test`,
+            // so funnel through a captured flag checked after.
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .cloud, "expected cloud winner, got \(String(describing: chainResult?.0))")
+        try expect(chainResult?.1 == false, "no earlier available rung failed ⇒ not degraded")
+        try expect(chainResult?.2 == "stub-cloud", "cloud rung's plan must be returned")
+    }
+
+    await test(".auto degrades to Local when cloud available but returns nil") {
+        let cloudHit = InvocationFlag()
+        let localHit = InvocationFlag()
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: true, yieldsPlan: false, onParse: { cloudHit.mark() }),
+            StubParseProvider(provenance: .local, available: true, yieldsPlan: true, onParse: { localHit.mark() }),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true),
+        ] }
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "hello", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(cloudHit.wasHit, "cloud parse() should have been attempted")
+        try expect(localHit.wasHit, "local parse() should have been attempted after cloud nil")
+        try expect(chainResult?.0 == .local, "expected local winner")
+        try expect(chainResult?.1 == true, "an earlier AVAILABLE rung returned nil ⇒ degraded")
+    }
+
+    await test(".auto skips UNavailable cloud without marking degraded") {
+        let cloudHit = InvocationFlag()
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: false, yieldsPlan: true, onParse: { cloudHit.mark() }),
+            StubParseProvider(provenance: .local, available: true, yieldsPlan: true),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true),
+        ] }
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "hello", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(!cloudHit.wasHit, "an UNavailable rung must NOT have parse() called")
+        try expect(chainResult?.0 == .local, "expected local winner (cloud unavailable)")
+        try expect(chainResult?.1 == false, "skipping an UNavailable rung is NOT a degrade")
+    }
+
+    await test(".auto falls to Heuristic floor when cloud+local both fail (degraded)") {
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: true, yieldsPlan: false),
+            StubParseProvider(provenance: .local, available: true, yieldsPlan: false),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true),
+        ] }
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "hello", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .heuristic, "expected heuristic floor winner")
+        try expect(chainResult?.1 == true, "two earlier available rungs failed ⇒ degraded")
+    }
+
+    await test("winner short-circuits: later rungs' parse() not called") {
+        let localHit = InvocationFlag()
+        let heuristicHit = InvocationFlag()
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: true, yieldsPlan: true),
+            StubParseProvider(provenance: .local, available: true, yieldsPlan: true, onParse: { localHit.mark() }),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true, onParse: { heuristicHit.mark() }),
+        ] }
+        await withCuratorMode(.auto) {
+            _ = await VoiceMemoParseRouter.parse(transcript: "hello", fallbackTitle: "F")
+        }
+        try expect(!localHit.wasHit, "local parse() must not run once cloud wins")
+        try expect(!heuristicHit.wasHit, "heuristic parse() must not run once cloud wins")
+    }
+
+    // ── mode-specific routing ────────────────────────────────────────────────
+
+    await test(".heuristics resolves to the floor (provenance .heuristic, not degraded)") {
+        // Real production chain (override nil) — heuristics mode is floor-only.
+        VoiceMemoParseRouter.providerOverride = nil
+        await withCuratorMode(.heuristics) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "remind me to call Bob", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .heuristic, "heuristics mode must produce .heuristic provenance")
+        try expect(chainResult?.1 == false, "floor-only chain is never degraded")
+    }
+
+    await test(".agent in-process preview resolves to the heuristic floor") {
+        VoiceMemoParseRouter.providerOverride = nil
+        await withCuratorMode(.agent) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "just some note", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .heuristic, "agent in-process preview uses the floor")
+        try expect(chainResult?.1 == false)
+    }
+
+    await test(".auto with the REAL stub cloud (unavailable) falls through offline") {
+        // The W1 CloudParseProvider is a stub (isAvailable==false). With no Ollama
+        // model configured in the hermetic test env, Local is also unavailable, so
+        // production .auto must land on the heuristic floor with NO degrade
+        // (unavailable rungs don't degrade).
+        VoiceMemoParseRouter.providerOverride = nil
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParseRouter.parse(transcript: "remind me to ship", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .heuristic, "real .auto chain falls to heuristic offline")
+        try expect(chainResult?.1 == false, "stub-unavailable cloud is skipped, not a degrade")
+    }
+
+    // ── heuristic floor guarantees ───────────────────────────────────────────
+
+    await test("HeuristicParseProvider is always available and never nil") {
+        let h = HeuristicParseProvider()
+        try expect(h.isAvailable(), "heuristic must always be available")
+        let plan = await h.parse(transcript: "remind me to water plants", fallbackTitle: "F", recordingPath: "")
+        try expect(plan != nil, "heuristic must never return nil")
+        try expect(plan?.provenance == .heuristic, "heuristic stamps .heuristic")
+        try expect(plan?.intents.isEmpty == false, "heuristic always yields ≥1 intent")
+    }
+
+    await test("CloudParseProvider is a W1 stub: unavailable + nil") {
+        let c = CloudParseProvider()
+        try expect(!c.isAvailable(), "W1 cloud stub must be unavailable")
+        let plan = await c.parse(transcript: "x", fallbackTitle: "F", recordingPath: "")
+        try expect(plan == nil, "W1 cloud stub must return nil")
+        try expect(c.provenance == .cloud, "cloud provenance is .cloud even as a stub")
+    }
+
+    await test("VoiceMemoPlan defaults provenance .heuristic + not degraded") {
+        // Locks the model default so every pre-existing constructor stays heuristic.
+        let plan = VoiceMemoPlan(generatedTitle: "T", skipMemoryKeep: false, summary: "s", actions: [], intents: [])
+        try expect(plan.provenance == .heuristic, "default provenance must be .heuristic")
+        try expect(plan.degraded == false, "default degraded must be false")
+    }
+
+    await test("ParseProvenance is Codable round-trip for all cases") {
+        for p in [ParseProvenance.agent, .cloud, .local, .heuristic] {
+            let data = try JSONEncoder().encode(p)
+            let back = try JSONDecoder().decode(ParseProvenance.self, from: data)
+            try expect(back == p, "round-trip failed for \(p)")
+        }
+    }
+
+    await test("parseWithOptionalOllama shim routes through the chain (provenance stamped)") {
+        // The retained shim must now yield a provenance-stamped plan (chain walk),
+        // proving processOne / ReviewResolver callers also get FRONTIER-FIRST.
+        VoiceMemoParseRouter.providerOverride = { _ in [
+            StubParseProvider(provenance: .cloud, available: true, yieldsPlan: true),
+            StubParseProvider(provenance: .heuristic, available: true, yieldsPlan: true),
+        ] }
+        await withCuratorMode(.auto) {
+            let plan = await VoiceMemoParser.parseWithOptionalOllama(transcript: "hi", fallbackTitle: "F")
+            chainResult = (plan.provenance, plan.degraded, plan.generatedTitle)
+        }
+        try expect(chainResult?.0 == .cloud, "shim must stamp the winning rung's provenance")
+        VoiceMemoParseRouter.providerOverride = nil
+    }
+}
+
+// File-scope sink for async-closure results (the harness `test` closure can't
+// receive a throw raised inside a nested `await body()` closure). Each test
+// writes here inside `withCuratorMode`, then asserts after the closure returns.
+private nonisolated(unsafe) var chainResult: (ParseProvenance, Bool, String)?

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1515,7 +1515,14 @@ set -euo pipefail
 # edited-pin preserved). runMemoryHubMemoTitleReviewRemediationTests. 2599 passed / 0 failed.
 # v3.8.3 release (2026-06-26): rebased onto origin/main (standing-orders init contract, afbad0d); combined
 # harness re-measured = 2602 (2599 PKT-MEM-114 branch + 3 init-contract net-new). make test 2602 / 0 failed.
-FLOOR="${BRIDGE_TEST_FLOOR:-2602}"
+# Voice Curator FRONTIER-FIRST W1 (2026-06-26): +19 net-new green — parse provider-chain abstraction +
+# plan provenance/degraded model (runVoiceMemoParseChainTests): providers(for:) chain ORDER per curator mode,
+# .auto frontier-first Cloud→Local→Heuristic winner selection by availability, degraded set IFF an earlier
+# AVAILABLE rung returned nil, heuristic floor always-available/never-nil, provenance stamp, .agent/.heuristics
+# → floor, W1 Cloud stub unavailable+nil, parseWithOptionalOllama shim routes through the chain, ParseProvenance
+# Codable + VoiceMemoPlan default-field lock. Stub providers injected via VoiceMemoParseRouter.providerOverride
+# (no real network/Ollama/agent). make test 2621 / 0 failed.
+FLOOR="${BRIDGE_TEST_FLOOR:-2621}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
> 🚧 **Draft / in progress** — a background workflow is actively implementing this branch (W1 landed; **W2 cloud-parse + W3 UX are in flight**). **Do not merge yet.** The author will mark it ready only after the full sprint is green, the version is bumped to **3.8.4/64**, and a trust-path diff review passes.

## What & why
Inverts the Voice Curator's **Understand** step from local-first to **frontier-first** with graceful degradation + provenance. The connected MCP agent (zero marginal API cost) or a cloud API parses intents *first*; local Ollama / heuristics are the in-a-pinch fallback. Also fixes the cockpit UX issues found during on-device testing (transcript truncation, clipped titles, invisible on-select transcription, internal-jargon labels).

## Waves
- **W1 — landed (`b02dbf1`):** `VoiceMemoParseRouter` + `VoiceMemoParseProvider` chain. `.auto` walks `[cloud → local → heuristic]` frontier-first with per-rung `isAvailable()` probes + graceful fall-through; new `VoiceMemoPlan.provenance` + `degraded`; `VoiceMemoProcessor.buildPlan` re-pointed onto the router.
- **W2 — in flight:** `MemoryHubCloudParse` — whole-transcript structured-JSON intent extraction on the existing `CloudChatTransport`. The 4000-char parser cap becomes a *local-only* artifact (frontier one-shots the whole transcript → long memos handled).
- **W3 — in flight:** cockpit UX — full scrollable transcript, full title, on-select "transcribing on-device" state, human labels (no more `registry_update` / `suppressed`), commit-value preview, provenance badge.
- **Review + remediate:** 5 adversarial lenses — trust non-regression · privacy (transcript→cloud) · fallback-safety · provenance correctness · design-critique.

## Trust
The chain only changes **who parses**; the produced `VoiceMemoIntent`s feed the **unchanged** election (lane-priority-first), processed-gate, guardrails, and append-only commit. No new MCP tools (`staticFeatureModuleToolCount` stays 187). The `.agent` defer path is untouched.

## Deferred to Phase 2 (explicitly, not papered over)
Local-rung map-reduce chunking for long transcripts (frontier large-context covers them now); cost/quota metering UI; the heavier 3-column layout redesign; the MCP-*client* interpretation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
