### PR TITLE
docs: correct install-copy signing guidance and skill sync note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ There is no way to run a single test file in isolation — all tests run from `T
 ```bash
 make app           # Release build + package .build/TheBridge.app
 make install       # sign → notarize → staple → ditto → /Applications/The Bridge.app (needs Developer ID + notary keychain profile)
-make install-copy  # Same .app to /Applications without sign/notarize — local dev only
+make install-copy  # Developer ID sign + copy → /Applications (no notarize) — daily dev install
 make dmg           # Create distributable DMG
 make sign          # Code-sign with Developer ID
 make notarize      # Submit to Apple notarization (requires keychain profile)
@@ -51,9 +51,11 @@ make release       # Full pipeline: clean → test → app → sign → notarize
 make check-appcast # Fail if appcast.xml does not match Info.plist version/build numbers
 ```
 
-**Production install ladder (canonical):** `make test` → `make app` → `make install` when signing credentials exist; otherwise `make install-copy` and accept ad-hoc / Gatekeeper differences. **`swift build` alone does not refresh `/Applications`** — always use the Makefile app target.
+**Production install ladder (canonical):** `make test` → `make app` → `make install` when signing credentials exist (notarized, Gatekeeper-stapled); otherwise `make install-copy` (signed with Developer ID, **not** notarized — ~2 min vs ~28 min). **`swift build` alone does not refresh `/Applications`** — always use the Makefile app target. Testing from `.build/TheBridge.app` without install breaks TCC identity; always install to `/Applications/The Bridge.app`.
 
-**Agents / Cursor / MCP-driven sessions:** After `make app`, use **`make install-copy`** or **`make install-agent-safe`** (same target) to copy `.build/TheBridge.app` → `/Applications/The Bridge.app` without running the full notarize pipeline. Avoid long `make install` / `make release` from the same session that hosts your MCP connection if the workflow would time out or abort. The `install` target only sends `killall Dock` (icon refresh), not the The Bridge process—historical friction is documented in `AGENT_FEEDBACK.md` and resolved by preferring `install-copy` for copy-only installs.
+**Agents / Cursor / MCP-driven sessions:** After `make app`, use **`make install-copy`** or **`make install-agent-safe`** (alias — same target: `check-stale-build sign` then copy) to refresh `/Applications/The Bridge.app` without the notarize pipeline. Neither target ships to users — only `git tag` + CI does (Sparkle). Avoid long `make install` / `make release` from the same session that hosts your MCP connection if the workflow would time out or abort. The `install` target only sends `killall Dock` (icon refresh), not the The Bridge process—historical friction is documented in `AGENT_FEEDBACK.md` and resolved by preferring `install-copy` for copy-only installs.
+
+**Notion skill sync:** After editing the **app-dev** skill page in Notion, run `skill_sync_notion` (Bridge MCP) on your Mac so `fetch_skill('app-dev')` serves the updated body. Bridge restart may be required if the skill cache was already loaded.
 
 If `make app` warns that `actool` failed, icons may fall back to PNGs; see Makefile `app` target (asset compile is best-effort). A common cause is a broken **ibtoold** plugin load (`xcodebuild -runFirstLaunch` or opening **Xcode** once to refresh system content), not Swift source errors.
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Other useful targets:
 ```bash
 make clean
 make install
-make install-copy    # or: make install-agent-safe — copy .app to /Applications without full notarize (agent-safe)
+make install-copy    # or: make install-agent-safe — Developer ID sign + copy to /Applications (no notarize)
 make release
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes agent-facing documentation that incorrectly described `make install-copy` as unsigned. The Makefile target depends on `sign` (`install-copy: check-stale-build sign`).

## Changes

- **AGENTS.md:** Clarify install-copy is Developer ID signed (not notarized); distinguish local install from Sparkle tag ship; remove misleading "ad-hoc / Gatekeeper" wording for install-copy; add post-edit `skill_sync_notion` reminder for app-dev Notion updates.
- **README.md:** Align install-copy one-liner with signing behavior.

## Why

The app-dev skill (Notion v5.0.3) documents accurate Bridge install ladder semantics. `AGENTS.md` was still telling agents install-copy skips signing, which causes TCC/csreq confusion during dev sessions.

## Verification

- Cross-checked against `Makefile` `install-copy` target (depends on `sign`).
- No code or test-floor changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90a33b01-c1f2-4772-90a5-9c4855bd400f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90a33b01-c1f2-4772-90a5-9c4855bd400f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

