### PR TITLE
docs(claude.md): correct /health tunnel-scoping claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,12 @@ A macOS menu-bar app that exposes the Mac + a Notion workspace to AI agents over
 - **Loopback contract (PKT-810 R5):** `/mcp` from direct loopback (no `Cf-*` header) is
   token-free; only tunnel (Cloudflare `Cf-Connecting-Ip`/`Cf-Ray`) requests are auth-gated.
   The legacy `/sse` + `/messages` routes are dispatched *before* that gate, so they enforce
-  their own check: tunnel-origin legacy requests are **403'd (loopback-only)**; only `/health`
-  + the PRM doc are intentionally tunnel-reachable without auth. cloudflared forwards ALL paths
-  to `:9700` (no path scoping), so the server is the trust boundary.
+  their own check: tunnel-origin legacy requests are **403'd (loopback-only)**, belt-and-
+  braces. Since v3.8.2, `cloudflared` itself (`~/.cloudflared/config.yml`) is path-scoped
+  to only `^/(mcp|\.well-known/)` — everything else, including `/health` and `/sse`, 404s
+  at the edge and never reaches the server. The PRM doc lives under `/.well-known/` so it
+  stays tunnel-reachable without auth; `/health` is loopback-only in practice (not just by
+  server-side gate) — hit it directly on `:9700` for local monitoring, not through the tunnel.
 - **Version:** `Config/Version.swift` (marketing 3.8.1, build 60) + root `Info.plist`
   (CFBundleShortVersionString/CFBundleVersion — the build reads the plist, keep both in sync).
   +1 patch per published install.


### PR DESCRIPTION
## Summary
- CLAUDE.md claimed cloudflared "forwards ALL paths to :9700 (no path scoping)" and that `/health` is "intentionally tunnel-reachable without auth."
- Neither matches the live tunnel config: `~/.cloudflared/config.yml` has scoped ingress to `^/(mcp|\.well-known/)` only since v3.8.2 (dated 2026-06-18) — `/health` and `/sse` 404 at the Cloudflare edge and never reach the server.
- Docs drifted from code when the tunnel was narrowed for defense-in-depth; this closes the gap. No behavior change, no code touched.

Found during a "Loops" closure pass over open threads from the branch-audit/connector-fix session.

## Test plan
- [x] Docs-only change, no build/test impact