### PR TITLE
fix: connections_health/session_info diagnostics mislabels

### DIFF
--- a/TheBridge/Modules/ConnectionsModule.swift
+++ b/TheBridge/Modules/ConnectionsModule.swift
@@ -77,9 +77,12 @@ public enum ConnectionsModule {
                 ])
             ]),
             handler: { arguments in
+                // Cached per the tool description above — validateLive:false reads
+                // last-known status (ConnectionHealthChecker's cache), no network
+                // round-trip. connections_validate is the live counterpart.
                 if case .object(let args) = arguments,
                    case .string(let connectionId) = args["connectionId"] {
-                    let connection = try await ConnectionRegistry.shared.getConnection(id: connectionId, validateLive: true)
+                    let connection = try await ConnectionRegistry.shared.getConnection(id: connectionId, validateLive: false)
                     return .object([
                         "id": .string(connection.id),
                         "provider": .string(connection.provider.rawValue),
@@ -88,7 +91,7 @@ public enum ConnectionsModule {
                     ])
                 }
 
-                let connections = try await ConnectionRegistry.shared.listConnections(validateLive: true)
+                let connections = try await ConnectionRegistry.shared.listConnections(validateLive: false)
                 let items = connections.map { connection in
                     Value.object([
                         "id": .string(connection.id),

--- a/TheBridge/Modules/SessionModule.swift
+++ b/TheBridge/Modules/SessionModule.swift
@@ -21,9 +21,6 @@ public enum SessionModule {
 
     public static let moduleName = "session"
 
-    /// Session start timestamp for uptime tracking.
-    private static let sessionStartTime = Date()
-
     /// Register all session module tools on the given router.
     /// V1-04: now accepts auditLog for session_info and session_clear.
     public static func register(
@@ -31,6 +28,13 @@ public enum SessionModule {
         auditLog: AuditLog,
         diagnosticsProvider: (@Sendable () async -> RuntimeDiagnostics)? = nil
     ) async {
+        // Captured HERE (register() runs once, at server boot) rather than as a
+        // lazily-initialized `static let` referenced only inside the handler
+        // closures below — a lazy static's first-access moment is whenever a
+        // client first calls session_info/session_clear, not process launch,
+        // so uptime silently measured "time since first call" instead of
+        // "time since boot".
+        let sessionStartTime = Date()
 
         // tools_list – open (V1-03, preserved)
         await router.register(ToolRegistration(

--- a/TheBridgeTests/ConnectionsModuleTests.swift
+++ b/TheBridgeTests/ConnectionsModuleTests.swift
@@ -126,6 +126,37 @@ func runConnectionsModuleTests() async {
         try expect(resolved == nil, "Unknown non-alias id should not resolve")
     }
 
+    // connections_health must stay cached (validateLive:false) per its own tool
+    // description ("doesn't hit the live service"). Regression guard for a bug
+    // where the handler passed validateLive:true — indistinguishable from
+    // connections_validate. `lastValidatedAt` is the deterministic signal:
+    // ConnectionRegistry sets it to a fresh timestamp ONLY on the live path
+    // (validateLive:true) and to nil on the cached path, for every Notion
+    // connection. This assertion only fires when a real Notion connection is
+    // configured (no test seam exists for ConnectionRegistry.shared), but it
+    // is a real regression guard on any machine with a live workspace.
+    await test("connections_health does not force a live re-validation") {
+        let result = try await router.dispatch(
+            toolName: "connections_health",
+            arguments: .object([:])
+        )
+        guard case .object(let dict) = result, case .array(let connections) = dict["connections"] else {
+            throw TestError.assertion("Expected a connections array from connections_health")
+        }
+        for entry in connections {
+            guard case .object(let conn) = entry, case .string(let provider) = conn["provider"] else {
+                continue
+            }
+            if provider == "notion" {
+                let lastValidatedAt = conn["lastValidatedAt"] ?? .null
+                try expect(
+                    lastValidatedAt == .null,
+                    "connections_health should report lastValidatedAt: null for cached Notion connections (validateLive:false), got \(lastValidatedAt)"
+                )
+            }
+        }
+    }
+
     await test("resolve returns nil for primary alias when no primary exists") {
         let noPrimary = [FakeConn(id: "notion:a", primary: false)]
         let resolved = ConnectionRegistry.resolve(

--- a/TheBridgeTests/SessionModuleTests.swift
+++ b/TheBridgeTests/SessionModuleTests.swift
@@ -244,6 +244,43 @@ func runSessionModuleTests() async {
         try expect(afterCount <= 1, "Audit log should be 0 or 1 after clear (session_clear itself gets logged), got \(afterCount)")
     }
 
+    // session_info: uptime is tracked per-registration (server-boot time), NOT
+    // shared process-wide state initialized on first tool call. Regression
+    // guard for a bug where `sessionStartTime` was a lazily-initialized
+    // `static let` only touched inside the handler closures: two independent
+    // registrations would silently share one epoch (whichever registration's
+    // session_info was called first), so uptime measured "time since first
+    // call" instead of "time since this server instance booted".
+    await test("independent registrations track independent start times") {
+        let gateA = SecurityGate()
+        let logA = AuditLog()
+        let routerA = ToolRouter(securityGate: gateA, auditLog: logA)
+        await SessionModule.register(on: routerA, auditLog: logA)
+
+        try await Task.sleep(nanoseconds: 300_000_000) // 300ms
+
+        let gateB = SecurityGate()
+        let logB = AuditLog()
+        let routerB = ToolRouter(securityGate: gateB, auditLog: logB)
+        await SessionModule.register(on: routerB, auditLog: logB)
+
+        let resultA = try await routerA.dispatch(toolName: "session_info", arguments: .object([:]))
+        let resultB = try await routerB.dispatch(toolName: "session_info", arguments: .object([:]))
+
+        guard case .object(let dictA) = resultA, case .double(let uptimeA) = dictA["uptimeSeconds"],
+              case .object(let dictB) = resultB, case .double(let uptimeB) = dictB["uptimeSeconds"] else {
+            throw TestError.assertion("Expected uptimeSeconds on both routers' session_info")
+        }
+
+        // Router A was registered ~300ms before router B. If each registration
+        // tracks its own start time, A's uptime should be meaningfully larger
+        // than B's. A shared/lazy epoch would make them nearly identical.
+        try expect(
+            uptimeA - uptimeB >= 0.2,
+            "Expected router A (registered ~300ms earlier) to show more uptime than B; got A=\(uptimeA) B=\(uptimeB)"
+        )
+    }
+
     // session_clear: returns previous uptime
     await test("session_clear returns previous uptime seconds") {
         let result = try await router.dispatch(

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2023,7 +2023,25 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3035}"
 # vocabulary round-trips through the shared filter). Measured 3095 passed,
 # 0 failed (3054 baseline + 41 = 3095, matching exactly). FLOOR raised
 # 3054 → 3095.
-FLOOR="${BRIDGE_TEST_FLOOR:-3095}"
+#
+# 2026-07-06: connector-reauth triage (independent branch, computed off the
+# same pre-merge 3054 baseline as the fields-param PKT above — the exact
+# monotonic-counter collision class in AGENT_FEEDBACK.md's 2026-07-02 entry,
+# reconciled by hand here) turned up two confirmed diagnostics bugs.
+# (1) connections_health's handler passed validateLive:true in both branches,
+# contradicting its own tool description ("doesn't hit the live service") —
+# indistinguishable from connections_validate; fixed to validateLive:false.
+# (2) SessionModule.sessionStartTime was a `static let` referenced only inside
+# the session_info/session_clear handler closures, so Swift lazily
+# initialized it on first TOOL CALL rather than at register() (server boot)
+# time — uptimeSeconds silently measured "time since first call", not "time
+# since boot". Moved the capture to a local value at the top of register().
+# +2 regression tests (independent-start-times in SessionModuleTests.swift,
+# cached-lastValidatedAt in ConnectionsModuleTests.swift), rebased on top of
+# the fields-param merge above. Measured 3097 passed, 0 failed on the
+# combined tree (3095 + 2, matching exactly, no other drift). FLOOR raised
+# 3095 → 3097.
+FLOOR="${BRIDGE_TEST_FLOOR:-3097}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- `connections_health` passed `validateLive:true` in both branches, contradicting its own tool description ("doesn't hit the live service") and making it indistinguishable from `connections_validate`. Fixed to `validateLive:false`.
- `SessionModule.sessionStartTime` was a `static let` referenced only inside the `session_info`/`session_clear` handler closures, so Swift lazily initialized it on first **tool call** rather than server boot — `uptimeSeconds` silently measured "time since first call" instead of "time since boot". Moved the capture to a local value at the top of `register()`.
- Found while triaging a claude.ai connector reauth report. The actual root cause (in-memory MCP session state lost across a service restart, surfaced to clients as a generic "reconnect" error) is a separate design question and is **not** addressed by this PR — tracked separately.
- +2 regression tests. Rebased on top of the just-merged fields-param PR (#84) — floor gate had an order-inversion collision (both branches computed off the same pre-merge 3054 baseline); reconciled by hand: 3095 → 3097, measured fresh on the combined tree, no other drift.

## Test plan
- [x] `make test` — 3097 passed, 0 failed
- [x] `make test-floor` — passed=3097 >= floor=3097

🤖 Generated with [Claude Code](https://claude.com/claude-code)