### PR TITLE
Notion icon test coverage + voice_memo_get timeout parity

### DIFF
--- a/TheBridge/Modules/VoiceMemo/VoiceMemoDiscovery.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoDiscovery.swift
@@ -98,11 +98,22 @@ public enum VoiceMemoDiscovery {
         return AppleVoiceMemoTranscriptExtractor.extract(from: audioURL)
     }
 
+    /// Test seam (mirrors VoiceMemoParseRouter.providerOverride) — when set,
+    /// short-circuits the real sidecar/Apple/Parakeet ladder entirely. Lets
+    /// GH #73 stage-timeout tests force a deterministic transcribe-stage hang
+    /// without depending on real transcription internals (which have no other
+    /// injection point and would otherwise make such a test flaky/slow/
+    /// environment-dependent).
+    nonisolated(unsafe) public static var resolveTranscriptOverride: (@Sendable (URL) async throws -> VoiceMemoTranscriptResolution)?
+
     /// Transcription ladder: sidecar cache → Apple tsrp → Parakeet fallback.
     public static func resolveTranscript(
         for audioURL: URL,
         forceParakeet: Bool = false
     ) async throws -> VoiceMemoTranscriptResolution {
+        if let override = resolveTranscriptOverride {
+            return try await override(audioURL)
+        }
         if !forceParakeet, let cached = loadTranscriptSidecar(for: audioURL) {
             let source = loadTranscriptMeta(for: audioURL)?.source ?? .sidecar
             return VoiceMemoTranscriptResolution(text: cached, source: source)

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -1140,7 +1140,28 @@ public enum VoiceMemoProcessor {
         let providerMode = stringArg(fromValue: args, "provider").flatMap { VoiceMemoCuratorMode(rawValue: $0.lowercased()) }
 
         if understand {
-            let (transcript, plan) = try await buildPlan(for: recording, options: options, curatorMode: providerMode)
+            let transcript: String
+            let plan: VoiceMemoPlan
+            do {
+                (transcript, plan) = try await buildPlan(for: recording, options: options, curatorMode: providerMode)
+            } catch let timeoutError as VoiceMemoStageTimeoutError {
+                // GH #73 parity fix (2026-07-09): voice_memo_process (processOne) and
+                // voice_memo_commit both catch a transcribe/understand-stage timeout
+                // inside buildPlan and degrade gracefully; this understand:true path
+                // let it propagate as a raw thrown error instead — a real completion
+                // payload asymmetry, though not a hang (bounded by the same stage
+                // budgets). No review-queue enqueue here (unlike commit): get is a
+                // read-only inspect call, not a write the caller is trying to persist.
+                return .object([
+                    "memo": memoValue(recording, transcript: inspectTranscript(for: recording).text ?? ""),
+                    "understood": .bool(false),
+                    "needsManual": .bool(true),
+                    "timedOut": .bool(true),
+                    "detail": .string(timeoutError.localizedDescription),
+                    "curatorMode": .string(VoiceMemoCuratorRouter.effectiveMode().rawValue),
+                    "processed": .bool(VoiceMemoProcessedStore.isProcessed(id: recording.id)),
+                ])
+            }
             recordConsidering(recording: recording, plan: plan)
             return .object([
                 "memo": memoValue(recording, transcript: transcript),

--- a/TheBridge/Notion/NotionClient.swift
+++ b/TheBridge/Notion/NotionClient.swift
@@ -211,7 +211,9 @@ public actor NotionClient {
 
     /// Initialize with a Notion integration API key.
     /// Resolution order: explicit parameter → NOTION_API_TOKEN env → NOTION_API_KEY env → config file
-    public init(apiKey: String? = nil) throws {
+    /// `session` is a test seam (mirrors WorkerTokenExchange's injectable-session
+    /// pattern) — omitted uses the real default-configured URLSession.
+    public init(apiKey: String? = nil, session: URLSession? = nil) throws {
         if let key = apiKey, !key.isEmpty {
             self.apiKey = key
             self.tokenSource = "explicit"
@@ -221,10 +223,14 @@ public actor NotionClient {
         } else {
             throw NotionClientError.missingAPIKey
         }
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 60
-        self.session = URLSession(configuration: config)
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 30
+            config.timeoutIntervalForResource = 60
+            self.session = URLSession(configuration: config)
+        }
         print("[NotionClient] Initialized — token source: \(tokenSource)")
     }
 

--- a/TheBridgeTests/NotionClientIconTests.swift
+++ b/TheBridgeTests/NotionClientIconTests.swift
@@ -1,0 +1,125 @@
+// NotionClientIconTests.swift — coverage for the Notion page icon write
+// feature (createPage/updatePage `icon` param), which shipped (c3b5699,
+// v3.9.5) with zero automated tests — only "live-verified against real
+// Notion." A URLProtocol stub intercepts the outbound request so no live
+// network call is made, mirroring WorkerTokenExchangeTests.swift's pattern.
+
+import Foundation
+import TheBridgeLib
+
+/// URLProtocol stub: captures the outbound request/body and returns a canned reply.
+final class StubNotionIconProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub: @unchecked Sendable { var status: Int; var body: Data }
+    nonisolated(unsafe) static var stub: Stub?
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+    nonisolated(unsafe) static var lastBody: Data?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastRequest = request
+        if let stream = request.httpBodyStream {
+            stream.open(); defer { stream.close() }
+            var data = Data(); var buf = [UInt8](repeating: 0, count: 4096)
+            while stream.hasBytesAvailable {
+                let n = stream.read(&buf, maxLength: buf.count)
+                if n > 0 { data.append(buf, count: n) } else { break }
+            }
+            Self.lastBody = data
+        } else {
+            Self.lastBody = request.httpBody
+        }
+        let s = Self.stub ?? Stub(status: 200, body: #"{"id":"stub-page-id"}"#.data(using: .utf8)!)
+        let resp = HTTPURLResponse(url: request.url!, statusCode: s.status,
+                                   httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: s.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func stubbedNotionSession() -> URLSession {
+    let cfg = URLSessionConfiguration.ephemeral
+    cfg.protocolClasses = [StubNotionIconProtocol.self]
+    return URLSession(configuration: cfg)
+}
+
+private func stubbedClient() throws -> NotionClient {
+    StubNotionIconProtocol.stub = .init(status: 200, body: #"{"id":"stub-page-id"}"#.data(using: .utf8)!)
+    StubNotionIconProtocol.lastRequest = nil
+    StubNotionIconProtocol.lastBody = nil
+    return try NotionClient(apiKey: "test-key-not-real", session: stubbedNotionSession())
+}
+
+@MainActor
+func runNotionClientIconTests() async {
+    await test("NotionClient.createPage: icon supplied merges into request body") {
+        let client = try stubbedClient()
+        let props = #"{"Name":{"title":[{"text":{"content":"x"}}]}}"#.data(using: .utf8)!
+        _ = try await client.createPage(parentId: "parent-1", properties: props, icon: "🎯")
+
+        let sent = try JSONSerialization.jsonObject(with: StubNotionIconProtocol.lastBody ?? Data()) as? [String: Any]
+        let icon = sent?["icon"] as? [String: Any]
+        try expect(icon?["type"] as? String == "emoji", "icon.type must be emoji, got \(sent ?? [:])")
+        try expect(icon?["emoji"] as? String == "🎯", "icon.emoji must carry the supplied emoji")
+    }
+
+    await test("NotionClient.createPage: icon omitted — no icon key in request body (byte-identical to prior behavior)") {
+        let client = try stubbedClient()
+        let props = #"{"Name":{"title":[{"text":{"content":"x"}}]}}"#.data(using: .utf8)!
+        _ = try await client.createPage(parentId: "parent-1", properties: props)
+
+        let sent = try JSONSerialization.jsonObject(with: StubNotionIconProtocol.lastBody ?? Data()) as? [String: Any]
+        try expect(sent?["icon"] == nil, "omitted icon must not add an icon key, got \(sent ?? [:])")
+    }
+
+    await test("NotionClient.updatePage: icon supplied merges into properties body") {
+        let client = try stubbedClient()
+        let props = #"{"Name":{"title":[{"text":{"content":"y"}}]}}"#.data(using: .utf8)!
+        _ = try await client.updatePage(pageId: "page-1", properties: props, icon: "✅")
+
+        let sent = try JSONSerialization.jsonObject(with: StubNotionIconProtocol.lastBody ?? Data()) as? [String: Any]
+        let icon = sent?["icon"] as? [String: Any]
+        try expect(icon?["type"] as? String == "emoji", "icon.type must be emoji, got \(sent ?? [:])")
+        try expect(icon?["emoji"] as? String == "✅", "icon.emoji must carry the supplied emoji")
+        // The original properties must still be present alongside the merged icon.
+        try expect(sent?["Name"] != nil, "original properties must survive the icon merge, got \(sent ?? [:])")
+    }
+
+    await test("NotionClient.updatePage: icon omitted — no icon key in request body (byte-identical to prior behavior)") {
+        let client = try stubbedClient()
+        let props = #"{"Name":{"title":[{"text":{"content":"y"}}]}}"#.data(using: .utf8)!
+        _ = try await client.updatePage(pageId: "page-1", properties: props)
+
+        let sent = try JSONSerialization.jsonObject(with: StubNotionIconProtocol.lastBody ?? Data()) as? [String: Any]
+        try expect(sent?["icon"] == nil, "omitted icon must not add an icon key, got \(sent ?? [:])")
+    }
+
+    await test("NotionClient.createPage: icon:\"\" is sent through as an explicit-but-empty emoji (documented edge-case behavior, not validated)") {
+        let client = try stubbedClient()
+        let props = #"{"Name":{"title":[{"text":{"content":"x"}}]}}"#.data(using: .utf8)!
+        _ = try await client.createPage(parentId: "parent-1", properties: props, icon: "")
+
+        let sent = try JSONSerialization.jsonObject(with: StubNotionIconProtocol.lastBody ?? Data()) as? [String: Any]
+        let icon = sent?["icon"] as? [String: Any]
+        // Bridge does no emptiness validation on `icon` by design (matches the
+        // read-side extractIconEmoji precedent) — an explicit empty string is
+        // NOT treated as "no icon"; it's passed through verbatim to Notion's API,
+        // which will reject or accept it on its own terms. This test documents
+        // that behavior so a future change to it is a deliberate decision, not
+        // an untested surprise.
+        try expect(icon?["type"] as? String == "emoji", "icon:\"\" must still merge as an emoji icon shape, got \(sent ?? [:])")
+        try expect(icon?["emoji"] as? String == "", "icon:\"\" must be sent through verbatim as an empty string, got \(sent ?? [:])")
+    }
+
+    await test("NotionClient.updatePage: icon merge fails loudly if properties body is not a JSON object") {
+        let client = try stubbedClient()
+        let notAnObject = #"[1,2,3]"#.data(using: .utf8)!
+        var threw = false
+        do { _ = try await client.updatePage(pageId: "page-1", properties: notAnObject, icon: "🎯") }
+        catch { threw = true }
+        try expect(threw, "a non-object properties body with an icon supplied must throw, not silently drop the icon")
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -880,6 +880,13 @@ await runEnableCloudAccessFlowTests()
 // {code} only) + response parse (access_token → token; non-2xx / missing → throw).
 await runWorkerTokenExchangeTests()
 
+// 2026-07-09: Notion page icon write (createPage/updatePage `icon` param,
+// c3b5699, v3.9.5) shipped with zero automated coverage — only
+// "live-verified against real Notion." URLProtocol-stubbed, same pattern as
+// WorkerTokenExchangeTests above (NotionClient gained an injectable
+// `session:` test seam for this).
+await runNotionClientIconTests()
+
 // WS-D (PKT-921, Bridge Cloud Access): heartbeat loop over the WS-C
 // BridgeCloudManager (start/stop on toggle, idempotent start), the
 // cloud-gated `bridge_status` MCP tool (gated registration + canonical

--- a/TheBridgeTests/VoiceMemoContentQualityGateTests.swift
+++ b/TheBridgeTests/VoiceMemoContentQualityGateTests.swift
@@ -448,6 +448,42 @@ func runVoiceMemoContentQualityGateTests() async {
         }
         try expect(threw, "scaling the production understandSeconds budget down must make a 4s operation time out")
     }
+
+    await test("GH #73 parity (2026-07-09): voice_memo_get understand:true degrades gracefully on a transcribe-stage timeout instead of throwing") {
+        defer {
+            VoiceMemoDiscovery.resolveTranscriptOverride = nil
+            VoiceMemoStageTimeout.testBudgetScale = nil
+        }
+        // Force the transcribe stage itself to hang, via the dedicated test seam —
+        // deterministic and fast, unlike trying to stall the real sidecar/Apple/
+        // Parakeet ladder (which has no other injection point).
+        VoiceMemoStageTimeout.testBudgetScale = 0.01 // transcribeSeconds -> ~2s
+        VoiceMemoDiscovery.resolveTranscriptOverride = { _ in
+            try await Task.sleep(nanoseconds: 4_000_000_000) // 4s > scaled ~2s budget
+            return VoiceMemoTranscriptResolution(text: "unreachable", source: .sidecar)
+        }
+
+        let fixture = try makeFixture(name: "get-stall-fixture", transcript: "irrelevant — override wins")
+        defer { teardownFixture(fixture) }
+
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let start = ContinuousClock.now
+        let result = try await VoiceMemoProcessor.get(args: .object([
+            "memoId": .string(fixture.recording.id),
+            "understand": .bool(true),
+        ]), router: router)
+        let elapsed = ContinuousClock.now - start
+
+        try expect(elapsed < .seconds(10), "get(args:) must terminate promptly once the scaled-down transcribe budget elapses — got \(elapsed), it previously would have propagated the raw timeout error but NOT necessarily hung; this asserts it also returns a real payload fast")
+        guard case .object(let envelope) = result else {
+            try expect(false, "voice_memo_get must return a structured envelope on a transcribe-stage timeout, not throw")
+            return
+        }
+        try expect(envelope["understood"] == .bool(false), "a timed-out understand attempt must report understood:false, got \(envelope["understood"] as Any)")
+        try expect(envelope["needsManual"] == .bool(true), "must signal needsManual:true, matching processOne/commit's degradation shape")
+        try expect(envelope["timedOut"] == .bool(true), "must signal timedOut:true")
+        try expect(envelope["memo"] != nil, "must still return the memo identity even on a degraded outcome")
+    }
 }
 
 // MARK: - Test-only stub providers


### PR DESCRIPTION
## Summary
Two follow-up fixes flagged by the pre-release audit for v3.9.8, deliberately kept out of that release since neither was blocking:

- **Notion page icon write test coverage** — `notion_page_create`/`notion_page_update`'s `icon` param shipped in v3.9.5 with zero automated tests, only "live-verified against real Notion." `NotionClient` gains an injectable `session:` test seam (mirrors `WorkerTokenExchange`'s existing pattern); a `URLProtocol` stub captures the outbound request body without any live network call.
- **`voice_memo_get` timeout handling asymmetry (GH #73 parity)** — `voice_memo_process`/`voice_memo_commit` both catch a transcribe-stage timeout inside `buildPlan` and degrade gracefully; `voice_memo_get`'s `understand:true` path let it propagate as a raw thrown error instead. Not a hang, but a real completion-payload inconsistency across the three voice-memo entry points. `VoiceMemoDiscovery` gains a `resolveTranscriptOverride` test seam (mirrors `VoiceMemoParseRouter.providerOverride`) so the fix has a genuine, deterministic, fast regression test rather than relying on the untestable real transcription ladder.

## Test plan
- [x] `make test`: 3125 passed, 0 failed (+7 from main: 6 Notion icon tests, 1 voice_memo_get timeout regression test)
- [x] All new tests are deterministic (URLProtocol/closure-based stubs, no live network or real transcription)

🤖 Generated with [Claude Code](https://claude.com/claude-code)