### PR TITLE
PKT-1131: Add UUID-first A.I. doctrine cache

### DIFF
--- a/TheBridge/Modules/Skills/SkillBodyCacheModels.swift
+++ b/TheBridge/Modules/Skills/SkillBodyCacheModels.swift
@@ -16,7 +16,12 @@
 // `BridgePaths.applicationSupport(.skillsBodyCache)`):
 //
 //   {
+//     "schemaVersion":  1,
 //     "pageId":         "<32-hex Notion uuid>",
+//     "slug":           "<human/routing identity>",
+//     "version":        "<Notion doctrine version>",
+//     "status":         "<Notion lifecycle status>",
+//     "maturity":       "<Notion maturity>",
 //     "markdown":       "<raw body from skillMarkdownString>",
 //     "title":          "<page title>",
 //     "url":            "<page url>",
@@ -42,8 +47,17 @@ import MCP
 /// `properties` key without re-flattening — and without persisting the
 /// (large) verbatim getPage properties blob. `Value` is `Codable`.
 public struct CachedSkillBody: Codable, Sendable, Equatable {
+    /// Cache wire version. The cache is derived and may be rebuilt at any time.
+    public let schemaVersion: Int
     /// Normalized 32-hex Notion id (no dashes, lowercased).
     public let pageId: String
+    /// Notion-authored human/routing identity fields. These are duplicated
+    /// from `properties` deliberately so UUID-addressed readers do not need
+    /// to know the current SKILLS database property names.
+    public let slug: String
+    public let version: String
+    public let status: String
+    public let maturity: String
     /// Raw body markdown as returned by `SkillsModule.skillMarkdownString`
     /// (pre-section-slice, pre-mention-resolution — the exact input the
     /// network path feeds `buildSkillResult`).
@@ -69,7 +83,12 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
     public let callCount: Int
 
     public init(
+        schemaVersion: Int = 1,
         pageId: String,
+        slug: String? = nil,
+        version: String? = nil,
+        status: String? = nil,
+        maturity: String? = nil,
         markdown: String,
         title: String,
         url: String,
@@ -79,7 +98,12 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
         ttlHours: Int = 24,
         callCount: Int = 1
     ) {
+        self.schemaVersion = schemaVersion
         self.pageId = Self.normalize(pageId)
+        self.slug = slug ?? Self.propertyString("Slug", in: properties)
+        self.version = version ?? Self.propertyString("Version", in: properties)
+        self.status = status ?? Self.propertyString("Status", in: properties)
+        self.maturity = maturity ?? Self.propertyString("Maturity", in: properties)
         self.markdown = markdown
         self.title = title
         self.url = url
@@ -91,17 +115,27 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case pageId, markdown, title, url, properties, lastEditedTime
+        case schemaVersion, pageId, slug, version, status, maturity
+        case markdown, title, url, properties, lastEditedTime
         case writtenAt, ttlHours, callCount
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.pageId = try c.decodeIfPresent(String.self, forKey: .pageId) ?? ""
+        self.schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
+        self.pageId = Self.normalize(try c.decodeIfPresent(String.self, forKey: .pageId) ?? "")
         self.markdown = try c.decodeIfPresent(String.self, forKey: .markdown) ?? ""
         self.title = try c.decodeIfPresent(String.self, forKey: .title) ?? ""
         self.url = try c.decodeIfPresent(String.self, forKey: .url) ?? ""
         self.properties = try c.decodeIfPresent(Value.self, forKey: .properties) ?? .object([:])
+        self.slug = try c.decodeIfPresent(String.self, forKey: .slug)
+            ?? Self.propertyString("Slug", in: properties)
+        self.version = try c.decodeIfPresent(String.self, forKey: .version)
+            ?? Self.propertyString("Version", in: properties)
+        self.status = try c.decodeIfPresent(String.self, forKey: .status)
+            ?? Self.propertyString("Status", in: properties)
+        self.maturity = try c.decodeIfPresent(String.self, forKey: .maturity)
+            ?? Self.propertyString("Maturity", in: properties)
         self.lastEditedTime = try c.decodeIfPresent(String.self, forKey: .lastEditedTime) ?? ""
         let raw = try c.decodeIfPresent(String.self, forKey: .writtenAt) ?? ""
         self.writtenAt = Self.iso8601.date(from: raw) ?? .distantPast
@@ -111,7 +145,12 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(schemaVersion, forKey: .schemaVersion)
         try c.encode(pageId, forKey: .pageId)
+        try c.encode(slug, forKey: .slug)
+        try c.encode(version, forKey: .version)
+        try c.encode(status, forKey: .status)
+        try c.encode(maturity, forKey: .maturity)
         try c.encode(markdown, forKey: .markdown)
         try c.encode(title, forKey: .title)
         try c.encode(url, forKey: .url)
@@ -125,7 +164,9 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
     /// Return a copy with `callCount` set to `n` (writtenAt/markdown kept).
     public func withCallCount(_ n: Int) -> CachedSkillBody {
         CachedSkillBody(
-            pageId: pageId, markdown: markdown, title: title, url: url,
+            schemaVersion: schemaVersion, pageId: pageId, slug: slug,
+            version: version, status: status, maturity: maturity,
+            markdown: markdown, title: title, url: url,
             properties: properties, lastEditedTime: lastEditedTime,
             writtenAt: writtenAt, ttlHours: ttlHours, callCount: n
         )
@@ -140,6 +181,47 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
         return now.timeIntervalSince(writtenAt) > ttl
     }
 
+    /// The minimum Notion-primary doctrine contract from PKT-1131. An
+    /// incomplete live fetch may still be returned to its caller, but it must
+    /// not replace a complete last-known-good cache entry.
+    public var hasMinimumDoctrinePayload: Bool {
+        !pageId.isEmpty
+            && !slug.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !version.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !maturity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Canonical dashed UUID for agent-facing envelopes.
+    public var uuid: String {
+        Self.canonicalUUID(pageId)
+    }
+
+    public static func canonicalUUID(_ pageId: String) -> String {
+        let id = Self.normalize(pageId)
+        guard isNotionUUID(id) else { return id }
+        let parts = [8, 4, 4, 4, 12]
+        var index = id.startIndex
+        var out: [String] = []
+        for size in parts {
+            let end = id.index(index, offsetBy: size)
+            out.append(String(id[index..<end]))
+            index = end
+        }
+        return out.joined(separator: "-")
+    }
+
+    public static func isNotionUUID(_ pageId: String) -> Bool {
+        let id = normalize(pageId)
+        return id.count == 32 && id.unicodeScalars.allSatisfy { scalar in
+            switch scalar.value {
+            case 48...57, 97...102: return true
+            default: return false
+            }
+        }
+    }
+
     /// Canonical id normalization shared by the store + reader: strip
     /// dashes/whitespace, lowercase. Callers may pass either id shape.
     public static func normalize(_ pageId: String) -> String {
@@ -147,6 +229,18 @@ public struct CachedSkillBody: Codable, Sendable, Equatable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "-", with: "")
             .lowercased()
+    }
+
+    /// Case-insensitive scalar lookup over the already-flattened Notion
+    /// properties map. Legacy cache files gain the explicit v1 identity on
+    /// decode without requiring an eager migration.
+    public static func propertyString(_ key: String, in properties: Value) -> String {
+        guard case .object(let dict) = properties,
+              let value = dict.first(where: { $0.key.caseInsensitiveCompare(key) == .orderedSame })?.value,
+              case .string(let string) = value else {
+            return ""
+        }
+        return string
     }
 
     /// ISO-8601 with fractional seconds + UTC — strings round-trip

--- a/TheBridge/Modules/Skills/SkillBodyCacheStore.swift
+++ b/TheBridge/Modules/Skills/SkillBodyCacheStore.swift
@@ -30,6 +30,17 @@ public actor SkillBodyCacheStore {
         self.clock = clock
     }
 
+    /// Aggregate result for a TTL sweep. Partial failures are explicit and
+    /// never evict a last-known-good entry.
+    public struct RefreshReport: Sendable, Equatable {
+        public let discovered: Int
+        public let refreshed: Int
+        public let skippedFresh: Int
+        public let failedPageIds: [String]
+
+        public var partialFailure: Bool { !failedPageIds.isEmpty }
+    }
+
     // MARK: - Read
 
     /// Returns the cached body for `pageId`, or nil when no file exists or
@@ -128,6 +139,10 @@ public actor SkillBodyCacheStore {
     public func refresh(pageId: String, client: NotionClient) async -> CachedSkillBody? {
         do {
             let entry = try await Self.fetchBody(pageId: pageId, client: client)
+            guard entry.hasMinimumDoctrinePayload else {
+                NSLog("[SkillBodyCacheStore] page=%@ missing minimum doctrine identity; retaining prior cache", pageId)
+                return nil
+            }
             try? write(entry)
             return entry
         } catch let error as NotionClientError {
@@ -170,6 +185,37 @@ public actor SkillBodyCacheStore {
         return warmed
     }
 
+    /// TTL poll over the configured Notion skill set. Fresh entries are not
+    /// touched; missing or expired entries are refreshed serially to respect
+    /// Notion API pressure. A failed refresh retains the previous file.
+    public func refreshExpired(source: BodySource, client: NotionClient) async -> RefreshReport {
+        let entries = await source.load()
+        var refreshed = 0
+        var skippedFresh = 0
+        var failed: [String] = []
+
+        for entry in entries {
+            let pid = entry.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pid.isEmpty else { continue }
+            if let cached = read(pageId: pid), !cached.isExpired(now: clock()) {
+                skippedFresh += 1
+                continue
+            }
+            if (await refresh(pageId: pid, client: client)) != nil {
+                refreshed += 1
+            } else {
+                failed.append(CachedSkillBody.normalize(pid))
+            }
+        }
+
+        return RefreshReport(
+            discovered: entries.count,
+            refreshed: refreshed,
+            skippedFresh: skippedFresh,
+            failedPageIds: failed
+        )
+    }
+
     // MARK: - Body fetch (network)
 
     /// Fetch a skill body from Notion and build a `CachedSkillBody`:
@@ -189,13 +235,14 @@ public actor SkillBodyCacheStore {
 
         let markdownData = try await client.getPageMarkdown(pageId: pageId)
         let rawMarkdown = SkillsModule.skillMarkdownString(fromMarkdownJSON: markdownData)
+        let flattened = Value.object(SkillsModule.flattenProperties(props))
 
         return CachedSkillBody(
             pageId: pageId,
             markdown: rawMarkdown,
             title: title,
             url: url,
-            properties: .object(SkillsModule.flattenProperties(props)),
+            properties: flattened,
             lastEditedTime: lastEdited,
             writtenAt: Date(),
             ttlHours: BridgeDefaults.skillsCacheTTLHoursEffective,
@@ -211,5 +258,36 @@ public actor SkillBodyCacheStore {
         let normalized = CachedSkillBody.normalize(pageId)
         return BridgePaths.applicationSupport(.skillsBodyCache)
             .appendingPathComponent("\(normalized).json", isDirectory: false)
+    }
+}
+
+extension SkillBodyCacheStore.BodySource {
+    /// Snapshot every configured Notion-source skill. This is intentionally
+    /// broader than the routing roster: PKT-1131 caches doctrine, not only
+    /// the thin set of routing parents.
+    @MainActor
+    public static func fromSkillsManager(_ manager: SkillsManager) -> SkillBodyCacheStore.BodySource {
+        let configured: [(id: String, title: String)] = manager.skills.compactMap { skill in
+            guard !skill.source.isFile else { return nil }
+            let pid = skill.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pid.isEmpty else { return nil }
+            return (id: pid, title: skill.name)
+        }
+        return SkillBodyCacheStore.BodySource(load: {
+            // The routing refresh runs immediately before the body sweep, so
+            // this view includes curated specialist rows as well as configured
+            // parents. Deduplicate by UUID because a specialist may also be
+            // configured directly.
+            let parents = await SkillsCacheReader.shared.readAll()
+            let routed = parents.flatMap { parent in
+                [(id: parent.parentId, title: parent.parentTitle)]
+                    + parent.children.map { (id: $0.id, title: $0.title) }
+            }
+            var seen: Set<String> = []
+            return (configured + routed).filter { entry in
+                let id = CachedSkillBody.normalize(entry.id)
+                return !id.isEmpty && seen.insert(id).inserted
+            }
+        })
     }
 }

--- a/TheBridge/Modules/SkillsManager.swift
+++ b/TheBridge/Modules/SkillsManager.swift
@@ -532,7 +532,8 @@ public final class SkillsManager {
     /// triggers the same code path on demand.
     public func kickoffBackgroundCacheRefresh() {
         // Snapshot on the main actor (this method IS main-actor).
-        let source = SkillsCacheWriter.ParentSource.fromSkillsManager(self)
+        let routingSource = SkillsCacheWriter.ParentSource.fromSkillsManager(self)
+        let bodySource = SkillBodyCacheStore.BodySource.fromSkillsManager(self)
         Task.detached(priority: .utility) {
             guard let client = try? NotionClient() else {
                 NSLog("[SkillsManager] cache refresh skipped — no Notion token")
@@ -540,9 +541,20 @@ public final class SkillsManager {
             }
             let enumerator = SkillsCacheWriter.ChildEnumerator.live(client: client)
             _ = await SkillsCacheWriter.shared.refreshAll(
-                source: source,
+                source: routingSource,
                 enumerator: enumerator
             )
+            let report = await SkillBodyCacheStore.shared.refreshExpired(
+                source: bodySource,
+                client: client
+            )
+            if report.partialFailure {
+                NSLog(
+                    "[SkillsManager] doctrine TTL refresh partial failure refreshed=%d failed=%d",
+                    report.refreshed,
+                    report.failedPageIds.count
+                )
+            }
         }
     }
 

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -164,6 +164,11 @@ public enum SkillsModule {
             description: """
             Fetch one skill page's full body, OR route into a domain's specialist.
 
+            IDENTITY: prefer `id` (the stable Notion UUID) when an agent already
+            knows the exact skill. Use `name` for human/routing labels and for
+            parent/child or intent-based specialist routing. Exactly one is
+            required; when both are supplied, `id` is authoritative.
+
             RECOMMENDED DEFAULT — call with the parent name + the current intent for \
             EACH new sub-task: name="project-keepr", intent="triage stale projects". \
             The server ranks the parent's curated specialists and returns the best \
@@ -195,6 +200,10 @@ public enum SkillsModule {
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
+                    "id": .object([
+                        "type": .string("string"),
+                        "description": .string("Preferred exact identity for agent calls: the skill's Notion UUID. Resolves configured Notion skills without fuzzy name matching.")
+                    ]),
                     "name": .object([
                         "type": .string("string"),
                         "description": .string("Skill name (case-insensitive). Accepts slash-delimited paths like 'project-keepr/update' to address a specialist; depth > 1 is rejected with an annotation.")
@@ -221,20 +230,64 @@ public enum SkillsModule {
                     ]),
                     "fields": .object([
                         "type": .string("array"),
-                        "description": .string("Optional. Array of top-level envelope keys to project the response down to — e.g. [\"content\"] or [\"title\",\"properties.status\"]. Valid keys: name, title, url, content, summary, triggerPhrases, antiTriggerPhrases, properties (no id/lastEditedTime/stale — those are registry-row-specific). Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Omitted or [] → full response, byte-identical to today. Unknown keys/paths silently absent, never an error. Composes freely with `section` — section picks WHICH slice `content` holds; fields picks WHICH top-level keys appear at all."),
+                        "description": .string("Optional. Array of top-level envelope keys to project the response down to — e.g. [\"content\",\"uuid\",\"version\"] or [\"title\",\"properties.status\"]. Valid identity keys include uuid, slug, version, status, maturity. Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Omitted or [] → the full response. Unknown keys/paths silently absent, never an error."),
                         "items": .object(["type": .string("string")])
                     ])
                 ]),
-                "required": .array([.string("name")])
+                "required": .array([])
             ]),
             handler: { arguments in
-                guard case .object(let args) = arguments,
-                      case .string(let rawName) = args["name"] else {
+                guard case .object(let args) = arguments else {
                     throw ToolRouterError.invalidArguments(
                         toolName: "fetch_skill",
-                        reason: "missing required 'name' parameter"
+                        reason: "expected an object with 'id' or 'name'"
                     )
                 }
+
+                let rawIDArg: String? = {
+                    guard case .string(let raw) = args["id"] else { return nil }
+                    return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                }()
+                let idArg: String? = {
+                    guard let raw = rawIDArg, !raw.isEmpty else { return nil }
+                    let normalized = CachedSkillBody.normalize(raw)
+                    return CachedSkillBody.isNotionUUID(normalized) ? normalized : nil
+                }()
+                let nameArg: String? = {
+                    guard case .string(let raw) = args["name"] else { return nil }
+                    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }()
+                guard idArg != nil || nameArg != nil else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "fetch_skill",
+                        reason: "one of 'id' (preferred UUID) or 'name' is required"
+                    )
+                }
+                if let rawIDArg, !rawIDArg.isEmpty, idArg == nil {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "fetch_skill",
+                        reason: "'id' must be a 32-hex Notion UUID (dashed or compact)"
+                    )
+                }
+
+                let uuidSkill: SkillConfig? = if let idArg {
+                    if let configured = lookupSkill(pageId: idArg) {
+                        configured
+                    } else {
+                        await lookupCachedSpecialist(pageId: idArg)
+                    }
+                } else {
+                    nil
+                }
+                if let idArg, uuidSkill == nil {
+                    return .object([
+                        "error": .string("Skill UUID is not configured in Bridge."),
+                        "id": .string(CachedSkillBody.canonicalUUID(idArg)),
+                        "hint": .string("Refresh or register the Notion skill in Settings → Skills; arbitrary Notion pages are not treated as doctrine.")
+                    ])
+                }
+                let rawName = uuidSkill?.name ?? nameArg ?? ""
 
                 // PKT-907 W1: parse slash-delimited path. Pre-PKT-907
                 // single-name calls flow through unchanged (the parser
@@ -248,6 +301,10 @@ public enum SkillsModule {
                 // PKT-907 W2: optional intent string. Only triggers
                 // specialist ranking when both are present.
                 let intentArg: String? = {
+                    // UUID addressing is exact: never route away from the
+                    // requested doctrine record because an intent was also
+                    // supplied by a generic client wrapper.
+                    guard idArg == nil else { return nil }
                     if case .string(let s) = args["intent"], !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         return s.trimmingCharacters(in: .whitespacesAndNewlines)
                     }
@@ -285,7 +342,7 @@ public enum SkillsModule {
                 let fieldsArg = try FieldsFilter.parseFieldsArgument(args, toolName: "fetch_skill")
 
                 // Look up skill in UserDefaults config (cache key includes metadata fingerprint)
-                guard let skillConfig = lookupSkill(named: name) else {
+                guard let skillConfig = uuidSkill ?? lookupSkill(named: name) else {
                     // W2 D4: fall back to the filesystem index. A file-
                     // source skill with this name (bundled or user dir)
                     // takes effect when Notion-skills don't shadow it.
@@ -407,7 +464,7 @@ public enum SkillsModule {
                     // touch the network, and it runs detached AFTER we return.
                     let store = SkillBodyCacheStore.shared
                     let n = await store.incrementCallCount(pageId: pageIdRaw)
-                    if n > 0, n % 5 == 0 {
+                    if n > 0, cachedBody.isExpired() || n % 5 == 0 {
                         let revalPageId = pageIdRaw
                         let knownEdited = cachedBody.lastEditedTime
                         let memCache = cache
@@ -516,6 +573,11 @@ public enum SkillsModule {
                         titleLookup: Self.makeSkillMentionTitleLookup(),
                         pageProperties: envelopeProperties
                     )
+                    result = Self.annotateDoctrineIdentity(
+                        result,
+                        pageId: envelopePageId,
+                        flattenedProperties: .object(Self.flattenProperties(envelopeProperties))
+                    )
                     // fb-resultsize: surface the section-selector outcome.
                     result = Self.annotateSection(
                         result,
@@ -537,7 +599,7 @@ public enum SkillsModule {
                         // HIT: bump callCount; on every 5th call kick a
                         // DETACHED freshness check (stale-while-revalidate).
                         let n = await bodyStore.incrementCallCount(pageId: envelopePageId)
-                        if n > 0, n % 5 == 0 {
+                        if n > 0, cachedBody?.isExpired() == true || n % 5 == 0 {
                             let revalPageId = envelopePageId
                             let knownEdited = cachedBody?.lastEditedTime ?? ""
                             let memCache = cache
@@ -555,7 +617,8 @@ public enum SkillsModule {
                         // resolved page id (callCount=1, lastEditedTime from
                         // the getPage JSON). flattenProperties matches the
                         // envelope's `properties` builder exactly.
-                        let lastEdited = pageJSON["last_edited_time"] as? String ?? ""
+                        let lastEdited = specialistDispatch.resolvedSpecialist?.lastEditedTime
+                            ?? (pageJSON["last_edited_time"] as? String ?? "")
                         let entry = CachedSkillBody(
                             pageId: envelopePageId,
                             markdown: rawMarkdown,
@@ -567,7 +630,11 @@ public enum SkillsModule {
                             ttlHours: BridgeDefaults.skillsCacheTTLHoursEffective,
                             callCount: 1
                         )
-                        try? await bodyStore.write(entry)
+                        if entry.hasMinimumDoctrinePayload {
+                            try? await bodyStore.write(entry)
+                        } else {
+                            NSLog("[fetch_skill] page=%@ not cached — minimum doctrine identity incomplete", envelopePageId)
+                        }
                     }
 
                     let liveResult = await MemoryRoutingAppendix.attach(
@@ -1786,6 +1853,7 @@ public enum SkillsModule {
         guard let client = try? NotionClient() else { return }
         do {
             let refreshed = try await SkillBodyCacheStore.fetchBody(pageId: pageId, client: client)
+            guard refreshed.hasMinimumDoctrinePayload else { return }
             // Same edit timestamp → body unchanged; leave the cache as-is
             // (do NOT rewrite — a rewrite would needlessly bump writtenAt
             // and reset the callCount cadence).
@@ -1953,6 +2021,12 @@ public enum SkillsModule {
             titleLookup: titleLookup,
             flattenedProperties: cachedBody.properties
         )
+        let identified = annotateDoctrineIdentity(
+            envelope,
+            pageId: cachedBody.pageId,
+            flattenedProperties: cachedBody.properties,
+            cachedIdentity: cachedBody
+        )
         // Plain request → empty dispatch (bare-parent fast path shape):
         // no resolvedSpecialist, no annotation, no siblings → adds nothing.
         let emptyDispatch = SpecialistDispatch(
@@ -1962,7 +2036,25 @@ public enum SkillsModule {
             matchScore: nil,
             matchReason: nil
         )
-        return annotateEnvelope(envelope, parentName: skill.name, dispatch: emptyDispatch)
+        return annotateEnvelope(identified, parentName: skill.name, dispatch: emptyDispatch)
+    }
+
+    /// Add the stable Notion-primary identity contract to a fetched doctrine
+    /// envelope. `content` remains the full body; duplicating it under a
+    /// second key would double large MCP payloads.
+    private static func annotateDoctrineIdentity(
+        _ value: Value,
+        pageId: String,
+        flattenedProperties: Value,
+        cachedIdentity: CachedSkillBody? = nil
+    ) -> Value {
+        guard case .object(var dict) = value else { return value }
+        dict["uuid"] = .string(CachedSkillBody.canonicalUUID(pageId))
+        dict["slug"] = .string(cachedIdentity?.slug ?? CachedSkillBody.propertyString("Slug", in: flattenedProperties))
+        dict["version"] = .string(cachedIdentity?.version ?? CachedSkillBody.propertyString("Version", in: flattenedProperties))
+        dict["status"] = .string(cachedIdentity?.status ?? CachedSkillBody.propertyString("Status", in: flattenedProperties))
+        dict["maturity"] = .string(cachedIdentity?.maturity ?? CachedSkillBody.propertyString("Maturity", in: flattenedProperties))
+        return .object(dict)
     }
 
     /// Public, network-free entry point mirroring `buildSkillResult` but
@@ -1985,25 +2077,32 @@ public enum SkillsModule {
         summary: String = "",
         triggerPhrases: [String] = [],
         antiTriggerPhrases: [String] = [],
+        pageId: String = "00000000000000000000000000000000",
         pageProperties: [String: Any] = [:],
         titleLookup: @escaping MentionResolver.TitleLookup
     ) async -> Value {
         let cfg = SkillConfig(
             name: name,
-            notionPageId: "00000000000000000000000000000000",
+            notionPageId: pageId,
             enabled: true,
             visibility: .standard,
             summary: summary,
             triggerPhrases: triggerPhrases,
             antiTriggerPhrases: antiTriggerPhrases
         )
-        return await buildSkillResult(
+        let flattened: Value = .object(flattenProperties(pageProperties))
+        let result = await buildSkillResult(
             skill: cfg,
             title: title,
             url: url,
             markdownJSONOrText: markdownJSONOrText,
             titleLookup: titleLookup,
             pageProperties: pageProperties
+        )
+        return annotateDoctrineIdentity(
+            result,
+            pageId: pageId,
+            flattenedProperties: flattened
         )
     }
 
@@ -2147,6 +2246,38 @@ public enum SkillsModule {
             $0.name.lowercased().contains(stripped) || stripped.contains($0.name.lowercased())
         }
         if subs.count == 1 { return subs[0] }
+        return nil
+    }
+
+    /// Exact UUID resolver for PKT-1131. Unlike the human-facing name path,
+    /// this never fuzzy-matches: one configured Notion page id maps to one
+    /// doctrine record. File-source skills have no Notion UUID and are
+    /// intentionally excluded.
+    private static func lookupSkill(pageId: String) -> SkillConfig? {
+        let wanted = CachedSkillBody.normalize(pageId)
+        guard CachedSkillBody.isNotionUUID(wanted) else { return nil }
+        return readAllSkills().first { skill in
+            CachedSkillBody.normalize(skill.notionPageId) == wanted
+        }
+    }
+
+    /// Resolve a curated specialist UUID from the existing routing cache.
+    /// The cache is derived from configured parents and cannot widen this
+    /// tool into an arbitrary Notion page reader.
+    private static func lookupCachedSpecialist(pageId: String) async -> SkillConfig? {
+        let wanted = CachedSkillBody.normalize(pageId)
+        guard CachedSkillBody.isNotionUUID(wanted) else { return nil }
+        for parent in await SkillsCacheReader.shared.readAll() {
+            if let child = parent.children.first(where: { CachedSkillBody.normalize($0.id) == wanted }) {
+                return SkillConfig(
+                    name: child.title,
+                    notionPageId: child.id,
+                    enabled: true,
+                    visibility: .standard,
+                    summary: child.summary
+                )
+            }
+        }
         return nil
     }
 
@@ -2422,6 +2553,7 @@ public enum SkillsModule {
             let url: String
             let pageId: String
             let properties: [String: Any]
+            let lastEditedTime: String
         }
         let resolvedSpecialist: ResolvedNotion?
         let resolvedPath: String?
@@ -2657,7 +2789,8 @@ public enum SkillsModule {
                         title: exact.title,
                         url: exact.url,
                         pageId: exact.pageId,
-                        properties: exact.properties
+                        properties: exact.properties,
+                        lastEditedTime: exact.lastEditedTime
                     ),
                     resolvedPath: "\(parentName)/\(exact.title)",
                     annotation: nil,
@@ -2672,7 +2805,8 @@ public enum SkillsModule {
                         title: partial.title,
                         url: partial.url,
                         pageId: partial.pageId,
-                        properties: partial.properties
+                        properties: partial.properties,
+                        lastEditedTime: partial.lastEditedTime
                     ),
                     resolvedPath: "\(parentName)/\(partial.title)",
                     annotation: nil,
@@ -2708,7 +2842,8 @@ public enum SkillsModule {
                             title: resolved.title,
                             url: resolved.url,
                             pageId: resolved.pageId,
-                            properties: resolved.properties
+                            properties: resolved.properties,
+                            lastEditedTime: resolved.lastEditedTime
                         ),
                         resolvedPath: "\(parentName)/\(resolved.title)",
                         annotation: nil,
@@ -2773,6 +2908,7 @@ public enum SkillsModule {
         let title: String
         let url: String
         let properties: [String: Any]
+        let lastEditedTime: String
     }
 
     /// Enumerate a parent skill's CURATED specialists and hydrate each to a
@@ -2824,9 +2960,11 @@ public enum SkillsModule {
             var props: [String: Any] = [:]
             var url = ""
             var resolvedTitle = ""
+            var lastEditedTime = ""
             if let pageData = try? await client.getPage(pageId: cid),
                let json = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any] {
                 url = json["url"] as? String ?? ""
+                lastEditedTime = json["last_edited_time"] as? String ?? ""
                 props = json["properties"] as? [String: Any] ?? [:]
                 if !props.isEmpty {
                     let t = NotionJSON.extractTitle(from: props)
@@ -2851,7 +2989,8 @@ public enum SkillsModule {
                 pageId: cid,
                 title: resolvedTitle,
                 url: url,
-                properties: props
+                properties: props,
+                lastEditedTime: lastEditedTime
             ))
         }
         return out

--- a/TheBridgeTests/FetchSkillPropertiesTests.swift
+++ b/TheBridgeTests/FetchSkillPropertiesTests.swift
@@ -422,7 +422,7 @@ func runFetchSkillPropertiesTests() async {
     }
 
     // ============================================================
-    // MARK: (d) ENVELOPE STABILITY — only `properties` is added
+    // MARK: (d) ENVELOPE STABILITY — additive doctrine identity
     // ============================================================
 
     // The literal pre-cu-sa envelope key set (cmd-w4 era): name, title,
@@ -430,10 +430,11 @@ func runFetchSkillPropertiesTests() async {
     // (summary / triggerPhrases / antiTriggerPhrases). cu-sa adds EXACTLY
     // one key — `properties` — and it is additive on EVERY path (the
     // default no-properties path now also emits `"properties": {}`), so
-    // the true stability contract is: (i) the legacy 9 keys + their
+    // PKT-1131 subsequently adds the explicit doctrine identity tuple.
+    // The stability contract is: (i) the legacy 9 keys + their
     // value types are byte-identical whether properties are empty or
     // populated, and (ii) the only key beyond the legacy set is
-    // `properties`. (The earlier draft of this test wrongly assumed a
+    // known additive keys. (The earlier draft of this test wrongly assumed a
     // runtime "baseline" that does NOT carry `properties`; since the key
     // is unconditionally additive, no such baseline exists — corrected
     // here to assert the real, stronger invariant rather than weaken it.)
@@ -441,8 +442,11 @@ func runFetchSkillPropertiesTests() async {
         "name", "title", "url", "blockCount", "truncated", "content",
         "summary", "triggerPhrases", "antiTriggerPhrases"
     ]
+    let additiveEnvelopeKeys: Set<String> = [
+        "properties", "uuid", "slug", "version", "status", "maturity"
+    ]
 
-    await test("cu-sa (d): legacy keys byte-identical empty↔populated; only `properties` added") {
+    await test("cu-sa (d): legacy keys byte-identical empty↔populated; doctrine identity is additive") {
         // Same inputs, differing ONLY in the new properties blob.
         let empty = await build(
             props: [:],
@@ -461,13 +465,13 @@ func runFetchSkillPropertiesTests() async {
             throw TestError.assertion("both results must be objects")
         }
 
-        // 1. The full key set is EXACTLY the legacy keys ∪ {properties}
-        //    — no key removed, no key added beyond `properties`, on both.
-        let expectedKeys = legacyEnvelopeKeys.union(["properties"])
+        // 1. The full key set is exactly the legacy keys plus the known
+        //    additive properties and doctrine-identity keys.
+        let expectedKeys = legacyEnvelopeKeys.union(additiveEnvelopeKeys)
         try expect(Set(e.keys) == expectedKeys,
-                   "empty-props envelope keys must be legacy ∪ {properties}; got \(Set(e.keys))")
+                   "empty-props envelope keys must be legacy plus additive identity; got \(Set(e.keys))")
         try expect(Set(p.keys) == expectedKeys,
-                   "populated-props envelope keys must be legacy ∪ {properties}; got \(Set(p.keys))")
+                   "populated-props envelope keys must be legacy plus additive identity; got \(Set(p.keys))")
 
         // 2. EVERY legacy key's value is byte-for-byte identical between
         //    the empty and populated envelopes (Value is Equatable —
@@ -498,7 +502,7 @@ func runFetchSkillPropertiesTests() async {
         }
     }
 
-    await test("cu-sa (d): default (no-arg) path emits exactly `properties:{}` and nothing else new") {
+    await test("cu-sa (d): default path emits empty properties plus explicit empty doctrine identity") {
         // The pre-cu-sa wrapper call shape (no pageProperties arg) and
         // the explicit empty-properties call must produce byte-identical
         // envelopes, and that envelope's ONLY non-legacy key is an empty
@@ -516,9 +520,8 @@ func runFetchSkillPropertiesTests() async {
         // Identical envelopes (the default arg IS `[:]`).
         try expect(Value.object(d) == Value.object(x),
                    "default no-arg path must equal explicit empty-props path")
-        // The only key beyond the legacy set is `properties`, == {}.
-        try expect(Set(d.keys).subtracting(legacyEnvelopeKeys) == ["properties"],
-                   "only `properties` may extend the legacy set; got \(Set(d.keys).subtracting(legacyEnvelopeKeys))")
+        try expect(Set(d.keys).subtracting(legacyEnvelopeKeys) == additiveEnvelopeKeys,
+                   "unexpected additive keys; got \(Set(d.keys).subtracting(legacyEnvelopeKeys))")
         guard case .object(let pm)? = d["properties"] else {
             throw TestError.assertion("`properties` must be an object")
         }

--- a/TheBridgeTests/SkillBodyCacheTests.swift
+++ b/TheBridgeTests/SkillBodyCacheTests.swift
@@ -41,7 +41,12 @@ private func sampleBody(
     markdown: String = "# Title\n\nbody line one\n\n## Sub\n\nsub body\n",
     title: String = "Demo Skill",
     url: String = "https://www.notion.so/demo",
-    properties: Value = .object(["Status": .string("Active")]),
+    properties: Value = .object([
+        "Slug": .string("demo-skill"),
+        "Version": .string("1.2.3"),
+        "Status": .string("Active"),
+        "Maturity": .string("Stable")
+    ]),
     lastEditedTime: String = "2026-06-11T10:00:00.000Z",
     writtenAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
     ttlHours: Int = 24,
@@ -71,6 +76,13 @@ func runSkillBodyCacheTests() async {
                 throw TestError.assertion("expected a cached body")
             }
             try expect(got.pageId == entry.pageId, "pageId mismatch")
+            try expect(got.schemaVersion == 1, "schemaVersion mismatch")
+            try expect(got.slug == "demo-skill", "slug mismatch")
+            try expect(got.version == "1.2.3", "version mismatch")
+            try expect(got.status == "Active", "status mismatch")
+            try expect(got.maturity == "Stable", "maturity mismatch")
+            try expect(got.hasMinimumDoctrinePayload, "minimum doctrine payload should be complete")
+            try expect(got.uuid == "11111111-1111-1111-1111-11111111aaaa", "canonical UUID mismatch")
             try expect(got.markdown == entry.markdown, "markdown mismatch")
             try expect(got.title == entry.title, "title mismatch")
             try expect(got.url == entry.url, "url mismatch")
@@ -389,7 +401,10 @@ func runSkillBodyCacheTests() async {
         )
         // Raw getPage properties blob → the network path flattens these.
         let rawProps: [String: Any] = [
-            "Status": ["type": "status", "status": ["name": "Active", "id": "s1"]]
+            "Slug": ["type": "rich_text", "rich_text": [["plain_text": "demo-skill"]]],
+            "Version": ["type": "rich_text", "rich_text": [["plain_text": "1.2.3"]]],
+            "Status": ["type": "status", "status": ["name": "Active", "id": "s1"]],
+            "Maturity": ["type": "select", "select": ["name": "Stable", "id": "m1"]]
         ]
 
         // NETWORK plain envelope: buildSkillResult with flattened props and
@@ -399,6 +414,7 @@ func runSkillBodyCacheTests() async {
             name: "demo", title: "Demo", url: "https://www.notion.so/p1",
             markdownJSONOrText: rawMarkdown,
             summary: "s", triggerPhrases: ["t"], antiTriggerPhrases: ["a"],
+            pageId: "1111111111111111111111111111aaaa",
             pageProperties: rawProps
         ) { _ in nil }
 

--- a/TheBridgeTests/SkillsModuleTests.swift
+++ b/TheBridgeTests/SkillsModuleTests.swift
@@ -97,14 +97,19 @@ func runSkillsModuleTests() async {
     // MARK: - Required Parameters
     // ============================================================
 
-    await test("fetch_skill requires 'name' parameter") {
+    await test("fetch_skill accepts UUID-first or name addressing") {
         let tools = await router.registrations(forModule: "skills")
         let tool = tools.first(where: { $0.name == "fetch_skill" })
         try expect(tool != nil, "fetch_skill not found")
         if case .object(let schema) = tool!.inputSchema,
            case .array(let required) = schema["required"] {
             let requiredNames = required.compactMap { if case .string(let s) = $0 { return s } else { return nil } }
-            try expect(requiredNames.contains("name"), "fetch_skill should require 'name'")
+            try expect(requiredNames.isEmpty, "schema-level required list should allow id or name")
+            guard case .object(let props)? = schema["properties"] else {
+                throw TestError.assertion("fetch_skill schema missing properties")
+            }
+            try expect(props["id"] != nil, "fetch_skill should expose stable UUID 'id'")
+            try expect(props["name"] != nil, "fetch_skill should preserve human/routing 'name'")
         }
     }
 
@@ -251,34 +256,77 @@ func runSkillsModuleTests() async {
         }
     }
 
-    await test("fetch_skill rejects missing name parameter") {
+    await test("fetch_skill rejects requests missing both id and name") {
         do {
             _ = try await router.dispatch(
                 toolName: "fetch_skill",
                 arguments: .object([:])
             )
-            throw TestError.assertion("Expected error for missing name parameter")
+            throw TestError.assertion("Expected error when id and name are both missing")
         } catch is ToolRouterError {
             // Expected — missing required parameter
         }
     }
 
-    await test("fetch_skill handles empty string name gracefully") {
-        let result = try await router.dispatch(
-            toolName: "fetch_skill",
-            arguments: .object(["name": .string("")])
-        )
-        // Should return error or empty result, not crash
-        if case .object(let dict) = result {
-            if case .string(let error) = dict["error"] {
-                try expect(!error.isEmpty, "Error message should be non-empty for empty name")
-            }
-            // Empty result object is also acceptable
-        } else if case .string = result {
-            // String response is acceptable
-        } else {
-            throw TestError.assertion("Expected structured result for empty skill name")
+    await test("fetch_skill rejects an empty name when no id is present") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("")])
+            )
+            throw TestError.assertion("Expected invalidArguments for an empty identity")
+        } catch is ToolRouterError {
+            // expected
         }
+    }
+
+    await test("fetch_skill rejects malformed UUID before name fallback") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["id": .string("not-a-uuid"), "name": .string("anything")])
+            )
+            throw TestError.assertion("Expected invalidArguments for malformed id")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    await test("fetch_skill rejects a 32-character non-hex id") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["id": .string(String(repeating: "g", count: 32))])
+            )
+            throw TestError.assertion("Expected invalidArguments for non-hex id")
+        } catch is ToolRouterError {
+            // expected
+        }
+    }
+
+    await test("fetch_skill doctrine envelope exposes UUID plus Notion identity") {
+        let data = try! JSONSerialization.data(withJSONObject: ["markdown": "# Body"])
+        let md = String(data: data, encoding: .utf8)!
+        let pageProps: [String: Any] = [
+            "Slug": ["type": "rich_text", "rich_text": [["plain_text": "demo-skill"]]],
+            "Version": ["type": "rich_text", "rich_text": [["plain_text": "2.0.0"]]],
+            "Status": ["type": "status", "status": ["name": "Testing"]],
+            "Maturity": ["type": "select", "select": ["name": "Stable"]]
+        ]
+        let envelope = await SkillsModule.buildSkillResultForTesting(
+            name: "demo-skill", title: "Demo", url: "https://n/demo",
+            markdownJSONOrText: md,
+            pageId: "11111111222233334444555555555555",
+            pageProperties: pageProps
+        ) { _ in nil }
+        guard case .object(let dict) = envelope else {
+            throw TestError.assertion("expected doctrine envelope")
+        }
+        try expect(dict["uuid"] == .string("11111111-2222-3333-4444-555555555555"), "uuid missing")
+        try expect(dict["slug"] == .string("demo-skill"), "slug missing")
+        try expect(dict["version"] == .string("2.0.0"), "version missing")
+        try expect(dict["status"] == .string("Testing"), "status missing")
+        try expect(dict["maturity"] == .string("Stable"), "maturity missing")
     }
 
     // ============================================================

--- a/docs/design/PKT-1131-ai-doctrine-cache.md
+++ b/docs/design/PKT-1131-ai-doctrine-cache.md
@@ -1,0 +1,87 @@
+# PKT-1131 — A.I. Doctrine Cache
+
+Status: implementation candidate for review
+Authority: Notion is the write source of truth; Bridge is a disposable, derived read cache.
+
+## Decision
+
+V1 caches **SKILLS only**. BOTS, AI LOGS, and BUGS have different state, retention, and write semantics and are intentionally excluded. Adding them to the same payload would blur doctrine with operational records and would couple this packet to schema owned by other Keeprs.
+
+Bridge extends its existing skill-body cache and `fetch_skill` protocol rather than introducing another registry or sync service:
+
+- Agent calls prefer the Notion page UUID through `fetch_skill.id`.
+- Slug/name remains available for people, routing, and compatibility.
+- A cached record contains schema version, canonical page UUID, slug, doctrine version, full Markdown body, status, maturity, mirrored Notion properties, source URL/title, Notion `last_edited_time`, cache write time, TTL, and call count.
+- UUID resolution is limited to configured Bridge skills and specialists discovered through their curated routing relations. An arbitrary Notion page ID cannot turn `fetch_skill` into an unrestricted page reader.
+- The response envelope exposes `uuid`, `slug`, `version`, `status`, and `maturity` beside the full `content` body.
+
+Disk files remain an implementation cache under Bridge's existing cache directory. They have no write-back path and can be deleted and rebuilt from Notion without loss of authoritative state.
+
+## Existing topology reused
+
+The implementation keeps the current separation:
+
+1. `SkillsManager` owns the configured-skill roster and parent/specialist topology.
+2. `SkillsCacheWriter` maintains the thin routing roster.
+3. `SkillBodyCacheStore` maintains full bodies, keyed by normalized Notion page ID, using atomic writes.
+4. `SkillsModule.fetch_skill` resolves a configured skill and serves memory, disk, or Notion while preserving the existing plain-fetch fast path.
+5. Notion mutation tools already evict affected skill-body entries.
+
+No new database, manifest, schema, or bidirectional synchronizer is added.
+
+## Fetch and identity protocol
+
+`fetch_skill` accepts one of:
+
+- `id`: canonical or compact Notion UUID. This is the preferred, exact agent identity and is authoritative if both fields are supplied.
+- `name`: existing human/routing label path, retained for compatibility.
+
+Success returns the stable identity tuple plus the full body. A malformed UUID is an input error; a well-formed but unconfigured UUID is a not-found error. Existing name ambiguity rules remain in force. Cache files written before schema version 1 decode compatibly and derive the identity tuple from mirrored properties when possible.
+
+## Invalidation and refresh
+
+V1 keeps the existing configurable TTL, defaulting to 24 hours, and strengthens it:
+
+- Startup performs a background sweep of configured Notion parents plus their curated routing specialists and refreshes entries that are missing or expired.
+- An expired entry triggers revalidation immediately when accessed; fresh entries keep the existing periodic validator cadence.
+- Notion `last_edited_time` remains the cheap content validator.
+- Known Notion writes evict the affected cache entry.
+- Refresh is atomic per UUID. A failed or incomplete refresh never replaces a complete last-known-good entry.
+- A refresh sweep returns explicit counts and failed UUIDs so partial failure is observable without invalidating successful records.
+
+A body hash adds little in V1 because detecting a changed hash still requires fetching Notion. Webhooks would reduce the stale window, but introduce host reachability, delivery authentication, retry storage, and multi-host fan-out. TTL plus source timestamps is the appropriate first protocol; a webhook can later act only as an eviction hint while TTL remains the repair path.
+
+## Failure semantics
+
+- Network or Notion failure: retain the prior complete cache record and report the failed UUID.
+- Missing required doctrine fields: serve the live result when possible, but do not persist it over a complete record.
+- Partial startup sweep: preserve successful refreshes and expose the failed IDs in the refresh report.
+- Deleted/unconfigured skill: UUID lookup fails closed; existing explicit cache eviction paths remain responsible for removing obsolete files.
+- Cache corruption: existing reader behavior treats the file as a miss and rebuilds from Notion.
+
+Required cache completeness is UUID, slug, version, non-empty full body, status, and maturity. This validation is Bridge-side only and does not mutate the Notion A.I. schema.
+
+## Risks and controls
+
+| Risk | Control / residual |
+| --- | --- |
+| Up to one TTL of staleness on an idle host | Startup sweep, access revalidation, and write eviction reduce the window; no push invalidation in V1. |
+| Multi-host refresh load | Sweep only missing/expired entries and run in the existing background startup task; large fleets may later need jitter or bounded concurrency. |
+| Slug rename or collision | UUID is the agent identity; slug is a label and compatibility route. |
+| Incomplete Notion records | Completeness gate refuses to overwrite last-known-good cache; source schema quality remains owned by NOTION Keepr. |
+| Local cache disclosure | Full doctrine already exists in the current Bridge cache; this change adds explicit metadata, not a new persistence surface. Existing local permissions remain the boundary. |
+| Old cache files lack explicit fields | Backward-compatible decoding derives fields from mirrored properties; incomplete legacy entries are refreshed. |
+| No webhook | TTL is deterministic repair. A future authenticated webhook should only evict by UUID, never write doctrine. |
+
+## Implementation and verification plan
+
+1. Extend `CachedSkillBody` with a versioned identity tuple and completeness validation.
+2. Add UUID-first `fetch_skill` resolution against configured skills and annotate all success envelopes.
+3. Add a startup missing/expired body sweep with explicit partial-failure reporting and last-known-good retention.
+4. Correct specialist freshness tracking to use the child's `last_edited_time`, not the parent's.
+5. Cover cache round-trip/backward shape, UUID schema/input behavior, and response identity in the standalone test suite.
+6. Run the repository test floor. Review and merge normally; no Notion schema migration or cache-to-Notion write is part of rollout.
+
+## Rollback
+
+Revert the implementation commit. Existing cache files remain readable by the new code and disposable by design; deleting them only causes a Notion rebuild. No authoritative doctrine or Notion schema must be rolled back.


### PR DESCRIPTION
## What changed

- extends the existing full-body skill cache with a versioned UUID/slug/version/status/maturity identity contract
- adds UUID-first exact addressing to `fetch_skill` while retaining name/slug routing compatibility
- refreshes missing or expired configured parents and curated specialists at startup using the existing 24-hour TTL
- retains last-known-good records on partial or incomplete refreshes and reports failed UUIDs
- corrects specialist freshness validation to use the specialist page timestamp
- records the protocol, risks, scope boundary, and rollback in `docs/design/PKT-1131-ai-doctrine-cache.md`

## Why

PKT-1131 needs multi-host agents to consume complete, stable-ID doctrine without making Bridge a second write source of truth. Notion remains authoritative; Bridge stores only a disposable one-way read cache.

## Scope

V1 is SKILLS-only. BOTS, AI LOGS, BUGS, Notion schema changes, webhook delivery, merge, and release are excluded.

## Validation

- `swift build -c debug`
- `make test-floor` — 3,152 passed, 0 failed
