### PR TITLE
PKT-1064 · feat(voice-memo): originating-Player attach + verify

### DIFF
--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -365,7 +365,45 @@ public enum VoiceMemoProcessor {
 
     static func executeMemoryKeep(_ intent: VoiceMemoIntent, plan: VoiceMemoPlan, transcript: String, router: ToolRouter) async throws -> String {
         let entityKey = intent.entityKey ?? "memory"
-        let fields = resolvedMemoryKeepFields(intent: intent, plan: plan)
+        return try await executeMemoryKeep(
+            entityKey: entityKey,
+            intent: intent,
+            plan: plan,
+            transcript: transcript,
+            router: router,
+            entity: await Self.loadRegistryEntity(key: entityKey)
+        )
+    }
+
+    /// Testable core: `entity` is the resolved registry binding for `entityKey`
+    /// (the property map that decides whether a PLAYERS relation can be
+    /// attached). Production resolves it from the shared config store; tests
+    /// inject a fixture entity so the attach/verify/graceful-BLOCKED branches
+    /// are exercised hermetically without live Notion.
+    @discardableResult
+    public static func executeMemoryKeep(
+        entityKey: String,
+        intent: VoiceMemoIntent,
+        plan: VoiceMemoPlan,
+        transcript: String,
+        router: ToolRouter,
+        entity: RegistryEntity?
+    ) async throws -> String {
+        var fields = resolvedMemoryKeepFields(intent: intent, plan: plan)
+
+        // PKT-1064 — attach the ORIGINATING Player relation to the new Memory
+        // row at create time. The Player is bound by property id through the
+        // registry contract, so the entity MUST expose a bound PLAYERS relation
+        // property. If it does not (absent/unbound binding), that is the
+        // "graceful BLOCKED" case: throw a descriptive error so the memo routes
+        // to REVIEW (queueReview in processOne) rather than being silently
+        // marked processed with no attribution. No crash.
+        guard let playersKey = Self.playersRelationKey(in: entity) else {
+            throw VoiceMemoError.playerRelationUnbound(entityKey)
+        }
+        let originatingPlayerId = Self.originatingPlayerId(for: intent)
+        fields[playersKey] = originatingPlayerId
+
         let createResult = try await router.dispatch(toolName: "registry_create", arguments: .object([
             "entity": .string(entityKey),
             "fields": .object(fields.mapValues { .string($0) }),
@@ -373,9 +411,87 @@ public enum VoiceMemoProcessor {
         guard let pageId = parseRegistryPageId(from: createResult) else {
             return "registry_create entity=\(entityKey) (memory_keep) — created but page id not parsed"
         }
+
+        // Verify the relation actually attached via a read-back. A create that
+        // reports success but drops the relation (schema mismatch, silent Notion
+        // no-op) must NOT be accepted as processed — throw so the memo routes to
+        // REVIEW with a visible assertion failure (packet Success Criteria).
+        try await Self.verifyPlayerAttached(
+            entityKey: entityKey,
+            pageId: pageId,
+            playersKey: playersKey,
+            expectedPlayerId: originatingPlayerId,
+            router: router
+        )
+
         // W3: summary + action items in Notion body — transcript remains UI-only (FR-005).
         try await appendSummaryBodyToNotionPage(pageId: pageId, plan: plan, fields: fields, router: router)
-        return "registry_create entity=\(entityKey) id=\(pageId) + summary body"
+        return "registry_create entity=\(entityKey) id=\(pageId) + player \(originatingPlayerId) + summary body"
+    }
+
+    /// Load the registry entity binding for `key` from the shared config store.
+    /// Returns nil when the store has no such entity (first run / unconfigured).
+    static func loadRegistryEntity(key: String) async -> RegistryEntity? {
+        await RegistryConfigStore.shared.loadOrSeed().entity(key)
+    }
+
+    /// The canonical field key of a BOUND `.relation` property whose Notion
+    /// column is "PLAYERS" on this entity, or nil when no such bound relation
+    /// exists (property absent from the map, or present but not yet bound to a
+    /// Notion property id). Matching is by the Notion display name (case- and
+    /// whitespace-insensitive) so a rename of the canonical key doesn't break it,
+    /// while an UNBOUND property still yields nil (can't write a relation with no
+    /// property id → graceful BLOCKED).
+    public static func playersRelationKey(in entity: RegistryEntity?) -> String? {
+        guard let entity else { return nil }
+        let match = entity.properties.first { prop in
+            prop.role == .relation
+                && prop.isBound
+                && prop.notionName.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() == "PLAYERS"
+        }
+        return match?.key
+    }
+
+    /// Default originating player = the primary user player (Isaiah, PLYR-5).
+    /// A future source-metadata owner override would slot in here; for Isaiah's
+    /// local Voice Memos library the default is authoritative (packet scope).
+    static let defaultOriginatingPlayerId = "dc8e8f3f-e607-4b5d-809e-ae289574f40c"
+
+    static func originatingPlayerId(for intent: VoiceMemoIntent) -> String {
+        // An explicit non-empty per-intent override wins; otherwise the primary
+        // user player. Kept deterministic — no ambiguous resolution (packet stop
+        // condition: originating Player must resolve deterministically).
+        if let explicit = intent.fields["originatingPlayer"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            return explicit
+        }
+        return defaultOriginatingPlayerId
+    }
+
+    /// Read the just-created row back and assert the PLAYERS relation contains
+    /// the expected player id. Throws `playerRelationVerifyFailed` when the
+    /// relation is absent/empty/wrong on read-back.
+    static func verifyPlayerAttached(
+        entityKey: String,
+        pageId: String,
+        playersKey: String,
+        expectedPlayerId: String,
+        router: ToolRouter
+    ) async throws {
+        let getResult = try await router.dispatch(toolName: "registry_get", arguments: .object([
+            "entity": .string(entityKey),
+            "id": .string(pageId),
+            "forceRefresh": .bool(true),
+        ]))
+        guard case .object(let envelope) = getResult,
+              case .object(let props)? = envelope["properties"],
+              case .array(let ids)? = props[playersKey] else {
+            throw VoiceMemoError.playerRelationVerifyFailed(entityKey, pageId, expectedPlayerId)
+        }
+        let attached = ids.contains { if case .string(let s) = $0 { return s == expectedPlayerId } else { return false } }
+        if !attached {
+            throw VoiceMemoError.playerRelationVerifyFailed(entityKey, pageId, expectedPlayerId)
+        }
     }
 
     public static func executeRegistryUpdate(_ intent: VoiceMemoIntent, explicitRowId: String? = nil, router: ToolRouter) async throws -> String {
@@ -1077,6 +1193,13 @@ public enum VoiceMemoError: Error, LocalizedError {
     case invalidIntent(String)
     case registryMatchFailed(String, String?)
     case registryAmbiguous(String, String?, Int)
+    /// The Memory entity has no BOUND PLAYERS relation property, so the
+    /// originating Player cannot be attached — a graceful BLOCKED → REVIEW,
+    /// never a silent successful processed receipt (PKT-1064).
+    case playerRelationUnbound(String)
+    /// The row was created but the read-back did not show the expected Player
+    /// relation attached (PKT-1064 post-write verification).
+    case playerRelationVerifyFailed(String, String, String)
 
     public var errorDescription: String? {
         switch self {
@@ -1085,6 +1208,10 @@ public enum VoiceMemoError: Error, LocalizedError {
             return "no registry row matched entity=\(entity) hint=\(hint ?? "nil")"
         case .registryAmbiguous(let entity, let hint, let count):
             return "ambiguous registry target entity=\(entity) hint=\(hint ?? "nil") matched \(count) rows — select a rowId"
+        case .playerRelationUnbound(let entity):
+            return "entity ‘\(entity)’ has no bound PLAYERS relation property — cannot attach the originating Player; bind PLAYERS via registry_introspect, then reprocess (BLOCKED, queued for review)"
+        case .playerRelationVerifyFailed(let entity, let pageId, let player):
+            return "originating Player \(player) not present on created \(entity) row \(pageId) after read-back — attach verification failed (queued for review)"
         }
     }
 }

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -709,6 +709,7 @@ await runVoiceMemoCloudParseTests()    // Voice Curator FRONTIER-FIRST (Phase 1 
 await runMemoryHubCockpitLabelsTests() // Voice Curator FRONTIER-FIRST (Phase 1 W3): cockpit human labels + provenance badge + commit-value preview
 await runVoiceCuratorPhase1RemediationTests() // Voice Curator FRONTIER-FIRST (Phase 1 W4): review remediation — durable cloud-send provenance + notifier lane + honest commit-write label
 await runVoiceMemoMCPRoutingTests() // PKT-MEM-120: Auto+MCP Execute defer, presence, awaiting-agent tags + notification gate
+await runVoiceMemoPlayerAttachTests() // PKT-1064: memo→Memory attaches + verifies the originating Player relation; absent/unbound PLAYERS → graceful BLOCKED
 // PKT-MEM-106 0a + 0b run early in runAllTests() (flake-avoidance) — not duplicated here.
 await runMemorySettingsTests()         // PKT-MEM-102: Memory Settings section + Inbox UI
 await runOllamaModuleTests()           // Local Ollama client + module (Wave 2a)

--- a/TheBridgeTests/VoiceMemoPlayerAttachTests.swift
+++ b/TheBridgeTests/VoiceMemoPlayerAttachTests.swift
@@ -1,0 +1,326 @@
+// VoiceMemoPlayerAttachTests.swift — PKT-1064 originating-Player relation
+// TheBridge · Tests
+//
+// The memo → Memory curator must attach the ORIGINATING Player relation to the
+// Memory row it creates (default = primary user player, Isaiah PLYR-5) AND
+// verify it attached by read-back. When the Memory entity has no bound PLAYERS
+// relation property, the write must BLOCK gracefully (throw → route to REVIEW),
+// never a silent successful processed receipt, and never a crash.
+//
+// Hermetic: `executeMemoryKeep(entityKey:…entity:)` takes an injected entity
+// binding, and stub `registry_create` / `registry_get` tools capture the write
+// and serve the read-back — no live Notion.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+/// Captures the fields registry_create was called with, and holds the row the
+/// stubbed registry_get should return for the verify read-back.
+private actor MemoryKeepStubState {
+    var createdFields: [String: Value] = [:]
+    var createdEntity: String = ""
+    /// Player ids the read-back reports as attached (empty = none).
+    var readbackPlayerIds: [String] = []
+    /// When true, the read-back envelope omits the players property entirely
+    /// (simulates a create that silently dropped the relation).
+    var omitPlayersOnReadback = false
+    var createCallCount = 0
+    var getCallCount = 0
+
+    func recordCreate(entity: String, fields: [String: Value]) {
+        createdEntity = entity
+        createdFields = fields
+        createCallCount += 1
+    }
+
+    func recordGet() { getCallCount += 1 }
+    func setReadback(_ ids: [String]) { readbackPlayerIds = ids }
+    func setOmitPlayers(_ omit: Bool) { omitPlayersOnReadback = omit }
+}
+
+private let kIsaiahPlayerId = "dc8e8f3f-e607-4b5d-809e-ae289574f40c"
+
+/// Memory entity fixture WITH a bound PLAYERS relation property (`players`).
+private func memoryEntityWithPlayers() -> RegistryEntity {
+    RegistryEntity(
+        key: "memory",
+        displayName: "Memory",
+        dataSourceId: "8a39359f-2246-40a2-8614-a487ba9abd23",
+        properties: [
+            RegistryProperty(key: "title", notionName: "Memory", notionPropertyId: "title", type: "title", role: .title),
+            RegistryProperty(key: "summary", notionName: "Relevant:", notionPropertyId: "sum1", type: "rich_text"),
+            RegistryProperty(key: "players", notionName: "PLAYERS", notionPropertyId: "rel1", type: "relation", role: .relation),
+        ],
+        cacheTTLSeconds: 3600,
+        hasBody: true
+    )
+}
+
+/// Memory entity fixture WITHOUT any PLAYERS relation (the current live binding).
+private func memoryEntityNoPlayers() -> RegistryEntity {
+    RegistryEntity(
+        key: "memory",
+        displayName: "Memory",
+        dataSourceId: "8a39359f-2246-40a2-8614-a487ba9abd23",
+        properties: [
+            RegistryProperty(key: "title", notionName: "Memory", notionPropertyId: "title", type: "title", role: .title),
+            RegistryProperty(key: "summary", notionName: "Relevant:", notionPropertyId: "sum1", type: "rich_text"),
+            RegistryProperty(key: "url", notionName: "URL", notionPropertyId: "url1", type: "url"),
+        ],
+        cacheTTLSeconds: 3600,
+        hasBody: true
+    )
+}
+
+/// Memory entity fixture where PLAYERS is present but UNBOUND (no property id).
+private func memoryEntityUnboundPlayers() -> RegistryEntity {
+    RegistryEntity(
+        key: "memory",
+        displayName: "Memory",
+        dataSourceId: "8a39359f-2246-40a2-8614-a487ba9abd23",
+        properties: [
+            RegistryProperty(key: "title", notionName: "Memory", notionPropertyId: "title", type: "title", role: .title),
+            RegistryProperty(key: "players", notionName: "PLAYERS", notionPropertyId: nil, type: "relation", role: .relation),
+        ],
+        cacheTTLSeconds: 3600,
+        hasBody: true
+    )
+}
+
+/// Register stub registry_create / registry_get / notion_blocks_append on the
+/// router (overwrites the real ones by name) driven by `state`. The read-back's
+/// players relation is projected under the `players` canonical key.
+private func installStubs(on router: ToolRouter, state: MemoryKeepStubState, pageId: String) async {
+    let create = ToolRegistration(
+        name: "registry_create", module: "stub", tier: .open,
+        description: "stub",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { args in
+            guard case .object(let a) = args,
+                  case .string(let entity)? = a["entity"],
+                  case .object(let fields)? = a["fields"] else {
+                return .object(["created": .bool(false)])
+            }
+            await state.recordCreate(entity: entity, fields: fields)
+            // Reflect whatever players value the caller wrote into the read-back,
+            // so verify passes on a faithful attach and fails when it was dropped.
+            if case .string(let p)? = fields["players"], !p.isEmpty {
+                await state.setReadback([p])
+            }
+            return .object([
+                "created": .bool(true),
+                "row": .object([
+                    "entity": .string(entity),
+                    "id": .string(pageId),
+                    "title": .string("Memo"),
+                    "url": .string(""),
+                    "properties": .object([:]),
+                ]),
+            ])
+        })
+
+    let get = ToolRegistration(
+        name: "registry_get", module: "stub", tier: .open,
+        description: "stub",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { args in
+            await state.recordGet()
+            let omit = await state.omitPlayersOnReadback
+            let ids = await state.readbackPlayerIds
+            var props: [String: Value] = ["title": .string("Memo")]
+            if !omit {
+                props["players"] = .array(ids.map { .string($0) })
+            }
+            return .object([
+                "entity": .string("memory"),
+                "id": .string(pageId),
+                "properties": .object(props),
+            ])
+        })
+
+    // Body append is irrelevant to attribution — accept and no-op.
+    let append = ToolRegistration(
+        name: "notion_blocks_append", module: "stub", tier: .open,
+        description: "stub",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in .object(["ok": .bool(true)]) })
+
+    await router.register(create)
+    await router.register(get)
+    await router.register(append)
+}
+
+private func memoryKeepIntent(fields: [String: String] = [:]) -> VoiceMemoIntent {
+    VoiceMemoIntent(
+        kind: .memoryKeep,
+        confidence: 0.95,
+        entityKey: "memory",
+        title: "Preferred stack",
+        fields: fields
+    )
+}
+
+private func memoryKeepPlan() -> VoiceMemoPlan {
+    VoiceMemoPlan(
+        generatedTitle: "Preferred stack",
+        skipMemoryKeep: false,
+        summary: "Keep this: my preferred stack is Bridge plus Cursor.",
+        actions: [],
+        intents: []
+    )
+}
+
+func runVoiceMemoPlayerAttachTests() async {
+    print("\n\u{1F517} PKT-1064 — originating-Player relation attach + verify")
+
+    // 1. Attaches the default originating player on memory_keep create.
+    await test("PKT-1064: memory_keep attaches the originating Player relation at create") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-123")
+
+        let detail = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: memoryKeepIntent(),
+            plan: memoryKeepPlan(),
+            transcript: "Keep this note.",
+            router: router,
+            entity: memoryEntityWithPlayers()
+        )
+
+        let fields = await state.createdFields
+        try expect(fields["players"] == .string(kIsaiahPlayerId),
+                   "create must carry players=\(kIsaiahPlayerId), got \(String(describing: fields["players"]))")
+        try expect(detail.contains(kIsaiahPlayerId), "detail should record the attached player")
+    }
+
+    // 2. Verify read-back confirms the relation is present.
+    await test("PKT-1064: verify read-back confirms the Player relation is present") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-verify")
+
+        _ = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: memoryKeepIntent(),
+            plan: memoryKeepPlan(),
+            transcript: "Keep this note.",
+            router: router,
+            entity: memoryEntityWithPlayers()
+        )
+
+        let gets = await state.getCallCount
+        try expect(gets >= 1, "a read-back registry_get must run to verify attachment")
+    }
+
+    // 3. Absent PLAYERS property → graceful BLOCKED (throws, no crash), and NO
+    //    row is created (we block before the write).
+    await test("PKT-1064: absent PLAYERS property blocks gracefully (throws, no crash)") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-none")
+
+        var threw = false
+        do {
+            _ = try await VoiceMemoProcessor.executeMemoryKeep(
+                entityKey: "memory",
+                intent: memoryKeepIntent(),
+                plan: memoryKeepPlan(),
+                transcript: "Keep this note.",
+                router: router,
+                entity: memoryEntityNoPlayers()
+            )
+        } catch let error as VoiceMemoError {
+            threw = true
+            if case .playerRelationUnbound = error {} else {
+                try expect(false, "expected playerRelationUnbound, got \(error)")
+            }
+        }
+        try expect(threw, "must throw when no bound PLAYERS relation exists")
+        let creates = await state.createCallCount
+        try expect(creates == 0, "must not create a Memory row when it cannot attribute a Player")
+    }
+
+    // 4. Present-but-UNBOUND PLAYERS property is treated as absent → BLOCKED.
+    await test("PKT-1064: unbound PLAYERS property (no property id) also blocks gracefully") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-unbound")
+
+        var threw = false
+        do {
+            _ = try await VoiceMemoProcessor.executeMemoryKeep(
+                entityKey: "memory",
+                intent: memoryKeepIntent(),
+                plan: memoryKeepPlan(),
+                transcript: "Keep this note.",
+                router: router,
+                entity: memoryEntityUnboundPlayers()
+            )
+        } catch let error as VoiceMemoError {
+            threw = true
+            if case .playerRelationUnbound = error {} else {
+                try expect(false, "expected playerRelationUnbound, got \(error)")
+            }
+        }
+        try expect(threw, "unbound PLAYERS must block like an absent one")
+    }
+
+    // 5. Read-back that omits the relation → verify failure (not a clean success).
+    await test("PKT-1064: read-back missing the relation fails verification") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-drop")
+        await state.setOmitPlayers(true)   // create "succeeds" but relation is gone
+
+        var threw = false
+        do {
+            _ = try await VoiceMemoProcessor.executeMemoryKeep(
+                entityKey: "memory",
+                intent: memoryKeepIntent(),
+                plan: memoryKeepPlan(),
+                transcript: "Keep this note.",
+                router: router,
+                entity: memoryEntityWithPlayers()
+            )
+        } catch let error as VoiceMemoError {
+            threw = true
+            if case .playerRelationVerifyFailed = error {} else {
+                try expect(false, "expected playerRelationVerifyFailed, got \(error)")
+            }
+        }
+        try expect(threw, "a dropped relation on read-back must fail verification")
+    }
+
+    // 6. An explicit per-intent originating player overrides the default.
+    await test("PKT-1064: explicit originatingPlayer override wins over the default") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let state = MemoryKeepStubState()
+        await installStubs(on: router, state: state, pageId: "page-override")
+        let other = "11111111-2222-3333-4444-555555555555"
+
+        _ = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: memoryKeepIntent(fields: ["originatingPlayer": other]),
+            plan: memoryKeepPlan(),
+            transcript: "Keep this note.",
+            router: router,
+            entity: memoryEntityWithPlayers()
+        )
+        let fields = await state.createdFields
+        try expect(fields["players"] == .string(other), "explicit override must be attached")
+    }
+
+    // 7. playersRelationKey matches the PLAYERS column case/space-insensitively
+    //    and only when bound.
+    await test("PKT-1064: playersRelationKey matches bound PLAYERS column, rename-safe") {
+        try expect(VoiceMemoProcessor.playersRelationKey(in: memoryEntityWithPlayers()) == "players",
+                   "should resolve the bound players relation key")
+        try expect(VoiceMemoProcessor.playersRelationKey(in: memoryEntityNoPlayers()) == nil,
+                   "no PLAYERS relation → nil")
+        try expect(VoiceMemoProcessor.playersRelationKey(in: memoryEntityUnboundPlayers()) == nil,
+                   "unbound PLAYERS → nil")
+        try expect(VoiceMemoProcessor.playersRelationKey(in: nil) == nil, "nil entity → nil")
+    }
+}

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1605,7 +1605,15 @@ set -euo pipefail
 # 2824 → 2854 measured green.
 # 2026-06-30 (Memory Hub W1–W3 UX + HITL): +6 tests — MemoryProcessInspectUnderstandTests;
 # MemoryProcessLayoutAXTests (+1 opt-in AX); floor 2857 → 2863 measured green.
-FLOOR="${BRIDGE_TEST_FLOOR:-2863}"
+# 2026-07-01 (PKT-1064 originating-Player relation attach/verify): +7 tests —
+# VoiceMemoPlayerAttachTests (memo→Memory attaches default player at create, verify
+# read-back present, absent-PLAYERS graceful BLOCKED, unbound-PLAYERS BLOCKED, dropped
+# relation fails verify, explicit override wins, playersRelationKey rename-safe match).
+# Branched off origin/main where FLOOR=2863; measured integrated green = 2870 (2863 +7),
+# 0 failed. FLOOR raised to 2870. NOTE: PKT-1041 is a PARALLEL UNMERGED branch that
+# independently raises FLOOR to 2872 — reconcile the two raises at merge (this branch's
+# +7 and 1041's raise are additive over the same 2863 base).
+FLOOR="${BRIDGE_TEST_FLOOR:-2870}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
`executeMemoryKeep` attaches the originating Player relation at create + read-back verifies it; an unbound PLAYERS relation → graceful BLOCK (no silent un-attributed rows). Re-scoped from the stale 4-part objective (sub-goals 1–3 already shipped).

- +7 tests · floor 2863→2870 · no version bump
- **Activation:** operator must bind the PLAYERS relation on the live Memory registry entity for the path to fire in production.
- REVIEW-FIRST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)