### PR TITLE
fix(bridge_initialize): report real caller origin instead of hardcoded "local"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v3.9.9 (build 79) — bridge_initialize origin-awareness fix — 2026-07-10
+
+- **Fix** — `bridge_initialize` always reported `connectionState: "local"` /
+  `capabilityState: "FULL"`, even for remote/cloud connector callers, because
+  its default context provider hardcoded that value instead of reading the
+  caller's real origin. Live-caught: a remote session called `bridge_initialize`,
+  was told it had full local capability, then had `shell_exec` immediately
+  refused with `origin: "remote"` by the Wave 1 broker — a real, confusing
+  contradiction between two subsystems that were never wired together. Fixed
+  to read `ToolDispatchContext.current.origin` (the same origin signal
+  `RemoteControlPlanePolicy` already uses): remote callers now correctly get
+  `connectionState: "online"` (still classifies `capabilityState: FULL` — no
+  downstream behavior change, just an honest label); local/no-ambient-context
+  callers are unaffected (`"local"`, as before).
+- Build-only release (marketing version unchanged) — this is a routine
+  internal bugfix, not a feature milestone. 3.9.9 is the mechanical next
+  version under this repo's roll-at-9 rule, but 4.0.0 is reserved for a
+  deliberate sale-ready release rather than being consumed here.
+- +2 tests (`BridgeInitializeTests.swift`): remote origin → `"online"`/`FULL`,
+  local/no-context → `"local"` (regression-proofing both directions).
+- test-floor **3126 → 3128**. Build **79**.
+
 ## v3.9.9 — Full Claude Connectors parity restored — 2026-07-09
 
 - **Reverts v3.9.8's `strictScopes` default (one day old).** An authenticated

--- a/Info.plist
+++ b/Info.plist
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>78</string>
+	<string>79</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -258,7 +258,22 @@ public enum AppVersion {
     ///   assertion into an explicit strictScopes:true regression test plus a
     ///   new test asserting the false default). staticFeatureModuleToolCount
     ///   unchanged (201). test-floor 3118 -> 3126.
-    public static let build = "78"
+    /// v3.9.9: 78 -> 79 -- build-only fix (marketing unchanged; operator decision
+    ///   2026-07-10 to reserve 4.0.0 for a deliberate sale-ready release rather
+    ///   than consume it on a routine internal bugfix, even though it's the
+    ///   mechanical next version under the roll-at-9 rule). bridge_initialize's
+    ///   defaultContextProvider hardcoded connectionState:"local" for every
+    ///   caller regardless of actual origin -- live-caught: a remote/cloud
+    ///   session called bridge_initialize, was told "local"/capabilityState
+    ///   FULL, then had shell_exec refused moments later with origin:"remote"
+    ///   by RemoteControlPlanePolicy. Fixed to read the same
+    ///   ToolDispatchContext.current.origin the Wave 1 broker already uses:
+    ///   .remote -> "online" (existing bridge_status vocabulary; already
+    ///   classifies FULL via capabilityState's default case, no downstream
+    ///   logic change), .local/no-ambient-context -> "local", unchanged. +2
+    ///   tests. staticFeatureModuleToolCount unchanged (201). test-floor
+    ///   3126 -> 3128.
+    public static let build = "79"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -34,16 +34,31 @@ public enum BridgeInitializeModule {
     }
 
     /// Resolves the live runtime context (connection + capability + clock) for a
-    /// handshake. Injectable so ServerManager can bind live cloud state and tests
-    /// can pin a deterministic instant. The default is a direct-loopback posture:
-    /// local channel, Mac tools available, app clock.
+    /// handshake. Injectable so tests can pin a deterministic instant. The
+    /// default reads the per-request `ToolDispatchContext.current` (set by
+    /// `ToolRouter` around every dispatch, same source `RemoteControlPlanePolicy`
+    /// reads) to report the CALLER'S actual origin, rather than assuming local.
     public typealias ContextProvider = @Sendable (_ client: String?) async -> BridgeInitializeContext
 
-    /// Default provider: local channel, Mac tools available, wall-clock now.
+    /// Default provider: origin-aware connection state, Mac tools available,
+    /// wall-clock now.
+    ///
+    /// 2026-07-10 fix: previously hardcoded `connectionState: "local"`
+    /// unconditionally — a remote/cloud connector caller would be told
+    /// `connectionState: "local"` / `capabilityState: "FULL"` here, then have
+    /// control-plane tools (shell_exec, credential_*, …) refused with
+    /// `origin: "remote"` moments later by `RemoteControlPlanePolicy`. Live-
+    /// verified as a real contradiction, not a hypothetical. Now reads the same
+    /// `ToolDispatchContext.current.origin` that policy already uses: `.remote`
+    /// → `"online"` (the existing vocabulary `bridge_status` uses for a healthy
+    /// tunnel; `BridgeInitializeService.capabilityState` already treats it as
+    /// `.full` via its default case — no downstream logic change needed).
+    /// `.local` (or no ambient context, e.g. stdio/tests) → `"local"`, unchanged.
     public static let defaultContextProvider: ContextProvider = { client in
-        BridgeInitializeContext(
+        let origin = ToolDispatchContext.current?.origin ?? .local
+        return BridgeInitializeContext(
             client: client,
-            connectionState: "local",
+            connectionState: origin == .remote ? "online" : "local",
             macToolsAvailable: true,
             bridgeState: "running",
             now: Date()

--- a/TheBridgeTests/BridgeInitializeTests.swift
+++ b/TheBridgeTests/BridgeInitializeTests.swift
@@ -292,6 +292,68 @@ func runBridgeInitializeTests() async {
         try expect(ann?.requiresConfirmation == false, "no confirmation (tier .open)")
         try expect(ann?.openWorld == false, "touches only this app's own doctrine/evidence")
     }
+
+    // ── defaultContextProvider origin-awareness (2026-07-10 fix) ────────
+    // Previously hardcoded connectionState: "local" unconditionally, so a
+    // remote/cloud connector caller was told "local"/FULL capability here,
+    // then had control-plane tools refused with origin:"remote" moments
+    // later by RemoteControlPlanePolicy — a real, live-observed contradiction.
+    await test("Init: defaultContextProvider reports connectionState=online for remote-origin callers") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let gate = SecurityGate()
+            let log = AuditLog()
+            let router = ToolRouter(securityGate: gate, auditLog: log)
+            await BridgeInitializeModule.register(on: router)
+            guard let reg = await router.allRegistrations().first(where: { $0.name == "bridge_initialize" }) else {
+                throw TestError.assertion("bridge_initialize must be registered")
+            }
+            let remoteContext = ToolDispatchContext(transportSessionId: "remote-test-session", origin: .remote)
+            let result = try await ToolDispatchContext.$current.withValue(remoteContext) {
+                try await reg.handler(.object([:]))
+            }
+            guard case .object(let d) = result else {
+                throw TestError.assertion("bridge_initialize result must be an object")
+            }
+            try expect(d["connectionState"] == .string("online"),
+                       "remote-origin caller must NOT be told connectionState=local, got \(String(describing: d["connectionState"]))")
+            try expect(d["capabilityState"] == .string("FULL"),
+                       "online + macToolsAvailable must still classify FULL")
+        }
+    }
+
+    await test("Init: defaultContextProvider reports connectionState=local for local-origin/no-ambient-context callers") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let gate = SecurityGate()
+            let log = AuditLog()
+            let router = ToolRouter(securityGate: gate, auditLog: log)
+            await BridgeInitializeModule.register(on: router)
+            guard let reg = await router.allRegistrations().first(where: { $0.name == "bridge_initialize" }) else {
+                throw TestError.assertion("bridge_initialize must be registered")
+            }
+            // No ToolDispatchContext.current set at all (e.g. stdio/local dispatch) —
+            // must still default to "local", not silently regress to something else.
+            let result = try await reg.handler(.object([:]))
+            guard case .object(let d) = result else {
+                throw TestError.assertion("bridge_initialize result must be an object")
+            }
+            try expect(d["connectionState"] == .string("local"),
+                       "no ambient dispatch context must default to local, got \(String(describing: d["connectionState"]))")
+
+            let localContext = ToolDispatchContext(transportSessionId: nil, origin: .local)
+            let result2 = try await ToolDispatchContext.$current.withValue(localContext) {
+                try await reg.handler(.object([:]))
+            }
+            guard case .object(let d2) = result2 else {
+                throw TestError.assertion("bridge_initialize result must be an object")
+            }
+            try expect(d2["connectionState"] == .string("local"),
+                       "explicit local origin must report connectionState=local")
+        }
+    }
 }
 
 // Per-test throwaway HOME so the on-disk standing-orders + receipt stores are

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2084,6 +2084,12 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3118}"
 # default) for a net +8 over 3118. Measured 3126 passed, 0 failed on this
 # branch. FLOOR raised 3118 -> 3126.
 FLOOR="${BRIDGE_TEST_FLOOR:-3126}"
+# v3.9.9 build 79 (2026-07-10): bridge_initialize origin-awareness fix
+# (defaultContextProvider hardcoded connectionState:"local" for every caller;
+# now reads ToolDispatchContext.current.origin). +2 tests
+# (BridgeInitializeTests.swift: remote origin -> "online"/FULL, local/no-
+# context -> "local"). Measured 3128 passed, 0 failed. FLOOR raised 3126 -> 3128.
+FLOOR="${BRIDGE_TEST_FLOOR:-3128}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- `bridge_initialize`'s `defaultContextProvider` hardcoded `connectionState: "local"` for every caller, regardless of actual origin — live-caught today via a remote/cloud connector session that was told `"local"`/`capabilityState: FULL`, then had `shell_exec` refused moments later with `origin: "remote"` by the Wave 1 broker. A real, reproducible contradiction between two subsystems that were never wired together (root-caused via direct code inspection, not guesswork).
- Fixed to read `ToolDispatchContext.current.origin` — the same `@TaskLocal` `RemoteControlPlanePolicy` already uses — mapping `.remote` → `"online"` (existing `bridge_status` vocabulary; already classifies `capabilityState: FULL` via the default case, so zero downstream logic change) and `.local`/no-ambient-context → `"local"`, unchanged.
- Build-only release (marketing stays `3.9.9`, build `78 → 79`) — operator decision to reserve `4.0.0` for a deliberate sale-ready release rather than consume it on a routine internal bugfix, even though `3.9.9` is the mechanical next version under this repo's roll-at-9 rule.

## Test plan
- [x] `make test` — 3128 passed, 0 failed (+2 new: remote origin → `"online"`/`FULL`, local/no-context → `"local"`)
- [x] `make test-floor` — floor 3128 met
- [ ] CI green on this PR
- [ ] Post-merge: rebuild+reinstall locally, live-verify via a fresh claude.ai connector session that `bridge_initialize` now reports `connectionState: "online"` for remote origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)