### PR TITLE
feat(observability): add diagnosis and build provenance (PKT-1116)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>AppIdentifierPrefix</key>
 	<string>VP24Z9CS22.</string>
+	<key>BridgeGitDirty</key>
+	<false/>
+	<key>BridgeGitSHA</key>
+	<string>unknown</string>
 	<key>CFBundleDisplayName</key>
 	<string>The Bridge</string>
 	<key>CFBundleExecutable</key>

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ SPARKLE_ED_KEY_FILE ?=
 LICENSE_PUBLIC_KEY_BASE64URL ?=
 LICENSE_KEY_INJECT_FILE = TheBridge/Core/Licensing/LicensePublicKeyInjected.swift
 
+# PKT-1116: snapshot source provenance when make starts, before the existing
+# license/OAuth injection prerequisites rewrite generated Swift inputs.
+BUILD_GIT_SHA   := $(shell git rev-parse --verify HEAD 2>/dev/null || echo unknown)
+BUILD_GIT_DIRTY := $(if $(shell git status --porcelain --untracked-files=normal 2>/dev/null),true,false)
+
 INFO_PLIST      = Info.plist
 RESOURCES_DIR   = TheBridge/App/Resources
 DMG_ICON        = $(RESOURCES_DIR)/Assets.xcassets/AppIcon.appiconset/icon_512x512.png
@@ -136,6 +141,10 @@ app: build extension jobrunner
 	@cp $(RELEASE_DIR)/$(BINARY_NAME) "$(APP_BUNDLE)/Contents/MacOS/$(BINARY_NAME)"
 	@install_name_tool -add_rpath "@loader_path/../Frameworks" "$(APP_BUNDLE)/Contents/MacOS/$(BINARY_NAME)"
 	@cp $(INFO_PLIST) $(APP_BUNDLE)/Contents/Info.plist
+	@# PKT-1116: stamp the packaged plist after the copy so the committed
+	@# Info.plist remains a stable placeholder and build provenance reflects
+	@# the exact source tree used for this bundle.
+	@bash scripts/stamp-build-provenance.sh "$(APP_BUNDLE)/Contents/Info.plist" "$(CURDIR)" "$(BUILD_GIT_SHA)" "$(BUILD_GIT_DIRTY)"
 	@test -f $(RESOURCES_DIR)/TheBridge.icns && \
 		cp $(RESOURCES_DIR)/TheBridge.icns $(APP_BUNDLE)/Contents/Resources/ || true
 	@for f in $(RESOURCES_DIR)/*.png; do \

--- a/TheBridge/Config/BuildProvenance.swift
+++ b/TheBridge/Config/BuildProvenance.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Build-time source provenance stamped into the packaged app's Info.plist.
+/// Raw SwiftPM/test binaries have no packaged plist seam and therefore report
+/// the explicit `unknown` fallback instead of probing git at runtime (a
+/// notarized app may not have a repository checkout at all).
+public struct BuildProvenance: Sendable, Equatable {
+    public static let gitSHAInfoKey = "BridgeGitSHA"
+    public static let gitDirtyInfoKey = "BridgeGitDirty"
+
+    public let gitSHA: String
+    public let gitDirty: Bool
+
+    public init(gitSHA: String, gitDirty: Bool) {
+        self.gitSHA = gitSHA
+        self.gitDirty = gitDirty
+    }
+
+    public static var current: BuildProvenance {
+        from(infoDictionary: Bundle.main.infoDictionary ?? [:])
+    }
+
+    public static func from(infoDictionary: [String: Any]) -> BuildProvenance {
+        let rawSHA = (infoDictionary[gitSHAInfoKey] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sha = (rawSHA?.isEmpty == false) ? rawSHA! : "unknown"
+        let dirty = infoDictionary[gitDirtyInfoKey] as? Bool ?? false
+        return BuildProvenance(gitSHA: sha, gitDirty: dirty)
+    }
+}

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -409,7 +409,9 @@ public enum BridgeConstants {
     ///   family, no new family). 199 + 1 = 200.
     /// Bridge Evolution W1 broker: + doctrine_sync (request-tier single writer
     ///   for doctrine-core.md, joins existing standing_orders family). 200 + 1 = 201.
-    public static let staticFeatureModuleToolCount = 201
+    /// PKT-1116 Observability: + audit_recent (read-only session-family audit
+    ///   projection; no new family). 201 + 1 = 202.
+    public static let staticFeatureModuleToolCount = 202
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Modules/AccessibilityModule.swift
+++ b/TheBridge/Modules/AccessibilityModule.swift
@@ -98,6 +98,12 @@ public enum AccessibilityModule {
         public static let maxDepthCeiling = 60
         /// Absolute cap on total visited nodes per traversal.
         public static let maxNodes = 20_000
+        /// Hard ceiling for the number of direct children serialized from any
+        /// one node. Prevents a single 200+ sibling group from dominating the
+        /// traversal before the global node budget can help.
+        public static let maxChildrenPerNode = 100
+        /// Hard cap for the final compact JSON payload returned by ax_tree.
+        public static let maxSerializedCharacters = 100_000
         /// Wall-clock budget for a single traversal.
         public static let timeBudget: TimeInterval = 8.0
         /// Per-message AX timeout (seconds). Bounds a single hung AX read so an
@@ -110,6 +116,8 @@ public enum AccessibilityModule {
     public enum TruncationReason: String, Sendable {
         case depth
         case nodeCount = "node_count"
+        case childrenPerNode = "children_per_node"
+        case byteBudget = "byte_budget"
         case time
         case cancelled
     }
@@ -122,18 +130,24 @@ public enum AccessibilityModule {
     public final class TraversalBudget {
         public let maxDepth: Int
         public let maxNodes: Int
+        public let maxChildrenPerNode: Int
+        public let maxSerializedCharacters: Int
         public let deadline: Date
         public private(set) var visited = 0
         public private(set) var truncation: TruncationReason?
 
         public init(requestedDepth: Int,
+                    requestedMaxChildren: Int = TraversalLimits.maxChildrenPerNode,
                     maxNodes: Int = TraversalLimits.maxNodes,
+                    maxSerializedCharacters: Int = TraversalLimits.maxSerializedCharacters,
                     timeBudget: TimeInterval = TraversalLimits.timeBudget,
                     now: Date = Date()) {
             // Clamp requested depth to [0, ceiling]; negative requests collapse
             // to a single-node read rather than an error.
             self.maxDepth = max(0, min(requestedDepth, TraversalLimits.maxDepthCeiling))
+            self.maxChildrenPerNode = max(1, min(requestedMaxChildren, TraversalLimits.maxChildrenPerNode))
             self.maxNodes = maxNodes
+            self.maxSerializedCharacters = max(256, maxSerializedCharacters)
             self.deadline = now.addingTimeInterval(timeBudget)
         }
 
@@ -169,6 +183,43 @@ public enum AccessibilityModule {
                 return false
             }
             return true
+        }
+
+        /// Pure per-node child allowance used only by ax_tree. Search traversal
+        /// intentionally does not call this method, preserving ax_inspect /
+        /// find_element behavior exactly.
+        public func childAllowance(totalCount: Int) -> (allowed: Int, truncated: Int) {
+            let safeTotal = max(0, totalCount)
+            let allowed = min(safeTotal, maxChildrenPerNode)
+            let truncated = safeTotal - allowed
+            if truncated > 0, truncation == nil { truncation = .childrenPerNode }
+            return (allowed, truncated)
+        }
+
+        /// Enforce the final serialized-output budget. If the full payload
+        /// would exceed the cap, replace it with a compact diagnostic instead
+        /// of returning a partial or invalid JSON document.
+        public func enforceSerializedOutputBudget(_ payload: Value) -> Value {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            guard let data = try? encoder.encode(payload),
+                  let json = String(data: data, encoding: .utf8) else {
+                truncation = .byteBudget
+                return byteBudgetNotice(estimatedCharacters: nil)
+            }
+            guard json.count > maxSerializedCharacters else { return payload }
+            truncation = .byteBudget
+            return byteBudgetNotice(estimatedCharacters: json.count)
+        }
+
+        private func byteBudgetNotice(estimatedCharacters: Int?) -> Value {
+            var notice: [String: Value] = [
+                "truncated": .string(TruncationReason.byteBudget.rawValue),
+                "characterBudget": .int(maxSerializedCharacters),
+                "message": .string("ax_tree output exceeded the serialized character budget; narrow maxDepth/maxChildren or use ax_inspect.")
+            ]
+            if let estimatedCharacters { notice["estimatedCharacters"] = .int(estimatedCharacters) }
+            return .object(notice)
         }
     }
 
@@ -365,22 +416,33 @@ public enum AccessibilityModule {
             position: position(el), size: size(el))
 
         if flat {
-            results.append(.object(d))
+            var admittedChildren: ArraySlice<AXUIElement> = []
             if budget.canDescend(currentDepth: depth) {
-                for child in children(el) {
+                let kids = children(el)
+                let allowance = budget.childAllowance(totalCount: kids.count)
+                if allowance.truncated > 0 {
+                    d["childrenTruncated"] = .int(allowance.truncated)
+                }
+                admittedChildren = kids.prefix(allowance.allowed)
+            }
+            results.append(.object(d))
+            for child in admittedChildren {
                     guard budget.admit() else { break }
                     _ = elementDict(child, depth: depth + 1, budget: budget,
                                     flat: true, path: curPath, results: &results)
-                }
             }
             return .null
         } else {
             if budget.canDescend(currentDepth: depth) {
                 let kids = children(el)
                 if !kids.isEmpty {
+                    let allowance = budget.childAllowance(totalCount: kids.count)
+                    if allowance.truncated > 0 {
+                        d["childrenTruncated"] = .int(allowance.truncated)
+                    }
                     var childValues: [Value] = []
-                    childValues.reserveCapacity(kids.count)
-                    for child in kids {
+                    childValues.reserveCapacity(allowance.allowed)
+                    for child in kids.prefix(allowance.allowed) {
                         guard budget.admit() else { break }
                         childValues.append(
                             elementDict(child, depth: depth + 1, budget: budget,
@@ -593,6 +655,9 @@ public enum AccessibilityModule {
         do {
             let pid = try resolvePid(params)
             let maxD = intParam(params, "maxDepth", default: 5)
+            let maxChildren = intParam(
+                params, "maxChildren",
+                default: TraversalLimits.maxChildrenPerNode)
             let flat = boolParam(params, "flat", default: false)
             let appEl = AXUIElementCreateApplication(pid)
             applyMessagingTimeout(appEl)
@@ -600,7 +665,9 @@ public enum AccessibilityModule {
                 throw AXModuleError.appNotFound(pid: pid)
             }
 
-            let budget = TraversalBudget(requestedDepth: maxD)
+            let budget = TraversalBudget(
+                requestedDepth: maxD,
+                requestedMaxChildren: maxChildren)
             _ = budget.admit() // count the root
             var flatResults: [Value] = []
             let tree = elementDict(appEl, depth: 0, budget: budget,
@@ -614,7 +681,7 @@ public enum AccessibilityModule {
                 out["tree"] = tree
             }
             if let reason = budget.truncation { out["truncated"] = .string(reason.rawValue) }
-            return .object(out)
+            return budget.enforceSerializedOutputBudget(.object(out))
         } catch let e as AXModuleError { return e.toResponse() } catch { return .object(["error": .string("Unexpected: \(error)")]) }
     }
 
@@ -755,12 +822,13 @@ public enum AccessibilityModule {
             name: "ax_tree",
             module: moduleName,
             tier: .open,
-            description: "Dump the full AX element tree for one app. Each element carries its stable AX `identifier` (the SwiftUI `.accessibilityIdentifier`) when set, so elements can be resolved by id rather than by volatile label. Expensive — cap with maxDepth. Use ax_inspect (mode='find_element') for targeted lookups.",
+            description: "Dump the bounded AX element tree for one app. Each element carries its stable AX `identifier` when set. Direct children are capped at 100 per node by default and the final JSON is capped at ~100k characters; truncation is marked. Use maxDepth/maxChildren to narrow output or ax_inspect (mode='find_element') for targeted lookups.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "pid":      .object(["type": .string("integer"), "description": .string("Process ID. Omit for frontmost app.")]),
                     "maxDepth": .object(["type": .string("integer"), "description": .string("Max traversal depth (default: 5)")]),
+                    "maxChildren": .object(["type": .string("integer"), "description": .string("Maximum direct children per node (default/hard ceiling: 100).")]),
                     "flat":     .object(["type": .string("boolean"), "description": .string("Return flat array instead of tree (default: false)")])
                 ])
             ]),

--- a/TheBridge/Modules/Cloud/CloudStatusModule.swift
+++ b/TheBridge/Modules/Cloud/CloudStatusModule.swift
@@ -105,23 +105,23 @@ public actor CloudHeartbeat {
 
 /// Builds the canonical `bridge_status` payload from a `CloudConnectionState`.
 ///
-/// SCHEMA (v1) — the WS-B static Worker JSON (PKT-920) MUST mirror this:
+/// SCHEMA (v2) — the WS-B static Worker JSON (PKT-920) MUST mirror this:
 ///   {
 ///     "tool":  "bridge_status",        // string, constant
 ///     "ok":    true,                   // bool, constant (the probe itself succeeded)
 ///     "state": "online",               // string raw value of CloudConnectionState
 ///                                       //   one of: disabled|connecting|online|degraded|offline
 ///     "up":    true,                   // bool — true iff state ∈ {online, degraded}
-///     "macToolsAvailable": true,       // bool — true iff Mac tools are exposed
-///                                       //   to a cloud caller in this state
-///                                       //   (same predicate as `up`)
-///     "schemaVersion": 1               // int — payload contract version
+///     "macToolsAvailable": true,       // bool — actual local dispatch surface
+///     "gitSHA": "0123abcd...",        // string — build-time commit
+///     "gitDirty": false,               // bool — build-time tree state
+///     "schemaVersion": 2               // int — payload contract version
 ///   }
 public enum CloudStatusPayload {
 
     /// Current payload contract version. Bump on any shape change so WS-B can
     /// detect drift.
-    public static let schemaVersion = 1
+    public static let schemaVersion = 2
 
     /// Whether the channel is "up" for serving delegated work. `.online` and
     /// `.degraded` both count as up (degraded = channel impaired but present);
@@ -130,21 +130,28 @@ public enum CloudStatusPayload {
         state == .online || state == .degraded
     }
 
-    /// Whether Mac tools should be exposed to a CLOUD caller in `state`. Mirrors
-    /// `isUp` and the tools/list conditional in `ServerManager`: online and
-    /// degraded expose tools; disabled, connecting, and offline do not.
-    public static func macToolsAvailable(_ state: CloudConnectionState) -> Bool {
-        isUp(state)
+    /// Whether the live router has any dispatchable Mac tools beyond the
+    /// always-visible cloud probe itself. This is intentionally independent of
+    /// tunnel state: `up` answers channel health; `macToolsAvailable` answers
+    /// local dispatch readiness.
+    public static func macToolsAvailable(in registrations: [ToolRegistration]) -> Bool {
+        registrations.contains { !ServerManager.cloudAlwaysVisibleTools.contains($0.name) }
     }
 
     /// The canonical `bridge_status` JSON value.
-    public static func make(state: CloudConnectionState) -> Value {
+    public static func make(
+        state: CloudConnectionState,
+        macToolsAvailable: Bool,
+        buildProvenance: BuildProvenance = .current
+    ) -> Value {
         .object([
             "tool":               .string("bridge_status"),
             "ok":                 .bool(true),
             "state":              .string(state.rawValue),
             "up":                 .bool(isUp(state)),
-            "macToolsAvailable":  .bool(macToolsAvailable(state)),
+            "macToolsAvailable":  .bool(macToolsAvailable),
+            "gitSHA":             .string(buildProvenance.gitSHA),
+            "gitDirty":           .bool(buildProvenance.gitDirty),
             "schemaVersion":      .int(schemaVersion)
         ])
     }
@@ -165,20 +172,30 @@ public enum CloudStatusModule {
     /// `manager`. Handler is `.open` tier (pure read of local cloud state —
     /// no Keychain, no tunnel mutation, no network).
     public static func register(on router: ToolRouter, manager: BridgeCloudManager) async {
-        await router.register(makeTool(manager: manager))
+        await router.register(makeTool(
+            manager: manager,
+            macToolsAvailabilityProvider: {
+                CloudStatusPayload.macToolsAvailable(in: await router.allRegistrations())
+            }
+        ))
     }
 
     /// Factory for the `bridge_status` registration (exposed for tests).
-    public static func makeTool(manager: BridgeCloudManager) -> ToolRegistration {
+    public static func makeTool(
+        manager: BridgeCloudManager,
+        macToolsAvailabilityProvider: @escaping @Sendable () async -> Bool,
+        buildProvenanceProvider: @escaping @Sendable () -> BuildProvenance = { .current }
+    ) -> ToolRegistration {
         ToolRegistration(
             name: toolName,
             module: moduleName,
             tier: .open,
             description: "Report Bridge Cloud Access health for this Mac. Returns the "
                 + "connection state (disabled|connecting|online|degraded|offline), whether the "
-                + "channel is up (online/degraded), and whether Mac tools are exposed to a cloud "
-                + "caller in the current state. Pure read of local cloud state — no side effects. "
-                + "Returns { tool, ok, state, up, macToolsAvailable, schemaVersion }.",
+                + "channel is up (online/degraded), whether local Mac-tool dispatch is available, "
+                + "and the packaged build git SHA/dirty stamp. "
+                + "Pure read of local state — no side effects. Returns { tool, ok, state, up, "
+                + "macToolsAvailable, gitSHA, gitDirty, schemaVersion }.",
             inputSchema: .object([
                 "type":       .string("object"),
                 "properties": .object([:]),
@@ -196,7 +213,12 @@ public enum CloudStatusModule {
             ),
             handler: { _ in
                 let state = await manager.state
-                return CloudStatusPayload.make(state: state)
+                let macToolsAvailable = await macToolsAvailabilityProvider()
+                return CloudStatusPayload.make(
+                    state: state,
+                    macToolsAvailable: macToolsAvailable,
+                    buildProvenance: buildProvenanceProvider()
+                )
             }
         )
     }

--- a/TheBridge/Modules/SessionModule.swift
+++ b/TheBridge/Modules/SessionModule.swift
@@ -6,8 +6,11 @@ import MCP
 
 // MARK: - SessionModule
 
-/// Provides session tools: tools_list (V1-03), session_info (V1-04), session_clear (V1-04).
+/// Provides session tools: tools_list, session_info, audit_recent, session_clear.
 public enum SessionModule {
+
+    public static let auditRecentDefaultLimit = 20
+    public static let auditRecentMaximumLimit = 100
 
     public struct RuntimeDiagnostics: Sendable {
         public let connections: Int
@@ -184,6 +187,109 @@ public enum SessionModule {
             }
         ))
 
+        // audit_recent — open (PKT-1116). Read-only projection of the
+        // already-retained in-memory audit trail. Deliberately omits
+        // `inputSummary`: agents need the refusal/result trail, not a replay of
+        // caller-supplied material. Credential-tool output summaries are also
+        // redacted defensively even though ToolRouter normally stores only an
+        // object-key summary.
+        await router.register(ToolRegistration(
+            name: "audit_recent",
+            module: moduleName,
+            tier: .open,
+            description: "Return the most-recent in-memory audit entries so an agent can diagnose why a tool call was approved, rejected, escalated, or failed. Filter by exact tool name, approval status, or security tier. Input summaries are never returned; credential-tool output summaries are redacted.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "description": .string("Maximum entries to return (default 20, range 1...100).")
+                    ]),
+                    "tool": .object([
+                        "type": .string("string"),
+                        "description": .string("Optional exact tool-name filter.")
+                    ]),
+                    "status": .object([
+                        "type": .string("string"),
+                        "enum": .array(ApprovalStatus.allCases.map { .string($0.rawValue) }),
+                        "description": .string("Optional approval status: approved | rejected | escalated | error.")
+                    ]),
+                    "tier": .object([
+                        "type": .string("string"),
+                        "enum": .array(SecurityTier.allCases.map { .string($0.rawValue) }),
+                        "description": .string("Optional security tier: open | notify | request.")
+                    ])
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Recent Audit Trail",
+                whenToUse: ["Diagnose why a recent Bridge tool call was blocked, escalated, or failed."],
+                whenNotToUse: ["Clearing audit history (use session_clear with explicit confirmation)."],
+                relatedTools: ["session_info", "session_clear"]
+            ),
+            handler: { arguments in
+                let args: [String: Value]
+                if case .object(let object) = arguments { args = object } else { args = [:] }
+
+                let limit: Int = {
+                    guard case .int(let requested) = args["limit"] else {
+                        return auditRecentDefaultLimit
+                    }
+                    return max(1, min(requested, auditRecentMaximumLimit))
+                }()
+                let toolFilter: String? = {
+                    guard case .string(let value) = args["tool"], !value.isEmpty else { return nil }
+                    return value
+                }()
+                let statusFilter: ApprovalStatus?
+                if case .string(let raw) = args["status"] {
+                    guard let parsed = ApprovalStatus(rawValue: raw) else {
+                        return .object(["error": .string("Invalid status '\(raw)'. Expected approved, rejected, escalated, or error.")])
+                    }
+                    statusFilter = parsed
+                } else {
+                    statusFilter = nil
+                }
+                let tierFilter: SecurityTier?
+                if case .string(let raw) = args["tier"] {
+                    guard let parsed = SecurityTier(rawValue: raw) else {
+                        return .object(["error": .string("Invalid tier '\(raw)'. Expected open, notify, or request.")])
+                    }
+                    tierFilter = parsed
+                } else {
+                    tierFilter = nil
+                }
+
+                // Use AuditLog's indexed read seams for the first available
+                // filter, then compose any remaining predicates locally.
+                var entries: [AuditEntry]
+                if let toolFilter {
+                    entries = await auditLog.entries(forTool: toolFilter)
+                } else if let statusFilter {
+                    entries = await auditLog.entries(withStatus: statusFilter)
+                } else if let tierFilter {
+                    entries = await auditLog.entries(forTier: tierFilter)
+                } else {
+                    entries = await auditLog.allEntries()
+                }
+                if let toolFilter { entries.removeAll { $0.toolName != toolFilter } }
+                if let statusFilter { entries.removeAll { $0.approvalStatus != statusFilter } }
+                if let tierFilter { entries.removeAll { $0.tier != tierFilter } }
+
+                let recent = entries
+                    .sorted { $0.timestamp > $1.timestamp }
+                    .prefix(limit)
+                    .map(auditEntryValue)
+                return .object([
+                    "entries": .array(Array(recent)),
+                    "count": .int(recent.count),
+                    "limit": .int(limit),
+                    "inputSummaryIncluded": .bool(false)
+                ])
+            }
+        ))
+
         // session_clear – notify (V1-04)
         await router.register(ToolRegistration(
             name: "session_clear",
@@ -221,5 +327,23 @@ public enum SessionModule {
                 ])
             }
         ))
+    }
+
+    /// Public pure projection for secrecy/shape tests. `inputSummary` and
+    /// `governanceNote` are intentionally absent from the wire response.
+    public static func auditEntryValue(_ entry: AuditEntry) -> Value {
+        let outputSummary = entry.toolName.hasPrefix("credential_")
+            ? "<redacted: credential tool>"
+            : entry.outputSummary
+        return .object([
+            "timestamp": .string(ISO8601DateFormatter().string(from: entry.timestamp)),
+            "toolName": .string(entry.toolName),
+            "tier": .string(entry.tier.rawValue),
+            "approvalStatus": .string(entry.approvalStatus.rawValue),
+            "outputSummary": .string(outputSummary),
+            "durationMs": .double(entry.durationMs),
+            "origin": entry.origin.map { .string($0.rawValue) } ?? .null,
+            "transportSessionId": entry.transportSessionId.map(Value.string) ?? .null
+        ])
     }
 }

--- a/TheBridge/Security/AuditLog.swift
+++ b/TheBridge/Security/AuditLog.swift
@@ -6,7 +6,7 @@ import Foundation
 
 // MARK: - Approval Status
 
-public enum ApprovalStatus: String, Sendable, Codable {
+public enum ApprovalStatus: String, Sendable, Codable, CaseIterable {
     case approved = "approved"
     case rejected = "rejected"
     case escalated = "escalated"

--- a/TheBridge/Server/ServerManager.swift
+++ b/TheBridge/Server/ServerManager.swift
@@ -278,8 +278,7 @@ public actor ServerManager {
 
         // 5. Wire ListTools handler — PKT-350: filter disabled tools
         let isCloudRequest = self.isCloudRequest
-        let cloudManager = self.cloudManager
-        await server.withMethodHandler(ListTools.self) { [router, toolAllowlist, isCloudRequest, cloudManager] _ in
+        await server.withMethodHandler(ListTools.self) { [router, toolAllowlist, isCloudRequest] _ in
             let disabledNames = CredentialsFeature.mergedDisabledToolNames()
             var registrations = await router.registrationsForListTools(disabledNames: disabledNames)
 
@@ -287,13 +286,16 @@ public actor ServerManager {
                 registrations = registrations.filter { allowlist.contains($0.name) }
             }
 
-            // WS-D (PKT-921): on a CLOUD request, hide Mac tools when the cloud
-            // channel is offline/disabled. A local stdio/SSE request (the
-            // default — `isCloudRequest` resolves false) always sees the full
-            // surface, so this is behaviour-preserving for existing clients.
+            // PKT-1116: use the same real router-dispatch signal that
+            // bridge_status reports. Tunnel health (`up`) and local dispatch
+            // availability are orthogonal; neither is inferred from the other.
             if await isCloudRequest() {
-                let cloudState = await cloudManager?.state ?? .disabled
-                registrations = Self.filterForCloud(registrations, cloudState: cloudState)
+                let allRegistrations = await router.allRegistrations()
+                let macToolsAvailable = CloudStatusPayload.macToolsAvailable(in: allRegistrations)
+                registrations = Self.filterForCloud(
+                    registrations,
+                    macToolsAvailable: macToolsAvailable
+                )
             }
 
             registrations = BrokerBootstrapToolOrdering.prioritize(registrations)
@@ -390,22 +392,20 @@ public actor ServerManager {
 
     // MARK: - WS-D (PKT-921): Bridge Cloud Access — heartbeat + tools/list filter
 
-    /// The set of tools a CLOUD caller may always see, regardless of channel
-    /// health. `bridge_status` is the cloud-safe probe; everything else is a
-    /// "Mac tool" hidden when the channel is offline/disabled.
+    /// The set of tools a CLOUD caller may always see. `bridge_status` is the
+    /// cloud-safe probe; everything else is hidden when the live router has no
+    /// dispatchable Mac-tool surface.
     public static let cloudAlwaysVisibleTools: Set<String> = [CloudStatusModule.toolName]
 
-    /// Pure, unit-testable tools/list conditional. For a CLOUD request:
-    ///   • state ∈ {.offline, .disabled, .connecting} → omit Mac tools (keep only
-    ///     `cloudAlwaysVisibleTools`, e.g. `bridge_status`).
-    ///   • state ∈ {.online, .degraded} → full list.
-    /// A non-cloud (local) request never calls this; it always gets the full
-    /// list. Mirrors `CloudStatusPayload.macToolsAvailable`.
+    /// Pure, unit-testable tools/list conditional. For a CLOUD request, expose
+    /// the same Mac-tool surface reported by `bridge_status.macToolsAvailable`.
+    /// Channel health is reported separately as `up` and does not stand in for
+    /// router readiness. A non-cloud request never calls this filter.
     public static func filterForCloud(
         _ registrations: [ToolRegistration],
-        cloudState: CloudConnectionState
+        macToolsAvailable: Bool
     ) -> [ToolRegistration] {
-        guard CloudStatusPayload.macToolsAvailable(cloudState) else {
+        guard macToolsAvailable else {
             return registrations.filter { cloudAlwaysVisibleTools.contains($0.name) }
         }
         return registrations

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -346,6 +346,7 @@ public enum ToolAnnotationCatalog {
         "screen_ocr": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "screen_record_start": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "screen_record_stop": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "audit_recent": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "session_clear": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "session_info": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),
         "shell_exec": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: true, openWorld: true),

--- a/TheBridgeTests/AccessibilityModuleTests.swift
+++ b/TheBridgeTests/AccessibilityModuleTests.swift
@@ -219,6 +219,80 @@ func runAccessibilityModuleTests() async {
         }
     }
 
+    await test("PKT-1116 TraversalBudget caps a 215-child node at 100 and reports omitted count") {
+        try await MainActor.run {
+            let b = AccessibilityModule.TraversalBudget(requestedDepth: 5)
+            let allowance = b.childAllowance(totalCount: 215)
+            try expect(allowance.allowed == 100, "expected 100 admitted children, got \(allowance.allowed)")
+            try expect(allowance.truncated == 115, "childrenTruncated must report 115 omitted children")
+            try expect(b.truncation == .childrenPerNode,
+                       "wide-node clamp must mark children_per_node")
+        }
+    }
+
+    await test("PKT-1116 maxChildren request is clamped to the hard 100-child ceiling") {
+        try await MainActor.run {
+            let high = AccessibilityModule.TraversalBudget(
+                requestedDepth: 5,
+                requestedMaxChildren: 10_000)
+            let low = AccessibilityModule.TraversalBudget(
+                requestedDepth: 5,
+                requestedMaxChildren: 7)
+            try expect(high.maxChildrenPerNode == AccessibilityModule.TraversalLimits.maxChildrenPerNode,
+                       "high request must clamp to the hard ceiling")
+            try expect(low.maxChildrenPerNode == 7, "caller may lower the per-node cap")
+        }
+    }
+
+    await test("PKT-1116 byte budget keeps an in-budget payload unchanged") {
+        try await MainActor.run {
+            let b = AccessibilityModule.TraversalBudget(
+                requestedDepth: 5,
+                maxSerializedCharacters: 512)
+            let payload: Value = .object(["tree": .string("small")])
+            let result = b.enforceSerializedOutputBudget(payload)
+            try expect(result == payload, "in-budget payload must remain byte-identical")
+            try expect(b.truncation == nil, "in-budget payload must not mark truncation")
+        }
+    }
+
+    await test("PKT-1116 byte budget returns a compact marked notice under the cap") {
+        try await MainActor.run {
+            let b = AccessibilityModule.TraversalBudget(
+                requestedDepth: 5,
+                maxSerializedCharacters: 512)
+            let oversized: Value = .object(["tree": .string(String(repeating: "x", count: 2_000))])
+            let result = b.enforceSerializedOutputBudget(oversized)
+            guard case .object(let object) = result else {
+                throw TestError.assertion("byte-budget replacement must be an object")
+            }
+            try expect(object["truncated"] == .string("byte_budget"),
+                       "replacement must mark truncated:byte_budget")
+            let data = try JSONEncoder().encode(result)
+            let chars = String(data: data, encoding: .utf8)?.count ?? .max
+            try expect(chars <= b.maxSerializedCharacters,
+                       "compact notice must stay under cap: \(chars) > \(b.maxSerializedCharacters)")
+            try expect(b.truncation == .byteBudget, "budget state must record byte_budget")
+        }
+    }
+
+    await test("PKT-1116 ax_tree schema exposes maxChildren without changing ax_inspect") {
+        let tools = await router.registrations(forModule: "accessibility")
+        guard let tree = tools.first(where: { $0.name == "ax_tree" }),
+              case .object(let schema) = tree.inputSchema,
+              case .object(let properties) = schema["properties"] else {
+            throw TestError.assertion("ax_tree schema must be inspectable")
+        }
+        try expect(properties["maxChildren"] != nil, "ax_tree must expose maxChildren")
+        guard let inspect = tools.first(where: { $0.name == "ax_inspect" }),
+              case .object(let inspectSchema) = inspect.inputSchema,
+              case .object(let inspectProperties) = inspectSchema["properties"] else {
+            throw TestError.assertion("ax_inspect schema must be inspectable")
+        }
+        try expect(inspectProperties["maxChildren"] == nil,
+                   "find_element/ax_inspect traversal contract must remain unchanged")
+    }
+
     // --- PKT-1005 remainder (a): identifier is queryable in serialized output ---
     //
     // ax_tree (elementDict) and ax_inspect mode=find_element (findElementPayload)

--- a/TheBridgeTests/CloudStatusModuleTests.swift
+++ b/TheBridgeTests/CloudStatusModuleTests.swift
@@ -10,10 +10,9 @@
 //   2. bridge_status registration is GATED — present after
 //      `registerCloudStatusTool`, absent after `deregister`; never in the
 //      static feature-module surface. Handler returns the canonical payload.
-//   3. CloudStatusPayload / tools/list conditional — `up` + `macToolsAvailable`
-//      by state, and `ServerManager.filterForCloud`: cloud+offline → only
-//      bridge_status; cloud+online/degraded → full; the local path is
-//      never filtered.
+//   3. CloudStatusPayload / tools-list conditional — tunnel `up` and real
+//      router dispatch availability are independent but share one
+//      `macToolsAvailable` signal between payload and filter.
 
 import Foundation
 import TheBridgeLib
@@ -45,6 +44,18 @@ private func sampleMacTools() -> [ToolRegistration] {
         )
     }
     return [mk("file_read"), mk("shell_exec"), mk("messages_send")]
+}
+
+private func makeStatusTool(
+    manager: BridgeCloudManager,
+    macToolsAvailable: Bool = true,
+    provenance: BuildProvenance = .init(gitSHA: "test-sha", gitDirty: false)
+) -> ToolRegistration {
+    CloudStatusModule.makeTool(
+        manager: manager,
+        macToolsAvailabilityProvider: { macToolsAvailable },
+        buildProvenanceProvider: { provenance }
+    )
 }
 
 func runCloudStatusModuleTests() async {
@@ -148,7 +159,7 @@ func runCloudStatusModuleTests() async {
 
     await test("WS-D bridge_status: handler returns the canonical payload shape") {
         let mgr = await makeManager(health: .healthy)   // → .online
-        let reg = CloudStatusModule.makeTool(manager: mgr)
+        let reg = makeStatusTool(manager: mgr)
         let out = try await reg.handler(.object([:]))
         guard case .object(let obj) = out else {
             throw TestError.assertion("payload must be a JSON object, got \(out)")
@@ -157,69 +168,78 @@ func runCloudStatusModuleTests() async {
         try expect(obj["ok"] == .bool(true), "ok field")
         try expect(obj["state"] == .string("online"), "state should be online, got \(String(describing: obj["state"]))")
         try expect(obj["up"] == .bool(true), "online ⇒ up=true")
-        try expect(obj["macToolsAvailable"] == .bool(true), "online ⇒ macToolsAvailable=true")
+        try expect(obj["macToolsAvailable"] == .bool(true), "injected dispatch signal")
+        try expect(obj["gitSHA"] == .string("test-sha"), "build-time SHA field")
+        try expect(obj["gitDirty"] == .bool(false), "build-time dirty field")
         try expect(obj["schemaVersion"] == .int(CloudStatusPayload.schemaVersion), "schemaVersion field")
+        try expect(CloudStatusPayload.schemaVersion == 2, "PKT-1116 payload shape must be schema v2")
     }
 
-    await test("WS-D bridge_status: degraded is 'up'; connecting/offline/disabled are 'down'") {
-        // Pure payload-builder checks across all five states.
+    await test("PKT-1116 bridge_status: up and macToolsAvailable can diverge") {
         try expect(CloudStatusPayload.isUp(.online), "online up")
         try expect(CloudStatusPayload.isUp(.degraded), "degraded up")
         try expect(!CloudStatusPayload.isUp(.connecting), "connecting not up")
         try expect(!CloudStatusPayload.isUp(.offline), "offline not up")
         try expect(!CloudStatusPayload.isUp(.disabled), "disabled not up")
 
-        if case .object(let deg) = CloudStatusPayload.make(state: .degraded) {
-            try expect(deg["up"] == .bool(true) && deg["macToolsAvailable"] == .bool(true),
-                       "degraded ⇒ up + macToolsAvailable true")
-        } else { throw TestError.assertion("degraded payload not an object") }
+        if case .object(let onlineWithoutDispatch) = CloudStatusPayload.make(
+            state: .online,
+            macToolsAvailable: false,
+            buildProvenance: .init(gitSHA: "sha", gitDirty: true)
+        ) {
+            try expect(onlineWithoutDispatch["up"] == .bool(true), "online channel must report up")
+            try expect(onlineWithoutDispatch["macToolsAvailable"] == .bool(false),
+                       "online channel must not fabricate local dispatch readiness")
+        } else { throw TestError.assertion("online payload not an object") }
 
-        if case .object(let conn) = CloudStatusPayload.make(state: .connecting) {
-            try expect(conn["up"] == .bool(false) && conn["macToolsAvailable"] == .bool(false),
-                       "connecting ⇒ up + macToolsAvailable false")
-        } else { throw TestError.assertion("connecting payload not an object") }
-
-        if case .object(let off) = CloudStatusPayload.make(state: .offline) {
-            try expect(off["up"] == .bool(false) && off["macToolsAvailable"] == .bool(false),
-                       "offline ⇒ up + macToolsAvailable false")
+        if case .object(let offlineWithDispatch) = CloudStatusPayload.make(
+            state: .offline,
+            macToolsAvailable: true,
+            buildProvenance: .init(gitSHA: "sha", gitDirty: false)
+        ) {
+            try expect(offlineWithDispatch["up"] == .bool(false), "offline channel must report down")
+            try expect(offlineWithDispatch["macToolsAvailable"] == .bool(true),
+                       "offline channel must preserve real local dispatch readiness")
         } else { throw TestError.assertion("offline payload not an object") }
     }
 
-    // MARK: - 3. tools/list conditional by state
+    await test("PKT-1116 bridge_status reads SHA and dirty flag from Info.plist shape") {
+        let clean = BuildProvenance.from(infoDictionary: [
+            BuildProvenance.gitSHAInfoKey: "abc123",
+            BuildProvenance.gitDirtyInfoKey: false
+        ])
+        try expect(clean == BuildProvenance(gitSHA: "abc123", gitDirty: false),
+                   "Info.plist build provenance must round-trip")
+        let fallback = BuildProvenance.from(infoDictionary: [:])
+        try expect(fallback.gitSHA == "unknown" && fallback.gitDirty == false,
+                   "non-app SwiftPM binaries need an explicit stable fallback")
+    }
 
-    await test("WS-D tools/list: CLOUD + .offline → only bridge_status (Mac tools hidden)") {
+    // MARK: - 3. tools/list conditional by real dispatch availability
+
+    await test("PKT-1116 tools/list: dispatch unavailable → only bridge_status") {
         var regs = sampleMacTools()
-        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
-        let filtered = ServerManager.filterForCloud(regs, cloudState: .offline)
+        regs.append(makeStatusTool(manager: await makeManager(health: .healthy), macToolsAvailable: false))
+        let filtered = ServerManager.filterForCloud(regs, macToolsAvailable: false)
         let names = Set(filtered.map(\.name))
         try expect(names == [CloudStatusModule.toolName],
-                   "offline cloud request must expose ONLY bridge_status, got \(names.sorted())")
+                   "unavailable Mac dispatch must expose ONLY bridge_status, got \(names.sorted())")
     }
 
-    await test("WS-D tools/list: CLOUD + .disabled → only bridge_status") {
+    await test("PKT-1116 tools/list: dispatch available → full list regardless of channel state") {
         var regs = sampleMacTools()
-        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
-        let filtered = ServerManager.filterForCloud(regs, cloudState: .disabled)
-        try expect(Set(filtered.map(\.name)) == [CloudStatusModule.toolName],
-                   "disabled cloud request must expose ONLY bridge_status")
+        regs.append(makeStatusTool(manager: await makeManager(health: .healthy)))
+        let filtered = ServerManager.filterForCloud(regs, macToolsAvailable: true)
+        try expect(filtered.count == regs.count,
+                   "available Mac dispatch must keep the full list")
     }
 
-    await test("WS-D tools/list: CLOUD + .connecting → only bridge_status") {
-        var regs = sampleMacTools()
-        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
-        let filtered = ServerManager.filterForCloud(regs, cloudState: .connecting)
-        try expect(Set(filtered.map(\.name)) == [CloudStatusModule.toolName],
-                   "connecting cloud request must expose ONLY bridge_status")
-    }
-
-    await test("WS-D tools/list: CLOUD + .online/.degraded → full list (Mac tools shown)") {
-        var regs = sampleMacTools()
-        regs.append(CloudStatusModule.makeTool(manager: await makeManager(health: .healthy)))
-        for state in [CloudConnectionState.online, .degraded] {
-            let filtered = ServerManager.filterForCloud(regs, cloudState: state)
-            try expect(filtered.count == regs.count,
-                       "\(state) must keep the full list (\(filtered.count) vs \(regs.count))")
-        }
+    await test("PKT-1116 router readiness ignores bridge_status-only surface") {
+        let statusOnly = [makeStatusTool(manager: await makeManager(health: .healthy))]
+        try expect(!CloudStatusPayload.macToolsAvailable(in: statusOnly),
+                   "bridge_status alone is not a dispatchable Mac-tool surface")
+        try expect(CloudStatusPayload.macToolsAvailable(in: statusOnly + sampleMacTools()),
+                   "a non-cloud registration proves Mac-tool dispatch availability")
     }
 
     await test("WS-D tools/list: non-cloud (local) request is never filtered") {
@@ -232,7 +252,7 @@ func runCloudStatusModuleTests() async {
         // WERE applied with a non-down state, is also a no-op — assert the
         // online passthrough as the local-equivalent invariant.
         let regs = sampleMacTools()
-        let passthrough = ServerManager.filterForCloud(regs, cloudState: .online)
+        let passthrough = ServerManager.filterForCloud(regs, macToolsAvailable: true)
         try expect(passthrough.count == regs.count, "online (local-equivalent) keeps full list")
     }
 }

--- a/TheBridgeTests/IntegrationTests/EndToEndTests.swift
+++ b/TheBridgeTests/IntegrationTests/EndToEndTests.swift
@@ -360,7 +360,7 @@ func runEndToEndTests() async {
 
         try expect(shell.count == 2, "ShellModule: expected 2")
         try expect(file.count == 12, "FileModule: expected 12")
-        try expect(session.count == 3, "SessionModule: expected 3")
+        try expect(session.count == 4, "SessionModule: expected 4 (PKT-1116 audit_recent)")
         try expect(messages.count == 6, "MessagesModule: expected 6")
         try expect(system.count == 3, "SystemModule: expected 3")
         try expect(contacts.count == 4, "ContactsModule: expected 4")

--- a/TheBridgeTests/SessionModuleTests.swift
+++ b/TheBridgeTests/SessionModuleTests.swift
@@ -20,9 +20,9 @@ func runSessionModuleTests() async {
     )
 
     // Registration
-    await test("SessionModule registers 3 tools") {
+    await test("SessionModule registers 4 tools") {
         let tools = await router.registrations(forModule: "session")
-        try expect(tools.count == 3, "Expected 3 session tools, got \(tools.count)")
+        try expect(tools.count == 4, "Expected 4 session tools, got \(tools.count)")
     }
 
     await test("SessionModule tool names match spec") {
@@ -30,6 +30,7 @@ func runSessionModuleTests() async {
         let names = Set(tools.map(\.name))
         try expect(names.contains("tools_list"), "Missing tools_list")
         try expect(names.contains("session_info"), "Missing session_info")
+        try expect(names.contains("audit_recent"), "Missing audit_recent")
         try expect(names.contains("session_clear"), "Missing session_clear")
     }
 
@@ -39,6 +40,7 @@ func runSessionModuleTests() async {
         let tierMap = Dictionary(uniqueKeysWithValues: tools.map { ($0.name, $0.tier) })
         try expect(tierMap["tools_list"] == .open, "tools_list should be green")
         try expect(tierMap["session_info"] == .open, "session_info should be green")
+        try expect(tierMap["audit_recent"] == .open, "audit_recent should be green")
         try expect(tierMap["session_clear"] == .notify, "session_clear should be orange")
     }
 
@@ -49,7 +51,7 @@ func runSessionModuleTests() async {
             arguments: .object([:])
         )
         if case .array(let tools) = result {
-            try expect(tools.count == 3, "Expected 3 tools from session-only router, got \(tools.count)")
+            try expect(tools.count == 4, "Expected 4 tools from session-only router, got \(tools.count)")
         } else {
             throw TestError.assertion("Expected array result from tools_list")
         }
@@ -70,7 +72,7 @@ func runSessionModuleTests() async {
             arguments: .object(["module": .string("session")])
         )
         if case .array(let tools) = result {
-            try expect(tools.count == 3, "Module filter should return only session tools, got \(tools.count)")
+            try expect(tools.count == 4, "Module filter should return only session tools, got \(tools.count)")
             for tool in tools {
                 if case .object(let dict) = tool,
                    case .string(let mod) = dict["module"] {
@@ -188,6 +190,89 @@ func runSessionModuleTests() async {
         }
         try expect(connections == 0, "Expected 0 connections with no provider, got \(connections)")
         try expect(activeClients == 0, "Expected 0 activeClients with no provider, got \(activeClients)")
+    }
+
+    // audit_recent: read-only refusal trail with composable filters and no
+    // caller input echo. Use a dedicated log/router so existing test traffic
+    // cannot obscure ordering or filter assertions.
+    await test("audit_recent returns newest entries and composes tool/status/tier filters") {
+        let auditGate = SecurityGate()
+        let auditLog = AuditLog()
+        let auditRouter = ToolRouter(securityGate: auditGate, auditLog: auditLog)
+        await SessionModule.register(on: auditRouter, auditLog: auditLog)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        await auditLog.append(AuditEntry(
+            timestamp: base, toolName: "shell_exec", tier: .request,
+            inputSummary: "secret-old", outputSummary: "denied-old",
+            durationMs: 2, approvalStatus: .rejected,
+            origin: .remote, transportSessionId: "session-old"))
+        await auditLog.append(AuditEntry(
+            timestamp: base.addingTimeInterval(1), toolName: "shell_exec", tier: .request,
+            inputSummary: "secret-new", outputSummary: "denied-new",
+            durationMs: 3, approvalStatus: .rejected,
+            origin: .local, transportSessionId: "session-new"))
+        await auditLog.append(AuditEntry(
+            timestamp: base.addingTimeInterval(2), toolName: "shell_exec", tier: .request,
+            inputSummary: "approved-input", outputSummary: "approved-output",
+            durationMs: 4, approvalStatus: .approved))
+
+        let result = try await auditRouter.dispatch(
+            toolName: "audit_recent",
+            arguments: .object([
+                "tool": .string("shell_exec"),
+                "status": .string("rejected"),
+                "tier": .string("request"),
+                "limit": .int(1)
+            ]))
+        guard case .object(let object) = result,
+              case .array(let entries) = object["entries"], entries.count == 1,
+              case .object(let newest) = entries[0] else {
+            throw TestError.assertion("Expected one filtered audit entry, got \(result)")
+        }
+        try expect(newest["outputSummary"] == .string("denied-new"), "newest matching entry must win")
+        try expect(newest["origin"] == .string("local"), "origin must be projected")
+        try expect(newest["transportSessionId"] == .string("session-new"), "transport session id must be projected")
+        try expect(newest["inputSummary"] == nil, "audit_recent must never expose inputSummary")
+        try expect(object["inputSummaryIncluded"] == .bool(false), "response must declare input omission")
+    }
+
+    await test("audit_recent redacts credential summaries and omits secret-bearing fields") {
+        let secret = "sk-proj-super-secret-value"
+        let entry = AuditEntry(
+            timestamp: Date(), toolName: "credential_read", tier: .request,
+            inputSummary: secret, outputSummary: secret,
+            durationMs: 1, approvalStatus: .approved,
+            governed: true, origin: .remote,
+            transportSessionId: "remote-credential-session",
+            governanceNote: secret)
+        let value = SessionModule.auditEntryValue(entry)
+        guard case .object(let object) = value else {
+            throw TestError.assertion("Expected audit projection object")
+        }
+        try expect(object["inputSummary"] == nil, "credential input summary must be omitted")
+        try expect(object["governanceNote"] == nil, "governance note must be omitted")
+        try expect(object["outputSummary"] == .string("<redacted: credential tool>"),
+                   "credential output summary must be redacted")
+        let encoded = String(data: try JSONEncoder().encode(value), encoding: .utf8) ?? ""
+        try expect(!encoded.contains(secret), "serialized audit projection must not contain credential material")
+    }
+
+    await test("audit_recent validates filter enums and clamps limit") {
+        let invalid = try await router.dispatch(
+            toolName: "audit_recent",
+            arguments: .object(["status": .string("nope")]))
+        guard case .object(let invalidObject) = invalid,
+              case .string = invalidObject["error"] else {
+            throw TestError.assertion("invalid status must return a structured error")
+        }
+        let clamped = try await router.dispatch(
+            toolName: "audit_recent",
+            arguments: .object(["limit": .int(10_000)]))
+        guard case .object(let clampedObject) = clamped else {
+            throw TestError.assertion("clamped response must be an object")
+        }
+        try expect(clampedObject["limit"] == .int(SessionModule.auditRecentMaximumLimit),
+                   "limit must clamp to the documented maximum")
     }
 
     // session_clear: requires confirm = true

--- a/scripts/stamp-build-provenance.sh
+++ b/scripts/stamp-build-provenance.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+PLIST_PATH="${1:?usage: stamp-build-provenance.sh <Info.plist> [repo-root] [git-sha] [git-dirty]}"
+REPO_ROOT="${2:-$(pwd)}"
+
+if [[ ! -f "$PLIST_PATH" ]]; then
+  echo "error: build provenance plist not found: $PLIST_PATH" >&2
+  exit 1
+fi
+
+GIT_SHA="${3:-$(git -C "$REPO_ROOT" rev-parse --verify HEAD)}"
+if [[ $# -ge 4 ]]; then
+  GIT_DIRTY="$4"
+else
+  GIT_DIRTY=false
+  if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=normal)" ]]; then
+    GIT_DIRTY=true
+  fi
+fi
+if [[ "$GIT_DIRTY" != "true" && "$GIT_DIRTY" != "false" ]]; then
+  echo "error: git-dirty must be true or false, got: $GIT_DIRTY" >&2
+  exit 1
+fi
+
+/usr/libexec/PlistBuddy -c "Delete :BridgeGitSHA" "$PLIST_PATH" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :BridgeGitDirty" "$PLIST_PATH" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :BridgeGitSHA string $GIT_SHA" "$PLIST_PATH"
+/usr/libexec/PlistBuddy -c "Add :BridgeGitDirty bool $GIT_DIRTY" "$PLIST_PATH"
+
+echo "Build provenance: git=$GIT_SHA dirty=$GIT_DIRTY"

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2090,6 +2090,13 @@ FLOOR="${BRIDGE_TEST_FLOOR:-3126}"
 # (BridgeInitializeTests.swift: remote origin -> "online"/FULL, local/no-
 # context -> "local"). Measured 3128 passed, 0 failed. FLOOR raised 3126 -> 3128.
 FLOOR="${BRIDGE_TEST_FLOOR:-3128}"
+# PKT-1116 Observability & Diagnosis (2026-07-11): +3 audit_recent tests
+# (filter/order, credential secrecy, enum/limit validation) and +5 ax_tree
+# traversal-budget tests (wide-child cap, maxChildren clamp, in-budget payload,
+# byte-budget notice, schema isolation). Cloud-status/build-provenance scenarios
+# replace/extend existing WS-D assertions without increasing their count.
+# Measured 3136 passed, 0 failed. FLOOR raised 3128 -> 3136.
+FLOOR="${BRIDGE_TEST_FLOOR:-3136}"
 # v3.7.6 (2026-06-04): credential policy defaults flipped ON; +1 isEnabled default-ON test (1776→1777).
 # v3.7·A (2026-05-28): SkillsCacheReader/Writer pipeline tests landed.
 # +12 SkillsCacheTests covering the on-disk skills cache that closes the


### PR DESCRIPTION
## Summary
- Adds `TheBridge/Config/BuildProvenance.swift` + `scripts/stamp-build-provenance.sh`, wired into `Info.plist`/`Makefile` so each build records where/how it was produced.
- Extends `CloudStatusModule`, `SessionModule`, `AccessibilityModule` diagnostics and `ToolAnnotations` with provenance-aware reporting.
- This directly resolves a build-provenance / drift-diagnosability gap flagged earlier in the branch-audit session (no way to tell, from a running install, whether it was built from a clean commit or a dirty worktree — which was the actual root cause of a prior production incident on `codex/cloud-oauth-readiness`).
- +regression tests across `AccessibilityModuleTests`, `CloudStatusModuleTests`, `SessionModuleTests`; floor bump included in `scripts/test-floor-gate.sh`.

Found as a clean, already-committed local branch during a git-branch audit — pushing for review, not auto-merged.

## Test plan
- [ ] CI green on this PR
- [ ] Confirm `make install-copy` still stamps provenance correctly on a real build (matches the single-invocation-with-env rule in CLAUDE.md)