### PR TITLE
fix(tools): stabilize agent discovery surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Every module exposes a `static func register(on router: ToolRouter) async` metho
 
 MCP metadata (`summary`, `triggerPhrases`, `antiTriggerPhrases`) is **authoritative** in app storage (`com.notionbridge.skills`). Optional Notion page `rich_text` properties mirror it for humans: **`Bridge Summary`**, **`Bridge Triggers`**, **`Bridge Anti-triggers`** (one phrase per line in the latter two). Use `manage_skill` **`sync_metadata_to_notion`** / **`sync_metadata_from_notion`** to copy in either direction; create those properties on the skill page if missing.
 
-- **`list_routing_skills`** (`.open`) — Returns enabled skills with `visibility == routing` and a non-empty Notion page id, including MCP metadata fields. Does not fetch page bodies.
+- **`skills_routing_list`** (`.open`) — Returns enabled skills with `visibility == routing` and a non-empty Notion page id, including MCP metadata fields. Does not fetch page bodies.
 - **`fetch_skill`** (`.open`) — Loads a configured skill page: paginates blocks, returns `summary` / `triggerPhrases` / `antiTriggerPhrases` next to `content`. Cache key includes a metadata fingerprint so metadata edits do not reuse stale fetches.
 - **`manage_skill`** (`.request`) — Registry CRUD, `set_visibility`, **`set_metadata`** (partial updates), and Notion sync actions above. Not a secrecy boundary: approved calls still see all skills.
 

--- a/TheBridge/Modules/SessionModule.swift
+++ b/TheBridge/Modules/SessionModule.swift
@@ -73,9 +73,13 @@ public enum SessionModule {
 
                 let registrations: [ToolRegistration]
                 if let filter = moduleFilter {
-                    registrations = await router.registrations(forModule: filter)
+                    registrations = BrokerBootstrapToolOrdering.prioritize(
+                        await router.registrations(forModule: filter)
+                    )
                 } else {
-                    registrations = await router.allRegistrations()
+                    registrations = BrokerBootstrapToolOrdering.prioritize(
+                        await router.allRegistrations()
+                    )
                 }
 
                 func summarize(_ s: String) -> String {
@@ -343,7 +347,10 @@ public enum SessionModule {
             "outputSummary": .string(outputSummary),
             "durationMs": .double(entry.durationMs),
             "origin": entry.origin.map { .string($0.rawValue) } ?? .null,
-            "transportSessionId": entry.transportSessionId.map(Value.string) ?? .null
+            "transportSessionId": entry.transportSessionId.map(Value.string) ?? .null,
+            "eventType": entry.eventType.map(Value.string) ?? .null,
+            "reportedClientName": entry.reportedClientName.map(Value.string) ?? .null,
+            "reportedClientVersion": entry.reportedClientVersion.map(Value.string) ?? .null
         ])
     }
 }

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -126,7 +126,7 @@ public enum SkillsModule {
             }
         }
         guard !skills.isEmpty else {
-            return "The Bridge MCP server. Call list_routing_skills to discover available skill-based capabilities.\n\n\(dispatchContract)"
+            return "The Bridge MCP server. Call skills_routing_list to discover available skill-based capabilities.\n\n\(dispatchContract)"
         }
         // Build compact JSON routing index
         var lines: [String] = []
@@ -140,7 +140,7 @@ public enum SkillsModule {
         return """
         The Bridge MCP server. \(skills.count) routing skill(s) available:
         \(lines.joined(separator: "\n"))
-        Use fetch_skill to load full skill content by name. Call list_routing_skills to refresh this index.
+        Use fetch_skill to load full skill content by name. Call skills_routing_list to refresh this index.
 
         \(dispatchContract)
         """

--- a/TheBridge/Security/AuditLog.swift
+++ b/TheBridge/Security/AuditLog.swift
@@ -28,6 +28,11 @@ public struct AuditEntry: Sendable, Codable {
     public let origin: ToolDispatchOrigin?
     public let transportSessionId: String?
     public let governanceNote: String?
+    /// Optional discriminator for non-tool-call events such as a pre-dispatch miss.
+    public let eventType: String?
+    /// Self-reported MCP clientInfo fields; labels, not authenticated identity.
+    public let reportedClientName: String?
+    public let reportedClientVersion: String?
 
     public init(
         timestamp: Date,
@@ -40,7 +45,10 @@ public struct AuditEntry: Sendable, Codable {
         governed: Bool? = nil,
         origin: ToolDispatchOrigin? = nil,
         transportSessionId: String? = nil,
-        governanceNote: String? = nil
+        governanceNote: String? = nil,
+        eventType: String? = nil,
+        reportedClientName: String? = nil,
+        reportedClientVersion: String? = nil
     ) {
         self.timestamp = timestamp
         self.toolName = toolName
@@ -53,6 +61,9 @@ public struct AuditEntry: Sendable, Codable {
         self.origin = origin
         self.transportSessionId = transportSessionId
         self.governanceNote = governanceNote
+        self.eventType = eventType
+        self.reportedClientName = reportedClientName
+        self.reportedClientVersion = reportedClientVersion
     }
 }
 

--- a/TheBridge/Server/RoutingIntegrityLayer.swift
+++ b/TheBridge/Server/RoutingIntegrityLayer.swift
@@ -70,7 +70,6 @@ public enum ToolSkillBindingRegistry {
     public static let manifestMarkerTools: Set<String> = [
         BridgeInitializeModule.toolName,
         "fetch_skill",
-        "list_routing_skills",
         "skills_routing_list",
     ]
 

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -751,7 +751,8 @@ public actor SSEServer {
                 ToolDispatchContext(
                     transportSessionId: sessionID,
                     origin: origin,
-                    client: session.clientName
+                    client: session.clientName,
+                    clientVersion: session.clientVersion
                 )
             ) {
                 await session.transport.handleRequest(request)
@@ -1034,7 +1035,6 @@ public actor SSEServer {
                 regs = regs.filter { allowlist.contains($0.name) }
             }
             regs = await connectorVisibleRegistrations(regs, token: token, auth: auth)
-            regs = BrokerBootstrapToolOrdering.prioritize(regs)
             let tools: [[String: Any]] = regs.compactMap { reg in
                 guard let data = try? JSONEncoder().encode(MCPToolFactory.tool(for: reg)),
                       let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -1254,6 +1254,7 @@ public actor SSEServer {
         // for this transport is owned by the actor's `resourceSubscribers`
         // set, keyed by sessionID (see `broadcastResourcesUpdated`).
         let resourceClientName = clientName
+        let resourceClientVersion = clientVersion
         let resourceSessionID = sessionID
         await server.withMethodHandler(ListResources.self) { _ in
             ListResources.Result(resources: BridgeResources.list)
@@ -1329,7 +1330,8 @@ public actor SSEServer {
             let dispatchContext = ToolDispatchContext.current ?? ToolDispatchContext(
                 transportSessionId: resourceSessionID,
                 origin: origin,
-                client: resourceClientName
+                client: resourceClientName,
+                clientVersion: resourceClientVersion
             )
             let (text, isError) = await router.dispatchFormatted(
                 toolName: params.name,

--- a/TheBridge/Server/ServerManager.swift
+++ b/TheBridge/Server/ServerManager.swift
@@ -301,8 +301,6 @@ public actor ServerManager {
                 )
             }
 
-            registrations = BrokerBootstrapToolOrdering.prioritize(registrations)
-
             // v3.0·0.5: single source of truth — same factory as SSETransport.
             let tools = registrations.map { MCPToolFactory.tool(for: $0) }
             return .init(tools: tools)

--- a/TheBridge/Server/SessionRegistry.swift
+++ b/TheBridge/Server/SessionRegistry.swift
@@ -57,21 +57,25 @@ public struct ToolDispatchContext: Sendable, Equatable {
     public let transportSessionId: String?
     public let origin: ToolDispatchOrigin
     public let client: String?
+    public let clientVersion: String?
 
     public init(
         transportSessionId: String?,
         origin: ToolDispatchOrigin,
-        client: String? = nil
+        client: String? = nil,
+        clientVersion: String? = nil
     ) {
         self.transportSessionId = transportSessionId
         self.origin = origin
         self.client = client
+        self.clientVersion = clientVersion
     }
 
     public static let localDefault = ToolDispatchContext(
         transportSessionId: nil,
         origin: .local,
-        client: nil
+        client: nil,
+        clientVersion: nil
     )
 }
 

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -122,13 +122,80 @@ public enum BrokerBootstrapToolOrdering {
 
     public static func prioritize(_ registrations: [ToolRegistration]) -> [ToolRegistration] {
         let rank = Dictionary(uniqueKeysWithValues: priority.enumerated().map { ($0.element, $0.offset) })
-        return registrations.enumerated().sorted { lhs, rhs in
-            let lhsRank = rank[lhs.element.name] ?? Int.max
-            let rhsRank = rank[rhs.element.name] ?? Int.max
+        return registrations.sorted { lhs, rhs in
+            let lhsRank = rank[lhs.name] ?? Int.max
+            let rhsRank = rank[rhs.name] ?? Int.max
             if lhsRank != rhsRank { return lhsRank < rhsRank }
-            return lhs.offset < rhs.offset
-        }.map(\.element)
+            let lhsKey = lhs.name.lowercased(with: Locale(identifier: "en_US_POSIX"))
+            let rhsKey = rhs.name.lowercased(with: Locale(identifier: "en_US_POSIX"))
+            if lhsKey != rhsKey { return lhsKey < rhsKey }
+            return lhs.name.utf8.lexicographicallyPrecedes(rhs.name.utf8)
+        }
     }
+}
+
+/// One actor-isolated view of the enabled tool registry. A revision changes
+/// whenever registration changes, so callers can distinguish a real dynamic
+/// surface update from ordering instability.
+public struct ToolManifestSnapshot: Sendable {
+    public let revision: UInt64
+    public let registrations: [ToolRegistration]
+}
+
+private struct DispatchMissKey: Hashable {
+    let session: String
+    let safeToolName: String
+}
+
+private enum DispatchMissTelemetry {
+    static let eventType = "dispatch_miss"
+    static let windowSeconds: TimeInterval = 60
+
+    static func safeToolName(_ raw: String) -> String {
+        let lower = raw.lowercased(with: Locale(identifier: "en_US_POSIX"))
+        let secretMarkers = ["sk-", "sk_", "secret", "bearer", "token", "api_key", "apikey"]
+        let looksSecret = secretMarkers.contains { lower.contains($0) }
+        let bytes = Array(raw.utf8)
+        let isIdentifier = !bytes.isEmpty
+            && bytes.count <= 128
+            && bytes[0].isASCIIAlpha
+            && bytes.allSatisfy { $0.isASCIIAlphaNumeric || $0 == 95 }
+        guard isIdentifier, !looksSecret else {
+            return "<invalid-name:\(stableDigest(raw))>"
+        }
+        return raw
+    }
+
+    static func safeLabel(_ raw: String?, maxBytes: Int) -> String? {
+        guard let raw else { return nil }
+        let lower = raw.lowercased(with: Locale(identifier: "en_US_POSIX"))
+        if ["secret", "bearer", "token", "api_key", "apikey", "sk-", "sk_"].contains(where: lower.contains) {
+            return "<redacted>"
+        }
+        var result = ""
+        for scalar in raw.unicodeScalars {
+            guard scalar.value >= 0x20, scalar.value != 0x7f else { continue }
+            let next = String(scalar)
+            guard result.utf8.count + next.utf8.count <= maxBytes else { break }
+            result.append(next)
+        }
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func stableDigest(_ raw: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in raw.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+private extension UInt8 {
+    var isASCIIAlpha: Bool { (65...90).contains(self) || (97...122).contains(self) }
+    var isASCIIAlphaNumeric: Bool { isASCIIAlpha || (48...57).contains(self) }
 }
 
 // PKT-373 P1-5: ExecutionPlanEntry removed (was dead code)
@@ -138,10 +205,12 @@ public enum BrokerBootstrapToolOrdering {
 /// Central dispatch hub. Every tool call flows through here.
 public actor ToolRouter {
     private var registry: [String: ToolRegistration] = [:]
+    private var manifestRevision: UInt64 = 0
     /// FB-4: withhold `tools/list` until `BridgeModuleRegistry` finishes so
     /// clients never cache a partial surface during startup registration.
     private var modulesRegistrationComplete = false
     private var routingManifestSessionIDs: Set<String> = []
+    private var dispatchMissWindows: [DispatchMissKey: Date] = [:]
     private let securityGate: SecurityGate
     private let auditLog: AuditLog
     private let sessionRegistry: SessionRegistry
@@ -179,11 +248,14 @@ public actor ToolRouter {
     /// Register a tool. Overwrites any existing registration with the same name.
     public func register(_ tool: ToolRegistration) {
         registry[tool.name] = tool
+        manifestRevision &+= 1
     }
 
     /// Remove a tool registration by name.
     public func deregister(name: String) {
-        registry.removeValue(forKey: name)
+        if registry.removeValue(forKey: name) != nil {
+            manifestRevision &+= 1
+        }
     }
 
     /// All currently registered tools.
@@ -222,8 +294,18 @@ public actor ToolRouter {
 
     /// Surface for MCP `tools/list` — empty until startup registration completes (FB-4).
     public func registrationsForListTools(disabledNames: Set<String>) -> [ToolRegistration] {
-        guard modulesRegistrationComplete else { return [] }
-        return enabledRegistrations(disabledNames: disabledNames)
+        toolManifestSnapshot(disabledNames: disabledNames).registrations
+    }
+
+    /// Atomic, revisioned source for every MCP `tools/list` transport.
+    public func toolManifestSnapshot(disabledNames: Set<String>) -> ToolManifestSnapshot {
+        guard modulesRegistrationComplete else {
+            return ToolManifestSnapshot(revision: manifestRevision, registrations: [])
+        }
+        let registrations = BrokerBootstrapToolOrdering.prioritize(
+            enabledRegistrations(disabledNames: disabledNames)
+        )
+        return ToolManifestSnapshot(revision: manifestRevision, registrations: registrations)
     }
 
     // MARK: Dispatch
@@ -257,6 +339,39 @@ public actor ToolRouter {
         let start = ContinuousClock.now
 
         guard let tool = registry[toolName] else {
+            let safeName = DispatchMissTelemetry.safeToolName(toolName)
+            let session = context.transportSessionId ?? "<none>:\(context.origin.rawValue)"
+            let key = DispatchMissKey(session: session, safeToolName: safeName)
+            let now = Date()
+            let shouldAudit: Bool
+            if let windowStart = dispatchMissWindows[key],
+               now.timeIntervalSince(windowStart) < DispatchMissTelemetry.windowSeconds {
+                shouldAudit = false
+            } else {
+                dispatchMissWindows[key] = now
+                shouldAudit = true
+            }
+            if dispatchMissWindows.count > 1_024 {
+                dispatchMissWindows = dispatchMissWindows.filter {
+                    now.timeIntervalSince($0.value) < DispatchMissTelemetry.windowSeconds
+                }
+            }
+            if shouldAudit {
+                await auditLog.append(AuditEntry(
+                    timestamp: now,
+                    toolName: safeName,
+                    tier: .open,
+                    inputSummary: "",
+                    outputSummary: "ERROR: unknown tool",
+                    durationMs: Self.elapsedMs(since: start),
+                    approvalStatus: .error,
+                    origin: context.origin,
+                    transportSessionId: context.transportSessionId,
+                    eventType: DispatchMissTelemetry.eventType,
+                    reportedClientName: DispatchMissTelemetry.safeLabel(context.client, maxBytes: 128),
+                    reportedClientVersion: DispatchMissTelemetry.safeLabel(context.clientVersion, maxBytes: 64)
+                ))
+            }
             throw ToolRouterError.unknownTool(toolName)
         }
 

--- a/TheBridgeTests/AgentSurfaceReliabilityTests.swift
+++ b/TheBridgeTests/AgentSurfaceReliabilityTests.swift
@@ -1,0 +1,264 @@
+// AgentSurfaceReliabilityTests.swift — deterministic discovery + safe miss telemetry
+// The Bridge · Tests
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runAgentSurfaceReliabilityTests() async {
+    print("\n\u{1F9ED} Agent Surface Reliability")
+
+    func registration(
+        _ name: String,
+        module: String = "test",
+        tier: SecurityTier = .open,
+        description: String = "description"
+    ) -> ToolRegistration {
+        ToolRegistration(
+            name: name,
+            module: module,
+            tier: tier,
+            description: description,
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object(["probe": .object(["type": .string("string")])])
+            ]),
+            handler: { _ in .object(["ok": .bool(true)]) }
+        )
+    }
+
+    func names(from value: Value) throws -> [String] {
+        guard case .array(let rows) = value else {
+            throw TestError.assertion("expected tool array, got \(value)")
+        }
+        return rows.compactMap { row in
+            guard case .object(let fields) = row,
+                  case .string(let name)? = fields["name"] else { return nil }
+            return name
+        }
+    }
+
+    func streamText(from response: HTTPResponse) async throws -> String {
+        guard case .stream(let stream, _) = response else {
+            throw TestError.assertion("expected SSE stream, got HTTP \(response.statusCode)")
+        }
+        var text = ""
+        for try await data in stream {
+            text += String(decoding: data, as: UTF8.self)
+        }
+        return text
+    }
+
+    func rpcObject(from text: String) throws -> [String: Any] {
+        for line in text.split(separator: "\n") {
+            guard line.hasPrefix("data: {") else { continue }
+            let payload = line.dropFirst("data: ".count)
+            guard let object = try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any] else {
+                continue
+            }
+            return object
+        }
+        throw TestError.assertion("SSE response did not contain a JSON-RPC data event: \(text)")
+    }
+
+    let shuffled: [ToolRegistration] = [
+        registration("zulu"),
+        registration("session_info", module: "session"),
+        registration("alpha"),
+        registration("bridge_initialize", module: "standing_orders"),
+        registration("tools_list", module: "session"),
+        registration("middle"),
+        registration("bridge_status", module: "cloud"),
+    ]
+    let expected = [
+        "bridge_initialize", "bridge_status", "tools_list", "session_info",
+        "alpha", "middle", "zulu",
+    ]
+
+    await test("agent surface: canonical order is bootstrap-first then alphabetical") {
+        let ordered = BrokerBootstrapToolOrdering.prioritize(shuffled)
+        try expect(ordered.map(\.name) == expected)
+
+        let before = Dictionary(uniqueKeysWithValues: shuffled.map { ($0.name, $0) })
+        for after in ordered {
+            guard let original = before[after.name] else {
+                throw TestError.assertion("ordering introduced unknown registration \(after.name)")
+            }
+            try expect(after.module == original.module, "module changed for \(after.name)")
+            try expect(after.tier == original.tier, "tier changed for \(after.name)")
+            try expect(after.description == original.description, "description changed for \(after.name)")
+            try expect(after.inputSchema == original.inputSchema, "schema changed for \(after.name)")
+        }
+    }
+
+    await test("agent surface: router snapshots are atomic, revisioned, filtered, and ordered") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        for item in shuffled { await router.register(item) }
+        await router.markModulesRegistrationComplete()
+
+        let first = await router.toolManifestSnapshot(disabledNames: ["middle"])
+        try expect(first.registrations.map(\.name) == expected.filter { $0 != "middle" })
+
+        await router.register(registration("beta"))
+        let second = await router.toolManifestSnapshot(disabledNames: ["middle"])
+        try expect(second.revision > first.revision, "dynamic registration must advance manifest revision")
+        try expect(second.registrations.map(\.name) == [
+            "bridge_initialize", "bridge_status", "tools_list", "session_info",
+            "alpha", "beta", "zulu",
+        ])
+    }
+
+    await test("agent surface: tools_list uses the canonical order") {
+        let router = ToolRouter(
+            securityGate: SecurityGate(),
+            auditLog: AuditLog(),
+            licenseStatusProvider: { .trial(daysRemaining: 5) }
+        )
+        await SessionModule.register(on: router, auditLog: AuditLog())
+        for item in shuffled where !["tools_list", "session_info"].contains(item.name) {
+            await router.register(item)
+        }
+        let result = try await router.dispatch(toolName: "tools_list", arguments: .object([:]))
+        let listed = try names(from: result)
+        try expect(Array(listed.prefix(4)) == [
+            "bridge_initialize", "bridge_status", "tools_list", "session_info",
+        ])
+        try expect(Array(listed.dropFirst(4)) == Array(listed.dropFirst(4)).sorted(),
+                   "tools_list remainder must be alphabetical: \(listed)")
+    }
+
+    await test("agent surface: stateful HTTP tools/list uses the canonical router snapshot") {
+        let log = AuditLog()
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: log)
+        for item in shuffled { await router.register(item) }
+        await router.markModulesRegistrationComplete()
+
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-surface-sessions-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+        let server = SSEServer(
+            router: router,
+            onToolCall: {},
+            sessionStore: SessionPersistenceStore(storeURL: storeURL)
+        )
+        let headers = [
+            "Host": "127.0.0.1:\(BridgeConstants.defaultSSEPort)",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        ]
+        let initialize = Data("""
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"\(BridgeConstants.mcpProtocolVersion)","capabilities":{},"clientInfo":{"name":"agent-surface-test","version":"1"}}}
+        """.utf8)
+        let initResponse = await server.handleHTTPRequest(
+            HTTPRequest(method: "POST", headers: headers, body: initialize)
+        )
+        guard let sessionID = initResponse.headers[HTTPHeaderName.sessionID] else {
+            throw TestError.assertion("initialize did not return MCP session id")
+        }
+        _ = try await streamText(from: initResponse)
+
+        var listHeaders = headers
+        listHeaders[HTTPHeaderName.sessionID] = sessionID
+        let listResponse = await server.handleHTTPRequest(HTTPRequest(
+            method: "POST",
+            headers: listHeaders,
+            body: Data(#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#.utf8)
+        ))
+        let rpc = try rpcObject(from: try await streamText(from: listResponse))
+        guard let result = rpc["result"] as? [String: Any],
+              let tools = result["tools"] as? [[String: Any]] else {
+            throw TestError.assertion("tools/list response missing result.tools: \(rpc)")
+        }
+        try expect(tools.compactMap { $0["name"] as? String } == expected)
+
+        let missResponse = await server.handleHTTPRequest(HTTPRequest(
+            method: "POST",
+            headers: listHeaders,
+            body: Data(#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"stateful_unknown","arguments":{"token":"never-log-me"}}}"#.utf8)
+        ))
+        _ = try await streamText(from: missResponse)
+        let misses = await log.allEntries().filter { $0.eventType == "dispatch_miss" }
+        try expect(misses.count == 1)
+        try expect(misses[0].transportSessionId == sessionID)
+        try expect(misses[0].reportedClientName == "agent-surface-test")
+        try expect(misses[0].reportedClientVersion == "1")
+        try expect(misses[0].inputSummary.isEmpty)
+    }
+
+    await test("agent surface: unknown calls audit one safe dispatch_miss without arguments") {
+        let log = AuditLog()
+        let router = ToolRouter(
+            securityGate: SecurityGate(),
+            auditLog: log,
+            licenseStatusProvider: { .trial(daysRemaining: 5) }
+        )
+        let context = ToolDispatchContext(
+            transportSessionId: "miss-session",
+            origin: .remote,
+            client: "agent-client",
+            clientVersion: "7.2"
+        )
+        let secret = "TOP-SECRET-ARGUMENT"
+        for _ in 0..<2 {
+            do {
+                _ = try await router.dispatch(
+                    toolName: "not_a_real_tool",
+                    arguments: .object(["token": .string(secret)]),
+                    context: context
+                )
+                throw TestError.assertion("unknown tool unexpectedly dispatched")
+            } catch let error as ToolRouterError {
+                guard case .unknownTool = error else { throw error }
+            }
+        }
+        do {
+            _ = try await router.dispatch(
+                toolName: "sk-proj-THIS-MUST-NOT-LEAK",
+                arguments: .object([:]),
+                context: context
+            )
+            throw TestError.assertion("secret-shaped tool name unexpectedly dispatched")
+        } catch let error as ToolRouterError {
+            guard case .unknownTool = error else { throw error }
+        }
+
+        let entries = await log.allEntries()
+        try expect(entries.count == 2, "duplicate misses must be rate-limited; got \(entries.count)")
+        try expect(entries.allSatisfy { $0.eventType == "dispatch_miss" })
+        try expect(entries[0].toolName == "not_a_real_tool")
+        try expect(entries[0].reportedClientName == "agent-client")
+        try expect(entries[0].reportedClientVersion == "7.2")
+        try expect(entries[0].origin == .remote)
+        try expect(entries[0].transportSessionId == "miss-session")
+        try expect(entries[0].inputSummary.isEmpty)
+        try expect(entries[1].toolName.hasPrefix("<invalid-name:"),
+                   "secret-shaped names must be replaced by a digest: \(entries[1].toolName)")
+        let encoded = String(decoding: try JSONEncoder().encode(entries), as: UTF8.self)
+        try expect(!encoded.contains(secret), "dispatch miss leaked call arguments")
+        try expect(!encoded.contains("THIS-MUST-NOT-LEAK"), "dispatch miss leaked invalid tool name")
+
+        // Persisted audit logs predate the optional miss/client fields. Keep
+        // decoding backward-compatible so startup never rejects old JSONL.
+        let legacyEntry = AuditEntry(
+            timestamp: Date(timeIntervalSince1970: 1),
+            toolName: "legacy_tool",
+            tier: .open,
+            inputSummary: "{}",
+            outputSummary: "ok",
+            durationMs: 1,
+            approvalStatus: .approved
+        )
+        let legacyData = try JSONEncoder().encode(legacyEntry)
+        var legacyObject = try JSONSerialization.jsonObject(with: legacyData) as! [String: Any]
+        legacyObject.removeValue(forKey: "eventType")
+        legacyObject.removeValue(forKey: "reportedClientName")
+        legacyObject.removeValue(forKey: "reportedClientVersion")
+        let decoded = try JSONDecoder().decode(
+            AuditEntry.self,
+            from: JSONSerialization.data(withJSONObject: legacyObject)
+        )
+        try expect(decoded.eventType == nil && decoded.reportedClientName == nil
+            && decoded.reportedClientVersion == nil,
+            "legacy audit entries must decode without the additive telemetry fields")
+    }
+}

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -58,6 +58,9 @@ func runRoutingIntegrityLayerTests() async {
             try expect(receipt.routingIntegrity.registryVersion == ToolSkillBindingRegistry.registryVersion)
             try expect(receipt.routingIntegrity.boundToolCount == ToolSkillBindingRegistry.bindings.count)
             try expect(receipt.routingIntegrity.manifestMarkerTools.contains(BridgeInitializeModule.toolName))
+            try expect(receipt.routingIntegrity.manifestMarkerTools.contains("skills_routing_list"))
+            try expect(!receipt.routingIntegrity.manifestMarkerTools.contains("list_routing_skills"),
+                       "bridge_initialize must not advertise the removed routing alias")
             let value = BridgeInitializeModule.receiptValue(receipt)
             guard case .object(let dict) = value,
                   case .object(let ril)? = dict["routingIntegrity"],

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -855,6 +855,7 @@ await runSkillsCacheTests()
 await runSkillBodyCacheTests()
 await runSkillBodyCacheEvictionTests()
 await runToolRouterListToolsReadyTests()
+await runAgentSurfaceReliabilityTests()
 
 // routing/specialist-relation (v3.7.4): specialists now sourced from the
 // parent's curated `Specialist` relation property (NotionJSON.extract-

--- a/TheBridgeTests/ToolConventionTests.swift
+++ b/TheBridgeTests/ToolConventionTests.swift
@@ -58,5 +58,9 @@ func runToolConventionTests() async {
         let instr = SkillsModule.buildRoutingInstructions()
         try expect(instr.contains("camelCase") && instr.contains("did you mean"),
                    "dispatch contract not surfaced in instructions")
+        try expect(instr.contains("skills_routing_list"),
+                   "instructions must advertise the canonical routing roster tool")
+        try expect(!instr.contains("list_routing_skills"),
+                   "instructions must not advertise the removed routing alias")
     }
 }

--- a/TheBridgeTests/Wave1BrokerTests.swift
+++ b/TheBridgeTests/Wave1BrokerTests.swift
@@ -426,10 +426,10 @@ func runWave1BrokerTests() async {
             "session_info",
         ])
         try expect(Array(ordered.dropFirst(4)) == [
-            "shell_exec",
-            "memory_remember",
             "contacts_search",
-        ], "non-bootstrap tools must keep their original relative order")
+            "memory_remember",
+            "shell_exec",
+        ], "non-bootstrap tools must use deterministic alphabetical order")
     }
 
     await test("W1 doctrine_sync: request-tier writer refreshes doctrine core") {

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -68,8 +68,8 @@ Do not shell out to `sed`/`python3` for in-place edits. Use the first-class edit
     context against current content and rejects on drift. Multi-file diffs must be split
     per file by the caller. Writes are atomic.
 
-`file_str_replace` and `file_apply_patch` still exist but are **deprecated 1-cycle
-aliases** of `file_edit` — prefer `file_edit`.
+The removed `file_str_replace` and `file_apply_patch` aliases are historical only.
+Use `file_edit` for surgical replacements and unified patches.
 
 Source: `TheBridge/Modules/CodeEditModule.swift`.
 

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2285,3 +2285,8 @@ set -euo pipefail
 # Recommended badge invariant, IconPickerCatalog emoji + SF Symbol
 # curation + de-duped + NSImage resolvable, CommandStore icon round-trip.
 # Baseline 1275 at HEAD 4554d32 + 14 + 25 + 19 + 27 = 1360.
+# Agent-surface reliability integration (2026-07-14): +5 net-new hermetic
+# tests cover deterministic manifest ordering, revision changes on registry
+# mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
+# redaction, and client name/version attribution. Measured 3207 passed, 0
+# failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3202}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."


### PR DESCRIPTION
## Summary
- makes every tools/list surface consume one deterministic, revisioned registry snapshot
- records rate-limited, redacted unknown-tool dispatch misses with client name/version attribution
- corrects stale skills_routing_list and removed-alias documentation
- preserves W2B/W2C reconnect, governance, and reset behavior from current main

## Verification
- git diff --check
- make check-counter-collisions
- make build (strict release build; generated OAuth identity restored to committed fail-closed source afterward)
- make test-floor twice from clean source state: 3207 passed, 0 failed both runs
- single authoritative FLOOR raised 3202 -> 3207 with sidecar provenance
- BridgeConstants tool/family counters unchanged

## Gate
Do not merge without explicit operator GO.