### PR TITLE
PKT-1065B · fix(diagnostics): session_info/bridge_status semantics + notion:primary alias

### DIFF
--- a/TheBridge/Config/ConnectionRegistry.swift
+++ b/TheBridge/Config/ConnectionRegistry.swift
@@ -68,12 +68,53 @@ public actor ConnectionRegistry {
         }
     }
 
+    /// The reserved symbolic alias segment that resolves to a provider's LIVE
+    /// primary connection at call time (e.g. `notion:primary`). Rename-safe: it
+    /// always tracks whichever connection is currently primary rather than a
+    /// fixed name. An exact-id match always wins first, so a connection literally
+    /// named "primary" is never shadowed.
+    public static let primaryAliasSegment = "primary"
+
+    /// Whether the name segment of `id` is the reserved `primary` alias
+    /// (case-insensitive), e.g. `notion:primary`. Pure and testable.
+    public static func isPrimaryAlias(id: String) -> Bool {
+        let parts = id.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2 else { return false }
+        return parts[1].lowercased() == primaryAliasSegment
+    }
+
+    /// Resolve `id` against a candidate set following alias rules:
+    /// an exact-id match always wins first (so a connection literally named
+    /// "primary" is never shadowed); otherwise, if `id`'s name segment is the
+    /// `primary` alias, return the candidate flagged primary. Pure and testable
+    /// (no live state), independent of provider.
+    public static func resolve<C>(
+        id: String,
+        in candidates: [C],
+        idOf: (C) -> String,
+        isPrimary: (C) -> Bool
+    ) -> C? {
+        if let exact = candidates.first(where: { idOf($0) == id }) {
+            return exact
+        }
+        if isPrimaryAlias(id: id) {
+            return candidates.first(where: isPrimary)
+        }
+        return nil
+    }
+
     public func getConnection(id: String, validateLive: Bool = true) async throws -> BridgeConnection {
         let provider = try parseProvider(from: id)
         switch provider {
         case .notion:
             let notionConnections = try await buildNotionConnections(validateLive: validateLive)
-            if let match = notionConnections.first(where: { $0.id == id }) {
+            // Exact-id-wins, then notion:primary → the live primary connection.
+            if let match = Self.resolve(
+                id: id,
+                in: notionConnections,
+                idOf: { $0.id },
+                isPrimary: { $0.isPrimary }
+            ) {
                 return match
             }
         case .stripe:

--- a/TheBridge/Modules/ConnectionsModule.swift
+++ b/TheBridge/Modules/ConnectionsModule.swift
@@ -47,7 +47,7 @@ public enum ConnectionsModule {
                 "properties": .object([
                     "connectionId": .object([
                         "type": .string("string"),
-                        "description": .string("Connection id, for example notion:primary or stripe:default")
+                        "description": .string("Connection id like notion:<name> or stripe:default. The symbolic alias notion:primary resolves to the live primary Notion workspace (rename-safe).")
                     ])
                 ]),
                 "required": .array([.string("connectionId")])

--- a/TheBridge/Modules/SessionModule.swift
+++ b/TheBridge/Modules/SessionModule.swift
@@ -127,12 +127,20 @@ public enum SessionModule {
             }
         ))
 
-        // session_info – open (V1-04)
+        // session_info – open (V1-04; PKT-1065B: explicit field scopes)
         await router.register(ToolRegistration(
             name: "session_info",
             module: moduleName,
             tier: .open,
-            description: "Return the current bridge session's uptime, connected client count, and audit log size.",
+            description: "Return this bridge PROCESS's diagnostics. IMPORTANT — scopes differ per field: "
+                + "`uptimeSeconds` is the whole bridge process's uptime (not a per-caller session). "
+                + "`connections`/`activeClients` count ONLY live HTTP (/mcp) + legacy SSE network sessions; "
+                + "a stdio-attached client (e.g. this local MCP connection) is NOT counted, so 0 clients is "
+                + "expected and normal when the only caller is on stdio — it does NOT contradict bridge_status. "
+                + "`toolCalls`/`auditLogSize` are the audit-log entry count accumulated since process start (or "
+                + "the last session_clear). This tool describes the LOCAL bridge process; `bridge_status` "
+                + "describes the CLOUD tunnel channel — the two are orthogonal. See the `scopes` field in the "
+                + "response for the authoritative per-field definitions.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),
@@ -141,7 +149,10 @@ public enum SessionModule {
             handler: { _ in
                 let uptime = max(0, Date().timeIntervalSince(sessionStartTime))
                 let auditSize = await auditLog.count()
-                let diagnostics = await diagnosticsProvider?() ?? RuntimeDiagnostics(connections: 1, activeClients: 1)
+                // No diagnostics provider (e.g. stdio-only assembly / unit tests) means
+                // there is no HTTP/SSE server to enumerate network sessions — report 0,
+                // NOT a fabricated 1. The `scopes` field explains why 0 is correct.
+                let diagnostics = await diagnosticsProvider?() ?? RuntimeDiagnostics(connections: 0, activeClients: 0)
                 let hours = Int(uptime) / 3600
                 let minutes = (Int(uptime) % 3600) / 60
                 let seconds = Int(uptime) % 60
@@ -153,7 +164,18 @@ public enum SessionModule {
                     "connections": .int(diagnostics.connections),
                     "toolCalls": .int(auditSize),
                     "activeClients": .int(diagnostics.activeClients),
-                    "auditLogSize": .int(auditSize)
+                    "auditLogSize": .int(auditSize),
+                    // Explicit per-field scope so a caller never has to guess why, e.g.,
+                    // activeClients is 0 while bridge_status reports the tunnel online.
+                    "scopes": .object([
+                        "uptimeSeconds": .string("Whole bridge PROCESS uptime in seconds (not a per-caller session)."),
+                        "uptime": .string("Same as uptimeSeconds, formatted as 'Hh Mm Ss'."),
+                        "connections": .string("Count of live HTTP (/mcp) + legacy SSE network sessions. Excludes stdio callers."),
+                        "activeClients": .string("Same population as `connections`: HTTP + legacy SSE sessions only. A stdio-attached caller is NOT counted, so 0 is normal and does not conflict with bridge_status."),
+                        "toolCalls": .string("Audit-log entry count since process start or last session_clear. Equal to auditLogSize."),
+                        "auditLogSize": .string("Number of audit-log entries retained for this process (since start or last session_clear)."),
+                        "note": .string("session_info describes the LOCAL bridge process; bridge_status describes the CLOUD tunnel channel. They are independent — neither implies the other.")
+                    ])
                 ])
             }
         ))

--- a/TheBridgeTests/ConnectionsModuleTests.swift
+++ b/TheBridgeTests/ConnectionsModuleTests.swift
@@ -75,4 +75,65 @@ func runConnectionsModuleTests() async {
             // Expected
         }
     }
+
+    // PKT-1065B: primary-connection symbolic alias resolution (pure, hermetic).
+    struct FakeConn { let id: String; let primary: Bool }
+    let fakeConns = [
+        FakeConn(id: "notion:default", primary: true),
+        FakeConn(id: "notion:work", primary: false)
+    ]
+
+    await test("isPrimaryAlias recognizes notion:primary (case-insensitive)") {
+        try expect(ConnectionRegistry.isPrimaryAlias(id: "notion:primary"), "notion:primary should be the alias")
+        try expect(ConnectionRegistry.isPrimaryAlias(id: "notion:PRIMARY"), "alias match should be case-insensitive")
+        try expect(!ConnectionRegistry.isPrimaryAlias(id: "notion:default"), "a real name is not the alias")
+        try expect(!ConnectionRegistry.isPrimaryAlias(id: "notion"), "id without a name segment is not the alias")
+    }
+
+    await test("resolve maps notion:primary to the live primary connection") {
+        let resolved = ConnectionRegistry.resolve(
+            id: "notion:primary",
+            in: fakeConns,
+            idOf: { $0.id },
+            isPrimary: { $0.primary }
+        )
+        try expect(resolved?.id == "notion:default", "notion:primary should resolve to the primary (notion:default), got \(resolved?.id ?? "nil")")
+    }
+
+    await test("resolve exact-id match wins over primary alias") {
+        // A connection literally named "primary" must not be shadowed by the alias.
+        let withLiteralPrimary = [
+            FakeConn(id: "notion:primary", primary: false),
+            FakeConn(id: "notion:default", primary: true)
+        ]
+        let resolved = ConnectionRegistry.resolve(
+            id: "notion:primary",
+            in: withLiteralPrimary,
+            idOf: { $0.id },
+            isPrimary: { $0.primary }
+        )
+        try expect(resolved?.id == "notion:primary" && resolved?.primary == false,
+                   "Exact id should win, resolving to the literally-named 'primary' connection")
+    }
+
+    await test("resolve returns nil for an unknown non-alias id") {
+        let resolved = ConnectionRegistry.resolve(
+            id: "notion:missing",
+            in: fakeConns,
+            idOf: { $0.id },
+            isPrimary: { $0.primary }
+        )
+        try expect(resolved == nil, "Unknown non-alias id should not resolve")
+    }
+
+    await test("resolve returns nil for primary alias when no primary exists") {
+        let noPrimary = [FakeConn(id: "notion:a", primary: false)]
+        let resolved = ConnectionRegistry.resolve(
+            id: "notion:primary",
+            in: noPrimary,
+            idOf: { $0.id },
+            isPrimary: { $0.primary }
+        )
+        try expect(resolved == nil, "primary alias should not resolve when nothing is primary")
+    }
 }

--- a/TheBridgeTests/SessionModuleTests.swift
+++ b/TheBridgeTests/SessionModuleTests.swift
@@ -148,6 +148,48 @@ func runSessionModuleTests() async {
         }
     }
 
+    // session_info: PKT-1065B explicit per-field scopes
+    await test("session_info includes explicit field scopes") {
+        let result = try await router.dispatch(
+            toolName: "session_info",
+            arguments: .object([:])
+        )
+        guard case .object(let dict) = result,
+              case .object(let scopes) = dict["scopes"] else {
+            throw TestError.assertion("Expected a 'scopes' object in session_info")
+        }
+        for key in ["uptimeSeconds", "connections", "activeClients", "toolCalls", "auditLogSize", "note"] {
+            try expect(scopes[key] != nil, "Missing scope documentation for '\(key)'")
+        }
+        // The scope note must explicitly disclaim conflict with bridge_status.
+        if case .string(let activeScope) = scopes["activeClients"] {
+            try expect(activeScope.contains("bridge_status"),
+                       "activeClients scope should reference bridge_status to explain the non-conflict")
+        } else {
+            throw TestError.assertion("activeClients scope should be a string")
+        }
+    }
+
+    // session_info: with NO diagnostics provider, network client counts are 0
+    // (not a fabricated 1) — a stdio-only caller is legitimately 0 clients.
+    await test("session_info reports 0 clients when no diagnostics provider is wired") {
+        let localGate = SecurityGate()
+        let localLog = AuditLog()
+        let localRouter = ToolRouter(securityGate: localGate, auditLog: localLog)
+        await SessionModule.register(on: localRouter, auditLog: localLog)
+        let result = try await localRouter.dispatch(
+            toolName: "session_info",
+            arguments: .object([:])
+        )
+        guard case .object(let dict) = result,
+              case .int(let connections) = dict["connections"],
+              case .int(let activeClients) = dict["activeClients"] else {
+            throw TestError.assertion("Expected connections and activeClients ints")
+        }
+        try expect(connections == 0, "Expected 0 connections with no provider, got \(connections)")
+        try expect(activeClients == 0, "Expected 0 activeClients with no provider, got \(activeClients)")
+    }
+
     // session_clear: requires confirm = true
     await test("session_clear rejects without confirm") {
         let result = try await router.dispatch(

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -1605,7 +1605,15 @@ set -euo pipefail
 # 2824 → 2854 measured green.
 # 2026-06-30 (Memory Hub W1–W3 UX + HITL): +6 tests — MemoryProcessInspectUnderstandTests;
 # MemoryProcessLayoutAXTests (+1 opt-in AX); floor 2857 → 2863 measured green.
-FLOOR="${BRIDGE_TEST_FLOOR:-2863}"
+# 2026-07-01 (PKT-1065B session_info/bridge_status semantics + connection alias):
+# +2 SessionModuleTests (explicit per-field `scopes`; 0-clients default when no
+# diagnostics provider) +5 ConnectionsModuleTests (notion:primary symbolic alias —
+# isPrimaryAlias, resolve-to-primary, exact-id-wins, unknown-id nil, no-primary nil).
+# Measured green off origin/main (9306800) = 2870 (2863 +7), failed=0. Note:
+# `make build` build-injects RemoteAccessIdentity.swift from local WorkOS env — that
+# file must be reverted before measuring/committing (fail-closed tests else fail).
+# FLOOR 2863 → 2870. Parallel unmerged branches reconcile at merge.
+FLOOR="${BRIDGE_TEST_FLOOR:-2870}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
Reconcile `session_info` field scopes with `bridge_status` semantics (the zero-uptime/clients conflict); implement `notion:primary` alias resolution (never-shadowed, tracks the live primary).

- +7 tests · floor 2863→2870 · no version bump
- ⚠️ **transport/connection surface — rebase on current main before merge**.
- REVIEW-FIRST · verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)