### PR TITLE
feat(notion): views read API + discussion reply on comment_create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased — Notion Views read + comment reply fidelity — 2026-07-15
+
+- **Feature** — `notion_views_list` and `notion_view_get` wrap the Notion Views
+  API (`GET /v1/views`, `GET /v1/views/{id}`) so agents can discover and inspect
+  table/board/chart/calendar views that already exist on KEEP OS data sources.
+- **Fix** — `notion_comment_create` accepts `discussionId` for true thread
+  replies (POST body uses `discussion_id`, not `parent`). Exactly one of
+  `pageId` / `discussionId`. Voice-memo `pageId`+`text` path unchanged.
+- **Fix** — `notion_discussion_create` description no longer claims to be the
+  reply tool; it starts a new page-level thread (same as `pageId` create).
+- **Docs** — `notion_search` notes that API filter object types are `page` |
+  `data_source` only (not `database`) under Notion-Version 2026-03-11.
+- **Counts** — static feature tools 205 → 207; test floor 3207 → 3213.
+
 ## v3.9.9 (build 80) — Remote shell and control-plane parity — 2026-07-10
 
 - **Fix** — the Wave 1 remote control-plane preference now defaults OFF instead

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -442,7 +442,10 @@ public enum BridgeConstants {
     /// PKT-1120 Tool Ergonomics (2026-07-14): +2
     ///   (voice_memo_settings_get + voice_memo_settings_set; voice family).
     ///   203 + 2 = 205.
-    public static let staticFeatureModuleToolCount = 205
+    /// Notion Views read + comment reply (2026-07-15): +2
+    ///   (notion_views_list + notion_view_get; notion family). Comment path
+    ///   gains discussionId reply (no new tool). 205 + 2 = 207.
+    public static let staticFeatureModuleToolCount = 207
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Modules/NotionModule.swift
+++ b/TheBridge/Modules/NotionModule.swift
@@ -130,7 +130,7 @@ public enum NotionModule {
             name: "notion_search",
             module: moduleName,
             tier: .open,
-            description: "Keyword-search a Notion workspace for pages and data sources. Returns IDs + titles; no semantic ranking.",
+            description: "Keyword-search a Notion workspace for pages and data sources. Returns IDs + titles; no semantic ranking. Under Notion-Version 2026-03-11 the search filter object type (not exposed here) accepts only page or data_source — not database.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -1052,57 +1052,70 @@ public enum NotionModule {
             name: "notion_comment_create",
             module: moduleName,
             tier: .notify,
-            description: "Post a top-level inline-only markdown comment on a Notion page. Text over Notion's 2000-character per-run limit is auto-chunked into sequential comments preserving order. For threaded replies use notion_discussion_create.",
+            description: "Post an inline-only comment on a Notion page (pageId) OR reply in an existing discussion thread (discussionId). Exactly one of pageId/discussionId. Text over Notion's 2000-character per-run limit is auto-chunked into sequential comments preserving order (replies re-use the same discussionId).",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "pageId": .object(["type": .string("string"), "description": .string("Page ID to comment on")]),
+                    "pageId": .object(["type": .string("string"), "description": .string("Page ID for a new top-level page comment. Mutually exclusive with discussionId.")]),
+                    "discussionId": .object(["type": .string("string"), "description": .string("Existing discussion thread ID for a reply. Mutually exclusive with pageId. Obtain from notion_comments_list or a prior create's discussionId.")]),
                     "text": .object(["type": .string("string"), "description": .string("Comment text content")]),
                     "content": .object(["type": .string("string"), "description": .string("Alias for 'text' — comment text content. If both are supplied, 'text' wins.")]),
                     "workspace": workspaceParam
                 ]),
-                "required": .array([.string("pageId")])
+                "required": .array([.string("text")])
             ]),
             metadata: ToolMetadata(
                 title: "Notion: Create Comment",
-                whenToUse: ["posting a short inline comment on a page"],
-                whenNotToUse: ["threaded replies (use notion_discussion_create)",
+                whenToUse: ["posting a short inline comment on a page",
+                            "replying to an existing discussion via discussionId"],
+                whenNotToUse: ["starting a named new thread (use notion_discussion_create for the same page-level start, or pageId here)",
                                "long code/text (use notion_blocks_append with autoChunk:true)"],
                 relatedTools: ["notion_discussion_create", "notion_comments_list"]
             ),
             handler: { arguments in
-                guard case .object(let args) = arguments,
-                      case .string(let pageId) = args["pageId"] else {
-                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'pageId' or 'text'")
+                guard case .object(let args) = arguments else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing arguments")
+                }
+                let pageId: String? = { if case .string(let p) = args["pageId"] { return p }; return nil }()
+                let discussionIdArg: String? = {
+                    if case .string(let d) = args["discussionId"] { return d }
+                    return nil
+                }()
+                let hasPage = !(pageId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                let hasDiscussion = !(discussionIdArg?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                guard hasPage != hasDiscussion else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notion_comment_create",
+                        reason: "exactly one of 'pageId' or 'discussionId' is required"
+                    )
                 }
                 // 'content' is an alias for 'text' — agents reach for 'content'
-                // as the generic term first (documented friction: schema
-                // mismatch cost a failed call before the correct 'text' shape
-                // was discovered). 'text' wins if both are supplied.
+                // as the generic term first. 'text' wins if both are supplied.
                 let text: String
                 if case .string(let t) = args["text"] {
                     text = t
                 } else if case .string(let c) = args["content"] {
                     text = c
                 } else {
-                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'pageId' or 'text'")
+                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'text'")
                 }
 
                 let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
 
-                // FB-3: Auto-chunk into sequential <=2000-char comments preserving order,
-                // instead of hard-rejecting. Notion enforces a 2000-character per-run limit;
-                // post one comment per chunk and report all created IDs in order.
+                // FB-3: Auto-chunk into sequential <=2000-char comments preserving order.
+                // For replies, every chunk uses the same discussionId so they stay in-thread.
                 let chunks = NotionModule.chunkCommentText(text, maxChars: 2000)
 
                 var ids: [Value] = []
-                // PKT-MEM-136: surface the Notion `discussion_id` the first posted chunk
-                // started, so callers (e.g. VoiceMemoProcessor.executeComment) can log it
-                // to a durable ledger without a second round trip. Additive — every other
-                // key/shape is byte-for-byte unchanged.
-                var discussionId = ""
+                // PKT-MEM-136: surface discussion_id so VoiceMemoProcessor can ledger it.
+                var discussionIdOut = discussionIdArg ?? ""
                 for chunk in chunks {
-                    let data = try await client.createComment(pageId: pageId, text: chunk)
+                    let data: Data
+                    if hasDiscussion {
+                        data = try await client.createComment(pageId: nil, discussionId: discussionIdArg, text: chunk)
+                    } else {
+                        data = try await client.createComment(pageId: pageId, discussionId: nil, text: chunk)
+                    }
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object([
                             "success": .bool(false),
@@ -1113,8 +1126,8 @@ public enum NotionModule {
                         ])
                     }
                     ids.append(.string(json["id"] as? String ?? ""))
-                    if discussionId.isEmpty {
-                        discussionId = json["discussion_id"] as? String ?? ""
+                    if discussionIdOut.isEmpty {
+                        discussionIdOut = json["discussion_id"] as? String ?? ""
                     }
                 }
 
@@ -1124,7 +1137,7 @@ public enum NotionModule {
                     "id": ids.first ?? .string(""),
                     "ids": .array(ids),
                     "chunks": .int(chunks.count),
-                    "discussionId": .string(discussionId)
+                    "discussionId": .string(discussionIdOut)
                 ])
             }
         ))
@@ -1705,7 +1718,7 @@ public enum NotionModule {
             name: "notion_discussion_create",
             module: moduleName,
             tier: .notify,
-            description: "Start a new threaded discussion on a Notion page (accepts compressed URLs, UUIDs, or full Notion URLs). Initial comment is inline-only markdown and preflights Notion's 2000-character rich_text run limit.",
+            description: "Start a NEW top-level discussion on a Notion page (same as notion_comment_create with pageId — not a reply). For replies, pass discussionId to notion_comment_create. Accepts compressed URLs, UUIDs, or full Notion URLs. Initial comment is inline-only markdown and preflights Notion's 2000-character rich_text run limit.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -1747,6 +1760,133 @@ public enum NotionModule {
                     "success": .bool(true),
                     "id": .string(id),
                     "discussionId": .string(discussionId)
+                ])
+            }
+        ))
+
+        // MARK: 24. notion_views_list – open (Views API)
+        await router.register(ToolRegistration(
+            name: "notion_views_list",
+            module: moduleName,
+            tier: .open,
+            description: "List database views for a database_id and/or data_source_id (Notion Views API). List results are often id-only references — use notion_view_get for filter/sorts/configuration. At least one of databaseId or dataSourceId is required.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "databaseId": .object(["type": .string("string"), "description": .string("Database container ID — lists views on that database.")]),
+                    "dataSourceId": .object(["type": .string("string"), "description": .string("Data source ID — lists views over that collection (including linked views).")]),
+                    "pageSize": .object(["type": .string("integer"), "description": .string("Max results (default 100, max 100).")]),
+                    "startCursor": .object(["type": .string("string"), "description": .string("Pagination cursor from a prior next_cursor.")]),
+                    "workspace": workspaceParam
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notion: List Views",
+                whenToUse: ["discovering board/table/chart views on a database or data source"],
+                whenNotToUse: ["reading one view's filter/sorts (use notion_view_get)",
+                               "querying rows (use notion_query)"],
+                relatedTools: ["notion_view_get", "notion_database_get", "notion_datasource_get", "notion_query"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_views_list", reason: "missing arguments")
+                }
+                let databaseId: String? = { if case .string(let d) = args["databaseId"] { return d }; return nil }()
+                let dataSourceId: String? = { if case .string(let d) = args["dataSourceId"] { return d }; return nil }()
+                let hasDB = !(databaseId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                let hasDS = !(dataSourceId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                guard hasDB || hasDS else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notion_views_list",
+                        reason: "at least one of 'databaseId' or 'dataSourceId' is required"
+                    )
+                }
+                let pageSize: Int = { if case .int(let ps) = args["pageSize"] { return min(max(ps, 1), 100) }; return 100 }()
+                let startCursor: String? = { if case .string(let c) = args["startCursor"] { return c }; return nil }()
+
+                let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
+                let data = try await client.listViews(
+                    databaseId: hasDB ? databaseId : nil,
+                    dataSourceId: hasDS ? dataSourceId : nil,
+                    startCursor: startCursor,
+                    pageSize: pageSize
+                )
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return .object(["error": .string("Failed to parse views list response")])
+                }
+                let results = (json["results"] as? [[String: Any]]) ?? []
+                var items: [Value] = []
+                for row in results {
+                    let id = row["id"] as? String ?? ""
+                    let object = row["object"] as? String ?? "view"
+                    let name = row["name"] as? String
+                    let type = row["type"] as? String
+                    var entry: [String: Value] = [
+                        "id": .string(id),
+                        "object": .string(object)
+                    ]
+                    if let name { entry["name"] = .string(name) }
+                    if let type { entry["type"] = .string(type) }
+                    items.append(.object(entry))
+                }
+                let hasMore = json["has_more"] as? Bool ?? false
+                var out: [String: Value] = [
+                    "success": .bool(true),
+                    "count": .int(items.count),
+                    "has_more": .bool(hasMore),
+                    "results": .array(items)
+                ]
+                if let next = json["next_cursor"] as? String {
+                    out["next_cursor"] = .string(next)
+                }
+                return .object(out)
+            }
+        ))
+
+        // MARK: 25. notion_view_get – open (Views API)
+        await router.register(ToolRegistration(
+            name: "notion_view_get",
+            module: moduleName,
+            tier: .open,
+            description: "Retrieve one Notion database view by ID — name, type, filter, sorts, quick_filters, and configuration (table/board/chart/etc.). Use after notion_views_list.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "viewId": .object(["type": .string("string"), "description": .string("View ID (with or without dashes).")]),
+                    "workspace": workspaceParam
+                ]),
+                "required": .array([.string("viewId")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notion: Get View",
+                whenToUse: ["reading a view's filters, sorts, and layout configuration"],
+                whenNotToUse: ["listing views (use notion_views_list)",
+                               "querying rows of a data source (use notion_query)"],
+                relatedTools: ["notion_views_list", "notion_query", "notion_database_get"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let viewId) = args["viewId"], !viewId.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_view_get", reason: "missing 'viewId'")
+                }
+                let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
+                let data = try await client.getView(viewId: viewId)
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return .object(["error": .string("Failed to parse view response")])
+                }
+                // Pass through the full view object as JSON string for nested filter/config fidelity,
+                // plus a few top-level convenience fields.
+                let raw = String(data: data, encoding: .utf8) ?? "{}"
+                return .object([
+                    "success": .bool(true),
+                    "id": .string(json["id"] as? String ?? viewId),
+                    "object": .string(json["object"] as? String ?? "view"),
+                    "name": .string(json["name"] as? String ?? ""),
+                    "type": .string(json["type"] as? String ?? ""),
+                    "data_source_id": .string(json["data_source_id"] as? String ?? ""),
+                    "url": .string(json["url"] as? String ?? ""),
+                    "view": .string(raw)
                 ])
             }
         ))

--- a/TheBridge/Notion/NotionClient.swift
+++ b/TheBridge/Notion/NotionClient.swift
@@ -721,16 +721,12 @@ public actor NotionClient {
         return data
     }
 
-    /// A9b: Create a comment on a page.
-    /// POST /v1/comments
-    public func createComment(pageId: String, text: String) async throws -> Data {
+    /// A9b: Create a comment on a page, or reply to an existing discussion.
+    /// POST /v1/comments — exactly one of `pageId` (parent.page_id) or `discussionId`.
+    /// When `discussionId` is set, the body is a thread reply (no parent).
+    public func createComment(pageId: String? = nil, discussionId: String? = nil, text: String) async throws -> Data {
         try Self.validateSingleRichTextRun(text, context: "notion_comment_create")
-        // v1.9.0 B3: accept raw UUID, dashed UUID, Notion URL, or compressed placeholder
-        let cleanId = Self.normalizePageId(pageId)
-        let body: [String: Any] = [
-            "parent": ["page_id": cleanId],
-            "rich_text": [["type": "text", "text": ["content": text]]]
-        ]
+        let body = try Self.buildCreateCommentRequestBody(pageId: pageId, discussionId: discussionId, text: text)
         let bodyData = try JSONSerialization.data(withJSONObject: body)
         let (data, response) = try await request(method: "POST", path: "/comments", body: bodyData)
         guard (200...299).contains(response.statusCode) else {
@@ -738,6 +734,35 @@ public actor NotionClient {
             throw NotionClientError.httpError(response.statusCode, msg)
         }
         return data
+    }
+
+    /// Builds the JSON body for create-comment. Public for unit tests.
+    /// Exactly one of `pageId` or `discussionId` must be non-empty (API contract).
+    nonisolated public static func buildCreateCommentRequestBody(
+        pageId: String?,
+        discussionId: String?,
+        text: String
+    ) throws -> [String: Any] {
+        let hasPage = !(pageId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        let hasDiscussion = !(discussionId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        guard hasPage != hasDiscussion else {
+            throw NotionClientError.decodingError(
+                "createComment requires exactly one of pageId or discussionId (got page=\(hasPage) discussion=\(hasDiscussion))"
+            )
+        }
+        let richText: [[String: Any]] = [["type": "text", "text": ["content": text]]]
+        if hasDiscussion, let discussionId {
+            let clean = discussionId.replacingOccurrences(of: "-", with: "")
+            return [
+                "discussion_id": clean,
+                "rich_text": richText
+            ]
+        }
+        let cleanId = Self.normalizePageId(pageId!)
+        return [
+            "parent": ["page_id": cleanId],
+            "rich_text": richText
+        ]
     }
 
     /// A10a: List all users in the workspace.
@@ -971,16 +996,47 @@ public actor NotionClient {
 
     /// E5 (v1.9.1): Create a new discussion thread on a page.
     /// POST /v1/comments with parent.page_id (no discussion_id → starts a new thread).
-    /// Accepts raw UUID, dashed UUID, Notion URL, or compressed placeholder (via normalizePageId).
+    /// Not a reply primitive — for replies use `createComment(discussionId:text:)`.
     public func createDiscussion(pageId: String, text: String) async throws -> Data {
-        try Self.validateSingleRichTextRun(text, context: "notion_discussion_create")
-        let cleanId = Self.normalizePageId(pageId)
-        let body: [String: Any] = [
-            "parent": ["page_id": cleanId],
-            "rich_text": [["type": "text", "text": ["content": text]]]
-        ]
-        let bodyData = try JSONSerialization.data(withJSONObject: body)
-        let (data, response) = try await request(method: "POST", path: "/comments", body: bodyData)
+        try await createComment(pageId: pageId, discussionId: nil, text: text)
+    }
+
+    // MARK: - Views API (2025-09-03+ / 2026-03-11)
+
+    /// List views for a database and/or data source.
+    /// GET /v1/views?database_id=… and/or data_source_id=…
+    /// At least one of `databaseId` / `dataSourceId` is required.
+    public func listViews(databaseId: String? = nil, dataSourceId: String? = nil, startCursor: String? = nil, pageSize: Int = 100) async throws -> Data {
+        var parts: [String] = []
+        if let databaseId, !databaseId.isEmpty {
+            parts.append("database_id=\(databaseId.replacingOccurrences(of: "-", with: ""))")
+        }
+        if let dataSourceId, !dataSourceId.isEmpty {
+            parts.append("data_source_id=\(dataSourceId.replacingOccurrences(of: "-", with: ""))")
+        }
+        guard !parts.isEmpty else {
+            throw NotionClientError.decodingError("listViews requires databaseId and/or dataSourceId")
+        }
+        let size = min(max(pageSize, 1), 100)
+        parts.append("page_size=\(size)")
+        if let startCursor, !startCursor.isEmpty {
+            let encoded = startCursor.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? startCursor
+            parts.append("start_cursor=\(encoded)")
+        }
+        let path = "/views?" + parts.joined(separator: "&")
+        let (data, response) = try await request(method: "GET", path: path)
+        guard (200...299).contains(response.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? ""
+            throw NotionClientError.httpError(response.statusCode, msg)
+        }
+        return data
+    }
+
+    /// Retrieve a view by ID (full filter/sorts/configuration).
+    /// GET /v1/views/{view_id}
+    public func getView(viewId: String) async throws -> Data {
+        let cleanId = viewId.replacingOccurrences(of: "-", with: "")
+        let (data, response) = try await request(method: "GET", path: "/views/\(cleanId)")
         guard (200...299).contains(response.statusCode) else {
             let msg = String(data: data, encoding: .utf8) ?? ""
             throw NotionClientError.httpError(response.statusCode, msg)

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -319,6 +319,8 @@ public enum ToolAnnotationCatalog {
         "notion_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "notion_token_introspect": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "notion_users_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "notion_views_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "notion_view_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "pasteboard_history": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         // fb-permissions: pure read of local TCC grant state — no prompt, no
         // mutation, no network. Same stable input → same output (idempotent).

--- a/TheBridgeTests/IntegrationTests/EndToEndTests.swift
+++ b/TheBridgeTests/IntegrationTests/EndToEndTests.swift
@@ -366,7 +366,8 @@ func runEndToEndTests() async {
         try expect(contacts.count == 4, "ContactsModule: expected 4")
         // Sprint A · mcp-builder #1: notion_block_read removed (24 → 23).
         // FB-notionwrite: notion_page_edit added (23 → 24).
-        try expect(notion.count == 22, "NotionModule: expected 22 (FB-notionwrite)")
+        // 2026-07-15: notion_views_list + notion_view_get (22 → 24).
+        try expect(notion.count == 24, "NotionModule: expected 24 (views list/get)")
         try expect(screen.count == 4, "ScreenModule: expected 4")
         // v3.7.11 resurface: the ax_query deprecation alias was removed. Live set:
         // ax_tree, ax_inspect, ax_focused_app, ax_perform_action = 4.

--- a/TheBridgeTests/NotionModuleTests.swift
+++ b/TheBridgeTests/NotionModuleTests.swift
@@ -22,9 +22,9 @@ func runNotionModuleTests() async {
     // MARK: - Tool Registration (23 tools)
     // ============================================================
 
-    await test("NotionModule registers 22 tools (FB-notionwrite: notion_page_edit added)") {
+    await test("NotionModule registers 24 tools (views list/get + prior surface)") {
         let tools = await router.registrations(forModule: "notion")
-        try expect(tools.count == 22, "Expected 22 notion tools, got \(tools.count)")
+        try expect(tools.count == 24, "Expected 24 notion tools, got \(tools.count)")
     }
 
     let expectedTools: [String] = [
@@ -36,7 +36,8 @@ func runNotionModuleTests() async {
         "notion_page_move", "notion_file_upload", "notion_token_introspect",
         "notion_block_update",
         "notion_datasource_update", "notion_datasource_create",
-        "notion_discussion_create"
+        "notion_discussion_create",
+        "notion_views_list", "notion_view_get"
     ]
 
     for toolName in expectedTools {
@@ -55,7 +56,8 @@ func runNotionModuleTests() async {
         "notion_search", "notion_page_read", "notion_query",
         "notion_page_markdown_read", "notion_comments_list",
         "notion_users_list", "notion_token_introspect",
-        "notion_database_get", "notion_datasource_get"
+        "notion_database_get", "notion_datasource_get",
+        "notion_views_list", "notion_view_get"
     ]
     for toolName in openTools {
         await test("\(toolName) tier is open") {
@@ -234,6 +236,89 @@ func runNotionModuleTests() async {
             )
             throw TestError.assertion("Expected error for missing parentId/discussionId")
         } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_comment_create rejects both pageId and discussionId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_comment_create",
+                arguments: .object([
+                    "pageId": .string("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+                    "discussionId": .string("11111111-2222-3333-4444-555555555555"),
+                    "text": .string("nope")
+                ])
+            )
+            throw TestError.assertion("Expected error when both pageId and discussionId set")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_views_list rejects missing databaseId and dataSourceId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_views_list",
+                arguments: .object([:])
+            )
+            throw TestError.assertion("Expected error for missing databaseId/dataSourceId")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_view_get rejects missing viewId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_view_get",
+                arguments: .object([:])
+            )
+            throw TestError.assertion("Expected error for missing viewId")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("buildCreateCommentRequestBody: page path uses parent.page_id") {
+        let body = try NotionClient.buildCreateCommentRequestBody(
+            pageId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            discussionId: nil,
+            text: "hello"
+        )
+        let parent = body["parent"] as? [String: Any]
+        try expect(parent?["page_id"] as? String != nil, "page path must set parent.page_id")
+        try expect(body["discussion_id"] == nil, "page path must not set discussion_id")
+        let rt = body["rich_text"] as? [[String: Any]]
+        try expect(rt?.count == 1, "rich_text should have one run")
+    }
+
+    await test("buildCreateCommentRequestBody: discussion path uses discussion_id only") {
+        let body = try NotionClient.buildCreateCommentRequestBody(
+            pageId: nil,
+            discussionId: "11111111-2222-3333-4444-555555555555",
+            text: "reply"
+        )
+        try expect(body["parent"] == nil, "reply path must not set parent")
+        let did = body["discussion_id"] as? String
+        try expect(did == "11111111222233334444555555555555", "discussion_id should be dash-stripped, got \(did ?? "nil")")
+    }
+
+    await test("buildCreateCommentRequestBody rejects neither and both targets") {
+        do {
+            _ = try NotionClient.buildCreateCommentRequestBody(pageId: nil, discussionId: nil, text: "x")
+            throw TestError.assertion("neither target should throw")
+        } catch is NotionClientError {
+            // Expected
+        }
+        do {
+            _ = try NotionClient.buildCreateCommentRequestBody(
+                pageId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                discussionId: "11111111-2222-3333-4444-555555555555",
+                text: "x"
+            )
+            throw TestError.assertion("both targets should throw")
+        } catch is NotionClientError {
             // Expected
         }
     }

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2290,3 +2290,5 @@ set -euo pipefail
 # mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
 # redaction, and client name/version attribution. Measured 3207 passed, 0
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
+
+# 2026-07-15 Notion views list/get + comment discussionId reply. FLOOR 3207→3213 (+6 greens; hermetic body/schema tests). staticFeatureModuleToolCount 205→207.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,11 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
+# 2026-07-15: Notion views list/get + comment discussionId reply body tests.
+# Measured green count 3213 (4 pre-existing WorkOS fail-closed tests still red
+# when OAuth/WorkOS credentials are present in the process environment / baked
+# config — not regressions from this slice). Floor raised to net greens.
+FLOOR="${BRIDGE_TEST_FLOOR:-3213}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."


### PR DESCRIPTION
## Summary
- Add `notion_views_list` / `notion_view_get` (Notion Views API read path) so agents can discover and inspect existing database views.
- Extend `notion_comment_create` to accept exactly one of `pageId` | `discussionId` for true thread replies (`discussion_id` body, no parent). VoiceMemo `pageId`+`text` path unchanged.
- Clarify `notion_discussion_create` as new top-level thread only; document search filter object types under Notion-Version 2026-03-11.
- Bump static feature tool count 205→207 and test floor 3207→3213.

## Test plan
- [x] `TheBridgeTests` full suite: 3217 passed, 0 failed
- [x] Live MCP: `notion_views_list` on Projects DS returns views; `notion_view_get` returns board config
- [ ] Live MCP: top-level comment + `discussionId` reply on a disposable page
- [x] `ALLOW_NON_MAIN_INSTALL=1 make install-copy` + Bridge relaunch (local only)