### PR TITLE
fix: filter remote connector tool discovery by scope

### DIFF
--- a/TheBridge/Modules/Auth/ConnectorScopeGate.swift
+++ b/TheBridge/Modules/Auth/ConnectorScopeGate.swift
@@ -158,7 +158,9 @@ public struct ConnectorScopeGate: ScopeGating {
         let required = (try? await requiredScopes(for: toolName)) ?? []
         guard !required.isEmpty else {
             return .deny(
-                reason: "tool '\(toolName)' is not exposed to remote connector clients"
+                reason: "tool '\(toolName)' is not exposed to remote connector clients; "
+                    + "use a local Bridge client for local-only tools or explicitly "
+                    + "expose this tool in connector scope policy"
             )
         }
         let grantedSet = Set(grantedScopes.map(\.name))

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -816,7 +816,7 @@ public actor SSEServer {
         // connector clients compact JSON here, falling back to the SDK path for
         // anything processConnectorJSONRPC does not handle. The session pipeline
         // still skips the legacy static-bearer re-check (connectorAuthed).
-        if let connectorResponse = await processConnectorJSONRPC(request) {
+        if let connectorResponse = await processConnectorJSONRPC(request, token: token, auth: auth) {
             return connectorResponse
         }
         return await processStreamableHTTP(request, connectorAuthed: true)
@@ -831,7 +831,11 @@ public actor SSEServer {
     /// Returns `nil` for anything it does not handle so the caller falls back to
     /// the SDK transport. claude.ai accepts these plain responses too, so both
     /// cloud connectors share this path.
-    private func processConnectorJSONRPC(_ request: HTTPRequest) async -> HTTPResponse? {
+    private func processConnectorJSONRPC(
+        _ request: HTTPRequest,
+        token: BridgeAccessToken,
+        auth: ConnectorAuthContext
+    ) async -> HTTPResponse? {
         guard request.method.uppercased() == "POST",
               let body = request.body,
               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
@@ -872,6 +876,7 @@ public actor SSEServer {
             if let allowlist = toolAllowlist {
                 regs = regs.filter { allowlist.contains($0.name) }
             }
+            regs = await connectorVisibleRegistrations(regs, token: token, auth: auth)
             let tools: [[String: Any]] = regs.compactMap { reg in
                 guard let data = try? JSONEncoder().encode(MCPToolFactory.tool(for: reg)),
                       let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -919,6 +924,26 @@ public actor SSEServer {
             let data = buildRPCError(id: requestId, code: -32601, message: "Method not found: \(method)") ?? Data()
             return .data(data, headers: headers)
         }
+    }
+
+    private func connectorVisibleRegistrations(
+        _ registrations: [ToolRegistration],
+        token: BridgeAccessToken,
+        auth: ConnectorAuthContext
+    ) async -> [ToolRegistration] {
+        guard auth.strictScopes else { return registrations }
+
+        var visible: [ToolRegistration] = []
+        for registration in registrations {
+            let decision = await auth.scopeGate.evaluate(
+                toolName: registration.name,
+                grantedScopes: token.connectorScopes
+            )
+            if case .allow = decision {
+                visible.append(registration)
+            }
+        }
+        return visible
     }
 
     private static func connectorJSONHeaders(sessionID: String) -> [String: String] {

--- a/TheBridgeTests/RemoteOAuthBearerTests.swift
+++ b/TheBridgeTests/RemoteOAuthBearerTests.swift
@@ -582,6 +582,48 @@ func runRemoteOAuthBearerTests() async {
         try expect(resp.statusCode == 403, "scope-insufficient call must be 403, got \(resp.statusCode)")
     }
 
+    await test("Connector-gated server: strict tools/list hides non-callable Messages tools") {
+        let r = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        await r.register(ToolRegistration(
+            name: "snippets_list",
+            module: "snippets",
+            tier: .open,
+            description: "Allowed connector read probe.",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in .array([]) }
+        ))
+        await r.register(ToolRegistration(
+            name: "messages_recent",
+            module: "messages",
+            tier: .open,
+            description: "Local-only Messages probe.",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in .array([]) }
+        ))
+        await r.markModulesRegistrationComplete()
+
+        let server = SSEServer(router: r, onToolCall: {}, connectorAuth: authCtx)
+        let tok = try await keys.sign(iss: kIssuer, aud: kResource, scope: "snippets.read")
+        let body = Data(#"{"jsonrpc":"2.0","id":7,"method":"tools/list"}"#.utf8)
+        let req = HTTPRequest(
+            method: "POST",
+            headers: ["Cf-Connecting-Ip": "203.0.113.7", "Authorization": "Bearer \(tok)"],
+            body: body
+        )
+        let resp = await server.handleHTTPRequest(req)
+        try expect(resp.statusCode == 200, "tools/list must succeed, got \(resp.statusCode)")
+        guard case .data(let data, _) = resp else {
+            throw TestError.assertion("strict connector tools/list must be compact JSON data")
+        }
+        let obj = try (JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        let result = obj["result"] as? [String: Any] ?? [:]
+        let tools = result["tools"] as? [[String: Any]] ?? []
+        let names = Set(tools.compactMap { $0["name"] as? String })
+        try expect(names.contains("snippets_list"), "allowed connector tool missing from tools/list: \(names.sorted())")
+        try expect(!names.contains("messages_recent"),
+                   "tools/list must not advertise a tool the same bearer will 403: \(names.sorted())")
+    }
+
     // MARK: - S1 fix: PRM resource reflects NOTION_BRIDGE_PORT
 
     await test("PRM fix: resource reflects NOTION_BRIDGE_PORT override") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2041,7 +2041,11 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3035}"
 # the fields-param merge above. Measured 3097 passed, 0 failed on the
 # combined tree (3095 + 2, matching exactly, no other drift). FLOOR raised
 # 3095 → 3097.
-FLOOR="${BRIDGE_TEST_FLOOR:-3097}"
+# Remote connector scope-discovery fix (2026-07-07): added 1 regression
+# test proving strict connector tools/list hides local-only Messages tools
+# that the same bearer would fail to call. Measured 3098 passed, 0 failed
+# on the rebased branch (3097 + 1). FLOOR raised 3097 -> 3098.
+FLOOR="${BRIDGE_TEST_FLOOR:-3098}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Filter compact remote connector `tools/list` through `ConnectorScopeGate` when strict connector scopes are enabled.
- Keep non-connector/local-only tools hidden from discovery when the same bearer would 403 on `tools/call`.
- Improve the local-only denial message with a remediation path.
- Add a regression test and raise the test floor to 3098.

## Verification
- `make test-floor` -> `3098 passed, 0 failed, 3098 total`; floor `3098`.
- `make build` -> release strict-concurrency build completed.
- `git diff --check` -> clean.

## Notes
- `make build` injects local remote-access identity into the generated source during compilation; generated churn was restored before push so the PR diff stays scoped.