### PR TITLE
feat(ollama): split routing/summary defaults + Qwen generate fix

### DIFF
--- a/TheBridge/Core/BridgeDefaults.swift
+++ b/TheBridge/Core/BridgeDefaults.swift
@@ -179,14 +179,17 @@ public enum BridgeDefaults {
     /// When true, extract Apple embedded `tsrp` transcript before Parakeet fallback.
     public static let voiceMemoAppleTranscript = "com.notionbridge.voiceMemo.appleTranscript"
 
-    /// Ollama model for one-sentence Memory summaries (Relevant:). Falls back to routing model.
+    /// Ollama model for one-sentence Memory summaries (Relevant:). Falls back to its quality default.
     public static let ollamaSummarizationModel = "com.notionbridge.ollama.summarizationModel"
 
     /// Voice memo curator Understand routing: auto | heuristics | local | agent | cloud.
     public static let voiceMemoCuratorMode = "com.notionbridge.voiceMemo.curatorMode"
 
-    /// Suggested default routing model (M1 16 GB — Gemma4 12B).
-    public static let ollamaRoutingModelDefault = "gemma4:12b"
+    /// Default operational model for routing, tool-oriented classification, and structured output.
+    public static let ollamaRoutingModelDefault = "qwen3.5:9b"
+
+    /// Default quality model for summaries and higher-complexity local reasoning.
+    public static let ollamaSummarizationModelDefault = "gemma4:12b-mlx"
 
     public static var ollamaBaseURLEffective: URL {
         let raw = UserDefaults.standard.string(forKey: ollamaBaseURL)?
@@ -229,7 +232,7 @@ public enum BridgeDefaults {
         let raw = UserDefaults.standard.string(forKey: ollamaSummarizationModel)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let raw, !raw.isEmpty { return raw }
-        return ollamaRoutingModelEffective
+        return ollamaSummarizationModelDefault
     }
 
     /// Apply first-run defaults for local models when keys are absent.
@@ -237,6 +240,9 @@ public enum BridgeDefaults {
         let d = UserDefaults.standard
         if d.string(forKey: ollamaRoutingModel)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
             d.set(ollamaRoutingModelDefault, forKey: ollamaRoutingModel)
+        }
+        if d.string(forKey: ollamaSummarizationModel)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            d.set(ollamaSummarizationModelDefault, forKey: ollamaSummarizationModel)
         }
         if d.object(forKey: voiceMemoOllamaRouting) == nil {
             d.set(true, forKey: voiceMemoOllamaRouting)

--- a/TheBridge/Modules/Ollama/OllamaClient.swift
+++ b/TheBridge/Modules/Ollama/OllamaClient.swift
@@ -10,13 +10,16 @@ public struct OllamaClient: Sendable {
     public struct GenerateOptions: Sendable {
         public var numPredict: Int
         public var temperature: Double
-        /// When true, ask Ollama to skip extended thinking (Qwen3+).
+        public var numContext: Int
         public var think: Bool?
+        public var keepAlive: String
 
-        public init(numPredict: Int = 256, temperature: Double = 0.2, think: Bool? = nil) {
+        public init(numPredict: Int = 256, temperature: Double = 0.2, numContext: Int = 4096, think: Bool? = false, keepAlive: String = "0") {
             self.numPredict = numPredict
             self.temperature = temperature
+            self.numContext = numContext
             self.think = think
+            self.keepAlive = keepAlive
         }
     }
 
@@ -68,12 +71,14 @@ public struct OllamaClient: Sendable {
             "model": model,
             "prompt": prompt,
             "stream": false,
+            "keep_alive": options.keepAlive,
             "options": [
                 "num_predict": options.numPredict,
                 "temperature": options.temperature,
+                "num_ctx": options.numContext,
             ],
         ]
-        if model.lowercased().contains("qwen"), let think = options.think {
+        if let think = options.think {
             payload["think"] = think
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)

--- a/TheBridge/UI/Sections/LocalModelsSection.swift
+++ b/TheBridge/UI/Sections/LocalModelsSection.swift
@@ -45,13 +45,13 @@ public struct LocalModelsSection: View {
                 modelPicker(
                     label: "Routing model",
                     selection: $routingModel,
-                    help: "Voice memo intent classification — default gemma4:12b on M1 16 GB"
+                    help: "Fast routing and structured output — default qwen3.5:9b on M1 Pro 16 GB"
                 )
 
                 modelPicker(
                     label: "Summary model",
                     selection: $summarizationModel,
-                    help: "One-sentence Memory summary (Relevant:) — empty uses routing model"
+                    help: "Higher-quality summaries and reasoning — default gemma4:12b-mlx"
                 )
 
                 Toggle(isOn: $voiceMemoOllamaRouting) {

--- a/TheBridgeTests/OllamaModuleTests.swift
+++ b/TheBridgeTests/OllamaModuleTests.swift
@@ -49,14 +49,20 @@ func runOllamaModuleTests() async {
         try expect(text.contains("memory_keep"), "JSON extracted from thinking")
     }
 
-    await test("BridgeDefaults.seedOllamaDefaultsIfNeeded sets gemma routing model") {
+    await test("BridgeDefaults.seedOllamaDefaultsIfNeeded sets split routing and summary models") {
         let d = UserDefaults.standard
         let savedRouting = d.string(forKey: BridgeDefaults.ollamaRoutingModel)
+        let savedSummary = d.string(forKey: BridgeDefaults.ollamaSummarizationModel)
         d.removeObject(forKey: BridgeDefaults.ollamaRoutingModel)
+        d.removeObject(forKey: BridgeDefaults.ollamaSummarizationModel)
         BridgeDefaults.seedOllamaDefaultsIfNeeded()
         let seeded = d.string(forKey: BridgeDefaults.ollamaRoutingModel)
-        try expect(seeded == BridgeDefaults.ollamaRoutingModelDefault, "default gemma4:12b")
+        let seededSummary = d.string(forKey: BridgeDefaults.ollamaSummarizationModel)
+        try expect(seeded == BridgeDefaults.ollamaRoutingModelDefault, "default qwen3.5:9b")
+        try expect(seededSummary == BridgeDefaults.ollamaSummarizationModelDefault, "default gemma4:12b-mlx")
         if let savedRouting { d.set(savedRouting, forKey: BridgeDefaults.ollamaRoutingModel) }
         else { d.removeObject(forKey: BridgeDefaults.ollamaRoutingModel) }
+        if let savedSummary { d.set(savedSummary, forKey: BridgeDefaults.ollamaSummarizationModel) }
+        else { d.removeObject(forKey: BridgeDefaults.ollamaSummarizationModel) }
     }
 }


### PR DESCRIPTION
## Summary
- Split first-run Ollama defaults: **routing** `qwen3.5:9b`, **summarization** `gemma4:12b-mlx` (with separate UserDefaults seeding; summary no longer falls back to routing model).
- **Local Models** settings copy updated to match the split roles.
- **OllamaClient.generate** defaults `think: false`, sends `think` for all models when set, and adds `keep_alive` + `num_ctx` so Qwen3 thinking mode does not yield empty `response` text.

## Test plan
- [x] `make test` — **2755 passed, 0 failed**
- [x] `make install-copy` — installed `/Applications/The Bridge.app` (v3.9.1 verify OK)
- [x] Ollama models present: `qwen3.5:9b`, `gemma4:12b-mlx`
- [x] Generate smoke: `POST /api/generate` with `think:false` on `qwen3.5:9b` returned `OK` (non-empty response)
- [ ] Manual: Settings → Local Models shows split defaults; one in-app generate path (voice memo routing or summary) after relaunch


Made with [Cursor](https://cursor.com)