### PR TITLE
fix(connectors): restore full Claude Connectors tool parity (v3.9.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v3.9.9 — Full Claude Connectors parity restored — 2026-07-09
+
+- **Reverts v3.9.8's `strictScopes` default (one day old).** An authenticated
+  remote/cloud connector token (ChatGPT, Claude web) once again reaches every
+  tool — `ConnectorAuthContext.strictScopes` default flipped back `true` →
+  `false`. Gating is now, as before v3.9.8, the per-tool `SecurityGate` tier
+  at dispatch only. The v3.9.8-era 36-tool allowlist is preserved and still
+  available as an opt-in ceiling (`ConnectorAuthContext(strictScopes: true)`)
+  for anyone who wants it later, e.g. a per-client Wave 4 ceiling.
+- **What stays active regardless of this flag:** `ToolRouter`'s Wave 1 broker
+  — the remote control-plane hard-blocklist (`shell_exec`/`applescript_exec`/
+  computer-control/`credential_*` + config-write tools `standing_orders_save`/
+  `delete`/`doctrine_sync`/`commands_*`) and the governed-session requirement
+  (`bridge_initialize` must precede a non-open-tier remote call) — is
+  origin-based, not scope-based, and is untouched by this release.
+- +1 test: `RemoteOAuthBearerTests.swift`'s old "default strictScopes"
+  destructive-step-up assertion was split into an explicit
+  `strictScopes: true` regression test (preserving that coverage) plus a new
+  test asserting the `false` default.
+- test-floor **3118 → 3126** (+7 backfilled from v3.9.8/PR #93's untracked
+  gain, +1 from this release). Build **78**.
+
 ## v3.9.8 — Connector-scope security + session governance — 2026-07-09
 
 **Note on this release:** v3.9.4 through v3.9.7 (below) were fully developed and

--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.9.8</string>
+	<string>3.9.9</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>77</string>
+	<string>78</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "3.9.8"
+    public static let marketing = "3.9.9"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -242,7 +242,23 @@ public enum AppVersion {
     ///   redesign + registry/fetch_skill fields projection + an AX-crash fix. Full
     ///   detail in CHANGELOG.md. staticFeatureModuleToolCount 200 → 201
     ///   (doctrine_sync). test-floor 3108 → 3118.
-    public static let build = "77"
+    /// v3.9.9: 77 -> 78 -- full Claude Connectors parity restored. Reverts
+    ///   v3.9.8's one-day-old ConnectorAuthContext.strictScopes default
+    ///   (false -> true) back to false: an authenticated connector token once
+    ///   again reaches every tool, gated only by the per-tool SecurityGate at
+    ///   dispatch, since WorkOS/AuthKit issues scope-less tokens and the
+    ///   ConnectorScopeGate allowlist would otherwise deny most of the
+    ///   catalog. The v3.9.8-era 36-tool allowlist remains available --
+    ///   ConnectorAuthContext(strictScopes: true) -- as an opt-in ceiling.
+    ///   Independent of this flag and unaffected: ToolRouter's Wave 1 broker
+    ///   (remote control-plane blocklist for shell/applescript/computer/
+    ///   credential + config-write tools, governed-session requirement) is
+    ///   origin-based, not scope-based, and stays fully active. +1 test
+    ///   (RemoteOAuthBearerTests.swift: split the old "default strictScopes"
+    ///   assertion into an explicit strictScopes:true regression test plus a
+    ///   new test asserting the false default). staticFeatureModuleToolCount
+    ///   unchanged (201). test-floor 3118 -> 3126.
+    public static let build = "78"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/TheBridge/Modules/Auth/ConnectorAuthContext.swift
+++ b/TheBridge/Modules/Auth/ConnectorAuthContext.swift
@@ -33,13 +33,19 @@ public struct ConnectorAuthContext: Sendable {
     /// where to discover the authorization server.
     public let resourceMetadataURL: String
 
-    /// Connector tool-authorization policy. DEFAULT true = enforce the remote
-    /// connector allowlist plus destructive-tool step-up before dispatch.
-    /// WorkOS/AuthKit directory tokens that carry only OpenID scopes still map
-    /// to the connector-reachable allowlist inside ConnectorScopeGate; tools
-    /// outside that allowlist are denied, and destructive tools require the
-    /// AS-minted step-up scope. Tests or legacy local shims can opt out by
-    /// passing false explicitly.
+    /// Connector tool-authorization policy. DEFAULT false (2026-07-09, operator
+    /// decision, reverting v3.9.8's one-day default) = full parity: an
+    /// authenticated connector token may reach every tool, gated only by the
+    /// per-tool SecurityGate at dispatch (WorkOS authenticates only the
+    /// operator, and AuthKit issues scope-less tokens, so the ConnectorScopeGate
+    /// allowlist would otherwise deny most of the catalog). The v3.9.8-era
+    /// 36-tool allowlist remains available — pass strictScopes: true — for
+    /// anyone who wants it back later, e.g. as a per-client Wave 4 ceiling.
+    /// Independent of this flag: ToolRouter's Wave 1 broker (remote
+    /// control-plane blocklist for shell/applescript/computer/credential +
+    /// config-write tools, and the governed-session requirement for non-open
+    /// tools) is origin-based, not scope-based, and stays fully active either
+    /// way.
     public let strictScopes: Bool
 
     public init(
@@ -49,7 +55,7 @@ public struct ConnectorAuthContext: Sendable {
         sessionBinding: ConnectorSessionBinding = ConnectorSessionBinding(),
         diagnostics: ConnectorAuthDiagnostics = ConnectorAuthDiagnostics(),
         resourceMetadataURL: String,
-        strictScopes: Bool = true
+        strictScopes: Bool = false
     ) {
         self.validator = validator
         self.scopeGate = scopeGate

--- a/TheBridgeTests/RemoteOAuthBearerTests.swift
+++ b/TheBridgeTests/RemoteOAuthBearerTests.swift
@@ -657,13 +657,18 @@ func runRemoteOAuthBearerTests() async {
         try expect(resp.statusCode == 403, "scope-insufficient call must be 403, got \(resp.statusCode)")
     }
 
-    await test("ConnectorAuthContext default strictScopes: OpenID-only destructive call requires step-up") {
+    await test("ConnectorAuthContext strictScopes=true (opt-in): OpenID-only destructive call requires step-up") {
+        // 2026-07-09: default flipped to false (full-parity revert of the
+        // v3.9.8-era default). strictScopes must now be requested explicitly
+        // to exercise the connector-layer scope/step-up gate — see the
+        // ConnectorAuthContext.strictScopes doc comment.
         let r = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
-        let defaultStrictAuth = ConnectorAuthContext(
+        let explicitStrictAuth = ConnectorAuthContext(
             validator: validator(keys: keys.verifyKeys),
-            resourceMetadataURL: prmURL
+            resourceMetadataURL: prmURL,
+            strictScopes: true
         )
-        let server = SSEServer(router: r, onToolCall: {}, connectorAuth: defaultStrictAuth)
+        let server = SSEServer(router: r, onToolCall: {}, connectorAuth: explicitStrictAuth)
         let tok = try await keys.sign(
             iss: kIssuer,
             aud: kResource,
@@ -672,15 +677,30 @@ func runRemoteOAuthBearerTests() async {
         let body = Data(#"{"method":"tools/call","params":{"name":"snippets_delete","arguments":{}}}"#.utf8)
         let req = HTTPRequest(
             method: "POST",
-            headers: ["Cf-Connecting-Ip": "203.0.113.7", "Authorization": "Bearer \(tok)", "Mcp-Session-Id": "default-strict"],
+            headers: ["Cf-Connecting-Ip": "203.0.113.7", "Authorization": "Bearer \(tok)", "Mcp-Session-Id": "explicit-strict"],
             body: body
         )
         let resp = await server.handleHTTPRequest(req)
         try expect(resp.statusCode == 403,
-                   "default strict auth must require step-up for destructive connector tools, got \(resp.statusCode)")
+                   "explicit strict auth must require step-up for destructive connector tools, got \(resp.statusCode)")
         let text = String(data: resp.bodyData ?? Data(), encoding: .utf8) ?? ""
         try expect(text.contains("step_up_required"),
                    "403 body must carry step_up_required, got: \(text)")
+    }
+
+    await test("ConnectorAuthContext default (strictScopes=false): connector-layer scope/step-up gate skipped") {
+        // Full-parity default: the connector-layer scope gate and step-up gate
+        // are bypassed entirely, so an insufficiently-scoped bearer is never
+        // rejected AT THIS LAYER for a destructive tool call — dispatch falls
+        // through to the tool router / SecurityGate tier, which is the sole
+        // remaining guardrail. This test only proves the connector-layer skip;
+        // it does not assert the eventual dispatch outcome (SecurityGate's
+        // `.request` tier is exercised by SecurityGate's own test suite).
+        let auth = ConnectorAuthContext(
+            validator: validator(keys: keys.verifyKeys),
+            resourceMetadataURL: prmURL
+        )
+        try expect(auth.strictScopes == false, "default strictScopes must be false (full parity)")
     }
 
     await test("Connector-gated server: strict tools/list hides non-callable Messages tools") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2074,6 +2074,16 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3108}"
 # MCPHTTPValidationTests.swift). Measured 3118 passed, 0 failed on the merged
 # tree (3108 + 10, no other drift). FLOOR raised 3108 -> 3118.
 FLOOR="${BRIDGE_TEST_FLOOR:-3118}"
+# v3.9.8 release + PR #93 (Notion icon tests + voice_memo_get timeout parity,
+# 2026-07-09) landed +7 tests on main without a floor bump (measured 3125
+# passed, 0 failed at that point — the floor was left stale at 3118). This
+# fix/connector-full-parity-revert branch (strictScopes default true -> false,
+# restoring full Claude Connectors tool parity) adds +1 test (the old
+# "default strictScopes" destructive-step-up test was split into an explicit
+# strictScopes:true regression test plus a new test asserting the false
+# default) for a net +8 over 3118. Measured 3126 passed, 0 failed on this
+# branch. FLOOR raised 3118 -> 3126.
+FLOOR="${BRIDGE_TEST_FLOOR:-3126}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Reverts v3.9.8's one-day-old `ConnectorAuthContext.strictScopes` default (`false` → `true`) back to `false`, per explicit operator direction to restore full tool parity for remote/cloud connectors (ChatGPT, Claude web).
- An authenticated connector token again reaches every tool, gated only by the per-tool `SecurityGate` tier at dispatch — same posture as every release before v3.9.8.
- The v3.9.8-era 36-tool allowlist remains available and untouched — pass `strictScopes: true` explicitly to opt back in.
- **Unaffected, still fully active:** `ToolRouter`'s Wave 1 broker — the remote control-plane hard-blocklist (`shell_exec`/`applescript_exec`/computer-control/`credential_*` + config-write tools) and the governed-session requirement (`bridge_initialize` before non-open remote calls) — is origin-based, not scope-based.
- Bumps version to 3.9.9 (build 78) and raises the test floor to 3126 (catches up +7 untracked from v3.9.8/PR #93, +1 new).

## Test plan
- [x] `make test` — 3126 passed, 0 failed
- [x] `make test-floor` — floor 3126 met
- [ ] CI green on this PR
- [ ] Post-merge: tag v3.9.9, verify Sparkle appcast, live-verify via the Claude Connectors live session that the full ~202-tool catalog is reachable again

🤖 Generated with [Claude Code](https://claude.com/claude-code)