### PR TITLE
feat(skills): enforce SKILLS Keepr routing governance

### DIFF
--- a/TheBridge/Modules/Skills/SkillRoutingGovernance.swift
+++ b/TheBridge/Modules/Skills/SkillRoutingGovernance.swift
@@ -1,0 +1,168 @@
+// SkillRoutingGovernance.swift — skill-system ownership enforcement
+// TheBridge · Skills
+
+import Foundation
+import MCP
+
+/// Validates the SKILLS Keepr route receipt required before an MCP caller may
+/// mutate the skill registry. The Settings UI does not pass through this
+/// surface, so operator-managed local configuration remains unaffected.
+public enum SkillRouteReceiptValidator {
+    public static let schema: Value = .object([
+        "type": .string("object"),
+        "description": .string("Current SKILLS Keepr route receipt. Required for every skill-system mutation."),
+        "properties": .object([
+            "domainOwner": .object([
+                "type": .string("string"),
+                "description": .string("Must identify SKILLS Keepr, normally 'skill-keepr'.")
+            ]),
+            "routeId": .object([
+                "type": .string("string"),
+                "description": .string("SKILLS Keepr route identifier, such as R2, R4, R6, R6B, or R8.")
+            ]),
+            "targetSkills": stringArraySchema("Skill names covered by this receipt."),
+            "changeManifest": stringArraySchema("Approved changes the worker may implement."),
+            "acceptanceTests": stringArraySchema("Tests or checks that must pass."),
+            "writeScope": stringArraySchema("Allowed write targets or property/body scopes.")
+        ]),
+        "required": .array([
+            .string("domainOwner"), .string("routeId"), .string("targetSkills"),
+            .string("changeManifest"), .string("acceptanceTests"), .string("writeScope")
+        ])
+    ])
+
+    /// Returns nil when the receipt is valid, otherwise a user-actionable error.
+    public static func validationError(
+        receipt: Value?,
+        expectedTargets: [String]
+    ) -> String? {
+        guard case .object(let fields)? = receipt else {
+            return missingReceiptMessage
+        }
+
+        guard case .string(let rawOwner)? = fields["domainOwner"],
+              ownerIsSkillKeepr(rawOwner) else {
+            return "routeReceipt.domainOwner must be 'skill-keepr' or 'skills-keepr'."
+        }
+
+        guard case .string(let rawRoute)? = fields["routeId"],
+              routeIsValid(rawRoute) else {
+            return "routeReceipt.routeId must be a SKILLS Keepr route such as R2, R4, R6, R6B, or R8."
+        }
+
+        let targets = stringArray(fields["targetSkills"])
+        guard !targets.isEmpty else {
+            return "routeReceipt.targetSkills must contain at least one governed skill."
+        }
+        guard !stringArray(fields["changeManifest"]).isEmpty else {
+            return "routeReceipt.changeManifest must contain at least one approved change."
+        }
+        guard !stringArray(fields["acceptanceTests"]).isEmpty else {
+            return "routeReceipt.acceptanceTests must contain at least one verification check."
+        }
+        guard !stringArray(fields["writeScope"]).isEmpty else {
+            return "routeReceipt.writeScope must contain at least one allowed write target."
+        }
+
+        let normalizedTargets = Set(targets.map(normalizeSkillName))
+        let missing = expectedTargets
+            .filter { !normalizedTargets.contains(normalizeSkillName($0)) }
+        if !missing.isEmpty {
+            return "routeReceipt.targetSkills does not cover: \(missing.joined(separator: ", ")). Re-route through SKILLS Keepr for the current target set."
+        }
+        return nil
+    }
+
+    public static let missingReceiptMessage =
+        "A current SKILLS Keepr routeReceipt is required before skill-system mutations. Re-route for the current sub-task and include domainOwner, routeId, targetSkills, changeManifest, acceptanceTests, and writeScope."
+
+    private static func stringArraySchema(_ description: String) -> Value {
+        .object([
+            "type": .string("array"),
+            "description": .string(description),
+            "items": .object(["type": .string("string")]),
+            "minItems": .int(1)
+        ])
+    }
+
+    private static func stringArray(_ value: Value?) -> [String] {
+        guard case .array(let values)? = value else { return [] }
+        return values.compactMap { item in
+            guard case .string(let text) = item else { return nil }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private static func ownerIsSkillKeepr(_ raw: String) -> Bool {
+        let normalized = normalizeSkillName(raw)
+        return normalized == "skill-keepr" || normalized == "skills-keepr"
+    }
+
+    private static func routeIsValid(_ raw: String) -> Bool {
+        let route = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard route.first == "R", route.count >= 2 else { return false }
+        let suffix = route.dropFirst()
+        if suffix == "6B" { return true }
+        guard let number = Int(suffix) else { return false }
+        return (0...10).contains(number)
+    }
+
+    private static func normalizeSkillName(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+            .replacingOccurrences(of: " ", with: "-")
+            .replacingOccurrences(of: "--", with: "-")
+    }
+}
+
+/// Pure routing-metadata checks surfaced by `skills_routing_list`.
+public enum SkillRoutingConsistencyLinter {
+    public static func warnings(
+        parentName: String,
+        summary: String,
+        triggerPhrases: [String],
+        antiTriggerPhrases: [String],
+        specialists: [SpecialistSummary]
+    ) -> [String] {
+        var warnings: [String] = []
+        let summaryText = summary.lowercased()
+        let triggers = triggerPhrases.joined(separator: " ").lowercased()
+        let antiTriggers = antiTriggerPhrases.joined(separator: " ").lowercased()
+        let specialistText = specialists
+            .map { "\($0.title) \($0.summary)" }
+            .joined(separator: " ")
+            .lowercased()
+
+        let claimsFrontDoor = summaryText.contains("mandatory front door")
+            || summaryText.contains("single point of entry")
+            || summaryText.contains("single entry point")
+        let hasBuilder = specialistText.contains("skill-builder")
+            || specialistText.contains("construction")
+            || specialistText.contains("scaffold")
+        let antiRoutesConstruction = antiTriggers.contains("create a new skill")
+            || antiTriggers.contains("create new skill")
+            || antiTriggers.contains("build new skill")
+            || antiTriggers.contains("skill construction")
+        let triggersConstruction = triggers.contains("create")
+            || triggers.contains("build")
+            || triggers.contains("scaffold")
+            || triggers.contains("restructure")
+            || triggers.contains("consolidate")
+
+        if claimsFrontDoor && hasBuilder && antiRoutesConstruction {
+            warnings.append("\(parentName) claims front-door ownership but anti-routes construction despite having a construction specialist.")
+        }
+        if hasBuilder && !triggersConstruction {
+            warnings.append("\(parentName) has a construction specialist but no construction or refactor trigger phrase.")
+        }
+        if !specialists.isEmpty && summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            warnings.append("\(parentName) has specialists but no routing summary.")
+        }
+        for specialist in specialists where specialist.summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            warnings.append("Specialist '\(specialist.title)' has an empty routing summary.")
+        }
+        return warnings
+    }
+}

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -75,6 +75,11 @@ public enum SkillsModule {
     intent. If fetch_skill returns a `disambiguate` annotation, pick from its \
     `candidates` (fetch_skill('parent/<name>')) rather than guessing; a \
     `    routingFooter` names the sibling specialists you can switch to.
+    Skill-system ownership: when the target is a KEEP OS skill or command \
+    definition, call fetch_skill('skill-keepr', intent: '<this sub-task>') \
+    before selecting a specialist or executor. A named worker does not \
+    transfer ownership. Re-route when targets change or planning moves to \
+    execution; normal use of an existing skill routes to that skill.
     After `fetch_skill(parent, intent:)`, read `scopedMemory.markdown` when \
     present and treat it as grounding for this sub-task only — re-fetch when \
     the intent changes (scope map uses the parent slug from `name`, not a \
@@ -624,7 +629,7 @@ public enum SkillsModule {
             name: "skill_create",
             module: moduleName,
             tier: .notify,
-            description: "Create one or more skills (Notion-source or file-source). For a single skill: name + url (+ optional visibility). For bulk: skills=[{name,url},...]. Replaces manage_skill action='add'/'bulk_add'.",
+            description: "Create one or more skills after SKILLS Keepr approves the construction route. Requires routeReceipt. For a single skill: name + url (+ optional visibility). For bulk: skills=[{name,url},...]. Replaces manage_skill action='add'/'bulk_add'.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -636,7 +641,8 @@ public enum SkillsModule {
                         "description": .string("Array of {name, url} objects for bulk creation."),
                         "items": .object(["type": .string("object")])
                     ]),
-                    "bypassConfirmation": .object(["type": .string("boolean")])
+                    "bypassConfirmation": .object(["type": .string("boolean")]),
+                    "routeReceipt": SkillRouteReceiptValidator.schema
                 ])
             ]),
             handler: { args in
@@ -651,6 +657,11 @@ public enum SkillsModule {
                             pairs.append((name: n, pageId: u))
                         }
                     }
+                    try Self.requireSkillRouteReceipt(
+                        dict,
+                        expectedTargets: pairs.map { $0.name },
+                        toolName: "skill_create"
+                    )
                     let result = writeBulkAdd(skills: pairs)
                     var bulk: [String: Value] = [
                         "action": .string("bulk_add"),
@@ -673,6 +684,11 @@ public enum SkillsModule {
                         reason: "single-skill mode requires 'name' and 'url' parameters"
                     )
                 }
+                try Self.requireSkillRouteReceipt(
+                    dict,
+                    expectedTargets: [name],
+                    toolName: "skill_create"
+                )
                 let vis = parseVisibilityArg(dict) ?? .standard
                 let parseResult = SkillURLParser.parse(url: url)
                 switch parseResult {
@@ -717,12 +733,13 @@ public enum SkillsModule {
             module: moduleName,
             tier: .request,
             neverAutoApprove: true,
-            description: "Delete one skill by name. Replaces manage_skill action='delete'.",
+            description: "Delete one skill by name after SKILLS Keepr approves the lifecycle route. Requires routeReceipt. Replaces manage_skill action='delete'.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "name": .object(["type": .string("string"), "description": .string("Skill name to delete.")]),
-                    "bypassConfirmation": .object(["type": .string("boolean")])
+                    "bypassConfirmation": .object(["type": .string("boolean")]),
+                    "routeReceipt": SkillRouteReceiptValidator.schema
                 ]),
                 "required": .array([.string("name")])
             ]),
@@ -734,6 +751,11 @@ public enum SkillsModule {
                         reason: "'name' parameter is required"
                     )
                 }
+                try Self.requireSkillRouteReceipt(
+                    dict,
+                    expectedTargets: [name],
+                    toolName: "skill_delete"
+                )
                 let success = writeDeleteSkill(named: name)
                 return .object([
                     "success": .bool(success),
@@ -749,7 +771,7 @@ public enum SkillsModule {
             name: "skill_update",
             module: moduleName,
             tier: .notify,
-            description: "Update one skill: toggle on/off, change its URL, set visibility, or replace MCP metadata (summary + trigger/anti-trigger phrases). Picks the right action automatically based on which fields are present. Replaces manage_skill toggle/update_url/set_visibility/set_metadata.",
+            description: "Update one skill after SKILLS Keepr approves the change. Requires routeReceipt. Supports toggle, URL, visibility, or MCP metadata changes. Replaces manage_skill toggle/update_url/set_visibility/set_metadata.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -760,7 +782,8 @@ public enum SkillsModule {
                     "summary": .object(["type": .string("string")]),
                     "triggerPhrases": .object(["type": .string("array"), "items": .object(["type": .string("string")])]),
                     "antiTriggerPhrases": .object(["type": .string("array"), "items": .object(["type": .string("string")])]),
-                    "bypassConfirmation": .object(["type": .string("boolean")])
+                    "bypassConfirmation": .object(["type": .string("boolean")]),
+                    "routeReceipt": SkillRouteReceiptValidator.schema
                 ]),
                 "required": .array([.string("name")])
             ]),
@@ -772,6 +795,11 @@ public enum SkillsModule {
                         reason: "'name' parameter is required"
                     )
                 }
+                try Self.requireSkillRouteReceipt(
+                    dict,
+                    expectedTargets: [name],
+                    toolName: "skill_update"
+                )
                 if case .bool(true) = dict["toggle"] {
                     let result = writeToggleSkill(named: name)
                     return .object([
@@ -862,13 +890,14 @@ public enum SkillsModule {
             name: "skill_rename",
             module: moduleName,
             tier: .notify,
-            description: "Rename one skill (preserves UUID, enabled state, visibility, metadata). Replaces manage_skill action='rename'.",
+            description: "Rename one skill after SKILLS Keepr approves identity propagation. Requires routeReceipt and preserves UUID, enabled state, visibility, and metadata. Replaces manage_skill action='rename'.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "name": .object(["type": .string("string"), "description": .string("Current skill name.")]),
                     "newName": .object(["type": .string("string"), "description": .string("New skill name.")]),
-                    "bypassConfirmation": .object(["type": .string("boolean")])
+                    "bypassConfirmation": .object(["type": .string("boolean")]),
+                    "routeReceipt": SkillRouteReceiptValidator.schema
                 ]),
                 "required": .array([.string("name"), .string("newName")])
             ]),
@@ -881,6 +910,11 @@ public enum SkillsModule {
                         reason: "'name' and 'newName' parameters are required"
                     )
                 }
+                try Self.requireSkillRouteReceipt(
+                    dict,
+                    expectedTargets: [name, newName],
+                    toolName: "skill_rename"
+                )
                 let success = writeRenameSkill(named: name, to: newName)
                 return .object([
                     "success": .bool(success),
@@ -897,7 +931,7 @@ public enum SkillsModule {
             name: "skill_sync_notion",
             module: moduleName,
             tier: .notify,
-            description: "Sync one skill's MCP metadata (summary + trigger/anti-trigger phrases) between local store and Notion. direction='push' uploads local → Notion. direction='pull' downloads Notion → local. Replaces manage_skill sync_metadata_to_notion / sync_metadata_from_notion.",
+            description: "Sync one skill's MCP metadata between local store and Notion. direction='push' is a skill-system mutation and requires routeReceipt; direction='pull' is read-only. Replaces manage_skill sync_metadata_to_notion / sync_metadata_from_notion.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -907,7 +941,8 @@ public enum SkillsModule {
                         "description": .string("'push' = local → Notion. 'pull' = Notion → local."),
                         "enum": .array([.string("push"), .string("pull")])
                     ]),
-                    "bypassConfirmation": .object(["type": .string("boolean")])
+                    "bypassConfirmation": .object(["type": .string("boolean")]),
+                    "routeReceipt": SkillRouteReceiptValidator.schema
                 ]),
                 "required": .array([.string("name"), .string("direction")])
             ]),
@@ -921,6 +956,13 @@ public enum SkillsModule {
                 }
                 let isPush = (dir == "push")
                 let actionLabel = isPush ? "sync_metadata_to_notion" : "sync_metadata_from_notion"
+                if isPush {
+                    try Self.requireSkillRouteReceipt(
+                        dict,
+                        expectedTargets: [name],
+                        toolName: "skill_sync_notion"
+                    )
+                }
                 guard let skill = lookupSkill(named: name) else {
                     return .object(["success": .bool(false), "action": .string(actionLabel), "message": .string("Skill not found.")])
                 }
@@ -989,6 +1031,19 @@ public enum SkillsModule {
     fileprivate static func unpackArgsObject(_ v: Value) -> [String: Value] {
         if case .object(let dict) = v { return dict }
         return [:]
+    }
+
+    private static func requireSkillRouteReceipt(
+        _ args: [String: Value],
+        expectedTargets: [String],
+        toolName: String
+    ) throws {
+        if let error = SkillRouteReceiptValidator.validationError(
+            receipt: args["routeReceipt"],
+            expectedTargets: expectedTargets
+        ) {
+            throw ToolRouterError.invalidArguments(toolName: toolName, reason: error)
+        }
     }
 
     // MARK: - UserDefaults Write Helpers (non-MainActor safe)
@@ -3091,6 +3146,43 @@ public enum SkillsModule {
                     dict["specialistsStale"] = .bool(true)
                 }
             }
+
+            let specialistSummaries: [SpecialistSummary] = {
+                guard case .array(let values)? = dict["specialists"] else { return [] }
+                return values.compactMap { value in
+                    guard case .object(let item) = value,
+                          case .string(let path)? = item["path"],
+                          case .string(let title)? = item["title"] else { return nil }
+                    let summary: String = {
+                        if case .string(let text)? = item["summary"] { return text }
+                        return ""
+                    }()
+                    return SpecialistSummary(path: path, title: title, summary: summary)
+                }
+            }()
+            let summary: String = {
+                if case .string(let text)? = dict["summary"] { return text }
+                return ""
+            }()
+            let triggers: [String] = {
+                guard case .array(let values)? = dict["triggerPhrases"] else { return [] }
+                return values.compactMap { if case .string(let text) = $0 { return text }; return nil }
+            }()
+            let antiTriggers: [String] = {
+                guard case .array(let values)? = dict["antiTriggerPhrases"] else { return [] }
+                return values.compactMap { if case .string(let text) = $0 { return text }; return nil }
+            }()
+            let warnings = SkillRoutingConsistencyLinter.warnings(
+                parentName: name,
+                summary: summary,
+                triggerPhrases: triggers,
+                antiTriggerPhrases: antiTriggers,
+                specialists: specialistSummaries
+            )
+            if !warnings.isEmpty {
+                dict["routingWarnings"] = .array(warnings.map(Value.string))
+            }
+
             out.append(.object(dict))
         }
         return out

--- a/TheBridgeTests/SkillsModuleTests.swift
+++ b/TheBridgeTests/SkillsModuleTests.swift
@@ -165,4 +165,160 @@ func runSkillsModuleTests() async {
         }
     }
 
+    // ============================================================
+    // MARK: - Skill-system ownership and routing governance
+    // ============================================================
+
+    let validReceipt: Value = .object([
+        "domainOwner": .string("skill-keepr"),
+        "routeId": .string("R6B"),
+        "targetSkills": .array([.string("nonexistent-governed-skill")]),
+        "changeManifest": .array([.string("Update routing metadata")]),
+        "acceptanceTests": .array([.string("Verify the target metadata")]),
+        "writeScope": .array([.string("Skill registry metadata")])
+    ])
+
+    await test("Every skill mutation schema exposes routeReceipt") {
+        let tools = await router.registrations(forModule: "skills")
+        for name in ["skill_create", "skill_delete", "skill_update", "skill_rename", "skill_sync_notion"] {
+            guard let tool = tools.first(where: { $0.name == name }) else {
+                throw TestError.assertion("Missing \(name)")
+            }
+            guard case .object(let schema) = tool.inputSchema,
+                  case .object(let properties)? = schema["properties"] else {
+                throw TestError.assertion("\(name) schema has no properties object")
+            }
+            try expect(properties["routeReceipt"] != nil, "\(name) must expose routeReceipt")
+        }
+    }
+
+    await test("Route receipt rejects missing governance context") {
+        let error = SkillRouteReceiptValidator.validationError(
+            receipt: nil,
+            expectedTargets: ["alpha"]
+        )
+        try expect(error != nil && error!.contains("SKILLS Keepr"),
+                   "Missing receipt should return a SKILLS Keepr routing error")
+    }
+
+    await test("Route receipt accepts R6B and matching targets") {
+        let error = SkillRouteReceiptValidator.validationError(
+            receipt: validReceipt,
+            expectedTargets: ["nonexistent governed skill"]
+        )
+        try expect(error == nil, "Valid R6B receipt should pass: \(error ?? "")")
+    }
+
+    await test("Route receipt rejects a stale target set") {
+        let error = SkillRouteReceiptValidator.validationError(
+            receipt: validReceipt,
+            expectedTargets: ["different-skill"]
+        )
+        try expect(error?.contains("does not cover") == true,
+                   "Target mismatch should require a fresh route")
+    }
+
+    await test("All skill mutation tools stop when routeReceipt is absent") {
+        let cases: [(tool: String, arguments: Value)] = [
+            ("skill_create", .object([
+                "name": .string("nonexistent-governed-skill"),
+                "url": .string("0123456789abcdef0123456789abcdef")
+            ])),
+            ("skill_delete", .object([
+                "name": .string("nonexistent-governed-skill")
+            ])),
+            ("skill_update", .object([
+                "name": .string("nonexistent-governed-skill"),
+                "summary": .string("Should never write")
+            ])),
+            ("skill_rename", .object([
+                "name": .string("nonexistent-governed-skill"),
+                "newName": .string("nonexistent-renamed-skill")
+            ])),
+            ("skill_sync_notion", .object([
+                "name": .string("nonexistent-governed-skill"),
+                "direction": .string("push")
+            ]))
+        ]
+
+        for testCase in cases {
+            do {
+                _ = try await router.dispatch(
+                    toolName: testCase.tool,
+                    arguments: testCase.arguments
+                )
+                throw TestError.assertion("Expected missing routeReceipt error for \(testCase.tool)")
+            } catch let error as ToolRouterError {
+                try expect(String(describing: error).contains("routeReceipt"),
+                           "\(testCase.tool) should identify the missing routeReceipt")
+            }
+        }
+    }
+
+    await test("skill_update accepts a governed receipt before target lookup") {
+        let result = try await router.dispatch(
+            toolName: "skill_update",
+            arguments: .object([
+                "name": .string("nonexistent-governed-skill"),
+                "summary": .string("Governed metadata update"),
+                "routeReceipt": validReceipt
+            ])
+        )
+        guard case .object(let dict) = result,
+              case .bool(let success)? = dict["success"] else {
+            throw TestError.assertion("Expected structured skill_update result")
+        }
+        try expect(!success, "Nonexistent target should fail after receipt validation")
+    }
+
+    await test("skill_sync_notion pull remains read-only and needs no receipt") {
+        let result = try await router.dispatch(
+            toolName: "skill_sync_notion",
+            arguments: .object([
+                "name": .string("nonexistent-governed-skill"),
+                "direction": .string("pull")
+            ])
+        )
+        guard case .object(let dict) = result,
+              case .bool(let success)? = dict["success"] else {
+            throw TestError.assertion("Expected structured sync result")
+        }
+        try expect(!success, "Nonexistent pull target should report not found, not a receipt error")
+    }
+
+    await test("Routing linter catches front-door construction contradiction") {
+        let warnings = SkillRoutingConsistencyLinter.warnings(
+            parentName: "skill-keepr",
+            summary: "Single point of entry for all skill development.",
+            triggerPhrases: ["Audit a skill"],
+            antiTriggerPhrases: ["Create a new skill"],
+            specialists: [
+                SpecialistSummary(
+                    path: "skill-keepr/skill-builder",
+                    title: "skill-builder",
+                    summary: "Owns new skill construction."
+                )
+            ]
+        )
+        try expect(warnings.count >= 2,
+                   "Contradictory parent metadata should emit ownership and trigger warnings")
+    }
+
+    await test("Routing linter accepts corrected SKILLS Keepr metadata") {
+        let warnings = SkillRoutingConsistencyLinter.warnings(
+            parentName: "skill-keepr",
+            summary: "Mandatory front door for skill creation, changes, and governance.",
+            triggerPhrases: ["Create a skill", "Build a skill", "Restructure a skill tree"],
+            antiTriggerPhrases: ["Use an existing skill without changing its definition"],
+            specialists: [
+                SpecialistSummary(
+                    path: "skill-keepr/skill-builder",
+                    title: "skill-builder",
+                    summary: "Owns new construction and read-only refactor advice."
+                )
+            ]
+        )
+        try expect(warnings.isEmpty, "Corrected routing metadata should be clean: \(warnings)")
+    }
+
 }

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1567,7 +1567,13 @@ set -euo pipefail
 # CredentialReference/FallbackChain/SyntaxValidator/TestResult). Plus 2 mechanical fixes:
 # MemoryHubActivityEventType custom Codable (unknown forward-compat), MemoryModuleTests
 # tool-count 5→6 (memory_update D35). All hermetic; no net/Ollama/audio. 2682→2744.
-FLOOR="${BRIDGE_TEST_FLOOR:-2744}"
+# 2026-06-28 (skill-system routing governance):
+# +9 tests covering routeReceipt schema exposure, missing/valid/stale receipt
+# validation, enforcement across all mutation tools, read-only metadata pull,
+# and routing-consistency lint detection/clean-state behavior. The clean base
+# measured 2746 passing tests; this branch measures 2755 passed / 0 failed.
+# 2744 recorded floor → 2755 measured floor.
+FLOOR="${BRIDGE_TEST_FLOOR:-2755}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary

- make SKILLS Keepr ownership explicit in the Bridge session handshake
- require a current SKILLS Keepr route receipt for skill create, delete, update, rename, and metadata push operations
- keep metadata pull read-only and receipt-free
- add routing-consistency warnings to `skills_routing_list`
- add regression coverage and raise the measured test floor

## Verification

- `make test`: 2,755 passed, 0 failed
- `make test-floor`: 2,755 passed, 0 failed
- production `make app` bundle built successfully
- installed bundle passed deep/strict codesign verification
- installed binary hash matched the signed source bundle
- live smoke test confirmed a mutation without `routeReceipt` is rejected before target lookup

## Scope

Exactly four files:

- `TheBridge/Modules/Skills/SkillRoutingGovernance.swift`
- `TheBridge/Modules/SkillsModule.swift`
- `TheBridgeTests/SkillsModuleTests.swift`
- `scripts/test-floor-gate.sh`

The prior mixed worktree is preserved separately on `backup-mixed-wip-2026-06-28` and is not part of this PR.