### PR TITLE
feat(registry): initialize create bodies from markdown

### DIFF
--- a/TheBridge/Modules/Registry/RegistryGateway.swift
+++ b/TheBridge/Modules/Registry/RegistryGateway.swift
@@ -22,6 +22,7 @@ public protocol RegistryNotionGateway: Sendable {
     func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow
     func archive(pageId: String, workspace: String?) async throws
     func markdown(pageId: String, workspace: String?) async throws -> String
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws
 }
 
 public extension RegistryNotionGateway {
@@ -100,6 +101,13 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
             if let content = obj["content"] as? String { return content }
         }
         return String(decoding: data, as: UTF8.self)
+    }
+
+    public func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {
+        let c = try await client(workspace)
+        _ = try await limiter.throttled {
+            try await c.replacePageMarkdown(pageId: pageId, markdown: markdown)
+        }
     }
 
     /// Build the `{"PROPERTY_NAME": <payload>}` envelope from bound fields,

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -12,11 +12,13 @@
 // connection resolution) and the read-through `RegistryRowCache`, so reads are
 // warm-cache fast and offline-tolerant.
 
+import CryptoKit
 import Foundation
 import MCP
 
 public enum RegistryModule {
     public static let moduleName = "registry"
+    public static let maxBodyMarkdownCharacters = 100_000
 
     // MARK: - Injectable seams (tests override; production uses live defaults)
 
@@ -57,9 +59,38 @@ public enum RegistryModule {
         return nil
     }
 
+    static func stringIfPresent(_ args: [String: Value], _ key: String) -> String? {
+        if case .string(let s)? = args[key] { return s }
+        return nil
+    }
+
     static func fields(_ args: [String: Value]) -> [String: Value] {
         if case .object(let o)? = args["fields"] { return o }
         return [:]
+    }
+
+    static func markdownHash(_ markdown: String) -> String {
+        SHA256.hash(data: Data(markdown.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func bodyWriteValue(
+        requested: Bool,
+        succeeded: Bool,
+        characters: Int,
+        markdownHash: String?,
+        operation: String = "replacePageMarkdown",
+        error: String? = nil
+    ) -> Value {
+        var out: [String: Value] = [
+            "requested": .bool(requested),
+            "succeeded": .bool(succeeded),
+            "operation": .string(operation),
+            "characters": .int(characters),
+            "maxCharacters": .int(maxBodyMarkdownCharacters),
+        ]
+        if let markdownHash { out["markdownSha256"] = .string(markdownHash) }
+        if let error { out["error"] = .string(error) }
+        return .object(out)
     }
 
     static func entityValue(_ e: RegistryEntity) -> Value {
@@ -315,12 +346,14 @@ public enum RegistryModule {
     public static func makeCreate() -> ToolRegistration {
         ToolRegistration(
             name: "registry_create", module: moduleName, tier: .notify,
-            description: "Create a new row in a registry entity from canonical field keys (create-then-update: a titled row is created first, then the rest of the properties are set). Each supplied field must already be bound to a Notion property id — run registry_introspect first.",
+            description: "Create a new row in a registry entity from canonical field keys. Optional bodyMarkdown initializes the newly-created Notion page body for body-bearing entities (see registry_entities hasBody=true); the supplied Markdown is copied as source content, not summarized, regenerated, or improved. Supported Markdown is Notion's page-markdown subset: headings, paragraphs, bulleted/numbered lists, code fences, block quotes, links, and inline emphasis. bodyMarkdown is optional, Max 100000 characters, and used only for initial creation via replacePageMarkdown on the new blank page. Use idempotencyKey to make retries return the first created page instead of creating duplicates. If the body write fails after row creation, the result is created=false with partialFailure=true and the page id plus body error; it is never reported as a successful creation.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "entity": .object(["type": .string("string")]),
                     "fields": .object(["type": .string("object"), "description": .string("Map of canonical field key → value (e.g. {\"name\":\"…\",\"status\":\"Active\"}).")]),
+                    "bodyMarkdown": .object(["type": .string("string"), "description": .string("Optional initial page body for body-bearing entities only. Copied verbatim as Markdown source through Notion's page-markdown writer; never summarized or rewritten. Max 100000 characters.")]),
+                    "idempotencyKey": .object(["type": .string("string"), "description": .string("Optional stable retry key/source id. Reusing the same key returns the first created page and avoids duplicate packets.")]),
                 ]),
                 "required": .array([.string("entity"), .string("fields")]),
             ]),
@@ -330,9 +363,148 @@ public enum RegistryModule {
                 }
                 let config = await loadConfig()
                 let entity = try requireEntity(key, in: config, tool: "registry_create")
-                let writer = RegistryWriter(gateway: gateway())
+                let bodyMarkdown = stringIfPresent(a, "bodyMarkdown")
+                let bodyRequested = bodyMarkdown != nil
+                if bodyRequested && !entity.hasBody {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "registry_create",
+                        reason: "entity ‘\(key)’ does not support page bodies — omit bodyMarkdown or choose an entity with hasBody=true")
+                }
+                if let bodyMarkdown, bodyMarkdown.count > maxBodyMarkdownCharacters {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "registry_create",
+                        reason: "bodyMarkdown is \(bodyMarkdown.count) characters; max is \(maxBodyMarkdownCharacters). Nothing was created.")
+                }
+                let bodyHash = bodyMarkdown.map(markdownHash)
+                let idempotencyKey = string(a, "idempotencyKey")
+                let idemStore = RegistryCreateIdempotencyStore.shared
+                let gateway = gateway()
+                if let idempotencyKey, let record = try await idemStore.record(entity: entity.key, key: idempotencyKey) {
+                    if let bodyHash, let priorHash = record.bodyMarkdownHash, priorHash != bodyHash {
+                        throw ToolRouterError.invalidArguments(
+                            toolName: "registry_create",
+                            reason: "idempotencyKey ‘\(idempotencyKey)’ was already used with different bodyMarkdown")
+                    }
+                    if record.bodyRequested, !record.bodySucceeded, let bodyMarkdown {
+                        do {
+                            try await gateway.writeMarkdown(pageId: record.row.pageId, workspace: entity.workspace, markdown: bodyMarkdown)
+                            let healed = record.withBodySuccess()
+                            try await idemStore.save(healed)
+                            return .object([
+                                "created": .bool(false),
+                                "idempotentReplay": .bool(true),
+                                "partialFailure": .bool(false),
+                                "row": rowValue(healed.row, stale: false),
+                                "bodyWrite": bodyWriteValue(
+                                    requested: true,
+                                    succeeded: true,
+                                    characters: healed.bodyCharacters,
+                                    markdownHash: healed.bodyMarkdownHash),
+                            ])
+                        } catch {
+                            let failed = record.withBodyFailure(String(describing: error))
+                            try? await idemStore.save(failed)
+                            return .object([
+                                "created": .bool(false),
+                                "idempotentReplay": .bool(true),
+                                "partialFailure": .bool(true),
+                                "reason": .string("body_write_failed"),
+                                "row": rowValue(failed.row, stale: false),
+                                "bodyWrite": bodyWriteValue(
+                                    requested: true,
+                                    succeeded: false,
+                                    characters: failed.bodyCharacters,
+                                    markdownHash: failed.bodyMarkdownHash,
+                                    error: failed.bodyError),
+                            ])
+                        }
+                    }
+                    return .object([
+                        "created": .bool(false),
+                        "idempotentReplay": .bool(true),
+                        "partialFailure": .bool(!record.bodySucceeded && record.bodyRequested),
+                        "row": rowValue(record.row, stale: false),
+                        "bodyWrite": bodyWriteValue(
+                            requested: record.bodyRequested,
+                            succeeded: record.bodySucceeded,
+                            characters: record.bodyCharacters,
+                            markdownHash: record.bodyMarkdownHash,
+                            error: record.bodyError),
+                    ])
+                }
+                let writer = RegistryWriter(gateway: gateway)
                 let row = try await writer.create(entity: entity, fields: fields(a))
-                return .object(["created": .bool(true), "row": rowValue(row, stale: false)])
+                if let idempotencyKey {
+                    try await idemStore.save(RegistryCreateIdempotencyRecord(
+                        entity: entity.key,
+                        key: idempotencyKey,
+                        row: row,
+                        bodyRequested: bodyRequested,
+                        bodySucceeded: !bodyRequested,
+                        bodyMarkdownHash: bodyHash,
+                        bodyCharacters: bodyMarkdown?.count ?? 0,
+                        bodyError: nil,
+                        createdAt: Date()))
+                }
+                guard let bodyMarkdown else {
+                    return .object([
+                        "created": .bool(true),
+                        "partialFailure": .bool(false),
+                        "row": rowValue(row, stale: false),
+                        "bodyWrite": bodyWriteValue(requested: false, succeeded: false, characters: 0, markdownHash: nil),
+                    ])
+                }
+                do {
+                    try await gateway.writeMarkdown(pageId: row.pageId, workspace: entity.workspace, markdown: bodyMarkdown)
+                    if let idempotencyKey {
+                        try await idemStore.save(RegistryCreateIdempotencyRecord(
+                            entity: entity.key,
+                            key: idempotencyKey,
+                            row: row,
+                            bodyRequested: true,
+                            bodySucceeded: true,
+                            bodyMarkdownHash: bodyHash,
+                            bodyCharacters: bodyMarkdown.count,
+                            bodyError: nil,
+                            createdAt: Date()))
+                    }
+                    return .object([
+                        "created": .bool(true),
+                        "partialFailure": .bool(false),
+                        "row": rowValue(row, stale: false),
+                        "bodyWrite": bodyWriteValue(
+                            requested: true,
+                            succeeded: true,
+                            characters: bodyMarkdown.count,
+                            markdownHash: bodyHash),
+                    ])
+                } catch {
+                    let err = String(describing: error)
+                    if let idempotencyKey {
+                        try? await idemStore.save(RegistryCreateIdempotencyRecord(
+                            entity: entity.key,
+                            key: idempotencyKey,
+                            row: row,
+                            bodyRequested: true,
+                            bodySucceeded: false,
+                            bodyMarkdownHash: bodyHash,
+                            bodyCharacters: bodyMarkdown.count,
+                            bodyError: err,
+                            createdAt: Date()))
+                    }
+                    return .object([
+                        "created": .bool(false),
+                        "partialFailure": .bool(true),
+                        "reason": .string("body_write_failed"),
+                        "row": rowValue(row, stale: false),
+                        "bodyWrite": bodyWriteValue(
+                            requested: true,
+                            succeeded: false,
+                            characters: bodyMarkdown.count,
+                            markdownHash: bodyHash,
+                            error: err),
+                    ])
+                }
             })
     }
 
@@ -445,5 +617,114 @@ public enum RegistryModule {
                 let envelope = try await reader.hydrate(entity: entity, pageId: id, forceRefresh: force)
                 return envelope.asValue()
             })
+    }
+}
+
+public struct RegistryCreateIdempotencyRecord: Codable, Sendable, Equatable {
+    public let entity: String
+    public let key: String
+    public let row: CachedRow
+    public let bodyRequested: Bool
+    public let bodySucceeded: Bool
+    public let bodyMarkdownHash: String?
+    public let bodyCharacters: Int
+    public let bodyError: String?
+    public let createdAt: Date
+
+    public init(
+        entity: String,
+        key: String,
+        row: CachedRow,
+        bodyRequested: Bool,
+        bodySucceeded: Bool,
+        bodyMarkdownHash: String?,
+        bodyCharacters: Int,
+        bodyError: String?,
+        createdAt: Date
+    ) {
+        self.entity = entity
+        self.key = key
+        self.row = row
+        self.bodyRequested = bodyRequested
+        self.bodySucceeded = bodySucceeded
+        self.bodyMarkdownHash = bodyMarkdownHash
+        self.bodyCharacters = bodyCharacters
+        self.bodyError = bodyError
+        self.createdAt = createdAt
+    }
+
+    public func withBodySuccess() -> RegistryCreateIdempotencyRecord {
+        RegistryCreateIdempotencyRecord(
+            entity: entity,
+            key: key,
+            row: row,
+            bodyRequested: bodyRequested,
+            bodySucceeded: true,
+            bodyMarkdownHash: bodyMarkdownHash,
+            bodyCharacters: bodyCharacters,
+            bodyError: nil,
+            createdAt: createdAt)
+    }
+
+    public func withBodyFailure(_ error: String) -> RegistryCreateIdempotencyRecord {
+        RegistryCreateIdempotencyRecord(
+            entity: entity,
+            key: key,
+            row: row,
+            bodyRequested: bodyRequested,
+            bodySucceeded: false,
+            bodyMarkdownHash: bodyMarkdownHash,
+            bodyCharacters: bodyCharacters,
+            bodyError: error,
+            createdAt: createdAt)
+    }
+}
+
+public actor RegistryCreateIdempotencyStore {
+    public static let shared = RegistryCreateIdempotencyStore()
+
+    private var loaded: [String: RegistryCreateIdempotencyRecord]?
+
+    public init() {}
+
+    private var fileURL: URL {
+        BridgePaths.applicationSupport(.registry).appendingPathComponent("create-idempotency.json")
+    }
+
+    private func composite(entity: String, key: String) -> String {
+        "\(entity)\u{1F}\(key)"
+    }
+
+    private func load() -> [String: RegistryCreateIdempotencyRecord] {
+        if let loaded { return loaded }
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: RegistryCreateIdempotencyRecord].self, from: data) else {
+            loaded = [:]
+            return [:]
+        }
+        loaded = decoded
+        return decoded
+    }
+
+    public func record(entity: String, key: String) throws -> RegistryCreateIdempotencyRecord? {
+        load()[composite(entity: entity, key: key)]
+    }
+
+    public func save(_ record: RegistryCreateIdempotencyRecord) throws {
+        var records = load()
+        records[composite(entity: record.entity, key: record.key)] = record
+        try BridgePaths.ensureApplicationSupport(.registry)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(records)
+        try data.write(to: fileURL, options: [.atomic])
+        loaded = records
+    }
+
+    public func resetForTesting() throws {
+        loaded = [:]
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
     }
 }

--- a/TheBridgeTests/DataSourcesViewModelTests.swift
+++ b/TheBridgeTests/DataSourcesViewModelTests.swift
@@ -31,6 +31,7 @@ private actor VMFakeGateway: RegistryNotionGateway {
     func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow { throw NSError(domain: "vmfake", code: 405) }
     func archive(pageId: String, workspace: String?) async throws {}
     func markdown(pageId: String, workspace: String?) async throws -> String { "" }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {}
 }
 
 private func fullSkillsSchema() -> DataSourceSchema {

--- a/TheBridgeTests/RegistryDataPathTests.swift
+++ b/TheBridgeTests/RegistryDataPathTests.swift
@@ -28,6 +28,7 @@ private actor FakeRegistryGateway: RegistryNotionGateway {
     private(set) var created: [[BoundField]] = []
     private(set) var updated: [(id: String, fields: [BoundField])] = []
     private(set) var archived: [String] = []
+    private(set) var markdownWrites: [(pageId: String, markdown: String)] = []
     private var nextId = 1
 
     func setFail(_ v: Bool) { failNetwork = v }
@@ -76,6 +77,10 @@ private actor FakeRegistryGateway: RegistryNotionGateway {
     func markdown(pageId: String, workspace: String?) async throws -> String {
         if failNetwork { throw FakeError.offline }
         return "# Body of \(pageId)\n\npossessed."
+    }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {
+        if failNetwork { throw FakeError.offline }
+        markdownWrites.append((pageId, markdown))
     }
 
     enum FakeError: Error { case offline, notFound }

--- a/TheBridgeTests/RegistryEdgeCaseTests.swift
+++ b/TheBridgeTests/RegistryEdgeCaseTests.swift
@@ -60,6 +60,7 @@ private actor EdgeGateway: RegistryNotionGateway {
     }
     func archive(pageId: String, workspace: String?) async throws { if failNetwork { throw Err.offline }; pages[CachedRow.normalize(pageId)] = nil }
     func markdown(pageId: String, workspace: String?) async throws -> String { if failNetwork { throw Err.offline }; return "# body \(pageId)" }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws { if failNetwork { throw Err.offline } }
     enum Err: Error { case offline, notFound }
 }
 

--- a/TheBridgeTests/RegistryHydrationTests.swift
+++ b/TheBridgeTests/RegistryHydrationTests.swift
@@ -48,6 +48,9 @@ private actor HydrationGateway: RegistryNotionGateway {
         if failNetwork { throw Err.offline }
         return "# packet body \(pageId)"
     }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {
+        if failNetwork { throw Err.offline }
+    }
     enum Err: Error { case offline, notFound, forbidden }
 }
 

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -13,9 +13,11 @@ private actor ModFakeGateway: RegistryNotionGateway {
     var schemaToReturn: DataSourceSchema
     var queryRows: [NotionRow]
     var pages: [String: NotionRow]
+    var failMarkdownWrite = false
     private(set) var created: [[BoundField]] = []
     private(set) var updated: [(String, [BoundField])] = []
     private(set) var archived: [String] = []
+    private(set) var markdownWrites: [(pageId: String, markdown: String)] = []
     init(schema: DataSourceSchema, queryRows: [NotionRow] = [], pages: [String: NotionRow] = [:]) {
         self.schemaToReturn = schema; self.queryRows = queryRows; self.pages = pages
     }
@@ -39,6 +41,11 @@ private actor ModFakeGateway: RegistryNotionGateway {
     }
     func archive(pageId: String, workspace: String?) async throws { archived.append(pageId) }
     func markdown(pageId: String, workspace: String?) async throws -> String { "# Possessed \(pageId)" }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {
+        if failMarkdownWrite { throw NSError(domain: "fake.markdown", code: 500) }
+        markdownWrites.append((pageId, markdown))
+    }
+    func setFailMarkdownWrite(_ value: Bool) { failMarkdownWrite = value }
 }
 
 private func skillsSchema() -> DataSourceSchema {
@@ -51,6 +58,14 @@ private func skillsSchema() -> DataSourceSchema {
         "Status": .init(id: "id_status", type: "status"),
         "Domain": .init(id: "id_domain", type: "select"),
         "Specialist": .init(id: "id_spec", type: "relation"),
+    ])
+}
+
+private func packetSchema() -> DataSourceSchema {
+    DataSourceSchema(columnsByName: [
+        "Packet Name": .init(id: "id_packet_title", type: "title"),
+        "Status": .init(id: "id_packet_status", type: "status"),
+        "PROJECT": .init(id: "id_packet_project", type: "relation"),
     ])
 }
 
@@ -74,6 +89,7 @@ private func withRegistryModuleEnv(_ fake: ModFakeGateway, _ body: () async thro
         BridgePaths.overrideHomeForTesting(nil)
         try? FileManager.default.removeItem(at: tmp)
     }
+    try? await RegistryCreateIdempotencyStore.shared.resetForTesting()
     try await body()
 }
 
@@ -183,6 +199,162 @@ func runRegistryModuleTests() async {
             let updatedCalls = await fake.updated.count
             try expect(createdCalls == 1 && updatedCalls == 1, "create-then-update (title create + rest patch)")
         }
+    }
+
+    await test("registry_create creates body-bearing packet with relation and verbatim Markdown body") {
+        let fake = ModFakeGateway(schema: packetSchema())
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeAddEntity().handler(.object([
+                "key": .string("session"),
+                "displayName": .string("Packets"),
+                "dataSourceId": .string("packet_ds"),
+                "hasBody": .bool(true),
+                "properties": .array([
+                    .object(["key": .string("name"), "notionName": .string("Packet Name"), "type": .string("title"), "role": .string("title")]),
+                    .object(["key": .string("status"), "notionName": .string("Status"), "type": .string("status"), "role": .string("status")]),
+                    .object(["key": .string("project"), "notionName": .string("PROJECT"), "type": .string("relation"), "role": .string("relation")]),
+                ]),
+            ]))
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("session")]))
+            let markdown = """
+            # Approved Proposal
+
+            Keep this **exact** wording.
+
+            - First item
+            - [Linked item](https://example.com)
+
+            > Quoted source text
+
+            ```json
+            {"copy":"verbatim"}
+            ```
+            """
+            let out = try await RegistryModule.makeCreate().handler(.object([
+                "entity": .string("session"),
+                "fields": .object([
+                    "name": .string("Bridge Tool Surface Completeness and Policy Coherence"),
+                    "status": .string("QUEUE"),
+                    "project": .array([.string("37fcbb58-889e-81f1-867e-d71b11dd9baf")]),
+                ]),
+                "bodyMarkdown": .string(markdown),
+            ]))
+            try expect(obj(out)["created"] == .bool(true), "created")
+            try expect(obj(out)["partialFailure"] == .bool(false), "not partial")
+            let created = await fake.created
+            let updated = await fake.updated
+            try expect(created.count == 1 && created[0].contains(where: { $0.notionName == "Packet Name" && $0.isTitle }), "title created")
+            try expect(updated.count == 1, "non-title fields patched")
+            try expect(updated[0].1.contains(where: { $0.notionName == "PROJECT" && $0.type == "relation" }), "PROJECT relation patched normally")
+            let writes = await fake.markdownWrites
+            try expect(writes.count == 1, "one body write")
+            try expect(writes[0].markdown == markdown, "markdown body must be passed verbatim")
+            let bodyWrite = obj(obj(out)["bodyWrite"] ?? .null)
+            try expect(bodyWrite["requested"] == .bool(true) && bodyWrite["succeeded"] == .bool(true), "body write receipt")
+        }
+    }
+
+    await test("registry_create remains compatible for property-only creates") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("skill")]))
+            let out = try await RegistryModule.makeCreate().handler(.object([
+                "entity": .string("skill"),
+                "fields": .object(["name": .string("Property Only")]),
+            ]))
+            try expect(obj(out)["created"] == .bool(true), "created")
+            let writes = await fake.markdownWrites
+            try expect(writes.isEmpty, "no body write for property-only create")
+        }
+    }
+
+    await test("registry_create rejects bodyMarkdown for non-body entity before row creation") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeAddEntity().handler(.object([
+                "key": .string("project"),
+                "dataSourceId": .string("project_ds"),
+                "hasBody": .bool(false),
+                "properties": .array([
+                    .object(["key": .string("name"), "notionName": .string("Skill Name"), "type": .string("title"), "role": .string("title")]),
+                ]),
+            ]))
+            var threw = false
+            do {
+                _ = try await RegistryModule.makeCreate().handler(.object([
+                    "entity": .string("project"),
+                    "fields": .object(["name": .string("No Body")]),
+                    "bodyMarkdown": .string("# Should not create"),
+                ]))
+            } catch { threw = true }
+            try expect(threw, "bodyMarkdown on non-body entity must fail")
+            try expect(await fake.created.isEmpty, "must fail before row creation")
+        }
+    }
+
+    await test("registry_create reports explicit partial failure when body write fails") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        await fake.setFailMarkdownWrite(true)
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("skill")]))
+            let out = try await RegistryModule.makeCreate().handler(.object([
+                "entity": .string("skill"),
+                "fields": .object(["name": .string("Body Fails")]),
+                "bodyMarkdown": .string("# Missing body"),
+            ]))
+            try expect(obj(out)["created"] == .bool(false), "partial failure must not be success")
+            try expect(obj(out)["partialFailure"] == .bool(true), "partial failure flag")
+            try expect(obj(out)["reason"] == .string("body_write_failed"), "structured reason")
+            try expect(await fake.created.count == 1, "row was created before body failed")
+        }
+    }
+
+    await test("registry_create idempotencyKey prevents duplicate create on retry") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("skill")]))
+            let args: Value = .object([
+                "entity": .string("skill"),
+                "fields": .object(["name": .string("Retry Safe")]),
+                "bodyMarkdown": .string("# Same body"),
+                "idempotencyKey": .string("approved-proposal-123"),
+            ])
+            let first = try await RegistryModule.makeCreate().handler(args)
+            let second = try await RegistryModule.makeCreate().handler(args)
+            try expect(obj(first)["created"] == .bool(true), "first creates")
+            try expect(obj(second)["created"] == .bool(false), "retry returns existing")
+            try expect(obj(second)["idempotentReplay"] == .bool(true), "replay flagged")
+            try expect(await fake.created.count == 1, "no duplicate row create")
+            try expect(await fake.markdownWrites.count == 1, "no duplicate body write after successful replay")
+        }
+    }
+
+    await test("registry_create rejects oversized bodyMarkdown before row creation") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("skill")]))
+            let tooLarge = String(repeating: "x", count: RegistryModule.maxBodyMarkdownCharacters + 1)
+            var threw = false
+            do {
+                _ = try await RegistryModule.makeCreate().handler(.object([
+                    "entity": .string("skill"),
+                    "fields": .object(["name": .string("Too Large")]),
+                    "bodyMarkdown": .string(tooLarge),
+                ]))
+            } catch { threw = true }
+            try expect(threw, "oversized body must fail")
+            try expect(await fake.created.isEmpty, "oversized body must fail before create")
+        }
+    }
+
+    await test("registry_create schema exposes bodyMarkdown and idempotencyKey") {
+        let reg = RegistryModule.makeCreate()
+        let schema = obj(reg.inputSchema)
+        let props = obj(schema["properties"] ?? .null)
+        try expect(props["bodyMarkdown"] != nil, "bodyMarkdown discoverable")
+        try expect(props["idempotencyKey"] != nil, "idempotencyKey discoverable")
+        try expect(reg.description.contains("bodyMarkdown initializes"), "description explains body behavior")
+        try expect(reg.description.contains("Max 100000"), "description documents max payload size")
     }
 
     await test("registry_possess loads the body of a body-bearing entity") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1575,7 +1575,13 @@ set -euo pipefail
 # 2744 recorded floor → 2755 measured floor.
 # 2026-06-29 (standing orders v7.0.2 transplant): +3 StandingOrdersTests (bundled seedIfEmpty,
 # parseDoctrineVersion, explicit doctrineVersion write bump). Current main floor 2755→2758.
-FLOOR="${BRIDGE_TEST_FLOOR:-2758}"
+# 2026-06-29 (registry_create body initialization):
+# +7 tests covering body-bearing one-call packet creation, relation patching,
+# verbatim Markdown body write, property-only compatibility, non-body validation,
+# explicit partial failure on body-write error, idempotency retry, oversized body
+# rejection, and schema discovery. make test-floor measured 2762 passed / 0 failed.
+# 2755 recorded floor → 2762 measured floor (rebased atop standing-orders 2758).
+FLOOR="${BRIDGE_TEST_FLOOR:-2762}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Registry create flows can initialize page bodies from markdown on create.
- +7 tests, floor 2755→2762.
- NOT related to PKT-1041 search/find.

## Test plan
- [x] `make test-floor` green (2762 passed, floor=2762)

Made with [Cursor](https://cursor.com)