### PR TITLE
PKT-1041 · feat(registry): registry_find convergent lookup

### DIFF
--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -238,7 +238,9 @@ public enum BridgeConstants {
     ///   (in-place AGENTS field update tool). 187 + 1 = 188.
     /// PKT-1061 Commands MCP (2026-06-29): +6 commands_* tools (list/get/search/create/update/delete). 188 + 6 = 194.
     /// Wave 3 FB (2026-06-29): + bridge_focus_settings (automation family). 194 + 1 = 195.
-    public static let staticFeatureModuleToolCount = 197
+    /// PKT-1041 registry_find (2026-07-01): + registry_find (convergent resolve-before-write
+    ///   lookup — read-only predicate match over the registry_list read-through/offline path). 197 + 1 = 198.
+    public static let staticFeatureModuleToolCount = 198
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -134,6 +134,7 @@ public enum RegistryModule {
         await router.register(makeRemoveEntity())
         await router.register(makeIntrospect())
         await router.register(makeList())
+        await router.register(makeFind())
         await router.register(makeGet())
         await router.register(makeCreate())
         await router.register(makeUpdate())
@@ -304,6 +305,50 @@ public enum RegistryModule {
                 if case .int(let n)? = a["limit"] { limit = max(1, min(500, n)) }
                 let reader = RegistryReader(gateway: gateway())
                 let rows = try await reader.list(entity: entity, limit: limit)
+                return .object([
+                    "entity": .string(key),
+                    "count": .int(rows.count),
+                    "rows": .array(rows.map { rowValue($0, stale: $0.isExpired()) }),
+                ])
+            })
+    }
+
+    // MARK: - registry_find
+
+    /// Convergent lookup: resolve an EXISTING row by canonical field
+    /// predicate(s) BEFORE a blind `registry_create`, so an agent converges on
+    /// the live row instead of minting a duplicate. Read-only; reuses the
+    /// `registry_list` read-through + offline path. Matching is by BOUND
+    /// PROPERTY ID (rename-safe) — predicate keys are the entity's canonical
+    /// field keys, matched against the id-resolved projection. Zero matches is
+    /// a valid empty result, NOT an error; multiple matches surface the
+    /// ambiguity so the caller can disambiguate before writing.
+    public static func makeFind() -> ToolRegistration {
+        ToolRegistration(
+            name: "registry_find", module: moduleName, tier: .open,
+            description: "Find EXISTING registry rows by canonical field value(s) BEFORE creating — the resolve-before-write convergence primitive that avoids duplicate rows. Read-only, cache-backed, offline-tolerant. Pass `where` as a map of canonical field key → value (ALL must match, AND); values are matched rename-safe by the entity's bound property id, not the raw Notion name. Scalars compare case-insensitively; relation/multi-select fields match if any element equals. Returns matching rows (id + title + projected properties); no match → empty (not an error); multiple → ambiguous, all returned.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "entity": .object(["type": .string("string"), "description": .string("Entity key.")]),
+                    "where": .object(["type": .string("object"), "description": .string("Map of canonical field key → value to match (e.g. {\"name\":\"Alpha\"} or {\"status\":\"Active\",\"slug\":\"x\"}). ALL predicates must match.")]),
+                    "limit": .object(["type": .string("integer"), "description": .string("Max rows scanned/returned (default 100, max 500; paginates internally).")]),
+                ]),
+                "required": .array([.string("entity"), .string("where")]),
+            ]),
+            handler: { args in
+                guard case .object(let a) = args, let key = string(a, "entity") else {
+                    throw ToolRouterError.invalidArguments(toolName: "registry_find", reason: "missing ‘entity’")
+                }
+                guard case .object(let predicates)? = a["where"], !predicates.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "registry_find", reason: "missing or empty ‘where’ — supply at least one field=value predicate")
+                }
+                let config = await loadConfig()
+                let entity = try requireEntity(key, in: config, tool: "registry_find")
+                var limit = 100
+                if case .int(let n)? = a["limit"] { limit = max(1, min(500, n)) }
+                let reader = RegistryReader(gateway: gateway())
+                let rows = try await reader.find(entity: entity, predicates: predicates, limit: limit)
                 return .object([
                     "entity": .string(key),
                     "count": .int(rows.count),

--- a/TheBridge/Modules/Registry/RegistryReader.swift
+++ b/TheBridge/Modules/Registry/RegistryReader.swift
@@ -136,6 +136,65 @@ public struct RegistryReader: Sendable {
         }
     }
 
+    // MARK: - Find (convergent lookup — resolve-before-write)
+
+    /// Resolve EXISTING rows by canonical field predicates BEFORE a blind
+    /// `create` — the convergence primitive that eliminates duplicate rows.
+    /// Read-only: matches `predicates` (canonical KEY → value) against the
+    /// entity's projected rows, which are keyed rename-safe by BOUND PROPERTY
+    /// ID (projection resolves each cell via `cell(for:)`, id-first), so a
+    /// Notion rename never breaks the match. Reuses `list` verbatim, so it
+    /// inherits the same read-through cache + offline fallback contract.
+    ///
+    /// Semantics: ALL predicates must match (AND). A row matches a predicate
+    /// when the projected value for that key equals the predicate value —
+    /// scalar values compared as case-insensitive strings; array values
+    /// (multi_select / relation / people) match when ANY element equals. An
+    /// absent key never matches. Zero matches is a valid, non-error result
+    /// (empty array). Ambiguous input naturally yields multiple rows.
+    public func find(entity: RegistryEntity, predicates: [String: Value], limit: Int = 100) async throws -> [CachedRow] {
+        let rows = try await list(entity: entity, limit: limit)
+        guard !predicates.isEmpty else { return rows }
+        return rows.filter { row in
+            guard case .object(let props) = row.properties else { return false }
+            return predicates.allSatisfy { key, wanted in
+                guard let have = props[key] else { return false }
+                return Self.valueMatches(have, wanted)
+            }
+        }
+    }
+
+    /// True when `have` (a projected cell value) satisfies the `wanted`
+    /// predicate value. Scalars compare as case-insensitive strings so
+    /// `"active"` matches a `.string("Active")` status; arrays match when ANY
+    /// element satisfies `wanted` (a relation/multi_select membership test).
+    static func valueMatches(_ have: Value, _ wanted: Value) -> Bool {
+        if case .array(let elems) = have {
+            return elems.contains { valueMatches($0, wanted) }
+        }
+        // If the predicate itself is an array, match when ANY wanted element hits.
+        if case .array(let wants) = wanted {
+            return wants.contains { valueMatches(have, $0) }
+        }
+        guard let h = scalarString(have), let w = scalarString(wanted) else { return false }
+        return h.compare(w, options: .caseInsensitive) == .orderedSame
+    }
+
+    /// Render a scalar `Value` to a comparable string; `nil` for containers.
+    private static func scalarString(_ v: Value) -> String? {
+        switch v {
+        case .string(let s): return s
+        case .int(let n): return String(n)
+        case .double(let d):
+            // Match the number codec's integral rendering (3.0 → "3").
+            if d == d.rounded() && abs(d) < 1e15 { return String(Int(d)) }
+            return String(d)
+        case .bool(let b): return b ? "true" : "false"
+        case .null: return nil
+        case .array, .object, .data: return nil
+        }
+    }
+
     // MARK: - Body (possess — Decision 2)
 
     /// Load an entity's page BODY on demand (the `possess`/`fetch_skill` verb).

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -70,7 +70,7 @@ public enum BridgeModuleRegistry {
         await StandingOrdersModule.register(on: router)
         await ShortcutsModule.register(on: router)
         await MemoryModule.register(on: router)
-        await RegistryModule.register(on: router)          // Data-Source Registry: generic CRUD + add/remove_entity + introspect + possess (10 tools)
+        await RegistryModule.register(on: router)          // Data-Source Registry: generic CRUD + add/remove_entity + introspect + possess + hydrate + find (12 tools)
         await VoiceMemoModule.register(on: router)       // Voice Memos curator: voice_memo_list + voice_memo_process (2 tools)
         await OllamaModule.register(on: router)          // Local Ollama: ollama_health + ollama_list_models (2 tools)
         await BridgeAutomationModule.register(on: router) // FB-AUTOMATION: bridge_settings_navigate

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -266,6 +266,9 @@ public enum ToolAnnotationCatalog {
         "registry_remove_entity": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "registry_introspect": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "registry_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        // PKT-1041 (2026-07-01): convergent resolve-before-write lookup — read-only
+        // predicate match over the registry_list read-through/offline path.
+        "registry_find": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "registry_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "registry_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "registry_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),

--- a/TheBridgeTests/RegistryDataPathTests.swift
+++ b/TheBridgeTests/RegistryDataPathTests.swift
@@ -227,6 +227,56 @@ func runRegistryDataPathTests() async {
         }
     }
 
+    await test("Reader.find: predicate match; offline → filters cached rows") {
+        try await withTempHomeReg { cache in
+            let gw = FakeRegistryGateway()
+            await gw.setQueryRows([
+                widgetRow(id: "dddd0000000000000000000000000001", name: "Ana", status: "Active", count: 1),
+                widgetRow(id: "dddd0000000000000000000000000002", name: "Ben", status: "Done", count: 2),
+                widgetRow(id: "dddd0000000000000000000000000003", name: "Ana", status: "Done", count: 3),
+            ])
+            let reader = RegistryReader(gateway: gw, cache: cache)
+            // Live find populates the cache.
+            let exact = try await reader.find(entity: widgetEntity(), predicates: ["name": .string("Ben")])
+            try expect(exact.count == 1 && exact.first?.pageId == "dddd0000000000000000000000000002", "exact match by name")
+            let ambiguous = try await reader.find(entity: widgetEntity(), predicates: ["name": .string("Ana")])
+            try expect(ambiguous.count == 2, "two rows named Ana")
+            let none = try await reader.find(entity: widgetEntity(), predicates: ["name": .string("Zed")])
+            try expect(none.isEmpty, "no match → empty, no throw")
+            // AND across two predicates.
+            let both = try await reader.find(entity: widgetEntity(), predicates: ["name": .string("Ana"), "status": .string("Done")])
+            try expect(both.count == 1 && both.first?.pageId == "dddd0000000000000000000000000003", "AND narrows to one")
+            // Offline: list() serves the cached rows, so find still resolves.
+            await gw.setFail(true)
+            let offline = try await reader.find(entity: widgetEntity(), predicates: ["status": .string("Done")])
+            try expect(offline.count == 2, "offline find filters the cached list")
+        }
+    }
+
+    await test("Reader.find: scalar number match + array (relation) membership") {
+        try await withTempHomeReg { cache in
+            let gw = FakeRegistryGateway()
+            let related = NotionRow(id: "eeee0000000000000000000000000001", url: "u", lastEditedTime: "2026-06-17T10:00:00.000Z", cells: [
+                "Name": NotionCell(id: "p_name", type: "title", value: .string("Rel")),
+                "Status": NotionCell(id: "p_status", type: "status", value: .string("Active")),
+                "Count": NotionCell(id: "p_count", type: "number", value: .double(7)),
+                "Links": NotionCell(id: "p_links", type: "relation", value: .array([.string("relidaaa"), .string("relidbbb")])),
+            ])
+            await gw.setQueryRows([related])
+            var entity = widgetEntity()
+            entity.properties.append(RegistryProperty(key: "links", notionName: "Links", notionPropertyId: "p_links", type: "relation", role: .relation))
+            let reader = RegistryReader(gateway: gw, cache: cache)
+            // Number predicate compares against the codec's integral rendering (7.0 → "7").
+            let byNum = try await reader.find(entity: entity, predicates: ["count": .string("7")])
+            try expect(byNum.count == 1, "scalar number matched by string ‘7’")
+            // Relation array membership: match when any related id equals.
+            let byRel = try await reader.find(entity: entity, predicates: ["links": .string("relidbbb")])
+            try expect(byRel.count == 1, "relation array membership match")
+            let byRelMiss = try await reader.find(entity: entity, predicates: ["links": .string("nope")])
+            try expect(byRelMiss.isEmpty, "no relation member equals → no match")
+        }
+    }
+
     await test("Reader.project: rename-safe — matches by bound id, not name") {
         // The live row's Notion NAME changed ("Name" → "Renamed"), but the id is
         // the same. Projection must still find it via the bound id.

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -100,14 +100,14 @@ func runRegistryModuleTests() async {
 
     // MARK: - Registration
 
-    await test("RegistryModule registers exactly 11 tools with expected names") {
+    await test("RegistryModule registers exactly 12 tools with expected names") {
         let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
         await RegistryModule.register(on: router)
         let tools = await router.registrations(forModule: "registry")
-        try expect(tools.count == 11, "expected 11 registry tools, got \(tools.count)")
+        try expect(tools.count == 12, "expected 12 registry tools, got \(tools.count)")
         let names = Set(tools.map { $0.name })
         try expect(names == ["registry_entities", "registry_add_entity", "registry_remove_entity", "registry_introspect",
-                             "registry_list", "registry_get", "registry_create", "registry_update", "registry_delete", "registry_possess",
+                             "registry_list", "registry_find", "registry_get", "registry_create", "registry_update", "registry_delete", "registry_possess",
                              "registry_hydrate"],
                    "tool names: \(names.sorted())")
     }
@@ -121,7 +121,7 @@ func runRegistryModuleTests() async {
         try expect(tier("registry_remove_entity") == .request, "remove_entity must be .request (destructive)")
         try expect(tier("registry_create") == .notify && tier("registry_update") == .notify && tier("registry_introspect") == .notify,
                    "writes are .notify")
-        try expect(tier("registry_get") == .open && tier("registry_list") == .open && tier("registry_entities") == .open && tier("registry_possess") == .open,
+        try expect(tier("registry_get") == .open && tier("registry_list") == .open && tier("registry_find") == .open && tier("registry_entities") == .open && tier("registry_possess") == .open,
                    "reads are .open")
     }
 
@@ -182,6 +182,122 @@ func runRegistryModuleTests() async {
         try await withRegistryModuleEnv(fake) {
             let out = try await RegistryModule.makeGet().handler(.object(["entity": .string("skill"), "id": .string("bbbb0000000000000000000000000001")]))
             try expect(obj(out)["title"] == .string("Gamma"), "got the row")
+        }
+    }
+
+    // MARK: - registry_find (convergent resolve-before-write)
+
+    await test("registry_find exact match → single row id") {
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: [
+            skillRow(id: "ffff0000000000000000000000000001", name: "Alpha"),
+            skillRow(id: "ffff0000000000000000000000000002", name: "Beta"),
+        ])
+        try await withRegistryModuleEnv(fake) {
+            let out = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["name": .string("Alpha")]),
+            ]))
+            try expect(obj(out)["count"] == .int(1), "exactly one match")
+            guard case .array(let rows)? = obj(out)["rows"], let r0 = rows.first else { throw TestError.assertion("no rows") }
+            try expect(obj(r0)["id"] == .string("ffff0000000000000000000000000001"), "the correct row id")
+            try expect(obj(r0)["title"] == .string("Alpha"), "and its title")
+        }
+    }
+
+    await test("registry_find no match → empty result, NOT an error") {
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: [
+            skillRow(id: "ffff0000000000000000000000000003", name: "Alpha"),
+        ])
+        try await withRegistryModuleEnv(fake) {
+            let out = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["name": .string("DoesNotExist")]),
+            ]))
+            try expect(obj(out)["count"] == .int(0), "zero matches")
+            guard case .array(let rows)? = obj(out)["rows"] else { throw TestError.assertion("rows missing") }
+            try expect(rows.isEmpty, "empty rows array, no throw")
+        }
+    }
+
+    await test("registry_find ambiguous → multiple row ids") {
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: [
+            skillRow(id: "ffff0000000000000000000000000004", name: "Dup"),
+            skillRow(id: "ffff0000000000000000000000000005", name: "Dup"),
+            skillRow(id: "ffff0000000000000000000000000006", name: "Other"),
+        ])
+        try await withRegistryModuleEnv(fake) {
+            let out = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["name": .string("Dup")]),
+            ]))
+            try expect(obj(out)["count"] == .int(2), "two ambiguous matches")
+            guard case .array(let rows)? = obj(out)["rows"] else { throw TestError.assertion("rows missing") }
+            let ids = Set(rows.compactMap { r -> String? in if case .string(let s)? = obj(r)["id"] { return s } else { return nil } })
+            try expect(ids == ["ffff0000000000000000000000000004", "ffff0000000000000000000000000005"], "both dup ids: \(ids.sorted())")
+        }
+    }
+
+    await test("registry_find matches by BOUND property id after introspect (rename-safe)") {
+        // Introspect binds Notion 'Description' → canonical key 'summary'. A find
+        // predicate on 'summary' must match via the bound id, not the raw name.
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: [
+            skillRow(id: "ffff0000000000000000000000000007", name: "Zeta"),   // summary = "desc of Zeta"
+        ])
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("skill")]))
+            // Case-insensitive scalar match on the id-resolved canonical key.
+            let out = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["summary": .string("DESC OF ZETA")]),
+            ]))
+            try expect(obj(out)["count"] == .int(1), "matched by bound id, case-insensitive")
+            guard case .array(let rows)? = obj(out)["rows"], let r0 = rows.first else { throw TestError.assertion("no rows") }
+            try expect(obj(r0)["id"] == .string("ffff0000000000000000000000000007"), "the Zeta row")
+        }
+    }
+
+    await test("registry_find AND semantics: all predicates must match") {
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: [
+            skillRow(id: "ffff0000000000000000000000000008", name: "Multi"),   // status = "Stable"
+        ])
+        try await withRegistryModuleEnv(fake) {
+            let hit = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["name": .string("Multi"), "status": .string("Stable")]),
+            ]))
+            try expect(obj(hit)["count"] == .int(1), "both predicates satisfied → match")
+            let miss = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("skill"),
+                "where": .object(["name": .string("Multi"), "status": .string("Deprecated")]),
+            ]))
+            try expect(obj(miss)["count"] == .int(0), "one predicate fails → no match")
+        }
+    }
+
+    await test("registry_find unknown entity → invalidArguments error") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            do {
+                _ = try await RegistryModule.makeFind().handler(.object([
+                    "entity": .string("ghost"),
+                    "where": .object(["name": .string("x")]),
+                ]))
+                throw TestError.assertion("expected unknown-entity error")
+            } catch let e as ToolRouterError {
+                if case .invalidArguments = e {} else { throw TestError.assertion("wrong error: \(e)") }
+            }
+        }
+    }
+
+    await test("registry_find empty/missing where → invalidArguments error") {
+        let fake = ModFakeGateway(schema: skillsSchema())
+        try await withRegistryModuleEnv(fake) {
+            do {
+                _ = try await RegistryModule.makeFind().handler(.object(["entity": .string("skill"), "where": .object([:])]))
+                throw TestError.assertion("expected empty-where error")
+            } catch let e as ToolRouterError {
+                if case .invalidArguments = e {} else { throw TestError.assertion("wrong error: \(e)") }
+            }
         }
     }
 

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1605,7 +1605,10 @@ set -euo pipefail
 # 2824 → 2854 measured green.
 # 2026-06-30 (Memory Hub W1–W3 UX + HITL): +6 tests — MemoryProcessInspectUnderstandTests;
 # MemoryProcessLayoutAXTests (+1 opt-in AX); floor 2857 → 2863 measured green.
-FLOOR="${BRIDGE_TEST_FLOOR:-2863}"
+# 2026-07-01 (PKT-1041 registry_find): +9 tests — RegistryModuleTests (+7: exact/none/
+# multi/bound-id/AND/unknown-entity/empty-where), RegistryDataPathTests (+2: reader
+# offline-cache filter + scalar-number/relation-array match); floor 2863 → 2872 measured green.
+FLOOR="${BRIDGE_TEST_FLOOR:-2872}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
Resolve an existing registry row by canonical field **before** writing, to prevent blind `registry_create` duplicates. Read-only; bound-property matching (rename-safe); reuses the `registry_list` read-through/offline cache path.

- +9 tests · floor 2863→2872 · staticFeatureModuleToolCount 197→198 · no version bump
- REVIEW-FIRST; verified green independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)