### PR TITLE
PKT-1065A · feat(init): deterministic init-core + handshake receipt

### DIFF
--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -238,7 +238,9 @@ public enum BridgeConstants {
     ///   (in-place AGENTS field update tool). 187 + 1 = 188.
     /// PKT-1061 Commands MCP (2026-06-29): +6 commands_* tools (list/get/search/create/update/delete). 188 + 6 = 194.
     /// Wave 3 FB (2026-06-29): + bridge_focus_settings (automation family). 194 + 1 = 195.
-    public static let staticFeatureModuleToolCount = 197
+    /// PKT-1065A (2026-07-01): + bridge_initialize (canonical init-core handshake +
+    ///   persisted receipt; joins the existing standing_orders family, no new family). 197 + 1 = 198.
+    public static let staticFeatureModuleToolCount = 198
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -1,0 +1,141 @@
+// BridgeInitializeModule.swift — PKT-1065A
+// TheBridge · Modules · StandingOrders
+//
+// The single canonical `bridge_initialize` MCP tool. One call runs the
+// deterministic init-core (`BridgeInitializeService.run`) — locate + load the
+// doctrine, verify the doctrine SHA-256, enforce required-source + integrity
+// policy, inspect routing + supplemental orders + capability — and PERSIST a
+// structured handshake receipt, emitting one distinct telemetry event.
+//
+// Tier `.open`: a pure read + local-evidence write (its own receipt file). It
+// mutates no operator config and exposes no secrets; it only records what the
+// bridge observed at handshake. Mirrors bridge_status / session_info posture.
+
+import Foundation
+import MCP
+
+public enum BridgeInitializeModule {
+
+    public static let moduleName = "standing_orders"
+    public static let toolName = "bridge_initialize"
+
+    /// Resolves the live runtime context (connection + capability + clock) for a
+    /// handshake. Injectable so ServerManager can bind live cloud state and tests
+    /// can pin a deterministic instant. The default is a direct-loopback posture:
+    /// local channel, Mac tools available, app clock.
+    public typealias ContextProvider = @Sendable (_ client: String?) async -> BridgeInitializeContext
+
+    /// Default provider: local channel, Mac tools available, wall-clock now.
+    public static let defaultContextProvider: ContextProvider = { client in
+        BridgeInitializeContext(
+            client: client,
+            connectionState: "local",
+            macToolsAvailable: true,
+            bridgeState: "running",
+            now: Date()
+        )
+    }
+
+    public static func register(
+        on router: ToolRouter,
+        contextProvider: @escaping ContextProvider = defaultContextProvider
+    ) async {
+        await router.register(makeTool(contextProvider: contextProvider))
+    }
+
+    /// Factory for the `bridge_initialize` registration (exposed for tests).
+    public static func makeTool(
+        contextProvider: @escaping ContextProvider = defaultContextProvider
+    ) -> ToolRegistration {
+        ToolRegistration(
+            name: toolName,
+            module: moduleName,
+            tier: .open,
+            description: "Run the canonical Bridge initialization handshake: locate + load the "
+                + "standing-orders doctrine (orders.md + manifest.json + metadata.json), verify the "
+                + "doctrine SHA-256 (expected vs actual), enforce the required-source + integrity "
+                + "policy, inspect the routing roster + supplemental orders + capability state, and "
+                + "persist a structured, durable handshake receipt. Initialization state "
+                + "(INCOMPLETE|DEGRADED|COMPLETE) is reported SEPARATELY from runtime capability "
+                + "state. Returns the full receipt { handshakeId, finalState, integrityResult, "
+                + "expectedHash, actualHash, routingRosterState, supplementalOrderCounts, "
+                + "capabilityState, telemetryEventRef, … }. Each call is one distinct evidence event.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "client": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional client name (e.g. the MCP clientInfo.name) to attribute this handshake to.")
+                    ])
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Bridge Initialize",
+                whenToUse: [
+                    "At session start, to run the canonical handshake and get a durable receipt proving the doctrine loaded and its integrity.",
+                    "To re-verify doctrine integrity + routing/capability state on demand."
+                ],
+                whenNotToUse: [
+                    "Editing standing orders (use standing_orders_save).",
+                    "Checking only cloud health (use bridge_status)."
+                ],
+                relatedTools: ["bridge_status", "session_info", "standing_orders_list"]
+            ),
+            handler: { arguments in
+                let client: String? = {
+                    if case .object(let a) = arguments, case .string(let s)? = a["client"] {
+                        let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
+                        return t.isEmpty ? nil : t
+                    }
+                    return nil
+                }()
+                let context = await contextProvider(client)
+                let receipt = await BridgeInitializeService.run(context: context)
+                return receiptValue(receipt)
+            }
+        )
+    }
+
+    // MARK: - Serialization
+
+    /// Serialize a `HandshakeReceipt` to the MCP `Value` result. All fields the
+    /// packet enumerates are present; nil hashes serialize as JSON null-safe
+    /// omission via `.string`-when-present.
+    public static func receiptValue(_ r: HandshakeReceipt) -> Value {
+        var d: [String: Value] = [
+            "ok": .bool(true),
+            "tool": .string(toolName),
+            "handshakeId": .string(r.handshakeId),
+            "schemaVersion": .int(r.schemaVersion),
+            "timestamp": .string(ISO8601DateFormatter().string(from: r.timestamp)),
+            "bridgeState": .string(r.bridgeState),
+            "macToolsAvailable": .bool(r.macToolsAvailable),
+            "doctrineVersion": .string(r.doctrineVersion),
+            "integrityResult": .string(r.integrityResult),
+            "routingRosterState": .string(r.routingRosterState),
+            "routingWarnings": .array(r.routingWarnings.map { .string($0) }),
+            "supplementalOrderCounts": .object([
+                "found": .int(r.supplementalOrderCounts.found),
+                "operative": .int(r.supplementalOrderCounts.operative),
+                "ignored": .int(r.supplementalOrderCounts.ignored),
+            ]),
+            "connectionState": .string(r.connectionState),
+            "telemetryEventRef": .string(r.telemetryEventRef),
+            "capabilityState": .string(r.capabilityState.rawValue),
+            "capabilityMatrix": .array(r.capabilityMatrix.map { entry in
+                var e: [String: Value] = [
+                    "capability": .string(entry.capability),
+                    "available": .bool(entry.available),
+                ]
+                if let detail = entry.detail { e["detail"] = .string(detail) }
+                return .object(e)
+            }),
+            "finalState": .string(r.finalState.rawValue),
+        ]
+        if let client = r.client { d["client"] = .string(client) }
+        if let expected = r.expectedHash { d["expectedHash"] = .string(expected) }
+        if let actual = r.actualHash { d["actualHash"] = .string(actual) }
+        return .object(d)
+    }
+}

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
@@ -1,0 +1,408 @@
+// BridgeInitializeService.swift — PKT-1065A
+// TheBridge · Modules · StandingOrders
+//
+// The canonical, deterministic init-core. One call to
+// `BridgeInitializeService.run(...)` executes the standing-orders manifest
+// sequence end-to-end and returns a structured, durable HANDSHAKE RECEIPT:
+//
+//   1. Locate + load the doctrine files (orders.md + manifest.json +
+//      metadata.json) via `StandingOrdersStore`.
+//   2. Compute the doctrine SHA-256 and compare expected(manifest) vs actual.
+//   3. Enforce the required-source + integrity policy (INCOMPLETE on a missing
+//      required source; DEGRADED on hash / version drift).
+//   4. Inspect the routing roster + supplemental orders + connection +
+//      capability state.
+//   5. PERSIST a structured `HandshakeReceipt` to disk (one file per handshake)
+//      and emit a per-handshake telemetry event linked to session telemetry.
+//
+// DESIGN — init-state vs capability-state are SEPARATE axes:
+//   • `finalState` (INCOMPLETE|DEGRADED|COMPLETE) is the INITIALIZATION verdict:
+//     did the doctrine + integrity + required routing roster load correctly?
+//   • `capabilityState` describes what the RUNTIME can do right now (Mac tools,
+//     cloud reachability). A perfectly initialized bridge can still be capability
+//     -limited (offline cloud), and a capability-rich bridge can be INCOMPLETE
+//     (missing doctrine). The two never collapse into one another.
+//
+// The clock is INJECTED (`now`). `Date.now` is unavailable in some contexts
+// (the app supplies its wall clock); tests pass a fixed instant for determinism.
+
+import Foundation
+import CryptoKit
+
+/// The runtime capability axis — SEPARATE from initialization state.
+/// Derived from the cloud connection state + whether Mac tools are exposed.
+public enum CapabilityState: String, Codable, Sendable, Equatable {
+    /// Mac tools available and (if cloud is enabled) reachable.
+    case full = "FULL"
+    /// Some capability present but impaired (degraded tunnel, cloud connecting).
+    case limited = "LIMITED"
+    /// Mac tools not exposed to callers in the current state (offline/disabled cloud).
+    case unavailable = "UNAVAILABLE"
+}
+
+/// One capability entry — a named runtime capability and whether it is live.
+public struct CapabilityEntry: Codable, Sendable, Equatable {
+    public let capability: String
+    public let available: Bool
+    public let detail: String?
+
+    public init(capability: String, available: Bool, detail: String? = nil) {
+        self.capability = capability
+        self.available = available
+        self.detail = detail
+    }
+}
+
+/// Supplemental-order tri-state counts. An order is:
+///   • `operative` — an active (non-archived), non-no-op directive;
+///   • `ignored`   — present but deliberately inert (archived, or explicitly
+///     marked TEMP / no-op via the `[no-op]` / `TEMP` marker convention);
+///   • `found`     — operative + ignored (every supplemental order located).
+public struct SupplementalOrderCounts: Codable, Sendable, Equatable {
+    public let found: Int
+    public let operative: Int
+    public let ignored: Int
+
+    public init(found: Int, operative: Int, ignored: Int) {
+        self.found = found
+        self.operative = operative
+        self.ignored = ignored
+    }
+}
+
+/// The persisted, structured handshake receipt. One per `run(...)`.
+public struct HandshakeReceipt: Codable, Sendable, Equatable {
+    public let handshakeId: String
+    public let schemaVersion: Int
+    public let timestamp: Date
+    public let client: String?
+    public let bridgeState: String
+    public let macToolsAvailable: Bool
+    public let doctrineVersion: String
+    public let expectedHash: String?
+    public let actualHash: String?
+    public let integrityResult: String
+    public let routingRosterState: String
+    public let routingWarnings: [String]
+    public let supplementalOrderCounts: SupplementalOrderCounts
+    public let connectionState: String
+    public let telemetryEventRef: String
+    public let capabilityState: CapabilityState
+    public let capabilityMatrix: [CapabilityEntry]
+    public let finalState: StandingOrdersStore.InitializationState
+
+    public init(
+        handshakeId: String,
+        schemaVersion: Int,
+        timestamp: Date,
+        client: String?,
+        bridgeState: String,
+        macToolsAvailable: Bool,
+        doctrineVersion: String,
+        expectedHash: String?,
+        actualHash: String?,
+        integrityResult: String,
+        routingRosterState: String,
+        routingWarnings: [String],
+        supplementalOrderCounts: SupplementalOrderCounts,
+        connectionState: String,
+        telemetryEventRef: String,
+        capabilityState: CapabilityState,
+        capabilityMatrix: [CapabilityEntry],
+        finalState: StandingOrdersStore.InitializationState
+    ) {
+        self.handshakeId = handshakeId
+        self.schemaVersion = schemaVersion
+        self.timestamp = timestamp
+        self.client = client
+        self.bridgeState = bridgeState
+        self.macToolsAvailable = macToolsAvailable
+        self.doctrineVersion = doctrineVersion
+        self.expectedHash = expectedHash
+        self.actualHash = actualHash
+        self.integrityResult = integrityResult
+        self.routingRosterState = routingRosterState
+        self.routingWarnings = routingWarnings
+        self.supplementalOrderCounts = supplementalOrderCounts
+        self.connectionState = connectionState
+        self.telemetryEventRef = telemetryEventRef
+        self.capabilityState = capabilityState
+        self.capabilityMatrix = capabilityMatrix
+        self.finalState = finalState
+    }
+}
+
+/// The immutable runtime inputs the init-core needs but cannot derive itself.
+/// Injected so the service stays pure + hermetically testable (no live cloud
+/// manager, no wall clock, no server actor reach-in).
+public struct BridgeInitializeContext: Sendable {
+    public let client: String?
+    /// The current connection state raw value (e.g. "online"/"offline"/"disabled").
+    public let connectionState: String
+    /// Whether Mac tools are exposed to a caller in the current state.
+    public let macToolsAvailable: Bool
+    /// The running bridge lifecycle label (e.g. "running").
+    public let bridgeState: String
+    /// Injected wall clock — `Date.now` is unavailable in some contexts.
+    public let now: Date
+
+    public init(
+        client: String? = nil,
+        connectionState: String = "local",
+        macToolsAvailable: Bool = true,
+        bridgeState: String = "running",
+        now: Date
+    ) {
+        self.client = client
+        self.connectionState = connectionState
+        self.macToolsAvailable = macToolsAvailable
+        self.bridgeState = bridgeState
+        self.now = now
+    }
+}
+
+/// The deterministic init-core. Stateless: every call reads the live on-disk
+/// doctrine + supplemental registry, classifies, persists a receipt, and emits
+/// a telemetry event.
+public enum BridgeInitializeService {
+
+    /// Current receipt schema contract version. Bump on any shape change.
+    public static let schemaVersion = 1
+
+    /// A supplemental order is deliberately inert ("ignored") when it is
+    /// archived OR explicitly marked as a no-op / TEMP directive. The marker
+    /// convention is a case-insensitive `[no-op]` / `[noop]` / `TEMP` token in
+    /// the title (cheap, operator-visible, and stable across edits).
+    public static func isIgnoredOrder(title: String, archived: Bool) -> Bool {
+        if archived { return true }
+        let t = title.lowercased()
+        return t.contains("[no-op]") || t.contains("[noop]") || t.contains("temp")
+    }
+
+    /// Derive the runtime capability axis from the connection state + Mac-tool
+    /// exposure. INDEPENDENT of initialization state.
+    ///   • local / online + Mac tools     → FULL
+    ///   • degraded / connecting          → LIMITED
+    ///   • Mac tools not exposed           → UNAVAILABLE
+    public static func capabilityState(connectionState: String, macToolsAvailable: Bool) -> CapabilityState {
+        guard macToolsAvailable else { return .unavailable }
+        switch connectionState.lowercased() {
+        case "degraded", "connecting":
+            return .limited
+        case "offline", "disabled":
+            // Mac tools reported available but the channel is down → limited.
+            return .limited
+        default:
+            return .full
+        }
+    }
+
+    /// Build (but do NOT persist) the receipt for the given context, reading the
+    /// live doctrine + supplemental registry. Pure aside from disk reads; used by
+    /// `run(...)` and directly by tests that want the classification without I/O
+    /// side effects. `telemetryEventRef` is the id of the event `run(...)` emits.
+    public static func buildReceipt(
+        context: BridgeInitializeContext,
+        supplemental: [StandingOrderSummary],
+        handshakeId: String = UUID().uuidString,
+        telemetryEventRef: String
+    ) -> HandshakeReceipt {
+        // 1–3: doctrine load + hash verify + integrity policy (init axis).
+        try? StandingOrdersStore.shared.ensureInitializationContract()
+        let report = StandingOrdersStore.shared.initializationReport()
+
+        // Compute actual doctrine hash from the live orders.md (nil when absent).
+        let actualHash: String? = {
+            guard let snapshot = try? StandingOrdersStore.shared.read(),
+                  report.doctrineLoaded else { return nil }
+            return StandingOrdersStore.sha256Hex(snapshot.markdown)
+        }()
+        // The manifest's expected hash (nil when the manifest is missing).
+        let expectedHash = StandingOrdersStore.shared.manifestDoctrineHash()
+
+        // 4: routing roster state + warnings (init axis — required source).
+        let routingIndex = SkillsModule.buildRoutingInstructions()
+        let routingLoaded = !routingIndex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        var routingWarnings: [String] = []
+        var finalState = report.state
+        if !routingLoaded {
+            routingWarnings.append("Required routing roster is empty.")
+            finalState = .incomplete
+        }
+
+        // Supplemental order tri-state (found / operative / ignored).
+        let found = supplemental.count
+        let ignored = supplemental.filter {
+            isIgnoredOrder(title: $0.title, archived: $0.archived)
+        }.count
+        let counts = SupplementalOrderCounts(
+            found: found,
+            operative: max(0, found - ignored),
+            ignored: ignored
+        )
+
+        // integrityResult: COMPLETE = clean; DEGRADED = hash/version drift only;
+        // MISSING when a required doctrine/integrity source is absent.
+        let integrityResult: String = {
+            if !report.doctrineLoaded || !report.manifestLoaded { return "MISSING_REQUIRED_SOURCE" }
+            switch report.state {
+            case .complete: return report.metadataVerified ? "VERIFIED" : "DEGRADED"
+            case .degraded: return "DEGRADED"
+            case .incomplete: return "MISSING_REQUIRED_SOURCE"
+            }
+        }()
+
+        // Capability axis — SEPARATE from finalState.
+        let capState = capabilityState(
+            connectionState: context.connectionState,
+            macToolsAvailable: context.macToolsAvailable
+        )
+        let matrix: [CapabilityEntry] = [
+            CapabilityEntry(capability: "mac_tools", available: context.macToolsAvailable),
+            CapabilityEntry(
+                capability: "cloud_channel",
+                available: context.connectionState.lowercased() == "online"
+                    || context.connectionState.lowercased() == "degraded"
+                    || context.connectionState.lowercased() == "local",
+                detail: context.connectionState
+            ),
+            CapabilityEntry(capability: "doctrine_loaded", available: report.doctrineLoaded),
+            CapabilityEntry(capability: "routing_roster", available: routingLoaded),
+        ]
+
+        return HandshakeReceipt(
+            handshakeId: handshakeId,
+            schemaVersion: schemaVersion,
+            timestamp: context.now,
+            client: context.client,
+            bridgeState: context.bridgeState,
+            macToolsAvailable: context.macToolsAvailable,
+            doctrineVersion: report.doctrineVersion,
+            expectedHash: expectedHash,
+            actualHash: actualHash,
+            integrityResult: integrityResult,
+            routingRosterState: routingLoaded ? "loaded" : "missing",
+            routingWarnings: routingWarnings,
+            supplementalOrderCounts: counts,
+            connectionState: context.connectionState,
+            telemetryEventRef: telemetryEventRef,
+            capabilityState: capState,
+            capabilityMatrix: matrix,
+            finalState: finalState
+        )
+    }
+
+    /// The canonical one-call init sequence. Reads the live supplemental
+    /// registry, builds the receipt, PERSISTS it durably, and emits a
+    /// per-handshake telemetry event linked to session telemetry.
+    @discardableResult
+    public static func run(
+        context: BridgeInitializeContext,
+        store: StandingOrdersRecordStore = .shared,
+        receiptStore: HandshakeReceiptStore = .shared
+    ) async -> HandshakeReceipt {
+        let supplemental = await store.list(includeArchived: true)
+        let handshakeId = UUID().uuidString
+        // The telemetry event id is bound INTO the receipt (each handshake =
+        // one distinct evidence event), then the event is emitted below.
+        let telemetryEventId = UUID().uuidString
+        let receipt = buildReceipt(
+            context: context,
+            supplemental: supplemental,
+            handshakeId: handshakeId,
+            telemetryEventRef: telemetryEventId
+        )
+        // Persist durably (best-effort; a write failure must not crash a
+        // handshake — the receipt is still returned and telemetry still fires).
+        try? receiptStore.persist(receipt)
+        // Emit the per-handshake telemetry event, linked to session telemetry.
+        DeliveryLog.shared.recordHandshakeInitialized(
+            eventID: telemetryEventId,
+            sessionID: context.client ?? handshakeId,
+            clientName: context.client,
+            handshakeId: handshakeId,
+            finalState: receipt.finalState.rawValue,
+            at: context.now
+        )
+        return receipt
+    }
+}
+
+// MARK: - Durable receipt persistence
+
+/// Persists handshake receipts to disk — one JSON file per handshake, so a
+/// controller/human can audit every init as distinct durable evidence. Stored
+/// under the standing-orders support dir in a `handshakes/` subfolder.
+public final class HandshakeReceiptStore: @unchecked Sendable {
+    public static let shared = HandshakeReceiptStore()
+
+    /// Cap on retained receipt files. Oldest are pruned on write so the folder
+    /// never grows unbounded across a long-lived install.
+    public static let retentionCap = 200
+
+    private let baseDir: URL
+
+    /// Default location: `…/The Bridge/standing-orders/handshakes/`. Injectable
+    /// for hermetic tests.
+    public init(baseDir: URL = HandshakeReceiptStore.defaultDir()) {
+        self.baseDir = baseDir
+    }
+
+    public static func defaultDir() -> URL {
+        BridgePaths.applicationSupport(.standingOrders)
+            .appendingPathComponent("handshakes", isDirectory: true)
+    }
+
+    private func fileURL(for id: String) -> URL {
+        baseDir.appendingPathComponent("\(id).json", isDirectory: false)
+    }
+
+    /// Write one receipt atomically. Filename is the handshakeId (unique per
+    /// handshake), so distinct handshakes never overwrite one another.
+    public func persist(_ receipt: HandshakeReceipt) throws {
+        if !FileManager.default.fileExists(atPath: baseDir.path) {
+            try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(receipt)
+        try data.write(to: fileURL(for: receipt.handshakeId), options: [.atomic])
+        pruneIfNeeded()
+    }
+
+    /// Load one receipt by id, or nil when absent/unreadable.
+    public func load(id: String) -> HandshakeReceipt? {
+        guard let data = try? Data(contentsOf: fileURL(for: id)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(HandshakeReceipt.self, from: data)
+    }
+
+    /// The number of persisted receipt files currently on disk.
+    public func count() -> Int {
+        (try? FileManager.default.contentsOfDirectory(at: baseDir, includingPropertiesForKeys: nil))?
+            .filter { $0.pathExtension == "json" }.count ?? 0
+    }
+
+    /// Prune oldest receipt files beyond the retention cap (by mtime).
+    private func pruneIfNeeded() {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: baseDir,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        ).filter({ $0.pathExtension == "json" }), files.count > Self.retentionCap else { return }
+        let sorted = files.sorted { a, b in
+            let da = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let db = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return da < db
+        }
+        for file in sorted.prefix(files.count - Self.retentionCap) {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    /// Test/diagnostic reset — remove every persisted receipt.
+    public func resetForTesting() {
+        try? FileManager.default.removeItem(at: baseDir)
+    }
+}

--- a/TheBridge/Modules/StandingOrders/StandingOrdersStore.swift
+++ b/TheBridge/Modules/StandingOrders/StandingOrdersStore.swift
@@ -369,6 +369,17 @@ public final class StandingOrdersStore: @unchecked Sendable {
         )
     }
 
+    /// The manifest's recorded EXPECTED doctrine SHA-256 (full 64-hex), or nil
+    /// when the manifest is missing/unreadable. This is the `expectedHash` the
+    /// init-core compares against the freshly-computed doctrine hash.
+    public func manifestDoctrineHash() -> String? {
+        guard let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(SourceManifest.self, from: data) else {
+            return nil
+        }
+        return manifest.sources.handshakeDoctrine.sha256
+    }
+
     /// Write new markdown. If `expectedHash` is supplied and does not match
     /// the current file's hash, throws `.staleHash` without writing.
     @discardableResult
@@ -637,6 +648,14 @@ public struct StandingOrderSummary: Sendable, Equatable {
     public let scope: StandingOrderScope
     public let updatedAt: Date
     public let archived: Bool
+
+    public init(id: String, title: String, scope: StandingOrderScope, updatedAt: Date, archived: Bool) {
+        self.id = id
+        self.title = title
+        self.scope = scope
+        self.updatedAt = updatedAt
+        self.archived = archived
+    }
 }
 
 public enum StandingOrdersRecordError: Error, Equatable, Sendable {

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -68,6 +68,7 @@ public enum BridgeModuleRegistry {
         await SnippetsModule.register(on: router)
         await CommandsModule.register(on: router)          // PKT-1061: CommandStore-backed commands_* (6 tools)
         await StandingOrdersModule.register(on: router)
+        await BridgeInitializeModule.register(on: router)  // PKT-1065A: canonical bridge_initialize handshake + persisted receipt (1 tool)
         await ShortcutsModule.register(on: router)
         await MemoryModule.register(on: router)
         await RegistryModule.register(on: router)          // Data-Source Registry: generic CRUD + add/remove_entity + introspect + possess (10 tools)

--- a/TheBridge/Server/DeliveryLog.swift
+++ b/TheBridge/Server/DeliveryLog.swift
@@ -40,6 +40,11 @@ public enum DeliveryEventKind: String, Sendable, Equatable, CaseIterable {
     case skillFetched
     /// A `memory_*` tool call (audit-only — memories surfaced telemetry).
     case memoryToolCall
+    /// A canonical `bridge_initialize` handshake (PKT-1065A). One distinct
+    /// evidence event per handshake, linked to the session by `sessionID`.
+    /// `uri` carries the handshakeId and `intent` the final init state so the
+    /// event stands alone as durable evidence without dereferencing the receipt.
+    case handshakeInitialized
 }
 
 /// One immutable telemetry event. `Sendable` so it can be built off-main and
@@ -343,6 +348,54 @@ public final class DeliveryLog {
             at: at
         )
         Task { @MainActor in DeliveryLog.shared.ingest(event) }
+    }
+
+    /// Record a canonical `bridge_initialize` handshake as ONE distinct
+    /// evidence event (PKT-1065A). `eventID` is injected so the persisted
+    /// receipt's `telemetryEventRef` and this event share one identity — each
+    /// handshake yields exactly one linkable evidence event. Linked to session
+    /// telemetry via `sessionID`. AUDIT ONLY — never gates dispatch.
+    public nonisolated func recordHandshakeInitialized(
+        eventID: UUID,
+        sessionID: String,
+        clientName: String?,
+        handshakeId: String,
+        finalState: String,
+        at: Date = Date()
+    ) {
+        let event = DeliveryEvent(
+            id: eventID,
+            sessionID: sessionID,
+            clientName: clientName,
+            kind: .handshakeInitialized,
+            uri: handshakeId,
+            intent: finalState,
+            at: at
+        )
+        Task { @MainActor in DeliveryLog.shared.ingest(event) }
+    }
+
+    /// Overload accepting a string event id (the receipt stores its
+    /// `telemetryEventRef` as a String). Parses to a `UUID` when possible so
+    /// the event's `id` matches the receipt ref; falls back to a fresh id for a
+    /// non-UUID string (the ref still travels in the receipt).
+    public nonisolated func recordHandshakeInitialized(
+        eventID: String,
+        sessionID: String,
+        clientName: String?,
+        handshakeId: String,
+        finalState: String,
+        at: Date = Date()
+    ) {
+        let uuid = UUID(uuidString: eventID) ?? UUID()
+        recordHandshakeInitialized(
+            eventID: uuid,
+            sessionID: sessionID,
+            clientName: clientName,
+            handshakeId: handshakeId,
+            finalState: finalState,
+            at: at
+        )
     }
 
     public nonisolated static func skillFetchFields(from arguments: Value?) -> (skill: String, intent: String?) {

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -110,6 +110,13 @@ public enum ToolAnnotationCatalog {
         // a no-op re-point), not an open world.
         "bridge_open_settings": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "bridge_focus_settings": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
+        // PKT-1065A: canonical init-core handshake. Reads the standing-orders
+        // doctrine + routing/capability state and writes ONE local evidence
+        // receipt (its own handshake file) — no operator config mutation, no
+        // secrets, no destruction. Not readOnly (it persists a receipt), but
+        // non-destructive; touches only this app's own doctrine/evidence, not an
+        // open world. Not idempotent — each handshake is a distinct evidence event.
+        "bridge_initialize": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         // WS-D (PKT-921): cloud-gated health probe. Reads the local
         // BridgeCloudManager state machine; touches nothing — pure read.
         "bridge_status": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),

--- a/TheBridgeTests/BridgeInitializeTests.swift
+++ b/TheBridgeTests/BridgeInitializeTests.swift
@@ -1,0 +1,308 @@
+// BridgeInitializeTests.swift — PKT-1065A
+// Covers the deterministic init-core (BridgeInitializeService) + the
+// bridge_initialize MCP tool + durable receipt persistence + per-handshake
+// telemetry:
+//   • manifest/metadata parse + hash verify (expected vs actual)
+//   • receipt serialize round-trip (Codable + MCP Value)
+//   • status classification: INCOMPLETE on a missing required source
+//   • no-op supplemental order → found-but-ignored tri-state counts
+//   • init-state vs capability-state are SEPARATE axes
+//   • each handshake is a distinct persisted receipt + distinct evidence event
+// File-I/O hermetic via a per-test throwaway HOME (BridgePaths override).
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runBridgeInitializeTests() async {
+    print("\n\u{1F91D} BridgeInitialize (PKT-1065A · init-core + handshake receipt)")
+
+    let fixedClock = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func ctx(
+        client: String? = "test-client",
+        connectionState: String = "local",
+        macTools: Bool = true
+    ) -> BridgeInitializeContext {
+        BridgeInitializeContext(
+            client: client,
+            connectionState: connectionState,
+            macToolsAvailable: macTools,
+            bridgeState: "running",
+            now: fixedClock
+        )
+    }
+
+    // ── COMPLETE path: doctrine + manifest + metadata all present ──────
+    await test("Init: fully-seeded doctrine classifies COMPLETE with matching hashes") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nbe terse")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(),
+                supplemental: [],
+                telemetryEventRef: "evt-1"
+            )
+            try expect(receipt.finalState == .complete, "expected COMPLETE, got \(receipt.finalState.rawValue)")
+            try expect(receipt.expectedHash != nil, "manifest must carry an expected doctrine hash")
+            try expect(receipt.actualHash != nil, "actual doctrine hash must be computed")
+            try expect(receipt.expectedHash == receipt.actualHash,
+                       "expected vs actual doctrine hash must match on a clean seed")
+            try expect(receipt.integrityResult == "VERIFIED",
+                       "clean seed integrityResult must be VERIFIED, got \(receipt.integrityResult)")
+            // doctrineVersion is sourced from the manifest the write path stamped
+            // (parse-from-markdown is a bundled-seed concern); it must be resolved,
+            // not the "unknown" sentinel a failed manifest load would leave.
+            try expect(receipt.doctrineVersion != "unknown",
+                       "doctrineVersion must be resolved from the manifest, got \(receipt.doctrineVersion)")
+            try expect(receipt.routingRosterState == "loaded" || receipt.routingRosterState == "missing")
+        }
+    }
+
+    await test("Init: bundled-seed doctrineVersion is parsed from the amendment record") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            StandingOrdersStore.bundledSeedOverrideForTesting = .init(
+                markdown: "# Orders\n\n> **Amendment record:** v9.1.2\n\nseed body",
+                doctrineVersion: "v9.1.2"
+            )
+            defer { StandingOrdersStore.bundledSeedOverrideForTesting = nil }
+            try StandingOrdersStore.shared.seedIfEmpty()
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(), supplemental: [], telemetryEventRef: "evt-1b")
+            try expect(receipt.doctrineVersion == "v9.1.2",
+                       "doctrineVersion from bundled seed manifest, got \(receipt.doctrineVersion)")
+            try expect(receipt.finalState == .complete)
+            try expect(receipt.expectedHash == receipt.actualHash, "seeded hashes match")
+        }
+    }
+
+    // ── INCOMPLETE path: required doctrine source missing ──────────────
+    await test("Init: missing required doctrine classifies INCOMPLETE (not silent success)") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            // No write → orders.md absent.
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(),
+                supplemental: [],
+                telemetryEventRef: "evt-2"
+            )
+            try expect(receipt.finalState == .incomplete,
+                       "missing required source must be INCOMPLETE, got \(receipt.finalState.rawValue)")
+            try expect(receipt.integrityResult == "MISSING_REQUIRED_SOURCE",
+                       "integrityResult must flag the missing source, got \(receipt.integrityResult)")
+            try expect(receipt.actualHash == nil, "no doctrine → no actual hash")
+        }
+    }
+
+    // ── DEGRADED path: doctrine present but hash drift ─────────────────
+    await test("Init: doctrine hash drift classifies DEGRADED (integrity, not required-source)") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\noriginal body")
+            // Tamper the orders.md on disk WITHOUT rewriting the manifest/metadata,
+            // so the recorded expected hash no longer matches the actual bytes.
+            let dir = BridgePaths.applicationSupport(.standingOrders)
+            let ordersURL = dir.appendingPathComponent("orders.md")
+            try "# Orders\n\nTAMPERED body".write(to: ordersURL, atomically: true, encoding: .utf8)
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(),
+                supplemental: [],
+                telemetryEventRef: "evt-3"
+            )
+            try expect(receipt.finalState == .degraded,
+                       "hash drift must be DEGRADED, got \(receipt.finalState.rawValue)")
+            try expect(receipt.expectedHash != receipt.actualHash,
+                       "expected vs actual must diverge after tamper")
+            try expect(receipt.integrityResult == "DEGRADED",
+                       "integrityResult must be DEGRADED, got \(receipt.integrityResult)")
+        }
+    }
+
+    // ── no-op supplemental order → found-but-ignored ───────────────────
+    await test("Init: TEMP supplemental order counts as found-but-ignored (operative excludes it)") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\nseed")
+            let operative = StandingOrderSummary(
+                id: "a", title: "Real directive", scope: .global,
+                updatedAt: fixedClock, archived: false)
+            let temp = StandingOrderSummary(
+                id: "b", title: "TEMP scratch note", scope: .global,
+                updatedAt: fixedClock, archived: false)
+            let archived = StandingOrderSummary(
+                id: "c", title: "Old directive", scope: .global,
+                updatedAt: fixedClock, archived: true)
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(),
+                supplemental: [operative, temp, archived],
+                telemetryEventRef: "evt-4"
+            )
+            try expect(receipt.supplementalOrderCounts.found == 3, "found = all located")
+            try expect(receipt.supplementalOrderCounts.ignored == 2,
+                       "TEMP + archived are ignored, got \(receipt.supplementalOrderCounts.ignored)")
+            try expect(receipt.supplementalOrderCounts.operative == 1,
+                       "only the real directive is operative, got \(receipt.supplementalOrderCounts.operative)")
+        }
+    }
+
+    await test("Init: isIgnoredOrder marker convention (TEMP / [no-op] / archived)") {
+        try expect(BridgeInitializeService.isIgnoredOrder(title: "TEMP foo", archived: false))
+        try expect(BridgeInitializeService.isIgnoredOrder(title: "cleanup [no-op]", archived: false))
+        try expect(BridgeInitializeService.isIgnoredOrder(title: "live", archived: true))
+        try expect(!BridgeInitializeService.isIgnoredOrder(title: "live directive", archived: false))
+    }
+
+    // ── init-state vs capability-state SEPARATION ──────────────────────
+    await test("Init: capability-state is SEPARATE from init-state") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            // No doctrine → INCOMPLETE init — but Mac tools fully available.
+            let full = BridgeInitializeService.buildReceipt(
+                context: ctx(connectionState: "local", macTools: true),
+                supplemental: [],
+                telemetryEventRef: "evt-5a"
+            )
+            try expect(full.finalState == .incomplete, "init is INCOMPLETE (no doctrine)")
+            try expect(full.capabilityState == .full,
+                       "capability is FULL despite INCOMPLETE init — axes are independent")
+
+            // Now seed doctrine (COMPLETE init) but report Mac tools unavailable.
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let unavail = BridgeInitializeService.buildReceipt(
+                context: ctx(connectionState: "offline", macTools: false),
+                supplemental: [],
+                telemetryEventRef: "evt-5b"
+            )
+            try expect(unavail.finalState == .complete, "init is COMPLETE (doctrine seeded)")
+            try expect(unavail.capabilityState == .unavailable,
+                       "capability UNAVAILABLE when Mac tools not exposed — independent of COMPLETE init")
+        }
+    }
+
+    await test("Init: capabilityState derivation (full / limited / unavailable)") {
+        try expect(BridgeInitializeService.capabilityState(connectionState: "local", macToolsAvailable: true) == .full)
+        try expect(BridgeInitializeService.capabilityState(connectionState: "online", macToolsAvailable: true) == .full)
+        try expect(BridgeInitializeService.capabilityState(connectionState: "degraded", macToolsAvailable: true) == .limited)
+        try expect(BridgeInitializeService.capabilityState(connectionState: "connecting", macToolsAvailable: true) == .limited)
+        try expect(BridgeInitializeService.capabilityState(connectionState: "offline", macToolsAvailable: true) == .limited)
+        try expect(BridgeInitializeService.capabilityState(connectionState: "local", macToolsAvailable: false) == .unavailable)
+    }
+
+    // ── receipt Codable round-trip ─────────────────────────────────────
+    await test("Init: receipt Codable round-trips losslessly") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(),
+                supplemental: [],
+                handshakeId: "hs-fixed",
+                telemetryEventRef: "evt-6"
+            )
+            let enc = JSONEncoder(); enc.dateEncodingStrategy = .iso8601
+            let dec = JSONDecoder(); dec.dateDecodingStrategy = .iso8601
+            let data = try enc.encode(receipt)
+            let back = try dec.decode(HandshakeReceipt.self, from: data)
+            try expect(back == receipt, "Codable round-trip must be lossless")
+            try expect(back.handshakeId == "hs-fixed")
+            try expect(back.telemetryEventRef == "evt-6")
+            try expect(back.schemaVersion == BridgeInitializeService.schemaVersion)
+        }
+    }
+
+    // ── MCP Value serialization has every packet-required field ────────
+    await test("Init: bridge_initialize tool result carries every required receipt field") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(), supplemental: [], telemetryEventRef: "evt-7")
+            guard case .object(let d) = BridgeInitializeModule.receiptValue(receipt) else {
+                throw TestError.assertion("receiptValue must be an object")
+            }
+            let required = [
+                "handshakeId", "schemaVersion", "timestamp", "bridgeState",
+                "macToolsAvailable", "doctrineVersion", "integrityResult",
+                "routingRosterState", "routingWarnings", "supplementalOrderCounts",
+                "connectionState", "telemetryEventRef", "capabilityState",
+                "capabilityMatrix", "finalState",
+            ]
+            for key in required {
+                try expect(d[key] != nil, "receipt Value missing required field '\(key)'")
+            }
+        }
+    }
+
+    // ── run(): durable persistence + distinct evidence per handshake ───
+    await test("Init: run() persists a durable receipt + emits one telemetry event") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let store = StandingOrdersRecordStore(storeURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("nb-init-\(UUID().uuidString).json"))
+            let receiptStore = HandshakeReceiptStore(baseDir: FileManager.default.temporaryDirectory
+                .appendingPathComponent("nb-hs-\(UUID().uuidString)", isDirectory: true))
+            receiptStore.resetForTesting()
+
+            let r1 = await BridgeInitializeService.run(context: ctx(), store: store, receiptStore: receiptStore)
+            let loaded = receiptStore.load(id: r1.handshakeId)
+            try expect(loaded != nil, "receipt must be durably persisted")
+            try expect(loaded?.handshakeId == r1.handshakeId)
+            try expect(receiptStore.count() == 1, "one handshake → one persisted receipt")
+        }
+    }
+
+    await test("Init: each handshake is a DISTINCT receipt (distinct id + file)") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let store = StandingOrdersRecordStore(storeURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("nb-init-\(UUID().uuidString).json"))
+            let receiptStore = HandshakeReceiptStore(baseDir: FileManager.default.temporaryDirectory
+                .appendingPathComponent("nb-hs-\(UUID().uuidString)", isDirectory: true))
+            receiptStore.resetForTesting()
+
+            let r1 = await BridgeInitializeService.run(context: ctx(), store: store, receiptStore: receiptStore)
+            let r2 = await BridgeInitializeService.run(context: ctx(), store: store, receiptStore: receiptStore)
+            try expect(r1.handshakeId != r2.handshakeId, "distinct handshakes → distinct ids")
+            try expect(r1.telemetryEventRef != r2.telemetryEventRef, "distinct evidence event per handshake")
+            try expect(receiptStore.count() == 2, "two handshakes → two persisted receipts")
+        }
+    }
+
+    // ── tool registration + tier ───────────────────────────────────────
+    await test("Init: bridge_initialize registers at tier .open under standing_orders module") {
+        let gate = SecurityGate()
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: gate, auditLog: log)
+        await BridgeInitializeModule.register(on: router)
+        let reg = await router.allRegistrations().first { $0.name == "bridge_initialize" }
+        try expect(reg != nil, "bridge_initialize must be registered")
+        try expect(reg?.tier == .open, "bridge_initialize must be tier .open")
+        try expect(reg?.module == "standing_orders", "joins the standing_orders family (no new family)")
+    }
+
+    await test("Init: bridge_initialize has an explicit annotation catalog entry") {
+        let ann = ToolAnnotationCatalog.annotations(for: "bridge_initialize")
+        try expect(ann != nil, "bridge_initialize must carry an explicit annotation")
+        try expect(ann?.destructiveHint == false, "not destructive")
+        try expect(ann?.requiresConfirmation == false, "no confirmation (tier .open)")
+        try expect(ann?.openWorld == false, "touches only this app's own doctrine/evidence")
+    }
+}
+
+// Per-test throwaway HOME so the on-disk standing-orders + receipt stores are
+// hermetic (BridgePaths override, mirrors withDeliveryTempHome).
+private func withInitTempHome(_ body: () async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("BridgeInitialize-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body()
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -718,6 +718,7 @@ await runWSHMenuBarTests()        // PKT-804 (v2.3): menu-bar quick-page
 await runSnippetsModuleTests()    // PKT-2135a9e9 (v2.3 · WS-D): snippets module
 await runCommandsModuleTests()    // PKT-1061: CommandStore commands_* MCP surface
 await runStandingOrdersModuleTests() // PKT-931 (v3.7·B): standing_orders_* MCP tools
+await runBridgeInitializeTests()  // PKT-1065A: canonical bridge_initialize init-core + persisted handshake receipt
 await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)
 await runFetchSkillMarkdownTests() // cmd-w4: fetch_skill /markdown + shared MentionResolver

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1605,7 +1605,14 @@ set -euo pipefail
 # 2824 → 2854 measured green.
 # 2026-06-30 (Memory Hub W1–W3 UX + HITL): +6 tests — MemoryProcessInspectUnderstandTests;
 # MemoryProcessLayoutAXTests (+1 opt-in AX); floor 2857 → 2863 measured green.
-FLOOR="${BRIDGE_TEST_FLOOR:-2863}"
+# 2026-07-01 (PKT-1065A · deterministic init-core + handshake receipt): +15 tests —
+# BridgeInitializeTests (manifest/metadata parse + hash verify, INCOMPLETE/DEGRADED/
+# COMPLETE classification, no-op supplemental found-but-ignored tri-state, init-state
+# vs capability-state separation, receipt Codable + MCP Value serialize, durable
+# per-handshake persistence + distinct evidence event, tool registration/tier/annotation).
+# Measured integrated green off origin/main = 2877 (0 failed). floor 2863 → 2877.
+# (Parallel unmerged branches reconcile at merge per the order-inversion rule.)
+FLOOR="${BRIDGE_TEST_FLOOR:-2877}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
Canonical `bridge_initialize` service+tool: manifest/hash verify, required-source/integrity policy (INCOMPLETE/DEGRADED/COMPLETE), a persisted structured HandshakeReceipt, init-state vs capability-state separation, and one per-handshake telemetry event.

- +14 tests · floor 2863→2877 · toolcount→198 · no version bump
- ⚠️ **auth/init surface — rebase on current main before merge** (app-dev Workflow C).
- Deferred: ContextProvider→live BridgeCloudManager wiring; auto-invoke at the MCP initialize handshake.
- REVIEW-FIRST · verified PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)