### PR TITLE
feat(memory): Wave 3 surfacing + governance (PKT-MEM-115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.9.0 — Unified Memory Wave 3 (surfacing + governance) — PKT-MEM-115
+
+- **Handshake memory inject** — Settings toggle (global OFF default); per-client overrides with Cursor launch-seeded ON; stdio `clientName` pass-through for per-client inject resolution.
+- **Memory-rides-routing** — `fetch_skill` returns optional `scopedMemory` appendix (post-cache merge; parent→scope map + intent recall).
+- **Agent memory UI** — pin/forget on Memory → Agent tab; provenance (`source` + date) in inject, recall, and appendix rows via `MemoryRowFormatter`.
+- **Lifecycle unchanged** — `reference` 90-day sweep + explicit TTL only; voice-memo `reference` behavior documented in UI.
+- test-floor 2667 → **2682** (+15 net-new, PKT-MEM-115 Wave 3, 2026-06-26). `staticFeatureModuleToolCount` unchanged (187).
+
 ## v3.8.5 — Sparkle staged-update triage (PKT-932)
 
 - **Sparkle resilience (PKT-932)** — fix a fragile `as!` delegate cast in Settings → Advanced that could trap during staged Sparkle updates; add operator triage doc (`docs/bridge/sparkle-triage.md`). No new MCP tools; test-floor unchanged (2667). Ships the PKT-932 fix merged post-v3.8.4 tag during release integration.

--- a/TheBridge/App/AppDelegate.swift
+++ b/TheBridge/App/AppDelegate.swift
@@ -294,6 +294,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             print("[PathMigration] WARNING: migration failed: \(error)")
         }
 
+        // PKT-MEM-115 Wave 3: fresh installs seed per-client Cursor inject ON.
+        MemoryAutoInjectClientStore.seedWave3DefaultsIfNeeded()
+
         // PKT-977 Wave 2: demote stale reference memories on launch (best-effort).
         Task {
             do {

--- a/TheBridge/Modules/MemoryRoutingAppendix.swift
+++ b/TheBridge/Modules/MemoryRoutingAppendix.swift
@@ -1,0 +1,76 @@
+// MemoryRoutingAppendix.swift — fetch_skill scopedMemory appendix (PKT-MEM-115)
+// TheBridge · Modules
+
+import Foundation
+import MCP
+
+/// Builds and attaches task-scoped memory to `fetch_skill` envelopes (post-cache).
+public enum MemoryRoutingAppendix {
+    /// Attach `scopedMemory` when hits exist; omit key on zero hits or error envelopes.
+    public static func attach(
+        to result: Value,
+        parent rawName: String,
+        intent: String?,
+        store: MemoryStore = .shared
+    ) async -> Value {
+        guard case .object(var obj) = result else { return result }
+        if obj["error"] != nil { return result }
+
+        let parent = MemoryRoutingScopeMap.parentSlug(from: rawName)
+        guard let appendix = await build(parent: parent, intent: intent, store: store) else {
+            return result
+        }
+        obj["scopedMemory"] = appendix
+        return .object(obj)
+    }
+
+    /// Build the appendix object, or nil when no memories match.
+    public static func build(
+        parent: String,
+        intent: String?,
+        store: MemoryStore = .shared
+    ) async -> Value? {
+        let scopes = MemoryRoutingScopeMap.scopes(for: parent)
+        do {
+            try await store.open()
+            let allLive = try await store.list(scope: nil, entity: nil)
+            let entityHint = MemoryRoutingScopeMap.extractEntityHint(
+                from: intent,
+                scopes: scopes,
+                liveEntities: MemoryRoutingScopeMap.liveEntities(in: scopes, from: allLive)
+            )
+            let query = intent?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            var collected: [MemoryEntry] = []
+            var seen = Set<String>()
+            for scope in scopes {
+                let batch = try await store.recall(
+                    query: query,
+                    scope: scope,
+                    entity: entityHint,
+                    limit: 3
+                )
+                for entry in batch where seen.insert(entry.id).inserted {
+                    collected.append(entry)
+                }
+                if collected.count >= 5 { break }
+            }
+            let entries = Array(collected.prefix(5))
+            guard !entries.isEmpty else { return nil }
+
+            let primaryScope = scopes.first ?? "global"
+            let markdownBody = entries.map(MemoryRowFormatter.rowLine).joined(separator: "\n")
+            let markdown = "### Scoped memory (\(primaryScope))\n\(markdownBody)"
+
+            return .object([
+                "parent": .string(parent),
+                "intent": .string(intent ?? ""),
+                "scopesQueried": .array(scopes.map { .string($0) }),
+                "count": .int(entries.count),
+                "markdown": .string(markdown),
+            ])
+        } catch {
+            return nil
+        }
+    }
+}

--- a/TheBridge/Modules/MemoryRoutingScopeMap.swift
+++ b/TheBridge/Modules/MemoryRoutingScopeMap.swift
@@ -66,11 +66,12 @@ public enum MemoryRoutingScopeMap {
 
         guard !tokens.isEmpty else { return nil }
 
-        let scopedEntities = liveEntities
-        for token in tokens where scopedEntities.contains(token) {
+        for token in tokens where liveEntities.contains(token) {
             return token
         }
-        return tokens.first
+        // Only filter by entity when a token matches a live row — avoids
+        // false-positive entity filters from verb-adjacent slug tokens.
+        return nil
     }
 
     /// Collect distinct non-empty entity strings for the given scopes.

--- a/TheBridge/Modules/MemoryRoutingScopeMap.swift
+++ b/TheBridge/Modules/MemoryRoutingScopeMap.swift
@@ -1,0 +1,88 @@
+// MemoryRoutingScopeMap.swift — keeper parent → memory scope map (PKT-MEM-115)
+// TheBridge · Modules
+
+import Foundation
+
+/// Maps `fetch_skill` parent slugs to agent-memory scopes for the routing appendix.
+public enum MemoryRoutingScopeMap {
+    public struct ScopePair: Sendable, Equatable {
+        public var primary: String
+        public var secondary: String?
+
+        public init(primary: String, secondary: String? = nil) {
+            self.primary = primary
+            self.secondary = secondary
+        }
+    }
+
+    private static let table: [String: ScopePair] = [
+        "focus-keepr": ScopePair(primary: "project", secondary: "global"),
+        "project-keepr": ScopePair(primary: "project", secondary: "global"),
+        "people-keepr": ScopePair(primary: "people"),
+        "mac-keepr": ScopePair(primary: "mac"),
+        "notion-keepr": ScopePair(primary: "skill", secondary: "project"),
+        "time-keepr": ScopePair(primary: "time"),
+        "skill-keepr": ScopePair(primary: "skill"),
+        "executor": ScopePair(primary: "project", secondary: "global"),
+    ]
+
+    private static let entityDenylist: Set<String> = [
+        "make", "install", "copy", "build", "test", "run", "the", "bridge", "keep",
+        "fetch", "skill", "open", "use", "for", "and", "with", "from", "this", "that",
+        "when", "what", "how", "help", "need", "want", "into", "onto", "over", "under",
+    ]
+
+    /// Parent slug from `fetch_skill` `name` (segment before first `/`).
+    public static func parentSlug(from rawName: String) -> String {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let slash = trimmed.firstIndex(of: "/") else { return trimmed }
+        return String(trimmed[..<slash])
+    }
+
+    public static func scopes(for parentSlug: String) -> [String] {
+        let key = parentSlug.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let pair = table[key] {
+            if let secondary = pair.secondary {
+                return [pair.primary, secondary]
+            }
+            return [pair.primary]
+        }
+        return ["global"]
+    }
+
+    /// Slug-like tokens from intent, minus common verbs; prefers a live entity match.
+    public static func extractEntityHint(
+        from intent: String?,
+        scopes: [String],
+        liveEntities: Set<String>
+    ) -> String? {
+        guard let intent, !intent.isEmpty else { return nil }
+        let normalized = intent.lowercased()
+        let tokens = normalized
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "-" })
+            .map(String.init)
+            .filter { $0.count >= 3 && $0.range(of: #"^[a-z0-9-]+$"#, options: .regularExpression) != nil }
+            .filter { !entityDenylist.contains($0) }
+
+        guard !tokens.isEmpty else { return nil }
+
+        let scopedEntities = liveEntities
+        for token in tokens where scopedEntities.contains(token) {
+            return token
+        }
+        return tokens.first
+    }
+
+    /// Collect distinct non-empty entity strings for the given scopes.
+    public static func liveEntities(in scopes: [String], from entries: [MemoryEntry]) -> Set<String> {
+        let scopeSet = Set(scopes.map { $0.lowercased() })
+        var result = Set<String>()
+        for entry in entries {
+            guard scopeSet.contains(entry.scope.lowercased()),
+                  let entity = entry.entity?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !entity.isEmpty else { continue }
+            result.insert(entity.lowercased())
+        }
+        return result
+    }
+}

--- a/TheBridge/Modules/MemoryRowFormatter.swift
+++ b/TheBridge/Modules/MemoryRowFormatter.swift
@@ -1,0 +1,57 @@
+// MemoryRowFormatter.swift — shared markdown rows for memory surfaces (PKT-MEM-115)
+// TheBridge · Modules
+
+import Foundation
+
+/// Pure formatter for agent-memory markdown rows. Used by handshake inject,
+/// `bridge://memory`, and `fetch_skill` `scopedMemory` appendix.
+public enum MemoryRowFormatter {
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .iso8601)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// One bullet row: type, text, optional entity, source, created date, use count.
+    public static func rowLine(_ entry: MemoryEntry) -> String {
+        var row = "- [\(entry.type.rawValue)] \(entry.text)"
+        if let entity = entry.entity?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !entity.isEmpty {
+            row += " · \(entity)"
+        }
+        let source = entry.source.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !source.isEmpty {
+            row += " · source: \(source)"
+        }
+        row += " · \(dayFormatter.string(from: entry.createdAt))"
+        if entry.useCount > 0 {
+            row += " · used \(entry.useCount)×"
+        }
+        return row
+    }
+
+    /// Grouped-by-scope markdown (pinned-first order preserved from input slice).
+    public static func markdown(_ entries: [MemoryEntry]) -> String {
+        guard !entries.isEmpty else { return "No memories stored yet." }
+
+        var scopeOrder: [String] = []
+        var byScope: [String: [MemoryEntry]] = [:]
+        for entry in entries {
+            if byScope[entry.scope] == nil { scopeOrder.append(entry.scope) }
+            byScope[entry.scope, default: []].append(entry)
+        }
+
+        var sections: [String] = []
+        for scope in scopeOrder {
+            var lines = ["## \(scope)"]
+            for entry in byScope[scope] ?? [] {
+                lines.append(rowLine(entry))
+            }
+            sections.append(lines.joined(separator: "\n"))
+        }
+        return sections.joined(separator: "\n\n")
+    }
+}

--- a/TheBridge/Modules/MemoryStore.swift
+++ b/TheBridge/Modules/MemoryStore.swift
@@ -581,6 +581,12 @@ public actor MemoryStore {
 
     /// On-launch catch-up: demote-not-delete stale `reference` rows and tombstone
     /// any row whose explicit `expiresAt` is in the past. Pinned rows are never swept.
+    ///
+    /// Lifecycle policy (PKT-MEM-115 / MEMORY-WAVE3-SURFACING-SPEC v2.0):
+    /// `decision` and `preference` rows have no default TTL; `reference` rows unused
+    /// for ~90 days are tombstoned; explicit `ttlSeconds` on remember sets `expiresAt`.
+    /// Passive surfaces (`handshakeSlice`, `bridge://memory`) never use-promote;
+    /// `recall` and `fetch_skill` `scopedMemory` do promote returned rows.
     public func consolidationSweep(now: Date = Date()) throws -> ConsolidationReport {
         try ensureOpen()
         var referenceDemoted = 0

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -74,7 +74,11 @@ public enum SkillsModule {
     specialist it returns. When the sub-task changes, re-route with a fresh \
     intent. If fetch_skill returns a `disambiguate` annotation, pick from its \
     `candidates` (fetch_skill('parent/<name>')) rather than guessing; a \
-    `routingFooter` names the sibling specialists you can switch to.
+    `    routingFooter` names the sibling specialists you can switch to.
+    After `fetch_skill(parent, intent:)`, read `scopedMemory.markdown` when \
+    present and treat it as grounding for this sub-task only — re-fetch when \
+    the intent changes (scope map uses the parent slug from `name`, not a \
+    resolved specialist title).
     Capture disambiguation: when something should be DONE for the user, use \
     reminders_create (a real Apple/iCloud reminder the user will see); when \
     something should be KNOWN by the agent for later, use the memory/remember \
@@ -283,7 +287,11 @@ public enum SkillsModule {
                         )
                         // fb-resultsize: apply the optional section selector
                         // to the file-source envelope's rendered `content`.
-                        return Self.applySectionToEnvelope(fileEnvelope, section: sectionArg)
+                        return await MemoryRoutingAppendix.attach(
+                            to: Self.applySectionToEnvelope(fileEnvelope, section: sectionArg),
+                            parent: name,
+                            intent: intentArg
+                        )
                     }
                     let closeMatches = closestSkillMatches(for: name)
                     let allSkills = listAvailableSkillNames()
@@ -310,7 +318,11 @@ public enum SkillsModule {
                 let cacheKey = "\(name.lowercased())|n=\(includeNested)|mb=\(maxBlocks)|md=\(maxDepth)|meta=\(skillConfig.metadataCacheToken)\(pathSelectorKey)\(sectionKey)"
 
                 if let cached = await cache.get(cacheKey) {
-                    return cached
+                    return await MemoryRoutingAppendix.attach(
+                        to: cached,
+                        parent: name,
+                        intent: intentArg
+                    )
                 }
 
                 guard skillConfig.enabled else {
@@ -385,7 +397,11 @@ public enum SkillsModule {
                             )
                         }
                     }
-                    return result
+                    return await MemoryRoutingAppendix.attach(
+                        to: result,
+                        parent: name,
+                        intent: intentArg
+                    )
                 }
 
                 // Fetch from Notion API
@@ -530,8 +546,11 @@ public enum SkillsModule {
                         try? await bodyStore.write(entry)
                     }
 
-                    return result
-
+                    return await MemoryRoutingAppendix.attach(
+                        to: result,
+                        parent: name,
+                        intent: intentArg
+                    )
                 } catch let error as NotionClientError {
                     // F10: 403 handling — structured error + "Access Lost" badge
                     if case .httpError(let code, let msg) = error, code == 403 {

--- a/TheBridge/Modules/StandingOrders/StandingOrdersDelivery.swift
+++ b/TheBridge/Modules/StandingOrders/StandingOrdersDelivery.swift
@@ -375,35 +375,7 @@ public enum StandingOrdersDelivery {
     /// `· used N×` segment omitted when useCount is 0. An empty slice renders a
     /// single one-line notice.
     public static func renderMemoryMarkdown(_ entries: [MemoryEntry]) -> String {
-        guard !entries.isEmpty else { return "No memories stored yet." }
-
-        // Stable scope ordering = first appearance in the (already-ranked)
-        // slice, so the highest-salience scope leads. Pinned-first is preserved
-        // because handshakeSlice emits pinned rows ahead of the rest.
-        var scopeOrder: [String] = []
-        var byScope: [String: [MemoryEntry]] = [:]
-        for e in entries {
-            if byScope[e.scope] == nil { scopeOrder.append(e.scope) }
-            byScope[e.scope, default: []].append(e)
-        }
-
-        var sections: [String] = []
-        for scope in scopeOrder {
-            var lines = ["## \(scope)"]
-            for e in byScope[scope] ?? [] {
-                var row = "- [\(e.type.rawValue)] \(e.text)"
-                if let entity = e.entity?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !entity.isEmpty {
-                    row += " · \(entity)"
-                }
-                if e.useCount > 0 {
-                    row += " · used \(e.useCount)×"
-                }
-                lines.append(row)
-            }
-            sections.append(lines.joined(separator: "\n"))
-        }
-        return sections.joined(separator: "\n\n")
+        MemoryRowFormatter.markdown(entries)
     }
 }
 
@@ -561,5 +533,14 @@ public final class MemoryAutoInjectClientStore: @unchecked Sendable {
     /// Test/diagnostic reset — clears all per-client overrides.
     public func resetForTesting() {
         defaults.removeObject(forKey: defaultsKey)
+    }
+
+    /// PKT-MEM-115 Wave 3: seed Cursor ON when the override map is empty and
+    /// global inject is OFF. Idempotent — does not overwrite operator edits.
+    public static func seedWave3DefaultsIfNeeded() {
+        let store = shared
+        guard store.allOverrides().isEmpty,
+              !BridgeDefaults.memoryHandshakeAutoInjectEffective else { return }
+        store.setOverride(true, forClient: "cursor")
     }
 }

--- a/TheBridge/Server/ServerManager.swift
+++ b/TheBridge/Server/ServerManager.swift
@@ -243,7 +243,7 @@ public actor ServerManager {
         // operator enables memory auto-inject the stdio client also receives
         // the salient memory slice at handshake. Default-OFF behaviour is
         // byte-identical to the sync path.
-        let composition = await StandingOrdersDelivery.asyncComposition(clientName: nil)
+        let composition = await StandingOrdersDelivery.asyncComposition(clientName: "stdio")
         let composedInstructions = composition.instructionsMarkdown
 
         // W2 telemetry: record the handshake we composed + shipped on the

--- a/TheBridge/UI/BridgeShell.swift
+++ b/TheBridge/UI/BridgeShell.swift
@@ -202,6 +202,20 @@ public enum BridgeAXID {
         public static let agentScopeFilter = id("agent.filter.scope")
         /// Agent type filter menu.
         public static let agentTypeFilter  = id("agent.filter.type")
+        /// Pin / unpin on an agent memory row.
+        public static let agentPinButton   = id("agent.pin")
+        /// Soft-forget on an agent memory row.
+        public static let agentForgetButton = id("agent.forget")
+        /// Surfacing settings card (inject controls).
+        public static let surfacingCard    = id("agent.surfacing")
+        /// Global handshake inject toggle.
+        public static let injectGlobalToggle = id("agent.inject.global")
+        /// New per-client override name field.
+        public static let injectClientNameField = id("agent.inject.clientName")
+        /// Add per-client override button.
+        public static let injectAddOverride = id("agent.inject.add")
+        /// Remove per-client override button (shared id).
+        public static let injectRemoveOverride = id("agent.inject.remove")
         // Pre-cockpit Process ids (process.list/preview/pipeline/dryRun/execute) were removed:
         // the PKT-MEM-106 0b cockpit replaced them with the `Process.*` nested enum below, and
         // they were orphaned (no view/test/manifest references).

--- a/TheBridge/UI/Sections/MemoryAgentTab.swift
+++ b/TheBridge/UI/Sections/MemoryAgentTab.swift
@@ -1,5 +1,5 @@
-// MemoryAgentTab.swift — Settings → Memory → Agent tab (PKT-MEM-104)
-// TheBridge · UI · Sections · read-only MemoryStore list
+// MemoryAgentTab.swift — Settings → Memory → Agent tab (PKT-MEM-104 + PKT-MEM-115)
+// TheBridge · UI · Sections
 
 import SwiftUI
 
@@ -9,6 +9,7 @@ public struct MemoryAgentTab: View {
     @State private var busy = false
     @State private var scopeFilter: ScopeFilter = .all
     @State private var typeFilter: TypeFilter = .all
+    @State private var forgetTarget: MemoryEntry?
 
     public enum ScopeFilter: String, CaseIterable, Identifiable {
         case all, global, mac, project, people, skill, time
@@ -42,11 +43,21 @@ public struct MemoryAgentTab: View {
         }
     }
 
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .iso8601)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
     public init() {}
 
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: BridgeTokens.Space.cardGap) {
+                MemorySurfacingSettingsCard()
                 filterBar
                 if !status.isEmpty {
                     Text(status)
@@ -70,6 +81,26 @@ public struct MemoryAgentTab: View {
             if busy {
                 ProgressView()
                     .controlSize(.small)
+            }
+        }
+        .confirmationDialog(
+            "Forget this memory?",
+            isPresented: Binding(
+                get: { forgetTarget != nil },
+                set: { if !$0 { forgetTarget = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Forget", role: .destructive) {
+                if let target = forgetTarget {
+                    Task { await forgetEntry(target) }
+                }
+                forgetTarget = nil
+            }
+            Button("Cancel", role: .cancel) { forgetTarget = nil }
+        } message: {
+            if let target = forgetTarget {
+                Text("“\(target.text)” will be soft-deleted and removed from recall and export.")
             }
         }
         .task { await reload() }
@@ -102,7 +133,7 @@ public struct MemoryAgentTab: View {
         BridgeGlassCard {
             VStack(alignment: .leading, spacing: 8) {
                 BridgeCardLabel("No agent memories")
-                Text("Agent memories saved via memory_remember appear here. This view is read-only.")
+                Text("Memories saved via memory_remember appear here. Pin important rows or forget stale ones — no inline editing.")
                     .font(BridgeTokens.Typeface.sub)
                     .foregroundStyle(BridgeTokens.fg4)
                     .fixedSize(horizontal: false, vertical: true)
@@ -133,14 +164,60 @@ public struct MemoryAgentTab: View {
                             .foregroundStyle(BridgeTokens.fg4)
                             .lineLimit(1)
                     }
+                    if !entry.source.isEmpty {
+                        Text("source: \(entry.source)")
+                            .font(BridgeTokens.Typeface.meta)
+                            .foregroundStyle(BridgeTokens.fg4)
+                            .lineLimit(1)
+                    }
+                    Text(Self.dayFormatter.string(from: entry.createdAt))
+                        .font(BridgeTokens.Typeface.meta)
+                        .foregroundStyle(BridgeTokens.fg4)
                     Spacer(minLength: 0)
                     Text("Used \(entry.useCount)×")
                         .font(BridgeTokens.Typeface.meta)
                         .foregroundStyle(BridgeTokens.fg4)
                 }
+                HStack(spacing: 10) {
+                    Button(entry.pinned ? "Unpin" : "Pin") {
+                        Task { await togglePin(entry) }
+                    }
+                    .accessibilityIdentifier(BridgeAXID.Memory.agentPinButton)
+                    Button("Forget", role: .destructive) {
+                        forgetTarget = entry
+                    }
+                    .accessibilityIdentifier(BridgeAXID.Memory.agentForgetButton)
+                    Spacer(minLength: 0)
+                }
             }
         }
         .accessibilityIdentifier(BridgeAXID.Memory.agentRow)
+    }
+
+    private func togglePin(_ entry: MemoryEntry) async {
+        busy = true
+        defer { busy = false }
+        do {
+            let store = MemoryStore.shared
+            try await store.open()
+            try await store.pin(id: entry.id, !entry.pinned)
+            await reload()
+        } catch {
+            status = "Could not update pin: \(error.localizedDescription)"
+        }
+    }
+
+    private func forgetEntry(_ entry: MemoryEntry) async {
+        busy = true
+        defer { busy = false }
+        do {
+            let store = MemoryStore.shared
+            try await store.open()
+            try await store.forget(id: entry.id)
+            await reload()
+        } catch {
+            status = "Could not forget memory: \(error.localizedDescription)"
+        }
     }
 
     private func reload() async {
@@ -152,6 +229,10 @@ public struct MemoryAgentTab: View {
             var list = try await store.list(scope: scopeFilter.scopeValue)
             if typeFilter != .all, let t = typeFilter.entryType {
                 list = list.filter { $0.type == t }
+            }
+            list.sort { lhs, rhs in
+                if lhs.pinned != rhs.pinned { return lhs.pinned }
+                return lhs.lastUsedAt > rhs.lastUsedAt
             }
             entries = list
             status = entries.isEmpty

--- a/TheBridge/UI/Sections/MemorySurfacingSettingsCard.swift
+++ b/TheBridge/UI/Sections/MemorySurfacingSettingsCard.swift
@@ -1,0 +1,110 @@
+// MemorySurfacingSettingsCard.swift — handshake inject controls (PKT-MEM-115)
+// TheBridge · UI · Sections
+
+import SwiftUI
+
+public struct MemorySurfacingSettingsCard: View {
+    @AppStorage(BridgeDefaults.memoryHandshakeAutoInject) private var globalInject = false
+    @State private var overrides: [String: Bool] = [:]
+    @State private var newClientName = ""
+
+    public init() {}
+
+    public var body: some View {
+        BridgeGlassCard {
+            VStack(alignment: .leading, spacing: 12) {
+                BridgeCardLabel("Handshake memory inject")
+                Text("Append salient agent memories to the MCP initialize instructions. Global default is off; Cursor is seeded on for new installs.")
+                    .font(BridgeTokens.Typeface.sub)
+                    .foregroundStyle(BridgeTokens.fg3)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Toggle("Inject for all clients", isOn: $globalInject)
+                    .accessibilityIdentifier(BridgeAXID.Memory.injectGlobalToggle)
+
+                if !overrides.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Per-client overrides")
+                            .font(BridgeTokens.Typeface.meta)
+                            .foregroundStyle(BridgeTokens.fg4)
+                        ForEach(overrides.keys.sorted(), id: \.self) { client in
+                            overrideRow(client: client)
+                        }
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    TextField("Client name (e.g. cursor)", text: $newClientName)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityIdentifier(BridgeAXID.Memory.injectClientNameField)
+                    Button("Add override") { addOverride() }
+                        .disabled(newClientName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .accessibilityIdentifier(BridgeAXID.Memory.injectAddOverride)
+                }
+
+                Text("MCP client names come from initialize clientInfo.name. Voice-memo agent_memory rows use type reference and may expire after 90 days without use.")
+                    .font(BridgeTokens.Typeface.meta)
+                    .foregroundStyle(BridgeTokens.fg4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityIdentifier(BridgeAXID.Memory.surfacingCard)
+        .onAppear(perform: reloadOverrides)
+        .onChange(of: globalInject) { _, _ in reloadOverrides() }
+    }
+
+    private func overrideRow(client: String) -> some View {
+        HStack(spacing: 10) {
+            Text(client)
+                .font(BridgeTokens.Typeface.sub)
+                .foregroundStyle(BridgeTokens.fg2)
+            Spacer(minLength: 8)
+            Picker("Override", selection: binding(for: client)) {
+                Text("Force ON").tag(OverrideChoice.on)
+                Text("Force OFF").tag(OverrideChoice.off)
+            }
+            .pickerStyle(.menu)
+            .frame(maxWidth: 140)
+            Button("Remove") { removeOverride(client) }
+                .accessibilityIdentifier(BridgeAXID.Memory.injectRemoveOverride)
+        }
+    }
+
+    private enum OverrideChoice: String {
+        case on, off
+    }
+
+    private func binding(for client: String) -> Binding<OverrideChoice> {
+        Binding(
+            get: {
+                (overrides[client] ?? true) ? .on : .off
+            },
+            set: { choice in
+                switch choice {
+                case .on:
+                    MemoryAutoInjectClientStore.shared.setOverride(true, forClient: client)
+                case .off:
+                    MemoryAutoInjectClientStore.shared.setOverride(false, forClient: client)
+                }
+                reloadOverrides()
+            }
+        )
+    }
+
+    private func reloadOverrides() {
+        overrides = MemoryAutoInjectClientStore.shared.allOverrides()
+    }
+
+    private func addOverride() {
+        let name = newClientName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        MemoryAutoInjectClientStore.shared.setOverride(true, forClient: name)
+        newClientName = ""
+        reloadOverrides()
+    }
+
+    private func removeOverride(_ client: String) {
+        MemoryAutoInjectClientStore.shared.setOverride(nil, forClient: client)
+        reloadOverrides()
+    }
+}

--- a/TheBridgeTests/MemoryModuleTests.swift
+++ b/TheBridgeTests/MemoryModuleTests.swift
@@ -749,15 +749,14 @@ func runMemoryModuleTests() async {
             "scope": .string("global"),
             "limit": .int(5)
         ]))
-        guard case .object(let top)? = memObjField(result, "memories"),
-              case .array(let rows) = top,
-              let first = rows.first,
-              case .object(let obj) = first,
-              case .string(let source)? = obj["source"] else {
+        if case .array(let rows)? = memObjField(result, "memories"),
+           let first = rows.first,
+           case .object(let obj) = first,
+           case .string(let source)? = obj["source"] {
+            try expect(source == "cursor", "source must round-trip; got \(source)")
+        } else {
             try expect(false, "recall must return memories with source")
-            return
         }
-        try expect(source == "cursor", "source must round-trip; got \(source)")
     }
 
     await test("MemoryStore pin toggles pinned flag") {

--- a/TheBridgeTests/MemoryModuleTests.swift
+++ b/TheBridgeTests/MemoryModuleTests.swift
@@ -738,4 +738,41 @@ func runMemoryModuleTests() async {
         store.resetForTesting()
         try expect(store.allOverrides().isEmpty, "resetForTesting must clear all overrides")
     }
+
+    await test("memory_recall response includes source field") {
+        let (store, url) = makeTempStore()
+        defer { Task { await store.close(); cleanup(url) } }
+        _ = try await store.remember(text: "provenance row", scope: "global", source: "cursor")
+        let router = await makeMemoryRouter(store)
+        let result = try await callMemoryHandler(router, "memory_recall", .object([
+            "query": .string("provenance"),
+            "scope": .string("global"),
+            "limit": .int(5)
+        ]))
+        guard case .object(let top)? = memObjField(result, "memories"),
+              case .array(let rows) = top,
+              let first = rows.first,
+              case .object(let obj) = first,
+              case .string(let source)? = obj["source"] else {
+            try expect(false, "recall must return memories with source")
+            return
+        }
+        try expect(source == "cursor", "source must round-trip; got \(source)")
+    }
+
+    await test("MemoryStore pin toggles pinned flag") {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("memory-pin-test-\(UUID().uuidString)", isDirectory: true)
+        let url = dir.appendingPathComponent("memory.sqlite")
+        let store = MemoryStore(path: url)
+        defer { Task { await store.close() } }
+        try await store.open()
+        let saved = try await store.remember(text: "pin target", scope: "global", source: "t")
+        try await store.pin(id: saved.id, true)
+        let pinned = try await store.get(id: saved.id)
+        try expect(pinned?.pinned == true, "pin must set pinned true")
+        try await store.pin(id: saved.id, false)
+        let unpinned = try await store.get(id: saved.id)
+        try expect(unpinned?.pinned == false, "pin must clear pinned flag")
+    }
 }

--- a/TheBridgeTests/MemoryRoutingAppendixTests.swift
+++ b/TheBridgeTests/MemoryRoutingAppendixTests.swift
@@ -1,0 +1,147 @@
+// MemoryRoutingAppendixTests.swift — PKT-MEM-115 scopedMemory appendix
+// TheBridge · Tests
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runMemoryRoutingAppendixTests() async {
+    print("\n[MemoryRoutingAppendix]")
+
+    await test("ScopeMap: focus-keepr maps to project + global") {
+        let scopes = MemoryRoutingScopeMap.scopes(for: "focus-keepr")
+        try expect(scopes == ["project", "global"], "got \(scopes)")
+    }
+
+    await test("ScopeMap: project-keepr alias maps to project + global") {
+        let scopes = MemoryRoutingScopeMap.scopes(for: "project-keepr")
+        try expect(scopes == ["project", "global"], "got \(scopes)")
+    }
+
+    await test("ScopeMap: unknown parent falls back to global") {
+        let scopes = MemoryRoutingScopeMap.scopes(for: "unknown-keeper")
+        try expect(scopes == ["global"], "got \(scopes)")
+    }
+
+    await test("ScopeMap: parentSlug strips child path") {
+        try expect(MemoryRoutingScopeMap.parentSlug(from: "mac-keepr/files") == "mac-keepr")
+    }
+
+    await test("ScopeMap: entity hint denylist drops common verbs") {
+        let hint = MemoryRoutingScopeMap.extractEntityHint(
+            from: "make install copy bridge build",
+            scopes: ["mac"],
+            liveEntities: []
+        )
+        try expect(hint == nil, "denylisted tokens should not produce entity, got \(String(describing: hint))")
+    }
+
+    await test("ScopeMap: entity hint prefers live entity match") {
+        let hint = MemoryRoutingScopeMap.extractEntityHint(
+            from: "install the-bridge copy",
+            scopes: ["mac"],
+            liveEntities: ["the-bridge"]
+        )
+        try expect(hint == "the-bridge", "got \(String(describing: hint))")
+    }
+
+    await test("RowFormatter: includes source and created date") {
+        let now = Date(timeIntervalSince1970: 1_718_000_000)
+        let entry = MemoryEntry(
+            scope: "mac", entity: "the-bridge", text: "Use make install-copy",
+            type: .fact, pinned: false, useCount: 2,
+            createdAt: now, lastUsedAt: now, source: "cursor", contentHash: "h"
+        )
+        let row = MemoryRowFormatter.rowLine(entry)
+        try expect(row.contains("source: cursor"), "row must include source; got \(row)")
+        try expect(row.contains("used 2×"), "row must include use count; got \(row)")
+        try expect(row.contains("the-bridge"), "row must include entity; got \(row)")
+    }
+
+    await test("Appendix: omits scopedMemory when no hits") {
+        let store = try await makeTempMemoryStore()
+        defer { Task { await store.close() } }
+        let base: Value = .object(["name": .string("mac-keepr"), "content": .string("body")])
+        let out = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "install", store: store)
+        guard case .object(let obj) = out else {
+            try expect(false, "expected object envelope")
+            return
+        }
+        try expect(obj["scopedMemory"] == nil, "must omit scopedMemory on zero hits")
+    }
+
+    await test("Appendix: attaches scopedMemory for mac scope recall") {
+        let store = try await makeTempMemoryStore()
+        defer { Task { await store.close() } }
+        _ = try await store.remember(
+            text: "Use make install-copy for agent sessions",
+            scope: "mac",
+            entity: "the-bridge",
+            type: .fact,
+            source: "cursor"
+        )
+        let base: Value = .object(["name": .string("mac-keepr"), "content": .string("body")])
+        let out = await MemoryRoutingAppendix.attach(
+            to: base,
+            parent: "mac-keepr",
+            intent: "make install-copy",
+            store: store
+        )
+        guard case .object(let obj) = out,
+              case .object(let appendix)? = obj["scopedMemory"] else {
+            try expect(false, "expected scopedMemory object")
+            return
+        }
+        guard case .string(let markdown)? = appendix["markdown"] else {
+            try expect(false, "expected markdown string")
+            return
+        }
+        try expect(markdown.contains("make install-copy"), "markdown must include memory text")
+        try expect(markdown.contains("source: cursor"), "markdown must include provenance")
+    }
+
+    await test("Appendix: post-cache freshness — second attach sees new row") {
+        let store = try await makeTempMemoryStore()
+        defer { Task { await store.close() } }
+        let base: Value = .object(["name": .string("mac-keepr"), "content": .string("cached")])
+        let first = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "x", store: store)
+        guard case .object(let firstObj) = first else {
+            try expect(false, "first attach failed")
+            return
+        }
+        try expect(firstObj["scopedMemory"] == nil, "no memory yet")
+
+        _ = try await store.remember(text: "Fresh fact after cache", scope: "mac", type: .fact, source: "test")
+        let second = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "Fresh", store: store)
+        guard case .object(let secondObj) = second,
+              case .object(let appendix)? = secondObj["scopedMemory"],
+              case .string(let markdown)? = appendix["markdown"] else {
+            try expect(false, "second attach should include new memory")
+            return
+        }
+        try expect(markdown.contains("Fresh fact after cache"), "appendix must reflect post-cache insert")
+    }
+
+    await test("Appendix: skips error envelopes") {
+        let store = try await makeTempMemoryStore()
+        defer { Task { await store.close() } }
+        let err: Value = .object(["error": .string("nope")])
+        let out = await MemoryRoutingAppendix.attach(to: err, parent: "mac-keepr", intent: nil, store: store)
+        guard case .object(let obj) = out else {
+            try expect(false, "expected object")
+            return
+        }
+        try expect(obj["scopedMemory"] == nil, "must not attach to error envelopes")
+        try expect(obj["error"] != nil, "error key preserved")
+    }
+}
+
+private func makeTempMemoryStore() async throws -> MemoryStore {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("bridge-memory-appendix-tests", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let url = dir.appendingPathComponent("memory.sqlite")
+    let store = MemoryStore(path: url)
+    try await store.open()
+    return store
+}

--- a/TheBridgeTests/MemoryRoutingAppendixTests.swift
+++ b/TheBridgeTests/MemoryRoutingAppendixTests.swift
@@ -76,7 +76,6 @@ func runMemoryRoutingAppendixTests() async {
         _ = try await store.remember(
             text: "Use make install-copy for agent sessions",
             scope: "mac",
-            entity: "the-bridge",
             type: .fact,
             source: "cursor"
         )
@@ -84,7 +83,7 @@ func runMemoryRoutingAppendixTests() async {
         let out = await MemoryRoutingAppendix.attach(
             to: base,
             parent: "mac-keepr",
-            intent: "make install-copy",
+            intent: "install-copy",
             store: store
         )
         guard case .object(let obj) = out,
@@ -104,7 +103,7 @@ func runMemoryRoutingAppendixTests() async {
         let store = try await makeTempMemoryStore()
         defer { Task { await store.close() } }
         let base: Value = .object(["name": .string("mac-keepr"), "content": .string("cached")])
-        let first = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "x", store: store)
+        let first = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "zzznomatch", store: store)
         guard case .object(let firstObj) = first else {
             try expect(false, "first attach failed")
             return
@@ -112,7 +111,7 @@ func runMemoryRoutingAppendixTests() async {
         try expect(firstObj["scopedMemory"] == nil, "no memory yet")
 
         _ = try await store.remember(text: "Fresh fact after cache", scope: "mac", type: .fact, source: "test")
-        let second = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "Fresh", store: store)
+        let second = await MemoryRoutingAppendix.attach(to: base, parent: "mac-keepr", intent: "", store: store)
         guard case .object(let secondObj) = second,
               case .object(let appendix)? = secondObj["scopedMemory"],
               case .string(let markdown)? = appendix["markdown"] else {
@@ -141,7 +140,7 @@ private func makeTempMemoryStore() async throws -> MemoryStore {
         .appendingPathComponent("bridge-memory-appendix-tests", isDirectory: true)
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
     let url = dir.appendingPathComponent("memory.sqlite")
-    let store = MemoryStore(path: url)
+    let store = MemoryStore(path: url, embedder: StubMemoryEmbedder())
     try await store.open()
     return store
 }

--- a/TheBridgeTests/MemoryRoutingAppendixTests.swift
+++ b/TheBridgeTests/MemoryRoutingAppendixTests.swift
@@ -83,7 +83,7 @@ func runMemoryRoutingAppendixTests() async {
         let out = await MemoryRoutingAppendix.attach(
             to: base,
             parent: "mac-keepr",
-            intent: "install-copy",
+            intent: "make install-copy",
             store: store
         )
         guard case .object(let obj) = out,

--- a/TheBridgeTests/StandingOrdersDeliveryTests.swift
+++ b/TheBridgeTests/StandingOrdersDeliveryTests.swift
@@ -187,16 +187,20 @@ func runStandingOrdersDeliveryTests() async {
         try expect(md.range(of: "## people")!.lowerBound < md.range(of: "## project")!.lowerBound,
                    "scopes follow first-appearance (ranked) order")
 
-        // Row shape: [type] text · entity · used N×
-        try expect(md.contains("- [preference] prefers concise replies · isaiah · used 3×"),
-                   "pinned entity row with use count; got:\n\(md)")
+        // Row shape: [type] text · entity · source · date · used N×
+        try expect(md.contains("- [preference] prefers concise replies · isaiah"),
+                   "entity row present; got:\n\(md)")
+        try expect(md.contains("source: t"), "row must include source; got:\n\(md)")
+        try expect(md.contains("used 3×"), "use count present; got:\n\(md)")
         // No entity → entity segment omitted; useCount 0 → use segment omitted.
         try expect(md.contains("- [fact] no entity here"), "no-entity row present")
+        try expect(md.contains("source: t"), "no-entity row still has source")
         try expect(!md.contains("- [fact] no entity here ·"),
-                   "no-entity / zero-use row must have NO trailing · segments")
+                   "no-entity row must not have a dangling entity segment")
         // useCount 1 still renders (only 0 is omitted).
-        try expect(md.contains("- [decision] ships in Q3 · atlas · used 1×"),
-                   "decision row with entity + use count 1")
+        try expect(md.contains("- [decision] ships in Q3 · atlas"),
+                   "decision row with entity; got:\n\(md)")
+        try expect(md.contains("used 1×"), "decision use count")
     }
 
     await test("Memory resource: read via temp-store actor bridges cleanly (pinned-first, non-empty)") {
@@ -229,6 +233,47 @@ func runStandingOrdersDeliveryTests() async {
         try expect(md.range(of: "pin me to the top")!.lowerBound
                    < md.range(of: "ordinary salient fact")!.lowerBound,
                    "pinned entry must render before the unpinned one")
+    }
+
+    await test("asyncComposition: per-client override ON injects memory block") {
+        let injectStore = MemoryAutoInjectClientStore.shared
+        injectStore.resetForTesting()
+        defer { injectStore.resetForTesting() }
+
+        try await withDeliveryTempHome { _ in
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\nwave3 inject")
+
+            let memStore = MemoryStore.shared
+            try await memStore.open()
+            _ = try await memStore.remember(text: "inject me at handshake", scope: "global", source: "cursor")
+
+            UserDefaults.standard.set(false, forKey: BridgeDefaults.memoryHandshakeAutoInject)
+            injectStore.setOverride(true, forClient: "cursor")
+
+            let sync = StandingOrdersDelivery.composition(clientName: "cursor")
+            let injected = await StandingOrdersDelivery.asyncComposition(clientName: "cursor")
+            try expect(injected.instructionsMarkdown.contains("## Memory"),
+                       "cursor override must inject memory section")
+            try expect(injected.instructionsMarkdown.contains("inject me at handshake"),
+                       "injected slice must include salient memory")
+            try expect(sync.instructionsMarkdown != injected.instructionsMarkdown,
+                       "injected composition must differ from sync when override ON")
+        }
+    }
+
+    await test("MemoryAutoInjectClientStore: seedWave3DefaultsIfNeeded is idempotent") {
+        let store = MemoryAutoInjectClientStore.shared
+        store.resetForTesting()
+        defer { store.resetForTesting() }
+
+        UserDefaults.standard.set(false, forKey: BridgeDefaults.memoryHandshakeAutoInject)
+        MemoryAutoInjectClientStore.seedWave3DefaultsIfNeeded()
+        try expect(store.override(forClient: "cursor") == true, "first seed sets cursor ON")
+        store.setOverride(false, forClient: "cursor")
+        MemoryAutoInjectClientStore.seedWave3DefaultsIfNeeded()
+        try expect(store.override(forClient: "cursor") == false,
+                   "seed must not overwrite non-empty override map")
     }
 }
 

--- a/TheBridgeTests/StandingOrdersDeliveryTests.swift
+++ b/TheBridgeTests/StandingOrdersDeliveryTests.swift
@@ -192,11 +192,9 @@ func runStandingOrdersDeliveryTests() async {
                    "entity row present; got:\n\(md)")
         try expect(md.contains("source: t"), "row must include source; got:\n\(md)")
         try expect(md.contains("used 3×"), "use count present; got:\n\(md)")
-        // No entity → entity segment omitted; useCount 0 → use segment omitted.
-        try expect(md.contains("- [fact] no entity here"), "no-entity row present")
-        try expect(md.contains("source: t"), "no-entity row still has source")
-        try expect(!md.contains("- [fact] no entity here ·"),
-                   "no-entity row must not have a dangling entity segment")
+        // No entity → entity segment omitted; source + date always present.
+        try expect(md.contains("- [fact] no entity here · source: t"), "no-entity row includes source; got:\n\(md)")
+        try expect(!md.contains("- [fact] no entity here · isaiah"), "no-entity row must not include a fake entity segment")
         // useCount 1 still renders (only 0 is omitted).
         try expect(md.contains("- [decision] ships in Q3 · atlas"),
                    "decision row with entity; got:\n\(md)")

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -887,6 +887,7 @@ await runCloudAccessWSGTests()
 // memory_* MCP tool registration + tiering + handler round-trip. All against
 // a TEMP DB path (never the real config-dir store, never the shared singleton).
 await runMemoryModuleTests()
+await runMemoryRoutingAppendixTests()
 
 // PKT-1007 Slice 1: Dense-vector recall + RRF fusion. StubMemoryEmbedder
 // (deterministic, no CoreML assets), MemoryEmbeddingIndex (index/rank/evict),

--- a/docs/operator/MEMORY-WAVE3-SURFACING-SPEC.md
+++ b/docs/operator/MEMORY-WAVE3-SURFACING-SPEC.md
@@ -1,0 +1,438 @@
+# Unified Memory — Wave 3 Surfacing & Governance Spec (v2.0)
+
+**Status:** v1.0 operator lock preserved; v2.0 incorporates codebase recon audit (2026-06-26)  
+**Packet label:** PKT-MEM-115 (proposed)  
+**Project:** The Bridge v3.8.x → v3.9.0 vertical — agent memory surfacing, routing integration, operator governance  
+**Depends on:** Wave 1 (`MemoryStore`, `memory_remember`/`memory_recall`) + Wave 2 (`export`/`import`, `consolidationSweep`, `asyncComposition`, `MemoryAutoInjectClientStore`, client-source threading)  
+**SSOT for:** implementation packets, test-floor raises, Settings UX, `fetch_skill` envelope extension  
+**Supersedes:** v1.0 (same file — see §0 Audit critique)
+
+---
+
+## 0. Audit critique (v1.0 → v2.0)
+
+Recon against live code (`MemoryModule`, `MemoryStore`, `StandingOrdersDelivery`, `SkillsModule`, `ServerManager`, `MemoryAgentTab`, standing orders v7.0.2). Items are ordered by severity.
+
+| # | Severity | Finding | v1.0 assumption | v2.0 resolution |
+|---|----------|---------|-----------------|-----------------|
+| C1 | **Blocker** | `fetch_skill` returns cached envelopes **before** any post-processing (`SkillsModule` L312–314). A `scopedMemory` appendix baked into the cache would go stale as memories change; omitting it from cache means cache hits skip the appendix entirely. | Appendix wired inside handler before `cache.set` | **Post-cache merge:** always append `scopedMemory` after cache get/set, never include memory state in `cacheKey` |
+| C2 | **Blocker** | `ServerManager` stdio initialize calls `asyncComposition(clientName: nil)` (L246) while tool dispatch uses synthetic `"stdio"` for `memory_remember` source (L322). Per-client Cursor inject cannot work on stdio until `clientName` is threaded on the stdio initialize path. | Cursor override works for all transports | Document stdio limitation in Phase A; add **stdio `clientName` pass-through** (use `"stdio"` or future initialize metadata) as a small seam fix in WP1 |
+| C3 | **High** | WP3 claims `memory_recall` must add `source` — **`entryValue` already exposes `source`** (`MemoryModule` L267). Remaining work is `renderMemoryMarkdown` + Agent tab meta row only. | Net-new recall shape | Downscope WP3 to formatter + UI; one assertion test that `source` is present (likely already true) |
+| C4 | **High** | `renderMemoryMarkdown` omits `source` and `createdAt` (only type, text, entity, useCount). Inject rows and `bridge://memory` inherit the gap. | WP3 covers this | Explicit shared row formatter used by inject, resource, and appendix |
+| C5 | **High** | Keeper→scope map lists `project-keepr` implicitly via examples; **v7.0.2 standing orders removed inline keeper prose** — roster is live via `skills_routing_list`. `project-keepr` may still resolve as a skill but is no longer a routing entry point. | Static keeper table is authoritative | Scope map keys on **`fetch_skill` `name` param (parent slug)**; derive canonical rows from live `skills_routing_list` names; map `project-keepr` → same scopes as `focus-keepr` for backward compatibility |
+| C6 | **High** | Appendix keyed on parent slug is **correct** for intent routing (`buildSkillResult` uses parent `skillConfig.name` even when a specialist body is swapped in). v1.0 did not document this invariant. | Unclear whether specialist envelope changes scope | Document: scope map uses **request parent**, not resolved specialist title |
+| C7 | **Medium** | Entity hint regex `[a-z0-9-]{3,}` on full `intent` will false-positive on common tokens (`make`, `install`, `bridge`). | Minimal regex is sufficient | v2: extract entity only from **slug-like tokens after normalization**, denylist common verbs, prefer tokens matching known `entity` values in store (optional second pass) |
+| C8 | **Medium** | Appendix promotion policy (`recall` use-promotes) vs handshake (`handshakeSlice` does **not** promote) is correct but unstated side effect: frequent `fetch_skill` re-routing will inflate `useCount` and salience. | Promotion is uniformly good | Keep promote on appendix; cap at 5 rows; document salience side effect in operator docs |
+| C9 | **Medium** | D7 "keep both contradictions below Jaccard" is imprecise: **`remember` supersedes at Jaccard ≥ 0.72** within scope+entity. Recall shows multiple rows only when texts are *semantically* conflicting but lexically distinct. | Contradiction handling is recall-only | Clarify D7: near-dup write-time supersede vs recall-time multi-row presentation |
+| C10 | **Medium** | Cursor seed `{"cursor": true}` has **no first-install migration** — `MemoryAutoInjectClientStore` returns empty dict on fresh install. UI "seed on first open" is fragile (Settings may never open). | Operator setup script is enough | Add **`seedDefaultsIfNeeded()`** on app launch (idempotent): global OFF, `cursor` → ON when override map empty |
+| C11 | **Medium** | MCP `clientInfo.name` for Cursor is **assumed** `"cursor"` — not verified in repo. Mismatch would break seeded override. | `cursor` is canonical | Add Delivery-audit log line for observed `clientName` at initialize; document how to fix override key in Settings |
+| C12 | **Medium** | Voice-memo `agent_memory` lane writes `type: reference` → **90-day unused tombstone** via `consolidationSweep`. Operators may not expect voice-captured facts to expire. | Lifecycle section is complete | Add operator-facing note in Memory Agent tab footer + spec §8; recommend `fact`/`preference` at commit time for durable voice captures (future voice-memo tweak — out of Wave 3 scope unless trivial) |
+| C13 | **Low** | `memory_pin` MCP tool is optional for Wave 3 — **MEMORY-HUB + UI can call `MemoryStore.pin` directly**; `memory_forget` already exists for agents. | +1 tool required | **Split:** Phase A ships UI pin/forget via store; `memory_pin` MCP is Phase A optional / Phase B if agent ergonomics need it |
+| C14 | **Low** | Agent tab empty state says **"read-only"** (`MemoryAgentTab` L105) — conflicts with planned pin/forget/inject controls. | UI work is additive | Update copy + empty-state layout as part of WP1/WP4 |
+| C15 | **Low** | `bridge-keepr` in scope map is harmless but **not a normal `fetch_skill` parent** (standing-orders identity). | Listed as keeper | Keep `global` fallback; remove `bridge-keepr` row from map (dead entry) |
+| C16 | **Low** | `staticFeatureModuleToolCount` = **187** today; optional `memory_pin` → 188 + `Version.swift` comment. | +1 always | Only bump if `memory_pin` ships |
+| C17 | **Low** | Cloud agent / CI **cannot run `make test`** (no Swift on Linux). Floor raise must happen on Mac. | Tests listed generically | Phase C explicitly Mac-only verification |
+
+**Net:** v1.0 direction is sound; v2.0 tightens transport seams, cache architecture, scope-map authority, promotion semantics, and scopes WP3/WP4 to match what code already does.
+
+---
+
+## 0.1 Executive summary (unchanged intent, revised execution)
+
+Wave 3 makes **agent memory useful without handshake bloat**:
+
+1. **Handshake auto-inject** — global OFF; per-client ON for Cursor (launch-seeded); Settings toggle; stdio `clientName` fix.
+2. **Memory-rides-routing** — `scopedMemory` appendix on `fetch_skill`, **post-cache**, parent-slug scope map.
+3. **Lifecycle** — keep launch sweep; no auto-TTL on `decision`/`preference`; document voice-memo `reference` behavior.
+4. **Provenance** — finish `renderMemoryMarkdown` + UI (recall JSON already has `source`).
+5. **Operator UI** — pin/forget + inject controls on Memory → Agent tab.
+6. **Sync** — defer cloud; export/import remains migration seam.
+
+**Explicit non-goals (Wave 3):** cloud sync, encryption-at-rest, operator text-edit CRUD, demote tiers, Jobs consolidation, Notion MEMORY DS bidirectional sync, NLP entity extraction.
+
+---
+
+## 0.2 Decision ledger (operator lock 2026-06-26, D7 clarified)
+
+| ID | Decision | Locked resolution | v2.0 note |
+|----|----------|-------------------|-----------|
+| D1 | Auto-inject default | **OFF global** | unchanged |
+| D2 | Per-client inject | **ON for `cursor`**, launch-seeded | + C10 migration, C11 verify client name |
+| D3 | Memory-rides-routing | **Minimal `scopedMemory` on `fetch_skill`** | + C1 post-cache merge |
+| D4 | Lifecycle TTL | **No default TTL** on `decision`/`preference`; `reference` 90d sweep | + C12 voice-memo note |
+| D5 | Memory lanes | **Source-agnostic dedup** | unchanged |
+| D6 | Provenance | **Thread MCP client into `source`**; surface in markdown + UI | recall JSON done (C3) |
+| D7 | Contradictions | **Near-dup write: supersede at Jaccard ≥ 0.72**; recall may return multiple distinct rows — agent reconciles | clarified (C9) |
+| D8 | Scope taxonomy | **Open-ended storage; documented canonical set** | map follows live roster (C5) |
+| D9 | UI posture | **Pin + forget + inject toggles**; no text edit | unchanged |
+| D10 | Sync | **Local-only** | unchanged |
+
+---
+
+## 1. Current baseline (recon-verified)
+
+| Capability | Location | Wave 3 touch |
+|------------|----------|--------------|
+| SQLite + FTS5 + embeddings + salience | `MemoryStore.swift` | scope map helper; optional `memory_pin` MCP |
+| `memory_remember` / `memory_recall` / `forget` / `export` / `import` | `MemoryModule.swift` | recall `source` ✅; formatter; optional `memory_pin` |
+| Client `source` on remember | `MemoryModule.argumentsWithClientSource`, SSE + stdio dispatch | verify HTTP; fix stdio inject `clientName` |
+| Handshake auto-inject | `StandingOrdersDelivery.asyncComposition` | UI + launch seed + stdio fix |
+| `handshakeSlice` (no promote) | `MemoryStore.swift` L491 | unchanged |
+| `bridge://memory` resource | `BridgeResources` + `memoryMarkdown()` | inherits new row formatter |
+| Launch `consolidationSweep` | `AppDelegate` | doc comment only |
+| Agent tab (read-only today) | `MemoryAgentTab.swift` | pin/forget/inject; copy fix |
+| `fetch_skill` envelope + cache | `SkillsModule.swift` | post-cache `scopedMemory` |
+
+**Storage:** `~/.config/notion-bridge/memory.sqlite` (relocates with `BRIDGE_CONFIG_PATH`).
+
+---
+
+## 2. Architecture — capture vs surface
+
+```text
+CAPTURE (explicit)                    SURFACE (passive)
+─────────────────────                   ─────────────────
+memory_remember                         handshake auto-inject (optional, no promote)
+voice_memo agent_memory lane            bridge://memory (opt-in read, no promote)
+                                        memory_recall (agent query, promotes)
+                                        fetch_skill scopedMemory (NEW, promotes)
+```
+
+**Invariants:**
+- No auto-capture from chat.
+- Passive surfaces (`handshakeSlice`, `bridge://memory`) never use-promote.
+- Active surfaces (`recall`, appendix) use-promote returned rows.
+
+---
+
+## 3. Work packages (v2.0)
+
+### WP1 — Handshake auto-inject UI, launch seed, stdio fix (D1, D2)
+
+**Goal:** Operator governs inject without `defaults write`; fresh policy = global OFF, Cursor ON; stdio clients can use per-client overrides.
+
+#### 3.1 Launch seed (new — C10)
+
+Idempotent on app launch (e.g. `AppDelegate` after store open):
+
+```swift
+// Pseudocode
+if MemoryAutoInjectClientStore.shared.allOverrides().isEmpty
+   && !BridgeDefaults.memoryHandshakeAutoInjectEffective {
+    MemoryAutoInjectClientStore.shared.setOverride(true, forClient: "cursor")
+}
+```
+
+Does not overwrite operator edits (non-empty override map skips seed).
+
+#### 3.2 Settings UI (`MemorySurfacingSettingsCard` extracted from `MemoryAgentTab`)
+
+| Control | Binds to |
+|---------|----------|
+| Handshake memory inject (global) | `BridgeDefaults.memoryHandshakeAutoInject` |
+| Per-client overrides | `MemoryAutoInjectClientStore` |
+| Helper text | Shows last observed MCP client names from Delivery audit (read-only, C11) |
+
+Tri-state per client: **Inherit** (remove key) / **Force ON** / **Force OFF** — maps to absent/`true`/`false` in store (already supported).
+
+#### 3.3 Stdio `clientName` seam (new — C2)
+
+`ServerManager` stdio initialize path:
+
+```swift
+// Today: asyncComposition(clientName: nil)
+// v2:    asyncComposition(clientName: "stdio")
+```
+
+Aligns with synthetic `"stdio"` already used for `memory_remember` source injection. Document that real per-client names require Streamable HTTP/SSE initialize with `clientInfo`.
+
+#### 3.4 Inject content (unchanged algorithm)
+
+1. `handshakeSlice(limit: 20)` — pinned first, salience; **no promote**
+2. `MemoryRowFormatter.markdown(entries)` (shared with WP3)
+3. Truncate to `memoryHandshakeTokenBudget` (2000 chars)
+4. Append `## Memory` after standing orders + routing trailer
+
+#### 3.5 Acceptance criteria
+
+- [ ] Launch seed: fresh install → `cursor` override ON without opening Settings
+- [ ] Global OFF + Cursor ON → HTTP Cursor sessions get `## Memory`; global OFF + no override → no block
+- [ ] stdio with override `"stdio": true` receives inject (after C2 fix)
+- [ ] `asyncComposition` OFF → byte-identical to `composition` (existing test)
+- [ ] Optional: Delivery audit records `memoryInjected` + `clientName`
+
+#### 3.6 Files
+
+- `TheBridge/App/AppDelegate.swift` (seed)
+- `TheBridge/Server/ServerManager.swift` (stdio clientName)
+- `TheBridge/UI/Sections/MemorySurfacingSettingsCard.swift` (new)
+- `TheBridge/UI/Sections/MemoryAgentTab.swift`
+- `TheBridgeTests/StandingOrdersDeliveryTests.swift` (+inject override tests)
+
+---
+
+### WP2 — Memory-rides-routing (`scopedMemory`) (D3)
+
+**Goal:** Task-scoped memory appendix on `fetch_skill` without extra tool calls or stale cache.
+
+#### 3.7 Scope map (`MemoryRoutingScopeMap.swift`)
+
+Keyed on **`fetch_skill` `name` parent slug** (before `/` child path). Align with live routing roster; legacy aliases preserved:
+
+| Parent slug | Primary | Secondary |
+|-------------|---------|-----------|
+| `focus-keepr` | `project` | `global` |
+| `project-keepr` | `project` | `global` |
+| `people-keepr` | `people` | — |
+| `mac-keepr` | `mac` | — |
+| `notion-keepr` | `skill` | `project` |
+| `time-keepr` | `time` | — |
+| `skill-keepr` | `skill` | — |
+| `executor` | `project` | `global` |
+| *unknown* | `global` | — |
+
+`bridge-keepr` omitted (not a fetch parent). Unknown parents → `global` only.
+
+#### 3.8 Entity hint (revised — C7)
+
+```text
+1. Normalize intent (trim, lowercased).
+2. Tokenize on whitespace/punctuation.
+3. Keep tokens matching ^[a-z0-9-]{3,}$ EXCEPT denylist:
+   make, install, copy, build, test, run, the, bridge, keep, fetch, skill, ...
+4. If multiple candidates, prefer one that matches an existing live entity in mapped scope(s) (single SQLite lookup).
+5. Else use first candidate; if none → no entity filter.
+```
+
+#### 3.9 Appendix builder (`MemoryRoutingAppendix.swift`)
+
+```swift
+// Pseudocode
+let parent = parsedParentSlug(name)  // "mac-keepr/update" → "mac-keepr"
+let scopes = MemoryRoutingScopeMap.scopes(for: parent)
+let entity = await MemoryRoutingScopeMap.extractEntityHint(intent, scopes: scopes, store: store)
+let query = intent?.trimmed ?? ""
+var entries: [MemoryEntry] = []
+for scope in scopes {
+    entries += try await store.recall(query: query, scope: scope, entity: entity, limit: 3)
+}
+entries = dedupeById(entries).prefix(5)
+// promotes via recall — document salience side effect (C8)
+```
+
+#### 3.10 Post-cache merge (critical — C1)
+
+In `SkillsModule` handler, **after** `if let cached = await cache.get(cacheKey) { ... }` return path AND after fresh build:
+
+```swift
+result = await MemoryRoutingAppendix.attach(to: result, parent: parentSlug, intent: intentArg)
+return result
+// Do NOT include appendix in cacheKey or cached payload.
+```
+
+Plain cache hits and network misses both get fresh memory. Appendix omitted when zero hits.
+
+#### 3.11 Envelope shape (additive)
+
+```json
+{
+  "name": "mac-keepr",
+  "content": "...",
+  "scopedMemory": {
+    "parent": "mac-keepr",
+    "intent": "install Bridge to Applications",
+    "scopesQueried": ["mac"],
+    "count": 2,
+    "markdown": "### Scoped memory (mac)\n- [fact] Use make install-copy … · source: cursor · 2026-06-26 · used 4×"
+  }
+}
+```
+
+#### 3.12 Dispatch contract addition
+
+> After `fetch_skill(parent, intent:)`, read `scopedMemory.markdown` when present. Treat as grounding for **this sub-task only**; re-fetch when intent changes. Scope map uses the **parent** slug from `name`, not a resolved specialist title.
+
+#### 3.13 Acceptance criteria
+
+- [ ] Cache hit + memory insert afterwards → appendix reflects new row (proves post-cache)
+- [ ] `fetch_skill('mac-keepr', intent: 'make install-copy')` returns appendix when mac memories exist
+- [ ] `fetch_skill('focus-keepr', intent: 'triage stale projects')` queries `project` + `global`
+- [ ] `project-keepr` alias still maps to `project` scope
+- [ ] Zero hits → no `scopedMemory` key
+- [ ] Hermetic tests with temp `MemoryStore` injected via test seam
+
+#### 3.14 Files
+
+- **New:** `MemoryRoutingScopeMap.swift`, `MemoryRoutingAppendix.swift`, `MemoryRowFormatter.swift`
+- `SkillsModule.swift` (post-cache attach only)
+- `TheBridgeTests/MemoryRoutingAppendixTests.swift` (new)
+- `ToolAnnotations.swift` (`fetch_skill` description)
+
+---
+
+### WP3 — Provenance finish (D5, D6, D7) — downscoped
+
+**Goal:** Visible provenance on all markdown surfaces; recall JSON already complete.
+
+#### 3.15 Shared row formatter (`MemoryRowFormatter.swift`)
+
+```markdown
+- [fact] Use make install-copy for agent sessions · the-bridge · source: cursor · 2026-06-26 · used 4×
+```
+
+Used by: `renderMemoryMarkdown`, `scopedMemory.markdown`, `bridge://memory` body.
+
+#### 3.16 Recall JSON
+
+`entryValue` already includes `source` — add/keep one regression test; update tool description if needed.
+
+#### 3.17 Agent tab meta row
+
+Show `source` + short `createdAt` date beside scope/type badges.
+
+#### 3.18 Acceptance criteria
+
+- [ ] `renderMemoryMarkdown` includes `source` + date
+- [ ] `bridge://memory` inherits formatter
+- [ ] UI shows source + date
+- [ ] D7 documented in tool descriptions (write-time supersede vs multi-row recall)
+
+#### 3.19 Files
+
+- `StandingOrdersDelivery.swift` (delegate to `MemoryRowFormatter`)
+- `MemoryAgentTab.swift`
+- `MemoryModuleTests.swift` (+1 source assertion)
+
+---
+
+### WP4 — Operator governance UI (D9)
+
+**Goal:** Pin and forget without MCP round-trip.
+
+#### 3.20 Pin / forget
+
+| Action | Implementation |
+|--------|----------------|
+| Pin / Unpin | `MemoryStore.pin(id:_:)` direct from UI |
+| Forget | `MemoryStore.forget(id:)` with confirm alert |
+
+**Optional MCP `memory_pin`** (notify tier) — defer unless agent callers need it; UI does not require it (C13). If shipped: +1 tool, annotation, registry count 187→188.
+
+#### 3.21 Acceptance criteria
+
+- [ ] Pin survives relaunch; pinned sort first in recall, inject, appendix
+- [ ] Forget tombstones; gone from list and export
+- [ ] Pinned rows exempt from `consolidationSweep` (already true)
+- [ ] Empty state copy no longer says "read-only"
+- [ ] AX IDs: `BridgeAXID.Memory.agentPinButton`, `agentForgetButton`
+
+#### 3.22 Files
+
+- `MemoryAgentTab.swift`
+- `BridgeAXID.swift`
+- Optional: `MemoryModule.swift` (`memory_pin`)
+
+---
+
+### WP5 — Lifecycle confirmation (D4) — docs + tests
+
+No algorithm change unless regression found.
+
+| Mechanism | Behavior |
+|-----------|----------|
+| `handshakeSlice` / resource | No promote |
+| `recall` / appendix | Promotes returned rows |
+| `reference` 90d unused | Tombstone on launch sweep |
+| `decision` / `preference` | Indefinite unless TTL or forget |
+| Voice-memo `agent_memory` → `reference` | Subject to 90d sweep — document in UI (C12) |
+
+Add cross-link doc comment on `consolidationSweep`.
+
+---
+
+### WP6 — Deferred (unchanged)
+
+Cloud sync, encryption, operator CRUD, demote tiers, Jobs consolidation, Claude `MEMORY.md` unification, Notion MEMORY DS sync.
+
+---
+
+## 4. Implementation phasing (revised)
+
+```text
+Phase A — operator-facing, low risk
+  WP1  inject UI + launch seed + stdio clientName
+  WP3  MemoryRowFormatter + UI provenance
+  WP4  pin/forget UI (no memory_pin unless trivial)
+
+Phase B — fetch_skill hot path
+  WP2  scope map + appendix + post-cache merge + dispatch contract
+
+Phase C — Mac-only verification
+  WP5  lifecycle audit
+  Live smoke: Cursor inject, fetch_skill appendix, pin/forget
+  Floor raise (+10–14 tests estimated)
+```
+
+**Merge order:** A → B. Phase B must not land without post-cache merge tests.
+
+---
+
+## 5. Test plan + floor
+
+| Test file | New cases |
+|-----------|-----------|
+| `StandingOrdersDeliveryTests.swift` | formatter rows; inject ON with override; OFF byte-identical |
+| `MemoryRoutingAppendixTests.swift` | scope map; entity denylist; post-cache freshness; empty omit |
+| `MemoryModuleTests.swift` | recall `source` regression; pin round-trip (if MCP ships) |
+| `MemoryAutoInjectClientStore` / seed | launch seed idempotency |
+
+**Floor raise:** measure on Mac after `make test`; +10–14 net-new → update `scripts/test-floor-gate.sh`.
+
+---
+
+## 6. MCP tool inventory delta
+
+| Tool | Wave 3 |
+|------|--------|
+| `memory_recall` | document `source` (already returned) |
+| `memory_pin` | **optional** — UI uses store directly |
+
+---
+
+## 7. Risks + mitigations (updated)
+
+| Risk | Mitigation |
+|------|------------|
+| Stale appendix in cache | Post-cache merge (C1) |
+| Wrong Cursor client key | Launch seed + audit log of observed name (C11) |
+| Entity false positives | Denylist + optional entity DB match (C7) |
+| Salience inflation from routing | Cap 5 appendix rows; document promotion (C8) |
+| Voice facts expire | Operator note; future type override at commit |
+| stdio clients miss Cursor override | stdio uses `"stdio"` key; document HTTP for Cursor |
+
+---
+
+## 8. Packet breakdown
+
+| Packet | Scope | Phase |
+|--------|-------|-------|
+| **PKT-MEM-115a** | WP1 + WP3 + WP4 | A |
+| **PKT-MEM-115b** | WP2 post-cache appendix | B |
+| **PKT-MEM-115c** | Mac verify + floor + CHANGELOG | C |
+
+---
+
+## 9. CHANGELOG entry (draft)
+
+```markdown
+## v3.9.0 — Unified Memory Wave 3 (surfacing + governance)
+
+- Handshake memory inject — Settings toggle (global OFF); per-client overrides with Cursor launch-seeded ON; stdio clientName fix.
+- Memory-rides-routing — `fetch_skill` returns optional `scopedMemory` appendix (post-cache; parent→scope map).
+- Agent memory UI — pin/forget on Memory → Agent tab; provenance in inject, recall, and appendix rows.
+- Lifecycle unchanged: `reference` 90d sweep + explicit TTL only.
+```
+
+---
+
+*v2.0 — recon audit 2026-06-26. Operator decisions from v1.0 stand; implementation proceeds on PKT-MEM-115a with revisions above.*

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1550,7 +1550,13 @@ set -euo pipefail
 # audio). SAME WorkOS-injection caveat: the 4 placeholder failures are the build-injected RemoteAccessIdentity.swift
 # (operator IdP baked locally), NOT this slice — measured 2667/0 with the committed fail-closed source restored
 # (gate EXIT=0). 2653→2667.
-FLOOR="${BRIDGE_TEST_FLOOR:-2667}"
+# 2026-06-26 (PKT-MEM-115 Wave 3 — memory surfacing + governance): +15 tests across
+# runMemoryRoutingAppendixTests (scope map, entity denylist, row formatter provenance,
+# appendix attach/omit, post-cache freshness, error-skip) plus StandingOrdersDelivery
+# inject-override composition + seedWave3DefaultsIfNeeded idempotency, MemoryModule
+# recall source + pin toggle. Hermetic temp DB / shared hermetic config path.
+# 2667→2682.
+FLOOR="${BRIDGE_TEST_FLOOR:-2682}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Memory Wave 3** per approved spec v2.0 (`docs/operator/MEMORY-WAVE3-SURFACING-SPEC.md`).

### WP1 — Handshake inject
- `MemorySurfacingSettingsCard` — global toggle + per-client overrides
- `MemoryAutoInjectClientStore.seedWave3DefaultsIfNeeded()` on launch (Cursor ON when map empty)
- Stdio initialize passes `clientName: "stdio"` into `asyncComposition`

### WP2 — Memory-rides-routing
- `MemoryRoutingScopeMap` + `MemoryRoutingAppendix` + **post-cache** `scopedMemory` merge on `fetch_skill`
- Dispatch contract updated in `SkillsModule`

### WP3 — Provenance
- `MemoryRowFormatter` shared by inject, `bridge://memory`, and appendix rows (`source` + date)

### WP4 — Operator UI
- Agent tab: pin/forget (direct `MemoryStore`), provenance meta, updated empty-state copy

### WP5 — Lifecycle
- Doc comment on `consolidationSweep` cross-linking spec

## Tests
- **+15** net-new tests (`MemoryRoutingAppendixTests`, inject override, seed idempotency, recall source, pin toggle)
- Floor **2667 → 2682**

## Verification
- Mac build: compile error in recall-source test fixed (`f64542e`)
- Run on device: `make test-floor` then `make install-copy` + Settings → Memory → Agent smoke

## Non-goals (deferred)
- `memory_pin` MCP tool (UI uses store directly)
- Cloud sync, operator text-edit CRUD
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90a33b01-c1f2-4772-90a5-9c4855bd400f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90a33b01-c1f2-4772-90a5-9c4855bd400f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

