### PR TITLE
feat(voice): list filters, commit receipts, registry identity projection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    # Workflow-level safety net. Cap the whole job at 45 minutes so a
+    # Workflow-level safety net. Cap the whole job at 60 minutes so a
     # hanging test (or a Swift toolchain stall on the GHA runner) fails
     # fast instead of riding the 6h default to cancellation. Locally
-    # the suite runs in <10min; 45min gives headroom for FluidAudio
-    # (Parakeet) fetch+compile on the macos runner's slower IO.
-    timeout-minutes: 45
+    # the suite runs in <10min; 60min gives headroom for FluidAudio
+    # (Parakeet) fetch+compile plus the full floor on the macos runner's
+    # slower IO.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,9 +39,10 @@ jobs:
 
       - name: Build release
         # Per-step timeout — Swift release build on macos-26 with strict
-        # concurrency + FluidAudio (Parakeet) fetch takes ~20min on GHA;
-        # 25min cap catches a stuck compile without burning the job budget.
-        timeout-minutes: 25
+        # concurrency + FluidAudio (Parakeet) fetch can exceed 25min on GHA;
+        # PR #107 reached the final link step before that cap killed it. A 35min
+        # cap keeps a bounded failure while allowing a healthy cold build.
+        timeout-minutes: 35
         run: make build
 
       - name: Run test suite + floor gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased — Voice Memo Reliability (list + receipts + identity projection) — 2026-07-15
+
+- **Fix** — `FieldsFilter` retains `id` / `entity` / `title` on projected registry
+  rows by default (`includeIdentity: true`) so `registry_find`/`list` projections
+  stay usable for follow-on writes without a second unprojected lookup.
+- **Feature** — `voice_memo_list` supports dateFrom/dateTo, hasTranscript,
+  transcriptContains, sort, limit/cursor pagination, and a `health` block
+  (curator job status + unprocessed/pending-review backlog).
+- **Feature** — `voice_memo_commit` returns structured receipts:
+  `memoState` / `intentState` / `completedIntents` / `remainingIntents` / `write`
+  while preserving legacy ok/memoId/intentKind/detail/markedProcessed fields.
+
 ## v3.9.9 (build 80) — Remote shell and control-plane parity — 2026-07-10
 
 - **Fix** — the Wave 1 remote control-plane preference now defaults OFF instead

--- a/TheBridge/Modules/FieldsFilter.swift
+++ b/TheBridge/Modules/FieldsFilter.swift
@@ -26,10 +26,20 @@
 //    type is broken caller code, not a typo.
 //  - No max-length cap: a Set-lookup filter is O(1) per key, nothing here
 //    to defend against (Round 2 Decision 1).
+//  - Identity keys (Voice Memo Reliability / registry audit): when projecting
+//    a non-empty `fields` set, always re-attach any of `id` / `entity` /
+//    `title` that were present on the source envelope (`includeIdentity`
+//    default true). Follow-on relation/update calls need the row id even
+//    when the caller only projected display fields.
 
 import MCP
 
 public enum FieldsFilter {
+
+    /// Immutable envelope keys re-attached after a non-empty projection when
+    /// `includeIdentity` is true (default). Only keys that exist on the source
+    /// envelope are restored — skill envelopes without `id` are unaffected.
+    public static let identityKeys: [String] = ["id", "entity", "title"]
 
     /// Parse the raw `fields` argument (if present) into a validated
     /// `[String]`. Returns `nil` when the key is absent — the "omitted"
@@ -73,12 +83,17 @@ public enum FieldsFilter {
     ///   `propertiesKey` (case-insensitive) keeps the WHOLE map and wins
     ///   over any narrower dotted selection for the same key (permissive
     ///   union — Success Criteria #3).
+    /// - `includeIdentity` (default `true`) re-attaches any of
+    ///   `identityKeys` that exist on the source envelope after projection,
+    ///   so callers who only ask for `properties.status` still receive a
+    ///   usable `id` for follow-on writes.
     /// - Non-object `envelope` (defensive — every real caller passes
     ///   `.object`) is returned untouched.
     public static func project(
         _ envelope: Value,
         fields: [String]?,
-        propertiesKey: String = "properties"
+        propertiesKey: String = "properties",
+        includeIdentity: Bool = true
     ) -> Value {
         guard let fields, !fields.isEmpty else { return envelope }
         guard case .object(let dict) = envelope else { return envelope }
@@ -120,6 +135,14 @@ public enum FieldsFilter {
             }
             if topLevelKeys.contains(key) {
                 result[key] = value
+            }
+        }
+
+        if includeIdentity {
+            for identityKey in identityKeys {
+                if result[identityKey] == nil, let value = dict[identityKey] {
+                    result[identityKey] = value
+                }
             }
         }
         return .object(result)

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -129,7 +129,7 @@ public enum RegistryModule {
     /// Shared description snippet for the `fields` result-projection param,
     /// reused verbatim across all 6 tools (Round 2 Decision 4 — one
     /// mechanism, learned once, recognized everywhere).
-    static let fieldsParamDescriptionSuffix = " Optional `fields` (array of strings) narrows the returned row to only the requested top-level keys — e.g. [\"title\",\"properties.status\"] — instead of the full envelope. Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Omitted or [] → unchanged full response. Unknown keys/paths are silently absent, never an error. On write tools this NEVER filters the operation-status wrapper (created/updated/matchedId/bodyWrite/idempotentReplay/partialFailure/reason) — only the row payload."
+    static let fieldsParamDescriptionSuffix = " Optional `fields` (array of strings) narrows the returned row to only the requested top-level keys — e.g. [\"title\",\"properties.status\"] — instead of the full envelope. Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Identity keys (`id`, `entity`, `title`) are always retained when present so projected list/find rows remain usable for follow-on updates. Omitted or [] → unchanged full response. Unknown keys/paths are silently absent, never an error. On write tools this NEVER filters the operation-status wrapper (created/updated/matchedId/bodyWrite/idempotentReplay/partialFailure/reason) — only the row payload."
 
     static func fieldsParamSchema() -> Value {
         .object([

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoListQuery.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoListQuery.swift
@@ -1,0 +1,149 @@
+// VoiceMemoListQuery.swift — filtered/paginated list for voice_memo_list
+// TheBridge · Modules · VoiceMemo
+//
+// Voice Memo Reliability packet (Ship The Bridge v4): unbounded
+// `voice_memo_list` returned 200+ memos forcing client-side date filtering.
+// This pure helper applies date range, processed-state, transcript presence,
+// text contains, sort, limit, and opaque cursor — no disk I/O of its own.
+
+import Foundation
+
+public struct VoiceMemoListQuery: Sendable, Equatable {
+    public var includeProcessed: Bool
+    /// Max rows to return (clamped 1...500). Nil → default 50.
+    public var limit: Int?
+    /// Opaque cursor from a prior response (`nextCursor`).
+    public var cursor: String?
+    public var dateFrom: Date?
+    public var dateTo: Date?
+    public var hasTranscript: Bool?
+    public var transcriptContains: String?
+    /// Default newest-first (`false`).
+    public var sortAscending: Bool
+
+    public static let defaultLimit = 50
+    public static let maxLimit = 500
+
+    public init(
+        includeProcessed: Bool = false,
+        limit: Int? = nil,
+        cursor: String? = nil,
+        dateFrom: Date? = nil,
+        dateTo: Date? = nil,
+        hasTranscript: Bool? = nil,
+        transcriptContains: String? = nil,
+        sortAscending: Bool = false
+    ) {
+        self.includeProcessed = includeProcessed
+        self.limit = limit
+        self.cursor = cursor
+        self.dateFrom = dateFrom
+        self.dateTo = dateTo
+        self.hasTranscript = hasTranscript
+        self.transcriptContains = transcriptContains
+        self.sortAscending = sortAscending
+    }
+
+    public var effectiveLimit: Int {
+        let raw = limit ?? Self.defaultLimit
+        return min(max(raw, 1), Self.maxLimit)
+    }
+}
+
+public struct VoiceMemoListPage: Sendable, Equatable {
+    public let memos: [VoiceMemoRecording]
+    public let totalMatched: Int
+    public let nextCursor: String?
+    public let hasMore: Bool
+
+    public init(memos: [VoiceMemoRecording], totalMatched: Int, nextCursor: String?, hasMore: Bool) {
+        self.memos = memos
+        self.totalMatched = totalMatched
+        self.nextCursor = nextCursor
+        self.hasMore = hasMore
+    }
+}
+
+public enum VoiceMemoListFilter {
+
+    /// Apply query filters + pagination over a pre-discovered recording set.
+    /// `isProcessed` is injected so tests can stub the processed store.
+    public static func page(
+        recordings: [VoiceMemoRecording],
+        query: VoiceMemoListQuery,
+        isProcessed: (String) -> Bool = { VoiceMemoProcessedStore.isProcessed(id: $0) }
+    ) -> VoiceMemoListPage {
+        var filtered = recordings.filter { rec in
+            if !query.includeProcessed, isProcessed(rec.id) { return false }
+            if let from = query.dateFrom, rec.recordedAt < from { return false }
+            if let to = query.dateTo, rec.recordedAt > to { return false }
+            if let wantTranscript = query.hasTranscript, rec.hasTranscript != wantTranscript { return false }
+            if let needle = query.transcriptContains?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !needle.isEmpty {
+                let hay = ((rec.transcript ?? "") + " " + rec.title)
+                    .lowercased()
+                if !hay.contains(needle.lowercased()) { return false }
+            }
+            return true
+        }
+
+        filtered.sort {
+            if query.sortAscending {
+                if $0.recordedAt != $1.recordedAt { return $0.recordedAt < $1.recordedAt }
+                return $0.id < $1.id
+            } else {
+                if $0.recordedAt != $1.recordedAt { return $0.recordedAt > $1.recordedAt }
+                return $0.id > $1.id
+            }
+        }
+
+        let total = filtered.count
+        let start: Int
+        if let cursor = query.cursor, let decoded = decodeCursor(cursor) {
+            if let idx = filtered.firstIndex(where: {
+                $0.id == decoded.id && abs($0.recordedAt.timeIntervalSince(decoded.recordedAt)) < 1.0
+            }) {
+                start = idx + 1
+            } else {
+                // Cursor not found: treat as start of list (idempotent resume).
+                start = 0
+            }
+        } else {
+            start = 0
+        }
+
+        let limit = query.effectiveLimit
+        guard start < filtered.count else {
+            return VoiceMemoListPage(memos: [], totalMatched: total, nextCursor: nil, hasMore: false)
+        }
+        let end = min(start + limit, filtered.count)
+        let slice = Array(filtered[start..<end])
+        let hasMore = end < filtered.count
+        let next: String? = hasMore ? encodeCursor(slice.last!) : nil
+        return VoiceMemoListPage(memos: slice, totalMatched: total, nextCursor: next, hasMore: hasMore)
+    }
+
+    // Cursor: base64url("ISO8601|id")
+    public static func encodeCursor(_ rec: VoiceMemoRecording) -> String {
+        let iso = ISO8601DateFormatter().string(from: rec.recordedAt)
+        let raw = "\(iso)|\(rec.id)"
+        return Data(raw.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    public static func decodeCursor(_ cursor: String) -> (recordedAt: Date, id: String)? {
+        var b64 = cursor
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64.append("=") }
+        guard let data = Data(base64Encoded: b64),
+              let raw = String(data: data, encoding: .utf8) else { return nil }
+        let parts = raw.split(separator: "|", maxSplits: 1).map(String.init)
+        guard parts.count == 2,
+              let date = ISO8601DateFormatter().date(from: parts[0]) else { return nil }
+        return (date, parts[1])
+    }
+}
+

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
@@ -31,7 +31,7 @@ public enum VoiceMemoModule {
             name: "voice_memo_list",
             module: moduleName,
             tier: .open,
-            description: "List Voice Memos recordings discovered on disk. Marks which are already processed by the morning curator job. Read-only.",
+            description: "List Voice Memos recordings discovered on disk with optional date/transcript/processed filters, limit/cursor pagination, and curator/backlog health. Read-only.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -39,22 +39,84 @@ public enum VoiceMemoModule {
                         "type": .string("boolean"),
                         "description": .string("Include memos already processed (default false)."),
                     ]),
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "description": .string("Max memos to return (default 50, max 500)."),
+                    ]),
+                    "cursor": .object([
+                        "type": .string("string"),
+                        "description": .string("Opaque pagination cursor from a prior nextCursor."),
+                    ]),
+                    "dateFrom": .object([
+                        "type": .string("string"),
+                        "description": .string("ISO-8601 lower bound on recordedAt (inclusive)."),
+                    ]),
+                    "dateTo": .object([
+                        "type": .string("string"),
+                        "description": .string("ISO-8601 upper bound on recordedAt (inclusive)."),
+                    ]),
+                    "hasTranscript": .object([
+                        "type": .string("boolean"),
+                        "description": .string("When set, only memos with/without a transcript body."),
+                    ]),
+                    "transcriptContains": .object([
+                        "type": .string("string"),
+                        "description": .string("Case-insensitive substring match against title + known transcript text."),
+                    ]),
+                    "sort": .object([
+                        "type": .string("string"),
+                        "description": .string("recordedAt_desc (default) or recordedAt_asc."),
+                    ]),
+                    "includeHealth": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Include curator job status + backlog counts (default true)."),
+                    ]),
                 ]),
             ]),
             metadata: ToolMetadata(
                 title: "Voice Memo List",
-                whenToUse: ["inspect unprocessed Voice Memos before running the curator", "debug discovery paths and transcript sidecars"],
+                whenToUse: [
+                    "inspect unprocessed Voice Memos before running the curator",
+                    "date-scoped triage without downloading the full backlog",
+                    "debug discovery paths and transcript sidecars",
+                ],
                 whenNotToUse: ["routing writes — use voice_memo_process"],
-                relatedTools: ["voice_memo_process"]
+                relatedTools: ["voice_memo_process", "voice_memo_settings_get"]
             ),
             handler: { args in
-                var includeProcessed = false
-                if case .object(let obj) = args, case .bool(let b)? = obj["includeProcessed"] { includeProcessed = b }
+                let obj: [String: Value]
+                if case .object(let o) = args { obj = o } else { obj = [:] }
+
+                var query = VoiceMemoListQuery()
+                if case .bool(let b)? = obj["includeProcessed"] { query.includeProcessed = b }
+                if case .int(let n)? = obj["limit"] { query.limit = n }
+                if case .double(let d)? = obj["limit"] { query.limit = Int(d) }
+                if case .string(let c)? = obj["cursor"] { query.cursor = c }
+                if case .bool(let b)? = obj["hasTranscript"] { query.hasTranscript = b }
+                if case .string(let s)? = obj["transcriptContains"] { query.transcriptContains = s }
+                if case .string(let sort)? = obj["sort"] {
+                    query.sortAscending = sort.lowercased().contains("asc")
+                }
+                let iso = ISO8601DateFormatter()
+                iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                let isoBasic = ISO8601DateFormatter()
+                if case .string(let from)? = obj["dateFrom"] {
+                    query.dateFrom = iso.date(from: from) ?? isoBasic.date(from: from)
+                }
+                if case .string(let to)? = obj["dateTo"] {
+                    query.dateTo = iso.date(from: to) ?? isoBasic.date(from: to)
+                }
+                var includeHealth = true
+                if case .bool(let b)? = obj["includeHealth"] { includeHealth = b }
+
                 let all = VoiceMemoDiscovery.listRecordings(roots: VoiceMemoDiscovery.defaultRecordingRoots())
-                let rows = all.filter { includeProcessed || !VoiceMemoProcessedStore.isProcessed(id: $0.id) }
-                return .object([
-                    "count": .int(rows.count),
-                    "memos": .array(rows.map { memo in
+                let page = VoiceMemoListFilter.page(recordings: all, query: query)
+
+                var result: [String: Value] = [
+                    "count": .int(page.memos.count),
+                    "totalMatched": .int(page.totalMatched),
+                    "hasMore": .bool(page.hasMore),
+                    "memos": .array(page.memos.map { memo in
                         .object([
                             "id": .string(memo.id),
                             "title": .string(memo.title),
@@ -65,7 +127,33 @@ public enum VoiceMemoModule {
                             "processed": .bool(VoiceMemoProcessedStore.isProcessed(id: memo.id)),
                         ])
                     }),
-                ])
+                ]
+                if let next = page.nextCursor { result["nextCursor"] = .string(next) }
+
+                if includeHealth {
+                    let unprocessed = all.filter { !VoiceMemoProcessedStore.isProcessed(id: $0.id) }.count
+                    let pendingReview = VoiceMemoReviewStore.pendingEntries().count
+                    var curatorStatus = "missing"
+                    var curatorActive = false
+                    do {
+                        try await JobStore.shared.open()
+                        if let job = try await JobStore.shared.fetch(id: VoiceMemoCuratorJob.jobId) {
+                            curatorStatus = job.status.rawValue
+                            curatorActive = job.status == .active
+                        }
+                    } catch {
+                        curatorStatus = "unavailable"
+                    }
+                    result["health"] = .object([
+                        "curatorJobId": .string(VoiceMemoCuratorJob.jobId),
+                        "curatorStatus": .string(curatorStatus),
+                        "curatorActive": .bool(curatorActive),
+                        "unprocessedCount": .int(unprocessed),
+                        "pendingReviewCount": .int(pendingReview),
+                        "backlogHealthy": .bool(unprocessed < 50 && curatorActive),
+                    ])
+                }
+                return .object(result)
             }
         )
     }

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -1422,14 +1422,19 @@ public enum VoiceMemoProcessor {
                 ),
                 provenance: "stage-timeout"
             ))
-            return .object([
-                "ok": .bool(false),
-                "needsManual": .bool(true),
-                "memoId": .string(recording.id),
-                "intentKind": .string(kind.rawValue),
-                "detail": .string(timeoutError.localizedDescription),
-                "markedProcessed": .bool(false),
-            ])
+            var receipt = commitReceipt(
+                ok: false,
+                memoId: recording.id,
+                intentKind: kind.rawValue,
+                intentState: "review_required",
+                detail: timeoutError.localizedDescription,
+                markedProcessed: false
+            )
+            if case .object(var obj) = receipt {
+                obj["needsManual"] = .bool(true)
+                receipt = .object(obj)
+            }
+            return receipt
         }
         var intent = plan.intents.first { $0.kind == kind } ?? VoiceMemoIntent(kind: kind, confidence: 1.0)
         if let entityKey = stringArg(obj, "entityKey") { intent.entityKey = entityKey }
@@ -1492,24 +1497,34 @@ public enum VoiceMemoProcessor {
                 entityHint: intent.entityHint,
                 provenance: "stage-timeout"
             ))
-            return .object([
-                "ok": .bool(false),
-                "needsManual": .bool(true),
-                "memoId": .string(recording.id),
-                "intentKind": .string(kind.rawValue),
-                "detail": .string(timeoutError.localizedDescription),
-                "markedProcessed": .bool(false),
-            ])
+            var receipt = commitReceipt(
+                ok: false,
+                memoId: recording.id,
+                intentKind: kind.rawValue,
+                intentState: "review_required",
+                detail: timeoutError.localizedDescription,
+                markedProcessed: false
+            )
+            if case .object(var obj) = receipt {
+                obj["needsManual"] = .bool(true)
+                receipt = .object(obj)
+            }
+            return receipt
         } catch let error as VoiceMemoError {
             if case .registryAmbiguous = error {
-                return .object([
-                    "ok": .bool(false),
-                    "needsManual": .bool(true),
-                    "memoId": .string(recording.id),
-                    "intentKind": .string(kind.rawValue),
-                    "detail": .string(error.localizedDescription),
-                    "markedProcessed": .bool(false),
-                ])
+                var receipt = commitReceipt(
+                    ok: false,
+                    memoId: recording.id,
+                    intentKind: kind.rawValue,
+                    intentState: "review_required",
+                    detail: error.localizedDescription,
+                    markedProcessed: false
+                )
+                if case .object(var obj) = receipt {
+                    obj["needsManual"] = .bool(true)
+                    receipt = .object(obj)
+                }
+                return receipt
             }
             if case .contentQualityRejected = error {
                 // GH #81 — the commit-time counterpart of processOne's queueReview: an
@@ -1531,14 +1546,19 @@ public enum VoiceMemoProcessor {
                     entityHint: intent.entityHint,
                     provenance: "content-quality-gate"
                 ))
-                return .object([
-                    "ok": .bool(false),
-                    "needsManual": .bool(true),
-                    "memoId": .string(recording.id),
-                    "intentKind": .string(kind.rawValue),
-                    "detail": .string(error.localizedDescription),
-                    "markedProcessed": .bool(false),
-                ])
+                var receipt = commitReceipt(
+                    ok: false,
+                    memoId: recording.id,
+                    intentKind: kind.rawValue,
+                    intentState: "review_required",
+                    detail: error.localizedDescription,
+                    markedProcessed: false
+                )
+                if case .object(var obj) = receipt {
+                    obj["needsManual"] = .bool(true)
+                    receipt = .object(obj)
+                }
+                return receipt
             }
             throw error
         }
@@ -1559,13 +1579,87 @@ public enum VoiceMemoProcessor {
         }
         let markedProcessed = try VoiceMemoProcessedGate.markProcessedIfClear(memoId: recording.id)
         recordCommitted(recording: recording, intentId: committedIntentId, kind: kind, detail: detail)
-        return .object([
-            "ok": .bool(true),
-            "memoId": .string(recording.id),
-            "intentKind": .string(kind.rawValue),
+        return commitReceipt(
+            ok: true,
+            memoId: recording.id,
+            intentKind: kind.rawValue,
+            intentState: "committed",
+            detail: detail,
+            markedProcessed: markedProcessed,
+            write: parseWriteDestination(detail: detail, kind: kind, intent: intent)
+        )
+    }
+
+    /// Structured commit receipt (Voice Memo Reliability packet SC #7 / proposed receipt).
+    /// Additive fields — existing clients still read ok/memoId/intentKind/detail/markedProcessed.
+    static func commitReceipt(
+        ok: Bool,
+        memoId: String,
+        intentKind: String,
+        intentState: String,
+        detail: String,
+        markedProcessed: Bool,
+        write: [String: Value]? = nil
+    ) -> Value {
+        let remaining = VoiceMemoReviewStore.pendingEntries()
+            .filter { $0.memoId == memoId }
+            .map { $0.intentKind }
+        let completed = VoiceMemoReviewStore.load().entries
+            .filter { $0.memoId == memoId && ($0.status == .resolved || $0.status == .dismissed) }
+            .map { $0.intentKind }
+        // Include the intent we just committed even if the review entry was just resolved.
+        var completedSet = Set(completed)
+        if ok { completedSet.insert(intentKind) }
+
+        let memoState: String
+        if markedProcessed {
+            memoState = "committed"
+        } else if !remaining.isEmpty {
+            memoState = "partially_committed"
+        } else if !ok {
+            memoState = intentState == "review_required" ? "review_required" : "failed"
+        } else {
+            memoState = "partially_committed"
+        }
+
+        var obj: [String: Value] = [
+            "ok": .bool(ok),
+            "memoId": .string(memoId),
+            "intentKind": .string(intentKind),
+            "intentState": .string(intentState),
+            "memoState": .string(memoState),
             "detail": .string(detail),
             "markedProcessed": .bool(markedProcessed),
-        ])
+            "completedIntents": .array(completedSet.sorted().map { .string($0) }),
+            "remainingIntents": .array(remaining.sorted().map { .string($0) }),
+        ]
+        if let write { obj["write"] = .object(write) }
+        return .object(obj)
+    }
+
+    /// Best-effort parse of lane execute() detail strings into a write receipt block.
+    static func parseWriteDestination(
+        detail: String,
+        kind: VoiceMemoIntentKind,
+        intent: VoiceMemoIntent
+    ) -> [String: Value]? {
+        // Common detail shapes: "memory_keep pageId=…", "registry_update contact rowId=…",
+        // "reminder id=…", "memory_remember scope=… (N chars)".
+        var write: [String: Value] = [
+            "tool": .string(kind.rawValue),
+        ]
+        if let entity = intent.entityKey { write["entity"] = .string(entity) }
+        if let title = intent.entityHint ?? intent.title { write["title"] = .string(title) }
+        // Capture first UUID-looking token as recordId when present.
+        let uuidPattern = #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32}"#
+        if let regex = try? NSRegularExpression(pattern: uuidPattern),
+           let match = regex.firstMatch(in: detail, range: NSRange(detail.startIndex..., in: detail)),
+           let range = Range(match.range, in: detail) {
+            write["recordId"] = .string(String(detail[range]))
+        }
+        if detail.contains("append") { write["mode"] = .string("append") }
+        write["detail"] = .string(detail)
+        return write
     }
 
     static func memoValue(_ recording: VoiceMemoRecording, transcript: String) -> Value {

--- a/TheBridgeTests/FieldsFilterTests.swift
+++ b/TheBridgeTests/FieldsFilterTests.swift
@@ -71,20 +71,29 @@ func runFieldsFilterTests() async {
     // MARK: #3 — top-level key selection
     // ============================================================
 
-    await test("FieldsFilter: single top-level key narrows to just that key") {
+    await test("FieldsFilter: single top-level key retains identity keys by default") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title"]))
+        // title was requested; id+entity re-attached as identity keys.
+        try expect(Set(projected.keys) == ["title", "id", "entity"], "got \(projected.keys.sorted())")
+        try expect(projected["title"] == .string("Alpha"), "title value preserved")
+        try expect(projected["id"] == .string("aaaa0000000000000000000000000001"), "id retained")
+        try expect(projected["entity"] == .string("skill"), "entity retained")
+    }
+
+    await test("FieldsFilter: includeIdentity:false allows pure single-key projection") {
+        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title"], includeIdentity: false))
         try expect(projected.count == 1, "expected exactly 1 key, got \(projected.count): \(projected.keys.sorted())")
         try expect(projected["title"] == .string("Alpha"), "title value preserved")
     }
 
     await test("FieldsFilter: multiple top-level keys all survive") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title", "id", "stale"]))
-        try expect(Set(projected.keys) == ["title", "id", "stale"], "got \(projected.keys.sorted())")
+        try expect(Set(projected.keys) == ["title", "id", "stale", "entity"], "got \(projected.keys.sorted())")
     }
 
-    await test("FieldsFilter: bare 'properties' keeps the WHOLE properties map") {
+    await test("FieldsFilter: bare 'properties' keeps the WHOLE properties map + identity") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties"]))
-        try expect(projected.count == 1, "only properties key expected")
+        try expect(Set(projected.keys) == ["properties", "id", "entity", "title"], "got \(projected.keys.sorted())")
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be an object")
         }
@@ -97,6 +106,7 @@ func runFieldsFilterTests() async {
 
     await test("FieldsFilter: properties.X sub-selects ONE property out of the map") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.summary"]))
+        try expect(projected["id"] != nil, "identity id retained with properties.X projection")
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be present as an object")
         }
@@ -129,8 +139,11 @@ func runFieldsFilterTests() async {
     // ============================================================
 
     await test("FieldsFilter: unknown top-level key → silently absent, no error") {
+        // With includeIdentity (default), only identity keys from the source remain.
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["doesNotExist"]))
-        try expect(projected.isEmpty, "unknown key must contribute nothing; got \(projected.keys.sorted())")
+        try expect(Set(projected.keys) == ["id", "entity", "title"], "got \(projected.keys.sorted())")
+        let pure = dict(FieldsFilter.project(sampleRow(), fields: ["doesNotExist"], includeIdentity: false))
+        try expect(pure.isEmpty, "unknown key must contribute nothing without identity; got \(pure.keys.sorted())")
     }
 
     await test("FieldsFilter: unknown property path → the requested property is silently absent (properties: {})") {
@@ -139,7 +152,7 @@ func runFieldsFilterTests() async {
         // and got zero matches" from "you never asked for properties at
         // all") — but it contains none of the sampleRow's real keys, i.e.
         // the unknown path silently contributes zero matches, never an error.
-        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.doesNotExist"]))
+        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.doesNotExist"], includeIdentity: false))
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be present as an object when a properties.X path was requested")
         }
@@ -148,7 +161,8 @@ func runFieldsFilterTests() async {
 
     await test("FieldsFilter: known + unknown top-level keys mixed → only known survive") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title", "ghost", "id"]))
-        try expect(Set(projected.keys) == ["title", "id"], "got \(projected.keys.sorted())")
+        // entity re-attached via includeIdentity even though not requested.
+        try expect(Set(projected.keys) == ["title", "id", "entity"], "got \(projected.keys.sorted())")
     }
 
     // ============================================================
@@ -176,8 +190,11 @@ func runFieldsFilterTests() async {
     await test("FieldsFilter: mixed-case top-level key is NOT matched case-insensitively (exact key match)") {
         // Top-level keys are exact-match (only the propertiesKey token itself
         // is treated case-insensitively) — this pins that distinction.
+        // Identity keys are still re-attached from the source envelope.
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["Title"]))
-        try expect(projected.isEmpty, "top-level keys are case-SENSITIVE except the properties token")
+        try expect(Set(projected.keys) == ["id", "entity", "title"], "got \(projected.keys.sorted())")
+        let pure = dict(FieldsFilter.project(sampleRow(), fields: ["Title"], includeIdentity: false))
+        try expect(pure.isEmpty, "top-level keys are case-SENSITIVE except the properties token")
     }
 
     // ============================================================

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -925,8 +925,10 @@ func runRegistryModuleTests() async {
                 "entity": .string("skill"), "id": .string("bbbb0000000000000000000000000001"),
                 "fields": .array([.string("title")]),
             ]))
-            try expect(obj(out).count == 1, "expected exactly 1 key, got \(obj(out).keys.sorted())")
+            // Identity keys (id/entity/title) retained with the requested projection.
             try expect(obj(out)["title"] == .string("Gamma"), "title value preserved")
+            try expect(obj(out)["id"] != nil, "id retained with projected fields")
+            try expect(obj(out)["entity"] != nil, "entity retained with projected fields")
         }
     }
 
@@ -974,7 +976,8 @@ func runRegistryModuleTests() async {
             guard case .array(let rows)? = obj(out)["rows"] else { throw TestError.assertion("rows missing") }
             try expect(rows.count == 2, "both rows present")
             for r in rows {
-                try expect(obj(r).count == 1 && obj(r)["title"] != nil, "each row projected to just title: \(obj(r))")
+                try expect(obj(r)["title"] != nil, "each row keeps title: \(obj(r))")
+                try expect(obj(r)["id"] != nil, "each projected row retains id: \(obj(r))")
             }
             // count/entity wrapper keys survive untouched (list has no write-status wrapper, but its own keys aren't row-shaped).
             try expect(obj(out)["count"] == .int(2), "count unaffected by fields")
@@ -991,7 +994,8 @@ func runRegistryModuleTests() async {
                 "fields": .array([.string("id")]),
             ]))
             guard case .array(let rows)? = obj(out)["rows"], let r0 = rows.first else { throw TestError.assertion("no rows") }
-            try expect(obj(r0).count == 1 && obj(r0)["id"] == .string("dddd0000000000000000000000000001"), "got \(obj(r0))")
+            try expect(obj(r0)["id"] == .string("dddd0000000000000000000000000001"), "id preserved: \(obj(r0))")
+            try expect(obj(r0)["title"] != nil || obj(r0)["entity"] != nil, "identity keys retained: \(obj(r0))")
         }
     }
 
@@ -1070,8 +1074,10 @@ func runRegistryModuleTests() async {
             try expect(obj(out)["updated"] == .bool(true), "wrapper key present")
             try expect(obj(out)["matchedId"] != nil, "wrapper key matchedId present")
             guard case .object(let row)? = obj(out)["row"] else { throw TestError.assertion("row missing") }
-            try expect(row.count == 1 && row["id"] == .string("ffff0000000000000000000000000010"),
-                       "row must be projected via resultFields to just id, got \(row)")
+            try expect(row["id"] == .string("ffff0000000000000000000000000010"),
+                       "row id preserved via resultFields, got \(row)")
+            try expect(row["entity"] != nil || row["title"] != nil,
+                       "identity keys retained on projected row, got \(row)")
         }
     }
 

--- a/TheBridgeTests/SkillsModuleTests.swift
+++ b/TheBridgeTests/SkillsModuleTests.swift
@@ -178,7 +178,7 @@ func runSkillsModuleTests() async {
             name: "demo", title: "Demo", url: "https://n/demo",
             markdownJSONOrText: md, summary: "sum", triggerPhrases: ["t1"], antiTriggerPhrases: ["a1"]
         ) { _ in nil }
-        let projected = FieldsFilter.project(envelope, fields: ["content"])
+        let projected = FieldsFilter.project(envelope, fields: ["content"], includeIdentity: false)
         guard case .object(let dict) = projected else { throw TestError.assertion("expected object") }
         try expect(dict.count == 1, "expected exactly 1 key, got \(dict.keys.sorted())")
         guard case .string(let content)? = dict["content"] else { throw TestError.assertion("content missing") }
@@ -196,7 +196,7 @@ func runSkillsModuleTests() async {
             name: "demo2", title: "Demo2", url: "https://n/demo2",
             markdownJSONOrText: md, pageProperties: pageProps
         ) { _ in nil }
-        let projected = FieldsFilter.project(envelope, fields: ["properties.status"])
+        let projected = FieldsFilter.project(envelope, fields: ["properties.status"], includeIdentity: false)
         guard case .object(let dict) = projected,
               case .object(let props)? = dict["properties"] else {
             throw TestError.assertion("expected projected properties object")
@@ -226,7 +226,9 @@ func runSkillsModuleTests() async {
         ) { _ in nil }
         let projected = FieldsFilter.project(envelope, fields: ["ghostKey", "title"])
         guard case .object(let dict) = projected else { throw TestError.assertion("expected object") }
-        try expect(Set(dict.keys) == ["title"], "only known key survives, got \(dict.keys.sorted())")
+        // title requested; id/entity re-attached only if present on skill envelope.
+        try expect(dict["title"] != nil, "title must survive")
+        try expect(dict["ghostKey"] == nil, "unknown key must not survive")
     }
 
     // ============================================================

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -642,6 +642,7 @@ await runRegistryDataPathTests()     // Data-Source Registry W2: live data path 
 await runRegistryModuleTests()       // Data-Source Registry W3: MCP tool surface (13 tools: generic CRUD + resolve_and_update + add/remove_entity + introspect + possess + hydrate, registration + handler behavior)
 await runRegistryAppendMergeTests()  // PKT-MEM-135: RegistryAppendMerge shared append-merge primitive (ported from VoiceMemoProcessor.mergeAppendRegistryFields)
 await runFieldsFilterTests()         // PKT: fields Param Across Registry Tools + fetch_skill — shared FieldsFilter primitive (parse + project), hermetic synthetic-Value fixtures
+await runVoiceMemoListQueryTests()   // Voice Memo Reliability: list date/transcript filters + cursor pagination
 await runDataSourcesViewModelTests() // Data-Source Registry W4: Settings pane scenarios (propose→confirm, TTL, drift, errors) + BE↔FE alignment
 await runRegistryEdgeCaseTests()     // Data-Source Registry: adversarial edge cases (codec chunking, pagination, cache concurrency, config race, writer)
 await runRegistryHydrationTests()    // Packet Runner v1 (FR-1/§8.3): packet-registry-v1 one-hop hydration envelope (primary+body+relations+provenance+warnings)

--- a/TheBridgeTests/VoiceMemoListQueryTests.swift
+++ b/TheBridgeTests/VoiceMemoListQueryTests.swift
@@ -1,0 +1,104 @@
+// VoiceMemoListQueryTests.swift — list filters + pagination (Voice Memo Reliability)
+// TheBridge · Tests
+
+import Foundation
+import TheBridgeLib
+
+func runVoiceMemoListQueryTests() async {
+    print("\n📋 VoiceMemoListQuery Tests")
+
+    // Local fixtures rebuilt inside each test body so closures stay Sendable.
+    func makePool() -> (pool: [VoiceMemoRecording], isProcessed: @Sendable (String) -> Bool) {
+        func rec(id: String, title: String, daysAgo: Int, transcript: String? = nil) -> VoiceMemoRecording {
+            let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
+            return VoiceMemoRecording(
+                id: id,
+                path: "/tmp/\(id).m4a",
+                title: title,
+                recordedAt: date,
+                transcript: transcript,
+                transcriptSource: transcript == nil ? .none : .sidecar
+            )
+        }
+        let pool = [
+            rec(id: "p1", title: "Old done", daysAgo: 30, transcript: "done body"),
+            rec(id: "u1", title: "July memo", daysAgo: 8, transcript: "greg flicek follow up"),
+            rec(id: "u2", title: "June memo", daysAgo: 40, transcript: "unrelated"),
+            rec(id: "u3", title: "No transcript", daysAgo: 2),
+            rec(id: "u4", title: "Recent", daysAgo: 1, transcript: "short"),
+        ]
+        let isProcessed: @Sendable (String) -> Bool = { $0 == "p1" }
+        return (pool, isProcessed)
+    }
+
+    await test("list filter: default excludes processed and pages with default limit") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 2),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 4, "unprocessed only → 4, got \(page.totalMatched)")
+        try expect(page.memos.count == 2, "limit 2")
+        try expect(page.hasMore, "hasMore")
+        try expect(page.nextCursor != nil, "nextCursor present")
+        try expect(page.memos.first?.id == "u4", "newest first, got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: cursor resumes after prior page") {
+        let (pool, isProcessed) = makePool()
+        let page1 = VoiceMemoListFilter.page(recordings: pool, query: VoiceMemoListQuery(limit: 2), isProcessed: isProcessed)
+        let page2 = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 2, cursor: page1.nextCursor),
+            isProcessed: isProcessed
+        )
+        try expect(page2.memos.count == 2, "second page size")
+        let ids1 = Set(page1.memos.map(\.id))
+        let ids2 = Set(page2.memos.map(\.id))
+        try expect(ids1.isDisjoint(with: ids2), "pages must not overlap: \(ids1) vs \(ids2)")
+    }
+
+    await test("list filter: dateFrom/dateTo scopes to window") {
+        let (pool, isProcessed) = makePool()
+        let from = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
+        let to = Calendar.current.date(byAdding: .day, value: -5, to: Date())!
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(includeProcessed: true, dateFrom: from, dateTo: to),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 1, "only July memo in window, got \(page.totalMatched)")
+        try expect(page.memos.first?.id == "u1", "got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: hasTranscript + transcriptContains") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(hasTranscript: true, transcriptContains: "Greg"),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 1, "greg match")
+        try expect(page.memos.first?.id == "u1", "got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: sort ascending") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 10, sortAscending: true),
+            isProcessed: isProcessed
+        )
+        try expect(page.memos.first?.id == "u2", "oldest unprocessed first, got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list cursor encode/decode round-trip") {
+        let (pool, _) = makePool()
+        let r = pool[0]
+        let c = VoiceMemoListFilter.encodeCursor(r)
+        let decoded = VoiceMemoListFilter.decodeCursor(c)
+        try expect(decoded?.id == r.id, "id round-trip")
+        try expect(decoded != nil, "decode ok")
+    }
+}

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2290,3 +2290,4 @@ set -euo pipefail
 # mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
 # redaction, and client name/version attribution. Measured 3207 passed, 0
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
+# 2026-07-15 Voice Memo Reliability (list filters/pagination/health + commit receipts + FieldsFilter identity keys). FLOOR 3207→3214 (+7).

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,9 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
+# 2026-07-15 Voice Memo Reliability: list filters + commit receipts + FieldsFilter
+# identity retention. Measured 3214 passed / 0 failed. FLOOR 3207→3214.
+FLOOR="${BRIDGE_TEST_FLOOR:-3214}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."


### PR DESCRIPTION
## Summary
Implements **slice 1** of the Ship The Bridge v4 packet *Bridge Voice Memo + Registry Reliability Feedback* (REVIEW-FIRST):

- **Registry projection identity** — `FieldsFilter` always retains `id` / `entity` / `title` when projecting (fixes projected list/find rows that lost IDs).
- **`voice_memo_list`** — dateFrom/dateTo, hasTranscript, transcriptContains, sort, limit/cursor pagination, and curator/backlog `health`.
- **`voice_memo_commit` receipts** — `memoState`, `intentState`, `completedIntents`, `remainingIntents`, optional `write` block (additive; legacy fields preserved).

## Packet status
FOCUS → **REVIEW** with partial OBJECTIVE_MET. SC 7/9/10 + registry identity done; SC 2/4/5/6/8 remain for follow-on.

## Test plan
- [x] Full suite: **3214 passed / 0 failed**
- [x] New `VoiceMemoListQueryTests` (6)
- [x] FieldsFilter + RegistryModule projection expectations updated
- [ ] No production install (packet prohibition until operator GO)