### PR TITLE
Align command routing and Packet Runner pilot config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,16 @@
 #     base64 string exported with `generate_keys -x key.txt` from the machine
 #     whose PUBLIC key is embedded in Info.plist (SUPublicEDKey). CI signs the
 #     appcast with this; ed25519 is deterministic, so the CI signature is
-#     byte-identical to a local `make dmg`. WITHOUT this secret the workflow
-#     still publishes the DMG but skips appcast regeneration (warns loudly).
+#     byte-identical to a local `make dmg`. Required for release dry-runs and tags.
 # - LICENSE_PUBLIC_KEY_BASE64URL: Ed25519 license PUBLIC key (base64url, raw
 #     32-byte) compiled into the build by `make inject-license-key` (Packet B,
 #     PRJCT-2754). Generate a keypair with `swift run license-cli keygen`; the
 #     operator holds the matching PRIVATE key in custody (mints customer tokens
 #     with `license-cli mint`, never committed). WITHOUT this secret the build
 #     is FAIL-CLOSED — no pasted license token activates (trial gate only).
+# - BRIDGE_OAUTH_ISSUER / BRIDGE_PUBLIC_RESOURCE / WORKOS_CLIENT_ID /
+#     WORKOS_BASE_URL / WORKOS_REDIRECT_URI: public WorkOS/OAuth identity baked
+#     into RemoteAccessIdentity.swift for the cloud connector.
 #
 # Branch-protection note: the "Commit appcast to main" step pushes appcast.xml
 # back to `main` (the Sparkle SUFeedURL is the raw main appcast.xml). The
@@ -94,6 +96,53 @@ jobs:
             echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
           fi
 
+      - name: Verify required release secrets
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          LICENSE_PUBLIC_KEY_BASE64URL: ${{ secrets.LICENSE_PUBLIC_KEY_BASE64URL }}
+          BRIDGE_OAUTH_ISSUER: ${{ secrets.BRIDGE_OAUTH_ISSUER }}
+          BRIDGE_PUBLIC_RESOURCE: ${{ secrets.BRIDGE_PUBLIC_RESOURCE }}
+          WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
+          WORKOS_BASE_URL: ${{ secrets.WORKOS_BASE_URL }}
+          WORKOS_REDIRECT_URI: ${{ secrets.WORKOS_REDIRECT_URI }}
+        run: |
+          missing=0
+          require_secret() {
+            local name="$1"
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} repository secret is not set"
+              missing=1
+            fi
+          }
+
+          for name in \
+            APPLE_CERTIFICATE_BASE64 \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_ID \
+            APPLE_ID_PASSWORD \
+            APPLE_TEAM_ID \
+            SPARKLE_ED_PRIVATE_KEY \
+            LICENSE_PUBLIC_KEY_BASE64URL \
+            BRIDGE_OAUTH_ISSUER \
+            BRIDGE_PUBLIC_RESOURCE \
+            WORKOS_CLIENT_ID \
+            WORKOS_BASE_URL \
+            WORKOS_REDIRECT_URI; do
+            require_secret "$name"
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Release preflight failed: provision missing repository secrets before running release dry-run or tag release."
+            exit 1
+          fi
+
+          echo "✅ Required release secrets are configured"
+
       - name: Install DMG tooling
         run: brew install create-dmg
 
@@ -149,16 +198,11 @@ jobs:
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
-          if [ -z "${SPARKLE_ED_PRIVATE_KEY:-}" ]; then
-            echo "::warning::SPARKLE_ED_PRIVATE_KEY secret is not set — CI will publish the DMG but will NOT regenerate or commit the Sparkle appcast (users won't be offered the update until appcast.xml is updated manually). Add the secret to enable the canonical release path. Export it locally with: .build/artifacts/sparkle/Sparkle/bin/generate_keys -x key.txt (the file holds the single-line base64 private key)."
-            echo "has_key=false" >> "$GITHUB_OUTPUT"
-          else
-            ED_KEY_FILE="$RUNNER_TEMP/sparkle_ed_private_key"
-            printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$ED_KEY_FILE"
-            chmod 600 "$ED_KEY_FILE"
-            echo "ED_KEY_FILE=$ED_KEY_FILE" >> "$GITHUB_ENV"
-            echo "has_key=true" >> "$GITHUB_OUTPUT"
-          fi
+          ED_KEY_FILE="$RUNNER_TEMP/sparkle_ed_private_key"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$ED_KEY_FILE"
+          chmod 600 "$ED_KEY_FILE"
+          echo "ED_KEY_FILE=$ED_KEY_FILE" >> "$GITHUB_ENV"
+          echo "has_key=true" >> "$GITHUB_OUTPUT"
 
       - name: Build notarized DMG (+ signed appcast when key present)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ design/
 # Stray test-run log dumps (redirected suite output)
 test_output.txt
 __pycache__/
+
+# Packet Runner v1 pilot — control latch (churns every cycle, not commit history)
+packet-runner/controller/latch_state.json

--- a/TheBridge/Modules/Commands/CommandStore.swift
+++ b/TheBridge/Modules/Commands/CommandStore.swift
@@ -346,9 +346,24 @@ public final class CommandStore: @unchecked Sendable {
         let body: String
     }
 
+    private static let executeSeedBody = """
+    ## Execute
+
+    Mode: delivery. A contract is approved and material work may begin.
+
+    Set in stone:
+    Resolve the parent Keepr first from the live routing roster (`skills_routing_list` / `list_routing_skills`), then load that parent contract with `fetch_skill('<parent-keepr>', intent: '<this sub-task>')`. Do not route directly to `executor` unless the active request is a packet dispatch or the parent Keepr explicitly selects executor as the specialist for this task.
+
+    For multi-domain work, build the route stack through the relevant parent Keeprs. The domain owner selects executor, orchestrator, or another specialist; the command does not bypass ownership.
+
+    Define done with tests, run them, and iterate until the evidence is green. Keep a working todo list and close loops at wave checkpoints.
+
+    Return a final summary: what shipped, test results, deltas vs the contract, and deferred items with reasons.
+    """
+
     private static let firstRunSeeds: [Seed] = [
         Seed(name: "Execute",     icon: .emoji("⚡"),  color: .orange,
-             body: "## Execute\n\nProceed with the plan we just landed. Use minimum tool calls; no narration."),
+             body: executeSeedBody),
         Seed(name: "Reflow",      icon: .emoji("🔁"),  color: .blue,
              body: "## Reflow\n\nRe-examine the plan from first principles. What changed? What's new evidence? What would you do differently if starting from scratch?"),
         Seed(name: "Discussion",  icon: .emoji("💬"),  color: .blue,

--- a/TheBridge/Modules/Commands/CommandStore.swift
+++ b/TheBridge/Modules/Commands/CommandStore.swift
@@ -102,18 +102,19 @@ public final class CommandStore: @unchecked Sendable {
         }
     }
 
-    /// First-run seed: populate slots 1–5 with example commands if the
+    /// First-run seed: populate the 10-slot Command Bridge palette if the
     /// store is empty. Idempotent.
     public func seedIfEmpty() throws {
         try ensureDir()
         if FileManager.default.fileExists(atPath: indexURL.path) { return }
-        for (slot, seed) in Self.firstRunSeeds.enumerated() {
+        for (idx, seed) in Self.firstRunSeeds.enumerated() {
+            let slot = idx == 9 ? 0 : idx + 1
             _ = try create(
                 name: seed.name,
                 icon: seed.icon,
                 color: seed.color,
                 body: seed.body,
-                keySlot: slot + 1   // slots 1…5
+                keySlot: slot
             )
         }
     }
@@ -346,6 +347,43 @@ public final class CommandStore: @unchecked Sendable {
         let body: String
     }
 
+    private static let initiateSeedBody = """
+    # Initiate Bridge
+
+    Mode: arrival. Orient before work moves.
+
+    Set in stone:
+    Run `bridge_initialize` first and treat its structured receipt as the source of truth for Bridge state, doctrine integrity, routing roster quality, supplemental-order counts, capability notes, and final initialization state. Do not maintain a parallel startup checklist in this command body.
+
+    After the receipt, ground in the current handoff or live project state. If there is no concrete handoff, use the current workspace and ask one clarifying question only if the target is genuinely ambiguous.
+
+    Stay in orientation mode until the operator fires another command or explicitly asks to move.
+    """
+
+    private static let proposeSeedBody = """
+    # Propose
+
+    Mode: shaping. Do not implement yet.
+
+    Restate the objective, identify the smallest coherent scope, name meaningful forks, and surface the cost of being wrong. Use choice-to-contract only when there is a real decision the operator should make.
+    """
+
+    private static let scopeCutSeedBody = """
+    # Scope Cut
+
+    Mode: trim. Separate what is truly required from what is merely adjacent.
+
+    Return IN / OUT / LATER with the reason each boundary exists. Prefer a smaller contract that can be verified over a wider one that depends on hope.
+    """
+
+    private static let validateSeedBody = """
+    # Validate
+
+    Mode: hardening. Check whether the plan is execution-ready.
+
+    Verify source-of-truth context, dependencies, gates, tests, and likely failure modes. If the work spans more than one domain, route through the relevant parent Keepr before any material execution.
+    """
+
     private static let executeSeedBody = """
     ## Execute
 
@@ -361,17 +399,67 @@ public final class CommandStore: @unchecked Sendable {
     Return a final summary: what shipped, test results, deltas vs the contract, and deferred items with reasons.
     """
 
+    private static let reviewSeedBody = """
+    # Review
+
+    Mode: checkpoint. Verify before release, merge, deletion, or irreversible action.
+
+    Lead with findings and evidence. Confirm tests, runtime state, external gates, and any operator decision required before the work can move forward.
+    """
+
+    private static let refocusSeedBody = """
+    # Refocus
+
+    Mode: realignment. Re-anchor the session.
+
+    Restate the original objective, current evidence, what changed, and the next smallest move. Flag drift plainly.
+    """
+
+    private static let openLoopsSeedBody = """
+    # Open Loops
+
+    Mode: inventory. List every unresolved thread from the current session or project.
+
+    Separate loops that need action, loops that need a decision, and loops that can be closed with evidence already present.
+    """
+
+    private static let closeAgentSeedBody = """
+    # Close Agent
+
+    Mode: closeout. Preserve what should survive this session.
+
+    Summarize shipped work, evidence, unresolved decisions, friction, and reusable learning. Write durable telemetry only where the active protocol requires it.
+    """
+
+    private static let handOffSeedBody = """
+    # Hand Off
+
+    Mode: transfer. Prepare the next agent to continue without rediscovery.
+
+    Include objective, current state, files/pages/PRs touched, exact evidence, blockers, and the next best action. Do not run close-agent from this command.
+    """
+
     private static let firstRunSeeds: [Seed] = [
+        Seed(name: "Initiate",    icon: .emoji("🧭"),  color: .purple,
+             body: initiateSeedBody),
+        Seed(name: "Propose",     icon: .emoji("🧩"),  color: .blue,
+             body: proposeSeedBody),
+        Seed(name: "Scope Cut",   icon: .emoji("✂️"),  color: .gray,
+             body: scopeCutSeedBody),
+        Seed(name: "Validate",    icon: .emoji("🔎"),  color: .yellow,
+             body: validateSeedBody),
         Seed(name: "Execute",     icon: .emoji("⚡"),  color: .orange,
              body: executeSeedBody),
-        Seed(name: "Reflow",      icon: .emoji("🔁"),  color: .blue,
-             body: "## Reflow\n\nRe-examine the plan from first principles. What changed? What's new evidence? What would you do differently if starting from scratch?"),
-        Seed(name: "Discussion",  icon: .emoji("💬"),  color: .blue,
-             body: "## Discussion\n\nWalk me through the tradeoffs before we commit.\n\n- What are we optimizing for?\n- What's the cost of being wrong?\n- What would change your mind?"),
-        Seed(name: "Open-loops",  icon: .emoji("📋"),  color: .green,
-             body: "## Open-loops\n\nList every open thread from this conversation. Order by importance. Mark which need user input."),
-        Seed(name: "Close-loop",  icon: .emoji("✅"),  color: .green,
-             body: "## Close-loop\n\nSummarize what shipped, what changed, what's still open. Surface anything I should know that you haven't said yet."),
+        Seed(name: "Review",      icon: .emoji("🧪"),  color: .red,
+             body: reviewSeedBody),
+        Seed(name: "Refocus",     icon: .emoji("🎯"),  color: .blue,
+             body: refocusSeedBody),
+        Seed(name: "Open Loops",  icon: .emoji("📋"),  color: .green,
+             body: openLoopsSeedBody),
+        Seed(name: "Close Agent", icon: .emoji("✅"),  color: .green,
+             body: closeAgentSeedBody),
+        Seed(name: "Hand Off",    icon: .emoji("📨"),  color: .brown,
+             body: handOffSeedBody),
     ]
 }
 

--- a/TheBridge/Modules/JobsManager.swift
+++ b/TheBridge/Modules/JobsManager.swift
@@ -1282,7 +1282,8 @@ public actor JobsManager {
                 "schedule": .string("0 17 * * 5"),
                 "description": .string("Compile a weekly status summary every Friday at 5pm."),
                 "actions": .array([.object(["tool": .string("shell_exec"), "arguments": .object(["command": .string("echo 'customize this template'")])])])
-            ]
+            ],
+            AmendmentLifecycle.jobTemplate()
         ]
         return .object(["templates": .array(templates.map { .object($0) })])
     }

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -209,6 +209,13 @@ public enum BridgeInitializeModule {
             "connectionState": .string(r.connectionState),
             "telemetryEventRef": .string(r.telemetryEventRef),
             "routingRosterQuality": .string(r.routingRosterQuality.rawValue),
+            "routingIntegrity": .object([
+                "registryVersion": .int(r.routingIntegrity.registryVersion),
+                "boundToolCount": .int(r.routingIntegrity.boundToolCount),
+                "manifestMarkerTools": .array(r.routingIntegrity.manifestMarkerTools.map { .string($0) }),
+                "descriptionCharBudget": .int(r.routingIntegrity.descriptionCharBudget),
+                "warnings": .array(r.routingIntegrity.warnings.map { .string($0) })
+            ]),
             "preflightIntent": .string(r.preflightIntent.rawValue),
             "capabilityNotes": .array(r.capabilityNotes.map { .string($0) }),
             "operatorSummary": .string(r.operatorSummary),

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
@@ -99,6 +99,8 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
     public let capabilityNotes: [String]
     public let session: BrokerSessionRecord?
     public let constitution: ConstitutionBundle?
+    /// PKT-1094: server-owned Routing Integrity Layer registry snapshot.
+    public let routingIntegrity: RoutingIntegrityReceipt
     public let finalState: StandingOrdersStore.InitializationState
 
     public init(
@@ -124,6 +126,7 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
         capabilityNotes: [String] = [],
         session: BrokerSessionRecord? = nil,
         constitution: ConstitutionBundle? = nil,
+        routingIntegrity: RoutingIntegrityReceipt = ToolSkillBindingRegistry.receipt(),
         finalState: StandingOrdersStore.InitializationState
     ) {
         self.handshakeId = handshakeId
@@ -148,6 +151,7 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
         self.capabilityNotes = capabilityNotes
         self.session = session
         self.constitution = constitution
+        self.routingIntegrity = routingIntegrity
         self.finalState = finalState
     }
 
@@ -191,7 +195,7 @@ public struct BridgeInitializeContext: Sendable {
 public enum BridgeInitializeService {
 
     /// Current receipt schema contract version. Bump on any shape change.
-    public static let schemaVersion = 2
+    public static let schemaVersion = 3
 
     /// A supplemental order is deliberately inert ("ignored") when it is
     /// archived OR explicitly marked as a no-op / TEMP directive. The marker
@@ -344,6 +348,7 @@ public enum BridgeInitializeService {
             capabilityNotes: capabilityNotes,
             session: session,
             constitution: constitution,
+            routingIntegrity: ToolSkillBindingRegistry.receipt(),
             finalState: finalState
         )
     }

--- a/TheBridge/Security/AuditLog.swift
+++ b/TheBridge/Security/AuditLog.swift
@@ -99,6 +99,11 @@ public actor AuditLog {
         entries.filter { $0.approvalStatus == status }
     }
 
+    /// Entries filtered by transport/session id.
+    public func entries(forSessionID sessionID: String) -> [AuditEntry] {
+        entries.filter { $0.transportSessionId == sessionID }
+    }
+
     /// Count of all entries.
     public func count() -> Int {
         entries.count

--- a/TheBridge/Server/MCPToolFactory.swift
+++ b/TheBridge/Server/MCPToolFactory.swift
@@ -41,6 +41,10 @@ public enum BridgeToolDescriptionRenderer {
             }
         }
 
+        if let governance = ToolSkillBindingRegistry.governanceDescription(for: reg.name) {
+            parts.append(governance)
+        }
+
         var s = parts.joined(separator: " — ")
         if s.count > charBudget {
             s = String(s.prefix(charBudget - 1)) + "\u{2026}"

--- a/TheBridge/Server/RoutingIntegrityLayer.swift
+++ b/TheBridge/Server/RoutingIntegrityLayer.swift
@@ -1,0 +1,410 @@
+// RoutingIntegrityLayer.swift - PKT-1094
+// TheBridge / Server
+//
+// Server-side routing integrity primitives. This is intentionally code-owned:
+// tool-to-skill bindings are no longer inferred from mutable skill-page prose.
+
+import Foundation
+import MCP
+
+public struct RoutingGovernanceSkill: Sendable, Codable, Equatable, Hashable {
+    public let slug: String
+    public let role: String
+
+    public init(slug: String, role: String) {
+        self.slug = slug
+        self.role = role
+    }
+}
+
+public struct ToolSkillBinding: Sendable, Codable, Equatable, Hashable {
+    public let toolName: String
+    public let governingSkills: [RoutingGovernanceSkill]
+    public let requiresManifestFetch: Bool
+    public let reason: String
+
+    public init(
+        toolName: String,
+        governingSkills: [RoutingGovernanceSkill],
+        requiresManifestFetch: Bool = true,
+        reason: String
+    ) {
+        self.toolName = toolName
+        self.governingSkills = governingSkills
+        self.requiresManifestFetch = requiresManifestFetch
+        self.reason = reason
+    }
+
+    public var governanceSummary: String {
+        governingSkills
+            .map { "\($0.slug) (\($0.role))" }
+            .joined(separator: ", ")
+    }
+}
+
+public struct RoutingIntegrityReceipt: Sendable, Codable, Equatable {
+    public let registryVersion: Int
+    public let boundToolCount: Int
+    public let manifestMarkerTools: [String]
+    public let descriptionCharBudget: Int
+    public let warnings: [String]
+
+    public init(
+        registryVersion: Int,
+        boundToolCount: Int,
+        manifestMarkerTools: [String],
+        descriptionCharBudget: Int,
+        warnings: [String] = []
+    ) {
+        self.registryVersion = registryVersion
+        self.boundToolCount = boundToolCount
+        self.manifestMarkerTools = manifestMarkerTools
+        self.descriptionCharBudget = descriptionCharBudget
+        self.warnings = warnings
+    }
+}
+
+public enum ToolSkillBindingRegistry {
+    public static let registryVersion = 1
+
+    public static let manifestMarkerTools: Set<String> = [
+        BridgeInitializeModule.toolName,
+        "fetch_skill",
+        "list_routing_skills",
+        "skills_routing_list",
+    ]
+
+    public static let bindings: [ToolSkillBinding] = [
+        ToolSkillBinding(
+            toolName: "messages_send",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "relationship intent and draft/review boundary"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "approved delivery mechanics"),
+            ],
+            reason: "Outbound Messages delivery must be routed through relationship intent and explicit delivery approval."
+        ),
+        ToolSkillBinding(
+            toolName: "messages_chat",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "conversation identity resolution"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "Messages data access"),
+            ],
+            reason: "Chat lookup feeds message delivery and must preserve contact/context routing."
+        ),
+        ToolSkillBinding(
+            toolName: "messages_recent",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "recent-contact disambiguation"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "Messages data access"),
+            ],
+            reason: "Recent-message lookup is frequently used for recipient resolution before delivery."
+        ),
+        ToolSkillBinding(
+            toolName: "messages_search",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "relationship context"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "Messages data search"),
+            ],
+            reason: "Message search carries relationship context and can drive outbound follow-up."
+        ),
+        ToolSkillBinding(
+            toolName: "messages_content",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "relationship context"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "Messages thread read"),
+            ],
+            reason: "Thread reads shape relationship actions and must follow the messaging route."
+        ),
+        ToolSkillBinding(
+            toolName: "messages_participants",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "identity disambiguation"),
+                RoutingGovernanceSkill(slug: "mac-message", role: "Messages participant read"),
+            ],
+            reason: "Participant reads are identity-critical before any delivery action."
+        ),
+        ToolSkillBinding(
+            toolName: "mail_send",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "recipient/context approval"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Mail delivery mechanics"),
+            ],
+            reason: "Outbound email requires relationship context and explicit send approval."
+        ),
+        ToolSkillBinding(
+            toolName: "mail_draft",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "relationship drafting"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Mail draft mechanics"),
+            ],
+            reason: "Email drafting belongs to relationship routing even though it is unsent."
+        ),
+        ToolSkillBinding(
+            toolName: "calendar_create",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "scheduling intent and availability"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Calendar write mechanics"),
+            ],
+            reason: "Calendar writes require time-domain routing before native EventKit mutation."
+        ),
+        ToolSkillBinding(
+            toolName: "calendar_update",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "reschedule/change intent"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Calendar write mechanics"),
+            ],
+            reason: "Calendar updates must be routed through time intent before mutation."
+        ),
+        ToolSkillBinding(
+            toolName: "calendar_delete",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "calendar consequence review"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Calendar delete mechanics"),
+            ],
+            reason: "Calendar deletion is destructive and must preserve time-domain review."
+        ),
+        ToolSkillBinding(
+            toolName: "reminders_create",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "do-this-later capture"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Reminders write mechanics"),
+            ],
+            reason: "Reminder creation is a time/action commitment and must be routed as such."
+        ),
+        ToolSkillBinding(
+            toolName: "reminders_update",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "deadline/action adjustment"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Reminders write mechanics"),
+            ],
+            reason: "Reminder updates alter commitments and need time-domain routing."
+        ),
+        ToolSkillBinding(
+            toolName: "reminders_delete",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "time-keepr", role: "reminder consequence review"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Reminders delete mechanics"),
+            ],
+            reason: "Reminder deletion is destructive and must preserve time-domain review."
+        ),
+        ToolSkillBinding(
+            toolName: "contacts_search",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "identity resolution"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Contacts read mechanics"),
+            ],
+            reason: "Contact lookup anchors relationship routing and recent-contact safeguards."
+        ),
+        ToolSkillBinding(
+            toolName: "contacts_resolve_handle",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "people-keepr", role: "recipient identity verification"),
+                RoutingGovernanceSkill(slug: "mac-keepr", role: "Contacts read mechanics"),
+            ],
+            reason: "Handle resolution is identity-critical before messaging or relationship actions."
+        ),
+        ToolSkillBinding(
+            toolName: "notion_page_create",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "notion-keepr", role: "workspace structure/content writes"),
+            ],
+            reason: "Notion page creation mutates workspace content and must follow Notion routing."
+        ),
+        ToolSkillBinding(
+            toolName: "notion_page_update",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "notion-keepr", role: "page property mutation"),
+            ],
+            reason: "Notion page updates mutate workspace records and must follow Notion routing."
+        ),
+        ToolSkillBinding(
+            toolName: "notion_page_edit",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "notion-keepr", role: "page body mutation"),
+            ],
+            reason: "Notion body edits mutate workspace content and must follow Notion routing."
+        ),
+        ToolSkillBinding(
+            toolName: "notion_blocks_append",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "notion-keepr", role: "block-level content mutation"),
+            ],
+            reason: "Notion block appends mutate workspace content and must follow Notion routing."
+        ),
+        ToolSkillBinding(
+            toolName: "manage_skill",
+            governingSkills: [
+                RoutingGovernanceSkill(slug: "skill-keepr", role: "skill registry governance"),
+            ],
+            reason: "Skill registry writes require SKILLS Keepr ownership."
+        ),
+    ]
+
+    private static let byTool: [String: ToolSkillBinding] = Dictionary(
+        uniqueKeysWithValues: bindings.map { ($0.toolName, $0) }
+    )
+
+    public static func binding(for toolName: String) -> ToolSkillBinding? {
+        byTool[toolName]
+    }
+
+    public static func requiresManifestFetch(_ toolName: String) -> Bool {
+        binding(for: toolName)?.requiresManifestFetch == true
+    }
+
+    public static func isManifestMarkerTool(_ toolName: String) -> Bool {
+        manifestMarkerTools.contains(toolName)
+    }
+
+    public static func callSatisfiesManifestMarker(toolName: String, result: Value) -> Bool {
+        guard isManifestMarkerTool(toolName) else { return false }
+        if toolName == BridgeInitializeModule.toolName,
+           case .object(let dict) = result,
+           case .string(let finalState)? = dict["finalState"] {
+            return finalState != StandingOrdersStore.InitializationState.incomplete.rawValue
+        }
+        return true
+    }
+
+    public static func governanceDescription(for toolName: String) -> String? {
+        guard let binding = binding(for: toolName) else { return nil }
+        return "Governance: governed by \(binding.governanceSummary). Manifest fetch required before dispatch."
+    }
+
+    public static func receipt() -> RoutingIntegrityReceipt {
+        RoutingIntegrityReceipt(
+            registryVersion: registryVersion,
+            boundToolCount: bindings.count,
+            manifestMarkerTools: manifestMarkerTools.sorted(),
+            descriptionCharBudget: BridgeToolDescriptionRenderer.charBudget,
+            warnings: bindings.isEmpty ? ["No server-side tool-skill bindings registered."] : []
+        )
+    }
+}
+
+public struct AmendmentMarker: Sendable, Equatable {
+    public let identifier: String
+    public let status: String
+    public let effectiveDate: Date
+    public let ageDays: Int
+    public let sourceLine: Int
+
+    public var isDueForCollapse: Bool {
+        status.uppercased() == "ACTIVE" && ageDays >= AmendmentLifecycle.dueForCollapseDays
+    }
+}
+
+public enum AmendmentLifecycle {
+    public static let dueForCollapseDays = 30
+
+    public static func scan(markdown: String, now: Date, calendar: Calendar = Calendar(identifier: .gregorian)) -> [AmendmentMarker] {
+        markdown
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .enumerated()
+            .compactMap { idx, rawLine in
+                parseLine(String(rawLine), sourceLine: idx + 1, now: now, calendar: calendar)
+            }
+    }
+
+    public static func dueForCollapse(markdown: String, now: Date, calendar: Calendar = Calendar(identifier: .gregorian)) -> [AmendmentMarker] {
+        scan(markdown: markdown, now: now, calendar: calendar)
+            .filter(\.isDueForCollapse)
+    }
+
+    public static func jobTemplate() -> [String: Value] {
+        [
+            "id": .string("weekly-amendment-collapse-scan"),
+            "name": .string("Weekly amendment collapse scan"),
+            "schedule": .string("0 9 * * 1"),
+            "description": .string("Scan standing-order and skill-page amendment markers for ACTIVE entries older than 30 days and flag them DUE_FOR_COLLAPSE."),
+            "actions": .array([
+                .object([
+                    "tool": .string("standing_orders_list"),
+                    "arguments": .object(["includeArchived": .bool(false)])
+                ])
+            ])
+        ]
+    }
+
+    private static func parseLine(
+        _ line: String,
+        sourceLine: Int,
+        now: Date,
+        calendar: Calendar
+    ) -> AmendmentMarker? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.localizedCaseInsensitiveContains("amendment") else { return nil }
+        guard let date = firstDate(in: trimmed) else { return nil }
+
+        let upper = trimmed.uppercased()
+        let status: String
+        if upper.contains("DUE_FOR_COLLAPSE") {
+            status = "DUE_FOR_COLLAPSE"
+        } else if upper.contains("SUPERSEDED") {
+            status = "SUPERSEDED"
+        } else if upper.contains("ACTIVE") {
+            status = "ACTIVE"
+        } else {
+            status = "UNKNOWN"
+        }
+
+        let id = firstIdentifier(in: trimmed) ?? "line-\(sourceLine)"
+        let days = calendar.dateComponents([.day], from: calendar.startOfDay(for: date), to: calendar.startOfDay(for: now)).day ?? 0
+        return AmendmentMarker(
+            identifier: id,
+            status: status,
+            effectiveDate: date,
+            ageDays: days,
+            sourceLine: sourceLine
+        )
+    }
+
+    private static func firstDate(in line: String) -> Date? {
+        guard let range = line.range(of: #"\d{4}-\d{2}-\d{2}"#, options: .regularExpression) else {
+            return nil
+        }
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: String(line[range]))
+    }
+
+    private static func firstIdentifier(in line: String) -> String? {
+        guard let range = line.range(of: #"\b[A-Z]{2,}-[A-Z0-9.-]+\b"#, options: .regularExpression) else {
+            return nil
+        }
+        return String(line[range])
+    }
+}
+
+public struct IdentityPropagationScanResult: Sendable, Equatable {
+    public let renameId: String
+    public let unresolvedHits: Int
+    public let completedScanCycles: Int
+
+    public init(renameId: String, unresolvedHits: Int, completedScanCycles: Int) {
+        self.renameId = renameId
+        self.unresolvedHits = unresolvedHits
+        self.completedScanCycles = completedScanCycles
+    }
+}
+
+public enum IdentityPropagationContract {
+    public enum CloseDecision: String, Sendable, Equatable {
+        case canClose = "CAN_CLOSE"
+        case blockedByImpactHits = "BLOCKED_BY_IMPACT_HITS"
+        case escalateAfterRepeatedHits = "ESCALATE_AFTER_REPEATED_HITS"
+    }
+
+    public static let escalationScanCycleCount = 3
+
+    public static func closeDecision(for result: IdentityPropagationScanResult) -> CloseDecision {
+        guard result.unresolvedHits > 0 else { return .canClose }
+        if result.completedScanCycles >= escalationScanCycleCount {
+            return .escalateAfterRepeatedHits
+        }
+        return .blockedByImpactHits
+    }
+}

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -1370,16 +1370,11 @@ public actor SSEServer {
             if let allowlist = toolAllowlist {
                 regs = regs.filter { allowlist.contains($0.name) }
             }
-            let tools: [[String: Any]] = regs.map { reg in
-                var t: [String: Any] = [
-                    "name": reg.name,
-                    "description": reg.description
-                ]
-                if let data = try? JSONEncoder().encode(reg.inputSchema),
-                   let schema = try? JSONSerialization.jsonObject(with: data) {
-                    t["inputSchema"] = schema
-                }
-                return t
+            let tools: [[String: Any]] = regs.compactMap { reg in
+                guard let data = try? JSONEncoder().encode(MCPToolFactory.tool(for: reg)),
+                      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else { return nil }
+                return object
             }
             return buildRPCResponse(id: requestId, result: ["tools": tools])
 

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -327,30 +327,6 @@ public actor ToolRouter {
             )
         }
 
-        if let sessionID = context.transportSessionId,
-           ToolSkillBindingRegistry.requiresManifestFetch(toolName),
-           !routingManifestSessionIDs.contains(sessionID) {
-            let binding = ToolSkillBindingRegistry.binding(for: toolName)
-            let governance = binding?.governanceSummary ?? "unregistered"
-            let duration = ContinuousClock.now - start
-            let ms = Double(duration.components.attoseconds) / 1_000_000_000_000_000.0
-                + Double(duration.components.seconds) * 1000.0
-            await auditLog.append(AuditEntry(
-                timestamp: Date(),
-                toolName: toolName,
-                tier: tool.tier,
-                inputSummary: stringifySummary(arguments),
-                outputSummary: "REJECTED: routing manifest required (\(governance))",
-                durationMs: ms,
-                approvalStatus: .rejected,
-                transportSessionId: sessionID
-            ))
-            throw ToolRouterError.routingManifestRequired(
-                toolName: toolName,
-                governingSkills: governance
-            )
-        }
-
         // F1: Resolve effective tier — user override takes precedence over registered default.
         // Overrides are stored as [String: String] in UserDefaults by ToolRegistryView.
         //
@@ -422,6 +398,37 @@ public actor ToolRouter {
                     "message": .string("Remote callers must call bridge_initialize before invoking notify/request-tier tools.")
                 ])
             }
+        }
+
+        // PKT-1094: per-tool routing manifest gate. Runs AFTER the broker's
+        // origin-level gates above (control-plane block, governed-remote-session)
+        // so a foundational "you're not initialized" rejection always takes
+        // precedence over this finer-grained "you haven't fetched THIS tool's
+        // governing skill route" one — calling bridge_initialize satisfies both
+        // at once (it is itself a manifest-marker tool), so there is no case
+        // where reordering costs a legitimate caller an extra round trip.
+        if let sessionID = context.transportSessionId,
+           ToolSkillBindingRegistry.requiresManifestFetch(toolName),
+           !routingManifestSessionIDs.contains(sessionID) {
+            let binding = ToolSkillBindingRegistry.binding(for: toolName)
+            let governance = binding?.governanceSummary ?? "unregistered"
+            let duration = ContinuousClock.now - start
+            let ms = Double(duration.components.attoseconds) / 1_000_000_000_000_000.0
+                + Double(duration.components.seconds) * 1000.0
+            await auditLog.append(AuditEntry(
+                timestamp: Date(),
+                toolName: toolName,
+                tier: tool.tier,
+                inputSummary: stringifySummary(arguments),
+                outputSummary: "REJECTED: routing manifest required (\(governance))",
+                durationMs: ms,
+                approvalStatus: .rejected,
+                transportSessionId: sessionID
+            ))
+            throw ToolRouterError.routingManifestRequired(
+                toolName: toolName,
+                governingSkills: governance
+            )
         }
 
         // SecurityGate enforcement (async for request-tier approvals)

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -130,6 +130,7 @@ public actor ToolRouter {
     /// FB-4: withhold `tools/list` until `BridgeModuleRegistry` finishes so
     /// clients never cache a partial surface during startup registration.
     private var modulesRegistrationComplete = false
+    private var routingManifestSessionIDs: Set<String> = []
     private let securityGate: SecurityGate
     private let auditLog: AuditLog
     private let sessionRegistry: SessionRegistry
@@ -198,6 +199,16 @@ public actor ToolRouter {
         modulesRegistrationComplete
     }
 
+    /// Test/diagnostic seam for PKT-1094: a session is marked only after a
+    /// successful bridge_initialize / fetch_skill / routing-skill manifest call.
+    public func hasRoutingManifestMarker(sessionID: String) -> Bool {
+        routingManifestSessionIDs.contains(sessionID)
+    }
+
+    public func markRoutingManifestFetched(sessionID: String) {
+        routingManifestSessionIDs.insert(sessionID)
+    }
+
     /// Surface for MCP `tools/list` — empty until startup registration completes (FB-4).
     public func registrationsForListTools(disabledNames: Set<String>) -> [ToolRegistration] {
         guard modulesRegistrationComplete else { return [] }
@@ -263,7 +274,8 @@ public actor ToolRouter {
                 inputSummary: stringifySummary(arguments),
                 outputSummary: "REJECTED: \(kind)",
                 durationMs: ms,
-                approvalStatus: .rejected
+                approvalStatus: .rejected,
+                transportSessionId: context.transportSessionId
             ))
             throw BridgeToolError.trialExpired(toolName: toolName, kind: kind)
         }
@@ -299,7 +311,8 @@ public actor ToolRouter {
                 inputSummary: stringifySummary(arguments),
                 outputSummary: "REJECTED: module group '\(gate.groupID.displayName)' disabled",
                 durationMs: ms,
-                approvalStatus: .rejected
+                approvalStatus: .rejected,
+                transportSessionId: context.transportSessionId
             ))
             throw BridgeToolError.moduleGroupDisabled(
                 toolName: toolName,
@@ -311,6 +324,30 @@ public actor ToolRouter {
             throw ToolRouterError.invalidArguments(
                 toolName: toolName,
                 reason: "Credentials are disabled. Turn on “Keychain credentials” in The Bridge Settings → Credentials."
+            )
+        }
+
+        if let sessionID = context.transportSessionId,
+           ToolSkillBindingRegistry.requiresManifestFetch(toolName),
+           !routingManifestSessionIDs.contains(sessionID) {
+            let binding = ToolSkillBindingRegistry.binding(for: toolName)
+            let governance = binding?.governanceSummary ?? "unregistered"
+            let duration = ContinuousClock.now - start
+            let ms = Double(duration.components.attoseconds) / 1_000_000_000_000_000.0
+                + Double(duration.components.seconds) * 1000.0
+            await auditLog.append(AuditEntry(
+                timestamp: Date(),
+                toolName: toolName,
+                tier: tool.tier,
+                inputSummary: stringifySummary(arguments),
+                outputSummary: "REJECTED: routing manifest required (\(governance))",
+                durationMs: ms,
+                approvalStatus: .rejected,
+                transportSessionId: sessionID
+            ))
+            throw ToolRouterError.routingManifestRequired(
+                toolName: toolName,
+                governingSkills: governance
             )
         }
 
@@ -411,7 +448,8 @@ public actor ToolRouter {
                 inputSummary: stringifySummary(arguments),
                 outputSummary: "REJECTED: \(reason)",
                 durationMs: ms,
-                approvalStatus: .rejected
+                approvalStatus: .rejected,
+                transportSessionId: context.transportSessionId
             ))
             throw ToolRouterError.securityRejection(toolName: toolName, reason: reason)
 
@@ -427,7 +465,8 @@ public actor ToolRouter {
                 inputSummary: stringifySummary(arguments),
                 outputSummary: "HANDOFF: \(command)",
                 durationMs: ms,
-                approvalStatus: .escalated
+                approvalStatus: .escalated,
+                transportSessionId: context.transportSessionId
             ))
             return .object([
                 "status": .string("handoff"),
@@ -456,6 +495,11 @@ public actor ToolRouter {
             } else {
                 governanceNote = nil
                 returnedResult = result
+            }
+
+            if let sessionID = context.transportSessionId,
+               ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) {
+                routingManifestSessionIDs.insert(sessionID)
             }
 
             // F2 + PKT-552: Fire-and-forget Notify-tier notification with structured context.
@@ -497,7 +541,8 @@ public actor ToolRouter {
                 inputSummary: stringifySummary(arguments),
                 outputSummary: "ERROR: \(error.localizedDescription)",
                 durationMs: ms,
-                approvalStatus: .error
+                approvalStatus: .error,
+                transportSessionId: context.transportSessionId
             ))
             throw error
         }
@@ -723,6 +768,7 @@ public enum ToolRouterError: Error, LocalizedError {
     case unknownTool(String)
     case invalidArguments(toolName: String, reason: String)
     case securityRejection(toolName: String, reason: String)
+    case routingManifestRequired(toolName: String, governingSkills: String)
 
     public var errorDescription: String? {
         switch self {
@@ -732,6 +778,8 @@ public enum ToolRouterError: Error, LocalizedError {
             return "\(name): \(reason)"
         case .securityRejection(let name, let reason):
             return "Security gate rejected \(name): \(reason)"
+        case .routingManifestRequired(let name, let governingSkills):
+            return "\(name) requires a routing manifest before dispatch. Fetch the governing skill route first (\(governingSkills)) or run bridge_initialize for this session."
         }
     }
 }

--- a/TheBridgeTests/CommandStoreTests.swift
+++ b/TheBridgeTests/CommandStoreTests.swift
@@ -142,22 +142,51 @@ func runCommandStoreTests() async {
         }
     }
 
-    await test("seedIfEmpty installs 5 commands on first run, idempotent thereafter") {
+    await test("seedIfEmpty installs the 10-slot command palette on first run, idempotent thereafter") {
         try await withTempHome { _ in
             try CommandStore.shared.resetForTesting()
             try CommandStore.shared.seedIfEmpty()
             let first = try CommandStore.shared.list()
-            try expect(first.count == 5, "expected 5 seeded commands, got \(first.count)")
+            try expect(first.count == 10, "expected 10 seeded commands, got \(first.count)")
 
             // Re-run is no-op (count unchanged).
             try CommandStore.shared.seedIfEmpty()
-            try expect(try CommandStore.shared.list().count == 5)
+            try expect(try CommandStore.shared.list().count == 10)
 
-            // Slots 1–5 should be assigned.
+            // Slots 1-9 and 0 should be assigned.
             for slot in 1...5 {
                 try expect(try CommandStore.shared.command(forKeySlot: slot) != nil,
                            "expected a command at slot \(slot)")
             }
+            for slot in 6...9 {
+                try expect(try CommandStore.shared.command(forKeySlot: slot) != nil,
+                           "expected a command at slot \(slot)")
+            }
+            try expect(try CommandStore.shared.command(forKeySlot: 0) != nil,
+                       "expected a command at slot 0")
+            try expect(try CommandStore.shared.command(forKeySlot: 1)?.slug == "initiate",
+                       "slot 1 must hold Initiate")
+            try expect(try CommandStore.shared.command(forKeySlot: 5)?.slug == "execute",
+                       "slot 5 must hold Execute")
+            try expect(try CommandStore.shared.command(forKeySlot: 0)?.slug == "hand-off",
+                       "slot 0 must hold Hand Off")
+        }
+    }
+
+    await test("seeded Initiate command delegates to bridge_initialize") {
+        try await withTempHome { _ in
+            try CommandStore.shared.resetForTesting()
+            try CommandStore.shared.seedIfEmpty()
+            guard let initiate = try CommandStore.shared.get(slug: "initiate") else {
+                try expect(false, "expected Initiate seed to exist")
+                return
+            }
+            try expect(initiate.body.contains("bridge_initialize"),
+                       "Initiate seed must call the canonical initializer")
+            try expect(initiate.body.contains("structured receipt"),
+                       "Initiate seed must treat the receipt as source of truth")
+            try expect(initiate.body.contains("Do not maintain a parallel startup checklist"),
+                       "Initiate seed must avoid duplicating the initializer protocol")
         }
     }
 

--- a/TheBridgeTests/CommandStoreTests.swift
+++ b/TheBridgeTests/CommandStoreTests.swift
@@ -161,6 +161,25 @@ func runCommandStoreTests() async {
         }
     }
 
+    await test("seeded Execute command routes through parent Keepr before executor") {
+        try await withTempHome { _ in
+            try CommandStore.shared.resetForTesting()
+            try CommandStore.shared.seedIfEmpty()
+            guard let execute = try CommandStore.shared.get(slug: "execute") else {
+                try expect(false, "expected Execute seed to exist")
+                return
+            }
+            try expect(execute.body.contains("skills_routing_list"),
+                       "Execute seed must load the live routing roster")
+            try expect(execute.body.contains("parent Keepr"),
+                       "Execute seed must route through a parent Keepr")
+            try expect(execute.body.contains("Do not route directly to `executor`"),
+                       "Execute seed must explicitly prevent direct executor routing")
+            try expect(!execute.body.contains("fetch_skill('executor')"),
+                       "Execute seed must not tell agents to fetch executor directly")
+        }
+    }
+
     await test("persistence: list survives a fresh process snapshot") {
         try await withTempHome { _ in
             try CommandStore.shared.resetForTesting()

--- a/TheBridgeTests/JobsModuleTests.swift
+++ b/TheBridgeTests/JobsModuleTests.swift
@@ -422,14 +422,14 @@ func runJobsModuleTests() async {
         }
     }
 
-    // --- job_templates handler (pure: 3 built-in presets) ---
+    // --- job_templates handler (pure built-in presets) ---
 
-    await test("job_templates: returns the 3 built-in presets with valid cron + non-empty action chains") {
+    await test("job_templates: returns built-in presets with valid cron + non-empty action chains") {
         let out = try await JobsManager.shared.listTemplates(args: .object([:]))
         guard case .object(let o) = out, case .array(let templates)? = o["templates"] else {
             throw TestError.assertion("shape")
         }
-        try expect(templates.count == 3, "expected 3 presets, got \(templates.count)")
+        try expect(templates.count == 4, "expected 4 presets, got \(templates.count)")
         var idSet = Set<String>()
         for t in templates {
             guard case .object(let tpl) = t else { throw TestError.assertion("template shape") }
@@ -440,7 +440,12 @@ func runJobsModuleTests() async {
             guard case .array(let actions)? = tpl["actions"] else { throw TestError.assertion("template missing actions") }
             try expect(!actions.isEmpty, "preset \(tid) must have a non-empty action chain")
         }
-        try expect(idSet == Set(["daily-desktop-cleanup", "hourly-screenshot-tidy", "friday-status-digest"]),
+        try expect(idSet == Set([
+            "daily-desktop-cleanup",
+            "hourly-screenshot-tidy",
+            "friday-status-digest",
+            "weekly-amendment-collapse-scan",
+        ]),
                    "unexpected preset id set: \(idSet)")
     }
 

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -86,7 +86,7 @@ func runRoutingIntegrityLayerTests() async {
                             "body": .string("dry-run probe"),
                             "confirm": .string("DRY_RUN")
                         ]),
-                        sessionID: "ril-session-a"
+                        context: ToolDispatchContext(transportSessionId: "ril-session-a", origin: .local)
                     )
                     throw TestError.assertion("messages_send reached handler without manifest marker")
                 } catch let error as ToolRouterError {
@@ -139,7 +139,7 @@ func runRoutingIntegrityLayerTests() async {
                 _ = try await router.dispatch(
                     toolName: BridgeInitializeModule.toolName,
                     arguments: .object(["client": .string("ril-session-b")]),
-                    sessionID: "ril-session-b"
+                    context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
                 )
                 let marked = await router.hasRoutingManifestMarker(sessionID: "ril-session-b")
                 try expect(marked, "bridge_initialize must mark the session")
@@ -151,7 +151,7 @@ func runRoutingIntegrityLayerTests() async {
                         "body": .string("dry-run probe"),
                         "confirm": .string("DRY_RUN")
                     ]),
-                    sessionID: "ril-session-b"
+                    context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
                 )
                 guard case .object(let dict) = allowed,
                       case .bool(false)? = dict["sent"],
@@ -168,7 +168,7 @@ func runRoutingIntegrityLayerTests() async {
                             "body": .string("dry-run probe"),
                             "confirm": .string("DRY_RUN")
                         ]),
-                        sessionID: "ril-session-c"
+                        context: ToolDispatchContext(transportSessionId: "ril-session-c", origin: .local)
                     )
                     throw TestError.assertion("marker leaked across sessions")
                 } catch let error as ToolRouterError {

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -1,0 +1,267 @@
+// RoutingIntegrityLayerTests.swift - PKT-1094
+// Server-owned tool/skill bindings, manifest-fetch dispatch gate, lifecycle
+// scanners, and identity-propagation close contract.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runRoutingIntegrityLayerTests() async {
+    print("\n\u{1F9ED} Routing Integrity Layer (PKT-1094)")
+
+    func fakeMessagesSendRegistration() -> ToolRegistration {
+        ToolRegistration(
+            name: "messages_send",
+            module: MessagesModule.moduleName,
+            tier: .open,
+            description: "Send an iMessage or SMS after explicit approval.",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in .object(["ok": .bool(true), "sent": .bool(true)]) }
+        )
+    }
+
+    await test("RIL registry: messages_send names governing skills") {
+        guard let binding = ToolSkillBindingRegistry.binding(for: "messages_send") else {
+            throw TestError.assertion("missing messages_send binding")
+        }
+        let slugs = Set(binding.governingSkills.map(\.slug))
+        try expect(slugs.contains("people-keepr"), "people-keepr must govern message intent")
+        try expect(slugs.contains("mac-message"), "mac-message must govern delivery mechanics")
+        try expect(binding.requiresManifestFetch)
+    }
+
+    await test("RIL discovery: messages_send tool description includes governance") {
+        let rendered = MCPToolFactory.tool(for: fakeMessagesSendRegistration()).description ?? ""
+        try expect(rendered.contains("Governance:"), "description must include governance annotation: \(rendered)")
+        try expect(rendered.contains("people-keepr"), "description must name people-keepr: \(rendered)")
+        try expect(rendered.contains("mac-message"), "description must name mac-message: \(rendered)")
+        try expect(rendered.count <= BridgeToolDescriptionRenderer.charBudget,
+                   "description budget breached: \(rendered.count)")
+    }
+
+    await test("RIL receipt: bridge_initialize carries registry snapshot") {
+        try await withRILTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nseed")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: BridgeInitializeContext(
+                    client: "ril-test",
+                    connectionState: "local",
+                    macToolsAvailable: true,
+                    bridgeState: "running",
+                    now: rilDate("2026-07-07")
+                ),
+                supplemental: [],
+                telemetryEventRef: "evt-ril"
+            )
+            try expect(receipt.schemaVersion == 3, "receipt schema must bump for RIL")
+            try expect(receipt.routingIntegrity.registryVersion == ToolSkillBindingRegistry.registryVersion)
+            try expect(receipt.routingIntegrity.boundToolCount == ToolSkillBindingRegistry.bindings.count)
+            try expect(receipt.routingIntegrity.manifestMarkerTools.contains(BridgeInitializeModule.toolName))
+            let value = BridgeInitializeModule.receiptValue(receipt)
+            guard case .object(let dict) = value,
+                  case .object(let ril)? = dict["routingIntegrity"],
+                  case .int(let count)? = ril["boundToolCount"] else {
+                throw TestError.assertion("receiptValue missing routingIntegrity.boundToolCount")
+            }
+            try expect(count == ToolSkillBindingRegistry.bindings.count)
+        }
+    }
+
+    await test("RIL gate: fresh session cannot dispatch messages_send before manifest marker") {
+        try await withRILTempHome {
+            let log = AuditLog()
+            let router = ToolRouter(
+                securityGate: SecurityGate(),
+                auditLog: log,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await MessagesModule.register(on: router)
+            try await withNoDisabledTools {
+                do {
+                    _ = try await router.dispatch(
+                        toolName: "messages_send",
+                        arguments: .object([
+                            "recipient": .string("+15555550123"),
+                            "body": .string("dry-run probe"),
+                            "confirm": .string("DRY_RUN")
+                        ]),
+                        sessionID: "ril-session-a"
+                    )
+                    throw TestError.assertion("messages_send reached handler without manifest marker")
+                } catch let error as ToolRouterError {
+                    if case .routingManifestRequired(let toolName, let governingSkills) = error {
+                        try expect(toolName == "messages_send")
+                        try expect(governingSkills.contains("people-keepr"))
+                    } else {
+                        throw TestError.assertion("wrong ToolRouterError case: \(error)")
+                    }
+                }
+            }
+            let entries = await log.entries(forSessionID: "ril-session-a")
+            try expect(entries.count == 1, "expected exactly one rejected audit entry, got \(entries.count)")
+            try expect(entries[0].toolName == "messages_send")
+            try expect(entries[0].approvalStatus == .rejected)
+            try expect(entries[0].outputSummary.contains("routing manifest required"))
+        }
+    }
+
+    await test("RIL gate: bridge_initialize marks only the current session; real messages_send no-send guard runs after marker") {
+        try await withRILTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nseed")
+
+            let log = AuditLog()
+            let router = ToolRouter(
+                securityGate: SecurityGate(),
+                auditLog: log,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await router.register(BridgeInitializeModule.makeTool(
+                contextProvider: { client in
+                    BridgeInitializeContext(
+                        client: client,
+                        connectionState: "local",
+                        macToolsAvailable: true,
+                        bridgeState: "running",
+                        now: rilDate("2026-07-07")
+                    )
+                },
+                preflightProvider: { CapabilityPreflightRegistry(probes: []) }
+            ))
+            await MessagesModule.register(on: router)
+
+            try await withNoDisabledTools {
+                UserDefaults.standard.set(
+                    ["messages_send": SecurityTier.open.rawValue],
+                    forKey: BridgeDefaults.tierOverrides
+                )
+                _ = try await router.dispatch(
+                    toolName: BridgeInitializeModule.toolName,
+                    arguments: .object(["client": .string("ril-session-b")]),
+                    sessionID: "ril-session-b"
+                )
+                let marked = await router.hasRoutingManifestMarker(sessionID: "ril-session-b")
+                try expect(marked, "bridge_initialize must mark the session")
+
+                let allowed = try await router.dispatch(
+                    toolName: "messages_send",
+                    arguments: .object([
+                        "recipient": .string("+15555550123"),
+                        "body": .string("dry-run probe"),
+                        "confirm": .string("DRY_RUN")
+                    ]),
+                    sessionID: "ril-session-b"
+                )
+                guard case .object(let dict) = allowed,
+                      case .bool(false)? = dict["sent"],
+                      case .string(let error)? = dict["error"],
+                      error.contains("confirm") else {
+                    throw TestError.assertion("messages_send did not reach real no-send confirmation guard")
+                }
+
+                do {
+                    _ = try await router.dispatch(
+                        toolName: "messages_send",
+                        arguments: .object([
+                            "recipient": .string("+15555550123"),
+                            "body": .string("dry-run probe"),
+                            "confirm": .string("DRY_RUN")
+                        ]),
+                        sessionID: "ril-session-c"
+                    )
+                    throw TestError.assertion("marker leaked across sessions")
+                } catch let error as ToolRouterError {
+                    if case .routingManifestRequired = error { /* expected */ }
+                    else { throw TestError.assertion("wrong error for unmarked second session: \(error)") }
+                }
+            }
+
+            let bTools = await log.entries(forSessionID: "ril-session-b").map(\.toolName)
+            try expect(bTools == [BridgeInitializeModule.toolName, "messages_send"],
+                       "session b audit sequence drift: \(bTools)")
+            let cEntries = await log.entries(forSessionID: "ril-session-c")
+            try expect(cEntries.count == 1 && cEntries[0].approvalStatus == .rejected)
+        }
+    }
+
+    await test("Amendment lifecycle: ACTIVE marker older than 30 days is due for collapse") {
+        let md = """
+        # Skill body
+        - RIL-17 Amendment Status: ACTIVE since 2026-06-01
+        - RIL-18 Amendment Status: ACTIVE since 2026-06-20
+        - RIL-19 Amendment Status: SUPERSEDED since 2026-05-01
+        """
+        let due = AmendmentLifecycle.dueForCollapse(markdown: md, now: rilDate("2026-07-07"))
+        try expect(due.map(\.identifier) == ["RIL-17"], "unexpected due markers: \(due.map(\.identifier))")
+        try expect(due[0].ageDays >= 30)
+    }
+
+    await test("Amendment lifecycle: scheduler template exposes weekly scan") {
+        let template = AmendmentLifecycle.jobTemplate()
+        guard case .string("weekly-amendment-collapse-scan")? = template["id"],
+              case .string("0 9 * * 1")? = template["schedule"],
+              case .array(let actions)? = template["actions"],
+              case .object(let first)? = actions.first,
+              case .string("standing_orders_list")? = first["tool"] else {
+            throw TestError.assertion("amendment lifecycle template shape drift: \(template)")
+        }
+    }
+
+    await test("Identity propagation: unresolved impact hits block rename close") {
+        let clean = IdentityPropagationScanResult(renameId: "rename-clean", unresolvedHits: 0, completedScanCycles: 1)
+        try expect(IdentityPropagationContract.closeDecision(for: clean) == .canClose)
+
+        let dirty = IdentityPropagationScanResult(renameId: "rename-dirty", unresolvedHits: 4, completedScanCycles: 1)
+        try expect(IdentityPropagationContract.closeDecision(for: dirty) == .blockedByImpactHits)
+
+        let repeated = IdentityPropagationScanResult(renameId: "rename-loop", unresolvedHits: 1, completedScanCycles: 3)
+        try expect(IdentityPropagationContract.closeDecision(for: repeated) == .escalateAfterRepeatedHits)
+    }
+}
+
+private func rilDate(_ yyyyMMdd: String) -> Date {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.date(from: yyyyMMdd)!
+}
+
+private func withRILTempHome(_ body: () async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("RoutingIntegrityLayer-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body()
+}
+
+private func withNoDisabledTools(_ body: () async throws -> Void) async throws {
+    let defaults = UserDefaults.standard
+    let priorDisabled = defaults.object(forKey: BridgeDefaults.disabledTools)
+    let priorToolOverrides = defaults.object(forKey: BridgeDefaults.tierOverrides)
+    let priorModuleOverrides = defaults.object(forKey: BridgeDefaults.moduleTierOverrides)
+    defaults.set([], forKey: BridgeDefaults.disabledTools)
+    defaults.removeObject(forKey: BridgeDefaults.tierOverrides)
+    defaults.removeObject(forKey: BridgeDefaults.moduleTierOverrides)
+    defer {
+        restore(defaults: defaults, key: BridgeDefaults.disabledTools, value: priorDisabled)
+        restore(defaults: defaults, key: BridgeDefaults.tierOverrides, value: priorToolOverrides)
+        restore(defaults: defaults, key: BridgeDefaults.moduleTierOverrides, value: priorModuleOverrides)
+    }
+    try await body()
+}
+
+private func restore(defaults: UserDefaults, key: String, value: Any?) {
+    if let value {
+        defaults.set(value, forKey: key)
+    } else {
+        defaults.removeObject(forKey: key)
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -764,6 +764,7 @@ await runRemoteOAuthOriginGatingTests() // PKT-810 R5: origin split — loopback
 await runBridgeFeatureFlagsTests()  // PKT-798 (v2.3 · WS-C): fail-closed capability gates
 await runBridgeModuleRegistryTests() // PKT v3.0·0.4: single-source module registrar
 await runMCPToolFactoryTests()       // PKT v3.0·0.5: metadata contract + unified Tool factory
+await runRoutingIntegrityLayerTests() // PKT-1094: server-owned tool-skill registry + manifest gate
 await runToolConventionTests()       // PKT v3.0·0.5: P0 — aliases + key convention + dispatch contract
 await runToolMetadataAuthoringTests() // PKT v3.0·0.5: P1 — projection + authored-metadata render
 await runArtifactModuleTests()    // PKT-743 (v2.2 · 3.1)

--- a/TheBridgeTests/Wave1BrokerTests.swift
+++ b/TheBridgeTests/Wave1BrokerTests.swift
@@ -95,7 +95,7 @@ func runWave1BrokerTests() async {
                 )
             }
 
-            try expect(receipt.schemaVersion == 2)
+            try expect(receipt.schemaVersion == 3)
             try expect(receipt.session?.transportSessionId == "http-session-2")
             try expect(receipt.session?.mode == .execute)
             try expect(receipt.session?.governed == true)

--- a/docs/operator/command-bridge-smoke-checklist.md
+++ b/docs/operator/command-bridge-smoke-checklist.md
@@ -47,8 +47,9 @@ placement, the macOS reduce-motion path, and focus-loss dismissal.
       a glass bubble with the icon; **unassigned slots are blank but
       hold their position** (the keycap labels 1, 2, 3 … 9, 0 stay
       aligned even with a sparse set of favorites)
-- [ ] Pressing a number key for an assigned slot (e.g. `1` if the
-      Execute command is bound) fires that command:
+- [ ] Pressing a number key for an assigned slot (e.g. `1` for
+      Initiate or `5` for Execute on the default engineering palette)
+      fires that command:
   - [ ] The popup closes
   - [ ] The system clipboard now holds the exact markdown body of the
         fired command (`pbpaste` to verify byte-for-byte)

--- a/packet-runner/COMPLETION_REPORT.md
+++ b/packet-runner/COMPLETION_REPORT.md
@@ -4,6 +4,14 @@
 
 > Production qualification requires the separate 20-cycle scheduled-pilot gate + authorized operator sign-off (§8.20). This report does **not** declare production readiness. Unattended scheduling is **disabled** (`config schedule: null`).
 
+## 2026-07-07 refresh evidence
+
+- `config/routine.config.ship-the-bridge-v4.json` now carries concrete pilot values for Ship The Bridge v4: project `37fcbb58-889e-81f1-867e-d71b11dd9baf`, task id `packet-runner-ship-the-bridge-v4`, repo-path evidence/latch `packet-runner/controller/latch_state.json`, model default `claude-sonnet-5`, and operator/reviewer/pause authority `Isaiah Peters`. `schedule` remains `null`.
+- The cycle prompt `agent/packet-runner-cycle.md` was aligned to those values; the stale operator placeholders for task id, project id, PACKETS registry entity, evidence/latch, model, identities, and timeouts were removed.
+- Live registry smoke test: `registry_hydrate(entity: "session", id: "388cbb58-889e-81d8-bf76-d79e78361155")` returned `schemaVersion: packet-registry-v1` with `warnings: []`; the `session` entity maps the PACKETS data source.
+- Deterministic controller suite refreshed: `python3 packet-runner/controller/test_decisions.py` -> **57 passed / 0 failed** across 64 distinct acceptance IDs.
+- Bridge full harness refreshed after command-routing edits: `make test` -> **3098 passed / 0 failed**.
+
 ---
 
 ## 1. All implementation changes & updated Notion assets

--- a/packet-runner/PILOT_TEST_GUIDE.md
+++ b/packet-runner/PILOT_TEST_GUIDE.md
@@ -18,6 +18,13 @@
 - [ ] **PACKETS registered as a registry entity** (so hydration works): `registry_add_entity` (bind DS `078e7c9e…` **by property id**) → `registry_introspect` → note the **entity name**. Smoke-test: `registry_hydrate(entity, <any packet id>)` returns the `packet-registry-v1` envelope (primary + body + one-hop relations + provenance + warnings).
 - [ ] **Get `main` locally to edit the config:** stash/commit any in-progress work on your current branch, then `git checkout main && git pull`.
 
+**Current pilot binding (verified 2026-07-07):** the live registry entity key for
+PACKETS is `session`; `registry_hydrate(entity: "session", id: "388cbb58-889e-81d8-bf76-d79e78361155")`
+returned `schemaVersion: packet-registry-v1` with `warnings: []`. The concrete config
+uses project `37fcbb58-889e-81f1-867e-d71b11dd9baf`, task id
+`packet-runner-ship-the-bridge-v4`, and repo-path latch
+`packet-runner/controller/latch_state.json`.
+
 ## Step 1 — Fill the config
 Edit `config/routine.config.ship-the-bridge-v4.json`; replace **every** `<<OPERATOR: …>>`:
 - `version` (semver, e.g. `1.0.0`); `provider.workspace_alias`

--- a/packet-runner/acceptance/ACCEPTANCE_EVIDENCE.md
+++ b/packet-runner/acceptance/ACCEPTANCE_EVIDENCE.md
@@ -3,6 +3,13 @@
 Honest, non-fabricated evidence status for every acceptance test. Classification +
 how-to-verify in [`ACCEPTANCE_MATRIX.md`](./ACCEPTANCE_MATRIX.md).
 
+**Refresh 2026-07-07:** deterministic controller verification was rerun after the
+Ship The Bridge v4 concrete-config alignment. `python3 packet-runner/controller/test_decisions.py`
+reported **57 passed / 0 failed** and 64 distinct acceptance IDs exercised. The class
+breakdown below remains the governing 2026-06-23 qualification ledger: provider
+integration, governance, and pilot-only rows still require live evidence and must not be
+marked satisfied by deterministic tests alone.
+
 ## Summary
 
 | Class | Count | Evidence status |

--- a/packet-runner/agent/packet-runner-cycle.md
+++ b/packet-runner/agent/packet-runner-cycle.md
@@ -71,27 +71,27 @@ uses the host's own Bash/git tools inside the isolated packet branch — not a B
 
 ## Operator-supplied configuration (fail closed if any is unresolved)
 
-These come from `packet-runner/config/routine.config.json` (the filled copy of
-`routine.config.template.json`). Do NOT invent any value. If a value below is still a
-placeholder at run time, that is a **preflight FAILURE** (Step 0): abort + report, mutate
-nothing.
+These come from `packet-runner/config/routine.config.ship-the-bridge-v4.json` (the filled
+copy of `routine.config.template.json`). Do NOT invent any value. If a value below is
+still a placeholder at run time, that is a **preflight FAILURE** (Step 0): abort + report,
+mutate nothing.
 
 | Config key | Value to use |
 |---|---|
-| `taskId` | `<<OPERATOR: scheduled-task id — confirm `packet-runner-ship-the-bridge-v4`>>` |
-| `project_id` (PROJECT scoping the QUEUE) | `<<OPERATOR: "Ship The Bridge v4" PROJECT page id>>` |
+| `taskId` | `packet-runner-ship-the-bridge-v4` |
+| `project_id` (PROJECT scoping the QUEUE) | `37fcbb58-889e-81f1-867e-d71b11dd9baf` (`Ship The Bridge v4`) |
 | PACKETS data source id | `078e7c9e-e53e-4c83-a893-af64f82b5123` (canonical, §4 / SCHEMA_GAP) |
-| PACKETS registry entity name (for `registry_hydrate`) | `<<OPERATOR: registry entity name registered for PACKETS via registry_add_entity + registry_introspect>>` |
+| PACKETS registry entity name (for `registry_hydrate`) | `session` (live registry key; smoke-tested against PKT-1042 on 2026-07-07) |
 | PROJECT relation property name on PACKETS | `PROJECT` (the relation column; confirm at preflight) |
 | `brief_page_id` (canonical latest-brief) | `389cbb58-889e-8165-b407-e5e6f0bd45b3` (created 2026-06-23) |
 | Bridge Inbox target | `openSettingsSection: "Inbox"` (native Inbox pane; mirror summary + Notion brief URL) |
-| `durable_evidence_destination` + **latch location** | `<<OPERATOR: stable Notion page/db or repo evidence path; the single-writer latch lives here — see Step 1>>` |
+| `durable_evidence_destination` + **latch location** | `repo_path: packet-runner/controller/latch_state.json` (whole-file JSON latch, git-ignored) |
 | `repository` / `default_branch` / `isolation_mode` | `KUP-IP/the-bridge` / `main` / `worktree` (confirm; branch per packet = `packet/<PKT-ID>-<slug>`) |
-| `model` default + allowlist | `<<OPERATOR: default model id + approved allowlist>>` |
-| reviewer / operator / pause-authority identities | `<<OPERATOR: reviewer + operator (default Isaiah) + provider-pause authority>>` |
+| `model` default + allowlist | default `claude-sonnet-5`; allowlist `claude-sonnet-5`, `claude-opus-4-8` |
+| reviewer / operator / pause-authority identities | `Isaiah Peters` |
 | `qualification_evidence_page_id` | `389cbb58-889e-8184-b8da-fb72881782d6` (created 2026-06-23; used only when `qualification_pilot_active`) |
 | `max_packets_per_cycle` | `1` |
-| `cycle_timeout_seconds` / `packet_timeout_seconds` | from config (cycle < schedule interval; packet < 14400s) |
+| `cycle_timeout_seconds` / `packet_timeout_seconds` | `1800` / `1200` (cycle < schedule interval; packet < 14400s) |
 | `maintenance_max_items` / `maintenance_time_budget_seconds` | `10` / `120` |
 | contract versions | executor `8.1.0-packet-runner` · orchestrator `7.1.0` · close-agent `3.2.0` · registry `packet-registry-v1` · receipt `packet-runner-receipt-v1` |
 
@@ -114,8 +114,8 @@ packet is touched.
    partial writes."** (This is the daily-report pattern verbatim — do not partially write.)
 2. **Config present + consistent:** every operator value above is resolved (no
    `<<OPERATOR: …>>` placeholder remains); contract/schema versions are in the supported
-   range; `cycle_timeout < schedule interval`; `packet_timeout < 14400s`; config does not
-   allow overlapping runs (P1, P13, P14).
+   range; `packet_timeout < 14400s`; if a schedule is enabled, `cycle_timeout < schedule
+   interval`; config does not allow overlapping runs (P1, P13, P14).
 3. **Project resolvable (P2):** `notion_page_read` (or `notion_query`) confirms `project_id`
    is accessible.
 4. **Repo isolation establishable (P3):** the `KUP-IP/the-bridge` clone is present, the

--- a/packet-runner/config/routine.config.ship-the-bridge-v4.json
+++ b/packet-runner/config/routine.config.ship-the-bridge-v4.json
@@ -1,14 +1,14 @@
 {
-  "_about": "Packet Runner CONCRETE PILOT configuration for the 'Ship The Bridge v4' routine (PRD §8.5A; MASTER_IMPLEMENTATION_SPEC.md v1.1 §3 WU-4). Authored from routine.config.template.json with the WU-4 DECIDED values filled. Every value that must come from the operator remains an explicit '<<OPERATOR: ...>>' placeholder — no IDs, tokens, or secret values are fabricated. Secret VALUES never live here — only safe aliases (PRD §8.9). Preflight fails closed before any packet mutation when this config is missing, inconsistent, points at an inaccessible project/repo/brief/qualification/evidence destination, allows overlapping runs, or uses contract/schema versions outside the supported range (PRD §8.5A configuration validation; CONTROLLER_SPEC.md §2 P1-P14).",
+  "_about": "Packet Runner CONCRETE PILOT configuration for the 'Ship The Bridge v4' routine (PRD §8.5A; MASTER_IMPLEMENTATION_SPEC.md v1.1 §3 WU-4). Authored from routine.config.template.json with the WU-4 DECIDED values filled. Operator-supplied pilot values are concrete here; secret VALUES never live here — only safe aliases (PRD §8.9). Preflight fails closed before any packet mutation when this config is missing, inconsistent, points at an inaccessible project/repo/brief/qualification/evidence destination, allows overlapping runs, or uses contract/schema versions outside the supported range (PRD §8.5A configuration validation; CONTROLLER_SPEC.md §2 P1-P14).",
   "_source_of_truth": "_refs/PRD-v1.0.md §8.5A; MASTER_IMPLEMENTATION_SPEC.md v1.1 §3 WU-4 (decided values) + Decision Ledger D1/D1'/D2/D3/D4/D-assume; companion logic in controller/CONTROLLER_SPEC.md + controller/decisions.py",
   "_status": "NOT production-qualified. Unattended scheduling stays OFF until Pilot Phase 1 + the live capability tests pass and the §8.20 20-cycle gate + operator sign-off complete (MASTER_IMPLEMENTATION_SPEC.md §0/§5).",
 
-  "version": "<<OPERATOR: routine config semver, e.g. 1.0.0 — set on first commit of this concrete config; dispatch carries it as routineConfigVersion (PRD §8.4)>>",
+  "version": "1.0.0",
 
   "provider": {
     "_note": "PRD §8.5A + FR-9. Decided per MASTER_IMPLEMENTATION_SPEC.md §3 WU-4 + Decision Ledger D1/D1'. Fully-local app-local Claude Code scheduled agent: ONE synchronous autonomous run = the whole cycle (the keep-os-daily-people-report pattern), failing closed if the Bridge is unreachable. The provider must satisfy all nine capabilities; selection evidence is recorded under provider_capability_results below. Do NOT build a generalized adapter framework for v1.",
     "name": "Claude Code app-local scheduled agent + Bridge MCP (loopback/connector)",
-    "workspace_alias": "<<OPERATOR: safe alias for the Claude Code account/workspace that owns the scheduled task — never a secret>>",
+    "workspace_alias": "isaiah-claude-code-local",
     "self_pause_action": {
       "_note": "Decided per Decision Ledger D1' #7 + decisions.py pause_gate/request_pause/may_reenable. Machine-callable self-pause = 'update_scheduled_task enabled:false' (scheduled-tasks MCP) backed by the controller fail-closed latch 'disabled' flag in durable_evidence_destination (PRD §8.5A, §8.13). Packet Runner may SET disabled within an incident boundary but may NEVER re-enable itself; re-enable is operator-only (may_reenable). Optional belt-and-suspenders: Bridge job_pause.",
       "kind": "machine_callable_pause",
@@ -26,11 +26,11 @@
   "_schedule_note": "INTENTIONALLY null (MASTER_IMPLEMENTATION_SPEC.md §3 WU-4 + WU-2 + Decision Ledger D-assume: cron = null, one-shot fire through Phase 1). PRD §8.5A + FR-8: schedule is an operator-supplied provider-native schedule, and NO unattended run is enabled until this value is reviewed. UNATTENDED RUNS STAY DISABLED until reviewed AND until the §8.20 20-cycle production-qualification gate passes with explicit operator sign-off. Until then, execution is manual Run-Now / one-shot 'fireAt' only (WU-5 Phase 1), under the same controller non-overlap latch. Replace null with the reviewed provider-native recurrence (WU-5 Phase 2) ONLY after qualification + authorization.",
   "schedule_fields_when_enabled": {
     "_note": "Reference shape only — NOT active while \"schedule\": null. Populate the live \"schedule\" field above (provider-native cron/recurrence in America/Chicago) after Phase-1 live tests pass and operator authorizes Phase 2. Missed runs are NOT backfilled (FR-8). Time zone / daylight-saving / manual-run behavior remain provider-native. App-local caveat (MASTER_IMPLEMENTATION_SPEC.md open-pt #5): the scheduled task fires only while the Claude Code app is open, else on next launch — confirm app-open-overnight or adopt the launchd->headless-claude enhancement before Phase 2.",
-    "cron_or_recurrence": "<<OPERATOR: reviewed provider-native schedule expression (America/Chicago); leave \"schedule\" null until Phase 2 authorized>>",
+    "cron_or_recurrence": "populate only after Phase 1 passes and Phase 2 is authorized; live schedule remains null until then",
     "missed_run_behavior": "no-backfill"
   },
 
-  "project_id": "<<OPERATOR: Ship The Bridge v4 PROJECT page id — the PROJECT relation target scoping the QUEUE query (PRD §6.2, FR-2; CONTROLLER_SPEC.md P2). NOT the PACKETS data source id (that is canonical: 078e7c9e-e53e-4c83-a893-af64f82b5123)>>",
+  "project_id": "37fcbb58-889e-81f1-867e-d71b11dd9baf",
   "_project_id_note": "MASTER_IMPLEMENTATION_SPEC.md Decision Ledger D2: pilot on 'Ship The Bridge v4' in the the-bridge repo. registry.queryQueue(project_id) selects Status==QUEUE AND PROJECT==project_id (CONTROLLER_SPEC.md §1 step 2). Preflight P2 fails closed if unresolvable/inaccessible.",
 
   "repository": {
@@ -49,16 +49,16 @@
 
   "durable_evidence_destination": {
     "_note": "PRD §8.5A + §8.18 + MASTER_IMPLEMENTATION_SPEC.md §3 WU-4 'Operator inputs still required'. Stable Notion page/file area OR repository evidence path for redacted incident exports and portable review artifacts. MUST NOT be an ephemeral local directory (preflight P6 fails closed otherwise). This SAME store ALSO hosts the controller single-writer latch {holder, acquired_at, expires_at, disabled} that enforces #1 non-overlap and #7 pause (WU-3; decisions.py OverlapLatch/overlap_gate/pause_gate). Set 'latch_location' to the exact Notion property/row/file within this destination that holds the latch.",
-    "kind": "<<OPERATOR: one of notion_page | notion_file_area | repo_path>>",
-    "locator": "<<OPERATOR: stable Notion page id OR repo evidence path for the durable evidence destination — never an ephemeral local dir>>",
-    "latch_location": "<<OPERATOR: exact location of the single-writer control latch within durable_evidence_destination (e.g. a Notion page/row/property or a repo file path) holding {holder, acquired_at, expires_at, disabled} — WU-3 latch store>>"
+    "kind": "repo_path",
+    "locator": "packet-runner/controller/latch_state.json",
+    "latch_location": "packet-runner/controller/latch_state.json — whole-file JSON record {holder, acquired_at, expires_at, disabled}; created by Step 2, git-ignored (churns every cycle, not meant to carry commit history)"
   },
 
   "max_packets_per_cycle": 1,
   "_max_packets_note": "PRD §8.5A + §6.6 + MASTER_IMPLEMENTATION_SPEC.md §3 WU-4 + Decision Ledger D-assume: pilot is exactly 1 packet per cycle. Increasing this is a persistent change requiring review (§8.13) and may expand only one dimension at a time after qualification (§8.20).",
 
-  "cycle_timeout_seconds": "<<OPERATOR: integer cycle timeout in seconds — MUST be shorter than the schedule interval once a schedule is set (PRD §8.5A; CONTROLLER_SPEC.md P14). Also bounds the latch expires_at = acquired_at + cycle_timeout (decisions.py OverlapLatch). While schedule is null/one-shot, set a sane upper bound for one synchronous run>>",
-  "packet_timeout_seconds": "<<OPERATOR: integer packet timeout in seconds — MUST be shorter than the 14400s (4h) stale-FOCUS threshold (PRD §8.5A, §8.14; CONTROLLER_SPEC.md P14)>>",
+  "cycle_timeout_seconds": 1800,
+  "packet_timeout_seconds": 1200,
 
   "maintenance_max_items": 10,
   "maintenance_time_budget_seconds": 120,
@@ -66,8 +66,8 @@
 
   "model": {
     "_note": "PRD §8.5A, FR-18, §8.13. Session-local model choice is allowed only within this allowlist; changing the default or allowlist is a persistent change requiring review (decisions.py select_model — never mutates the persisted default). Preflight P8 fails closed if the default is unavailable or outside the allowlist. Provide model ID strings only — no credentials.",
-    "default": "<<OPERATOR: default model id (e.g. an approved claude-* id) for the scheduled agent run>>",
-    "allowlist": ["<<OPERATOR: approved model id #1>>", "<<OPERATOR: approved model id #2 (optional; repeat as needed)>>"]
+    "default": "claude-sonnet-5",
+    "allowlist": ["claude-sonnet-5", "claude-opus-4-8"]
   },
 
   "allowed_execution_modes": ["inline"],
@@ -81,16 +81,16 @@
       "local git + build/test tooling for the the-bridge worktree (non-consequential verification)"
     ],
     "credential_aliases": [
-      "<<OPERATOR: safe credential alias for Notion/Bridge access, e.g. notion:primary — name only, never the secret>>",
-      "<<OPERATOR: safe credential alias for the the-bridge git repo, e.g. github:primary — name only, never the secret>>"
+      "notion:primary",
+      "github:primary"
     ]
   },
 
   "authorized_identities": {
     "_note": "PRD §8.5A + §8.10 + §8.13 + MASTER_IMPLEMENTATION_SPEC.md §3 WU-4 'Operator inputs still required'. Reviewer/operator identities and who holds provider pause/re-enable authority. Re-enablement of a paused routine is an explicit operator decision; the routine may NEVER re-enable itself (decisions.py may_reenable).",
-    "reviewers": ["<<OPERATOR: reviewer identity #1 (Notion person / handle authorized to issue PACKET DECISION approvals)>>"],
-    "operators": ["<<OPERATOR: operator identity (e.g. Isaiah) — packet author, final authority, scheduling controller>>"],
-    "provider_pause_authority": ["<<OPERATOR: identity holding pause/re-enable authority for taskId packet-runner-ship-the-bridge-v4 (e.g. Isaiah)>>"]
+    "reviewers": ["Isaiah Peters"],
+    "operators": ["Isaiah Peters"],
+    "provider_pause_authority": ["Isaiah Peters"]
   },
 
   "provider_capability_results": {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2090,6 +2090,22 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3126}"
 # (BridgeInitializeTests.swift: remote origin -> "online"/FULL, local/no-
 # context -> "local"). Measured 3128 passed, 0 failed. FLOOR raised 3126 -> 3128.
 FLOOR="${BRIDGE_TEST_FLOOR:-3128}"
+# PR #87 reconciliation (2026-07-11): merged codex/ship-v4-packet-closeout's
+# Routing Integrity Layer (PKT-1094 — ToolSkillBindingRegistry, per-tool
+# manifest-fetch gate, HandshakeReceipt.routingIntegrity, schemaVersion 2->3)
+# onto post-w1-broker main. Real conflicts in ToolRouter.swift/AuditLog.swift/
+# SSETransport.swift/ServerManager.swift over the same dispatch signature both
+# sides touched (flat sessionID: String? vs w1-broker's ToolDispatchContext) —
+# resolved by keeping context-based dispatch everywhere and threading RIL's
+# manifest gate through it. One real (non-mechanical) test failure surfaced
+# after conflicts compiled clean: the manifest gate fired before w1-broker's
+# governed-session gate for messages_send, producing the wrong rejection
+# reason for an ungoverned remote session. Fixed by moving the manifest-gate
+# check to run after the broker's origin-level gates, not by changing the
+# test. +10 tests (RoutingIntegrityLayerTests.swift). Measured 3138 passed,
+# 0 failed on the merged tree (3128 + 10, no other drift). FLOOR raised
+# 3128 -> 3138.
+FLOOR="${BRIDGE_TEST_FLOOR:-3138}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Align the seeded Execute command with parent-Keepr routing before executor selection.
- Add a regression test for Execute command routing language.
- Fill Ship The Bridge v4 Packet Runner pilot config values and refresh pilot/evidence docs without enabling unattended scheduling.

## Verification
- git diff --check
- python3 packet-runner/controller/test_decisions.py
- jq empty packet-runner/config/routine.config.ship-the-bridge-v4.json
- make test

## Packet Notes
- PKT-1065: remaining D command-alignment blocker implemented and verified.
- PKT-1042: preflight/config readiness improved; live one-shot cycle evidence still required before Done.
- PKT-1016: unchanged blocked release gates; appcast/version mismatch and missing secrets remain.

PKT-801 intentionally untouched.