### PR TITLE
feat(commands): CommandStore-backed commands_* MCP tools (PKT-1061)

### DIFF
--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -236,7 +236,8 @@ public enum BridgeConstants {
     ///   (PKT-MEM-106 Phase 0 added internal types only — no new MCP tools.)
     /// Memory Hub UX Reconstruction (D35/D41, 2026-06-27): + memory_update
     ///   (in-place AGENTS field update tool). 187 + 1 = 188.
-    public static let staticFeatureModuleToolCount = 188
+    /// PKT-1061 Commands MCP (2026-06-29): +6 commands_* tools (list/get/search/create/update/delete). 188 + 6 = 194.
+    public static let staticFeatureModuleToolCount = 194
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -264,5 +265,6 @@ public enum BridgeConstants {
     /// Tool-Dev (PRJCT-2754): + bgprocess family (bg_run/bg_poll/bg_kill) = 28.
     /// Voice Memos curator (2026-06-24): + voice family = 29.
     /// Local Ollama (2026-06-24): + ollama family = 30.
-    public static let staticFeatureModuleFamilyCount = 30
+    /// PKT-1061 (2026-06-29): + commands family = 31.
+    public static let staticFeatureModuleFamilyCount = 31
 }

--- a/TheBridge/Modules/Commands/CommandsModule.swift
+++ b/TheBridge/Modules/Commands/CommandsModule.swift
@@ -1,0 +1,274 @@
+// CommandsModule.swift — PKT-1061
+// TheBridge · Modules · Commands
+//
+// CommandStore-backed commands_* MCP tools. Bridge Commands (hot-key palette)
+// are NOT Snippets — agents must use this module, not snippets_*, for local
+// user-authored command payloads.
+
+import Foundation
+import MCP
+
+public enum CommandsModule {
+
+    public static let moduleName = "commands"
+
+    public static func register(on router: ToolRouter, store: CommandStore = .shared) async {
+        await router.register(makeList(store))
+        await router.register(makeGet(store))
+        await router.register(makeSearch(store))
+        await router.register(makeCreate(store))
+        await router.register(makeUpdate(store))
+        await router.register(makeDelete(store))
+    }
+
+    // MARK: - Helpers
+
+    private static func isoString(_ date: Date?) -> Value {
+        guard let date else { return .null }
+        return .string(date.ISO8601Format())
+    }
+
+    private static func commandValue(_ c: CommandStore.Command, includeBody: Bool) -> Value {
+        var d: [String: Value] = [
+            "slug": .string(c.slug),
+            "name": .string(c.name),
+            "icon": iconValue(c.icon),
+            "keySlot": c.keySlot.map { .int($0) } ?? .null,
+            "lastUsedAt": isoString(c.lastUsedAt),
+        ]
+        if let color = c.color {
+            d["color"] = .string(color.rawValue)
+        }
+        if includeBody {
+            d["body"] = .string(c.body)
+        } else {
+            let preview = c.body.replacingOccurrences(of: "\n", with: " ")
+            d["preview"] = .string(preview.count > 80 ? String(preview.prefix(80)) + "…" : preview)
+        }
+        return .object(d)
+    }
+
+    private static func iconValue(_ icon: CommandStore.Icon) -> Value {
+        switch icon {
+        case .emoji(let s): return .object(["kind": .string("emoji"), "value": .string(s)])
+        case .symbol(let n): return .object(["kind": .string("symbol"), "value": .string(n)])
+        }
+    }
+
+    private static func parseIcon(_ args: [String: Value]) -> CommandStore.Icon {
+        if let sym = stringArg(args, "iconSymbol"), !sym.isEmpty {
+            return .symbol(sym)
+        }
+        if let emoji = stringArg(args, "iconEmoji"), !emoji.isEmpty {
+            return .emoji(emoji)
+        }
+        return .emoji("📝")
+    }
+
+    private static func parseColor(_ args: [String: Value]) -> CommandStore.NotionColor? {
+        guard let raw = stringArg(args, "color") else { return nil }
+        return CommandStore.NotionColor(rawValue: raw.lowercased())
+    }
+
+    private static func intArg(_ args: [String: Value], _ k: String) -> Int? {
+        if case .int(let n)? = args[k] { return n }
+        if case .double(let d)? = args[k] { return Int(d) }
+        return nil
+    }
+
+    private static func errEnvelope(_ tool: String, _ message: String, code: String) -> Value {
+        .object(["ok": .bool(false), "tool": .string(tool), "error": .string(code), "message": .string(message)])
+    }
+
+    private static func stringArg(_ args: [String: Value], _ k: String) -> String? {
+        if case .string(let s)? = args[k] { return s }
+        return nil
+    }
+
+    private static func resolveSlug(store: CommandStore, slugOrName: String) throws -> String? {
+        let key = slugOrName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return nil }
+        if try store.get(slug: key) != nil { return key }
+        let slug = CommandStore.slugify(key)
+        if try store.get(slug: slug) != nil { return slug }
+        let lower = key.lowercased()
+        return try store.list().first(where: { $0.name.lowercased() == lower })?.slug
+    }
+
+    // MARK: - Tools
+
+    private static func makeList(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_list", module: moduleName, tier: .open,
+            description: "List Bridge Commands (CommandStore hot-key palette payloads) as [{slug, name, preview, keySlot, …}]. Not Snippets — use commands_* for palette commands.",
+            inputSchema: .object(["type": .string("object"), "properties": .object([:])]),
+            handler: { _ in
+                do {
+                    let items = try store.list()
+                    return .object(["ok": .bool(true), "commands": .array(items.map { commandValue($0, includeBody: false) })])
+                } catch {
+                    return errEnvelope("commands_list", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+
+    private static func makeGet(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_get", module: moduleName, tier: .open,
+            description: "Get one Bridge Command by slug or display name → full body markdown. Not snippets_get.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "slugOrName": .object(["type": .string("string"), "description": .string("Command slug or display name.")])
+                ]),
+                "required": .array([.string("slugOrName")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let key = stringArg(args, "slugOrName") else {
+                    throw ToolRouterError.invalidArguments(toolName: "commands_get", reason: "missing required 'slugOrName'")
+                }
+                do {
+                    guard let slug = try resolveSlug(store: store, slugOrName: key),
+                          let cmd = try store.get(slug: slug) else {
+                        return errEnvelope("commands_get", "no command matching '\(key)'", code: "not_found")
+                    }
+                    return .object(["ok": .bool(true), "command": commandValue(cmd, includeBody: true)])
+                } catch {
+                    return errEnvelope("commands_get", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+
+    private static func makeSearch(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_search", module: moduleName, tier: .open,
+            description: "Search Bridge Commands by name substring (CommandStore). Read-only.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object(["type": .string("string"), "description": .string("Search query.")])
+                ]),
+                "required": .array([.string("query")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let q = stringArg(args, "query") else {
+                    throw ToolRouterError.invalidArguments(toolName: "commands_search", reason: "missing required 'query'")
+                }
+                do {
+                    let results = try store.search(q)
+                    return .object(["ok": .bool(true), "results": .array(results.map { commandValue($0, includeBody: false) })])
+                } catch {
+                    return errEnvelope("commands_search", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+
+    private static func makeCreate(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_create", module: moduleName, tier: .request,
+            description: "Create a Bridge Command (markdown body). Rejects duplicate slug.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string"), "description": .string("Display name.")]),
+                    "body": .object(["type": .string("string"), "description": .string("Markdown payload copied to clipboard when fired.")]),
+                    "keySlot": .object(["type": .string("integer"), "description": .string("Optional hot-key slot 0–9.")]),
+                    "iconEmoji": .object(["type": .string("string"), "description": .string("Optional emoji icon.")]),
+                    "iconSymbol": .object(["type": .string("string"), "description": .string("Optional SF Symbol name.")]),
+                    "color": .object(["type": .string("string"), "description": .string("Optional Notion color when icon is symbol.")])
+                ]),
+                "required": .array([.string("name"), .string("body")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      let name = stringArg(args, "name"), let body = stringArg(args, "body") else {
+                    throw ToolRouterError.invalidArguments(toolName: "commands_create", reason: "missing required 'name' or 'body'")
+                }
+                do {
+                    let cmd = try store.create(
+                        name: name,
+                        icon: parseIcon(args),
+                        color: parseColor(args),
+                        body: body,
+                        keySlot: intArg(args, "keySlot")
+                    )
+                    return .object(["ok": .bool(true), "slug": .string(cmd.slug), "command": commandValue(cmd, includeBody: true)])
+                } catch CommandStore.StoreError.slugTaken(let slug) {
+                    return errEnvelope("commands_create", "command slug '\(slug)' already exists", code: "duplicate_slug")
+                } catch {
+                    return errEnvelope("commands_create", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+
+    private static func makeUpdate(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_update", module: moduleName, tier: .request,
+            description: "Update a Bridge Command by slug (partial fields).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "slug": .object(["type": .string("string"), "description": .string("Command slug.")]),
+                    "name": .object(["type": .string("string"), "description": .string("New display name (optional).")]),
+                    "body": .object(["type": .string("string"), "description": .string("New markdown body (optional).")]),
+                    "keySlot": .object(["type": .string("integer"), "description": .string("Hot-key slot 0–9 or omit to leave unchanged.")]),
+                    "clearKeySlot": .object(["type": .string("boolean"), "description": .string("When true, clears key slot.")]),
+                    "iconEmoji": .object(["type": .string("string"), "description": .string("Optional emoji icon.")]),
+                    "iconSymbol": .object(["type": .string("string"), "description": .string("Optional SF Symbol name.")]),
+                    "color": .object(["type": .string("string"), "description": .string("Optional color for symbol icons.")])
+                ]),
+                "required": .array([.string("slug")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let slug = stringArg(args, "slug") else {
+                    throw ToolRouterError.invalidArguments(toolName: "commands_update", reason: "missing required 'slug'")
+                }
+                do {
+                    guard var cmd = try store.get(slug: slug) else {
+                        return errEnvelope("commands_update", "no command with slug '\(slug)'", code: "not_found")
+                    }
+                    if let name = stringArg(args, "name") { cmd.name = name.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    if let body = stringArg(args, "body") { cmd.body = body }
+                    if stringArg(args, "iconEmoji") != nil || stringArg(args, "iconSymbol") != nil {
+                        cmd.icon = parseIcon(args)
+                    }
+                    if let color = parseColor(args) { cmd.color = color }
+                    if case .bool(true)? = args["clearKeySlot"] { cmd.keySlot = nil }
+                    else if let slot = intArg(args, "keySlot") { cmd.keySlot = slot }
+                    let updated = try store.update(cmd)
+                    return .object(["ok": .bool(true), "command": commandValue(updated, includeBody: true)])
+                } catch CommandStore.StoreError.slugNotFound(let s) {
+                    return errEnvelope("commands_update", "no command with slug '\(s)'", code: "not_found")
+                } catch {
+                    return errEnvelope("commands_update", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+
+    private static func makeDelete(_ store: CommandStore) -> ToolRegistration {
+        ToolRegistration(
+            name: "commands_delete", module: moduleName, tier: .request,
+            neverAutoApprove: true,
+            description: "Delete a Bridge Command by slug. Destructive; requires confirmation.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "slug": .object(["type": .string("string"), "description": .string("Command slug.")])
+                ]),
+                "required": .array([.string("slug")])
+            ]),
+            handler: { arguments in
+                guard case .object(let args) = arguments, let slug = stringArg(args, "slug") else {
+                    throw ToolRouterError.invalidArguments(toolName: "commands_delete", reason: "missing required 'slug'")
+                }
+                do {
+                    try store.delete(slug: slug)
+                    return .object(["ok": .bool(true)])
+                } catch CommandStore.StoreError.slugNotFound(let s) {
+                    return errEnvelope("commands_delete", "no command with slug '\(s)'", code: "not_found")
+                } catch {
+                    return errEnvelope("commands_delete", error.localizedDescription, code: "store_error")
+                }
+            })
+    }
+}

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -66,6 +66,7 @@ public enum BridgeModuleRegistry {
         await PasteboardHistoryModule.register(on: router)
         await ArtifactModule.register(on: router)
         await SnippetsModule.register(on: router)
+        await CommandsModule.register(on: router)          // PKT-1061: CommandStore-backed commands_* (6 tools)
         await StandingOrdersModule.register(on: router)
         await ShortcutsModule.register(on: router)
         await MemoryModule.register(on: router)

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -354,6 +354,12 @@ public enum ToolAnnotationCatalog {
         "snippets_rename": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "snippets_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "snippets_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: false),
+        "commands_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
+        "commands_delete": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: false),
+        "commands_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
+        "commands_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
+        "commands_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
+        "commands_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "spotlight_query": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         // standing_orders_* (PKT-931): operator-curated config. read/list are
         // read-only but tier .notify (deliberate exception — see ReadOnlyTierAuditTests).

--- a/TheBridgeTests/CommandsModuleTests.swift
+++ b/TheBridgeTests/CommandsModuleTests.swift
@@ -1,0 +1,99 @@
+// CommandsModuleTests.swift — PKT-1061
+// CommandStore-backed commands_* MCP tools: registration/tier, list/get/search, CRUD.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runCommandsModuleTests() async {
+    print("\n📋 CommandsModule Tests (PKT-1061)")
+
+    let gate = SecurityGate()
+    let log = AuditLog()
+    let router = ToolRouter(securityGate: gate, auditLog: log)
+    await CommandsModule.register(on: router)
+
+    await test("CommandsModule registers 6 tools under module=\"commands\"") {
+        let regs = await router.registrations(forModule: "commands")
+        let names = Set(regs.map(\.name))
+        let expected: Set<String> = [
+            "commands_list", "commands_get", "commands_search",
+            "commands_create", "commands_update", "commands_delete"
+        ]
+        try expect(expected.isSubset(of: names), "missing — got \(names.sorted())")
+        try expect(regs.count == 6, "expected 6, got \(regs.count)")
+    }
+
+    await test("commands tier split: read-only .open, mutating .request") {
+        let regs = await router.registrations(forModule: "commands")
+        let readOnly: Set<String> = ["commands_list", "commands_get", "commands_search"]
+        for r in regs {
+            if readOnly.contains(r.name) {
+                try expect(r.tier == .open, "\(r.name) must be .open")
+            } else {
+                try expect(r.tier == .request, "\(r.name) must be .request")
+            }
+        }
+    }
+
+    await test("commands_delete carries neverAutoApprove") {
+        let regs = await router.registrations(forModule: "commands")
+        let del = regs.first { $0.name == "commands_delete" }
+        try expect(del?.neverAutoApprove == true)
+    }
+
+    await test("commands_list + get round-trip via dispatch") {
+        try CommandStore.shared.resetForTesting()
+        _ = try CommandStore.shared.create(name: "Smoke", icon: .emoji("🔥"), body: "## Smoke\n\nBody text")
+        let (listText, _) = try await router.dispatchFormatted(toolName: "commands_list", arguments: .object([:]))
+        try expect(listText.contains("\"ok\":true") || listText.contains("\"ok\" : true"))
+        try expect(listText.contains("smoke"))
+        let (getText, _) = try await router.dispatchFormatted(
+            toolName: "commands_get",
+            arguments: .object(["slugOrName": .string("Smoke")])
+        )
+        try expect(getText.contains("Body text"))
+    }
+
+    await test("commands_get resolves slug by display name") {
+        try CommandStore.shared.resetForTesting()
+        _ = try CommandStore.shared.create(name: "Close-loop", icon: .emoji("✅"), body: "loop body")
+        let (text, _) = try await router.dispatchFormatted(
+            toolName: "commands_get",
+            arguments: .object(["slugOrName": .string("Close-loop")])
+        )
+        try expect(text.contains("loop body"))
+    }
+
+    await test("commands_search finds substring") {
+        try CommandStore.shared.resetForTesting()
+        _ = try CommandStore.shared.create(name: "Execute", icon: .emoji("⚡"), body: "x")
+        _ = try CommandStore.shared.create(name: "Reflow", icon: .emoji("🔁"), body: "y")
+        let (text, _) = try await router.dispatchFormatted(
+            toolName: "commands_search",
+            arguments: .object(["query": .string("exec")])
+        )
+        try expect(text.contains("execute"))
+        try expect(!text.contains("reflow"))
+    }
+
+    await test("commands_create rejects duplicate slug") {
+        try CommandStore.shared.resetForTesting()
+        _ = try CommandStore.shared.create(name: "Dup", icon: .emoji("d"), body: "1")
+        let (text, _) = try await router.dispatchFormatted(
+            toolName: "commands_create",
+            arguments: .object(["name": .string("dup"), "body": .string("2")])
+        )
+        try expect(text.contains("duplicate_slug"))
+    }
+
+    await test("commands_delete removes command") {
+        try CommandStore.shared.resetForTesting()
+        let c = try CommandStore.shared.create(name: "Gone", icon: .emoji("x"), body: "z")
+        _ = try await router.dispatchFormatted(
+            toolName: "commands_delete",
+            arguments: .object(["slug": .string(c.slug)])
+        )
+        try expect(try CommandStore.shared.get(slug: c.slug) == nil)
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -708,6 +708,7 @@ await runGhModuleTests()
 await runGitModuleTests()
 await runWSHMenuBarTests()        // PKT-804 (v2.3): menu-bar quick-page
 await runSnippetsModuleTests()    // PKT-2135a9e9 (v2.3 · WS-D): snippets module
+await runCommandsModuleTests()    // PKT-1061: CommandStore commands_* MCP surface
 await runStandingOrdersModuleTests() // PKT-931 (v3.7·B): standing_orders_* MCP tools
 await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1583,7 +1583,8 @@ set -euo pipefail
 # 2755 recorded floor → 2762 measured floor (rebased atop standing-orders 2758).
 # 2026-06-29 (v3.9.2 release train): measured 2765 passed / 0 failed after #68+#66+#67 merge.
 # 2762 recorded floor → 2765 measured floor.
-FLOOR="${BRIDGE_TEST_FLOOR:-2765}"
+# 2026-06-29 (PKT-1061 commands_* MCP): +8 CommandsModuleTests (registration/tier/CRUD dispatch). 2765→2773.
+FLOOR="${BRIDGE_TEST_FLOOR:-2773}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Adds `commands_list`, `commands_get`, `commands_search`, `commands_create`, `commands_update`, `commands_delete` backed by `CommandStore` (Bridge Commands palette — **not** Snippets).
- Read tools tier `.open`; mutating tools tier `.request`; `commands_delete` has `neverAutoApprove`.
- +8 tests; floor **2773**; `staticFeatureModuleToolCount` **194**.

## User scenario — PKT-1061

| Step | Action | Expected | Layer |
|------|--------|----------|-------|
| 1 | `commands_list` on fresh store | Returns seeded or user commands, not snippets | L3 |
| 2 | `commands_get slugOrName=Execute` | Full markdown body from CommandStore | L3 |
| 3 | Agent intent "run my Bridge command" | Routes to `commands_*`, not `snippets_*` | L4 doc |

**Stop:** REVIEW-FIRST — do not merge without operator GO.

## Test plan
- [x] `make test-floor` → 2773/2773
- [x] ToolAnnotationAudit (6 new catalog entries)
- [ ] Operator: `commands_list` via MCP after install-copy

Made with [Cursor](https://cursor.com)