### PR TITLE
Resolve audited agent feedback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SPARKLE_ARTIFACT_DIR = $(BUILD_DIR)/artifacts/sparkle/Sparkle
 SPARKLE_FRAMEWORK = $(SPARKLE_ARTIFACT_DIR)/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework
 SPARKLE_TOOLS_DIR = $(SPARKLE_ARTIFACT_DIR)/bin
 
-.PHONY: debug build test test-floor check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree inject-license-key inject-remote-access
+.PHONY: debug build test test-floor test-clean check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree inject-license-key inject-remote-access
 
 # ── Debug Build ────────────────────────────────────────────────
 debug:
@@ -129,6 +129,14 @@ test:
 # Used by CI so a shrunk/disabled suite fails. Floor provenance lives in
 # scripts/test-floor-gate.sh.
 test-floor:
+	./scripts/test-floor-gate.sh
+
+# Branch/tool-surface switch verification: clear every SwiftPM object before
+# running the same locked floor gate. Use when a worktree changes branches or
+# cherry-picks a module-registration change; prevents stale tools from a prior
+# HEAD surviving in .build and producing a false surface-audit failure.
+test-clean:
+	swift package clean
 	./scripts/test-floor-gate.sh
 
 # PKT-1115: detect duplicate monotonic counter/FLOOR claims across open PRs.
@@ -327,6 +335,7 @@ install: check-clean-tree check-stale-build notarize
 	@killall Dock 2>/dev/null || true
 	$(VERIFY_INSTALL)
 	@echo "✅ Installed: /Applications/The Bridge.app"
+	@echo "🔌 Reconnect every MCP client after relaunch so it re-runs initialize + tools/list."
 
 # v1.7.0: Copy-only install (no notarize dep, no killall) (F3)
 install-copy: check-clean-tree check-stale-build sign
@@ -340,6 +349,7 @@ install-copy: check-clean-tree check-stale-build sign
 	$(VERIFY_INSTALL)
 	@echo "Installed: /Applications/The Bridge.app"
 	@echo "Restart The Bridge manually to pick up changes."
+	@echo "Reconnect every MCP client after relaunch so it re-runs initialize + tools/list."
 
 # Alias for agents / remote MCP sessions: same as install-copy (no notarize; does not kill The Bridge).
 install-agent-safe: install-copy

--- a/TheBridge/Modules/ContactsModule.swift
+++ b/TheBridge/Modules/ContactsModule.swift
@@ -18,6 +18,76 @@ public enum ContactsModule {
 
     public static let moduleName = "contacts"
 
+    public struct HandleAttribution: Sendable, Equatable {
+        public let resolvedName: String?
+        public let source: String
+        public let confidence: String
+        public let failureReason: String?
+
+        public init(resolvedName: String?, source: String, confidence: String, failureReason: String?) {
+            self.resolvedName = resolvedName
+            self.source = source
+            self.confidence = confidence
+            self.failureReason = failureReason
+        }
+    }
+
+    /// Best-effort exact-handle lookup for Messages attribution. It never
+    /// prompts for Contacts access: messages_recent remains a passive read.
+    public static func exactHandleAttributionIfAuthorized(_ handle: String) -> HandleAttribution {
+        guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+            return HandleAttribution(
+                resolvedName: nil,
+                source: "contacts",
+                confidence: "unavailable",
+                failureReason: "contacts_permission_not_authorized"
+            )
+        }
+
+        let store = CNContactStore()
+        let predicate: NSPredicate
+        if handle.contains("@") {
+            predicate = CNContact.predicateForContacts(matchingEmailAddress: handle)
+        } else {
+            predicate = CNContact.predicateForContacts(matching: CNPhoneNumber(stringValue: toE164(handle) ?? handle))
+        }
+
+        do {
+            let contacts = try store.unifiedContacts(matching: predicate, keysToFetch: fullKeys)
+            guard contacts.count == 1, let contact = contacts.first else {
+                return HandleAttribution(
+                    resolvedName: nil,
+                    source: "contacts",
+                    confidence: contacts.isEmpty ? "none" : "ambiguous",
+                    failureReason: contacts.isEmpty ? "no_exact_contact_match" : "multiple_exact_contact_matches"
+                )
+            }
+            let name = CNContactFormatter.string(from: contact, style: .fullName)
+                ?? "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty else {
+                return HandleAttribution(
+                    resolvedName: nil,
+                    source: "contacts",
+                    confidence: "none",
+                    failureReason: "exact_contact_has_no_display_name"
+                )
+            }
+            return HandleAttribution(
+                resolvedName: name,
+                source: "contacts_exact_handle",
+                confidence: "exact",
+                failureReason: nil
+            )
+        } catch {
+            return HandleAttribution(
+                resolvedName: nil,
+                source: "contacts",
+                confidence: "unavailable",
+                failureReason: "contacts_query_failed"
+            )
+        }
+    }
+
     // MARK: - TCC Helper
 
     /// Ensures Contacts access is authorized or limited. Triggers TCC prompt if `.notDetermined`.

--- a/TheBridge/Modules/JobsManager.swift
+++ b/TheBridge/Modules/JobsManager.swift
@@ -1321,8 +1321,9 @@ public actor JobsManager {
         var overall: ExecutionRecord.Status = .success
 
         for (idx, step) in job.actionChain.enumerated() {
-            let mcpArgs = Self.substitutePrev(step.arguments, prev: stepResults.last)
+            let previousResult = stepResults.last
             do {
+                let mcpArgs = try Self.substitutePrev(step.arguments, prev: previousResult)
                 let toolName = Self.canonicalActionToolName(step.tool)
                 let result = try await router.dispatch(toolName: toolName, arguments: .object(mcpArgs))
                 stepResults.append(JSONValue.fromMCP(result))
@@ -1342,6 +1343,7 @@ public actor JobsManager {
                     // One retry with a short backoff.
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
                     do {
+                        let mcpArgs = try Self.substitutePrev(step.arguments, prev: previousResult)
                         let toolName = Self.canonicalActionToolName(step.tool)
                         let result = try await router.dispatch(toolName: toolName, arguments: .object(mcpArgs))
                         stepResults[stepResults.count - 1] = JSONValue.fromMCP(result)
@@ -1416,18 +1418,83 @@ public actor JobsManager {
         throw JobsModuleError.invalidActionChain("missing required arg '\(key)'")
     }
 
-    /// Substitute the literal `"$prev_result"` token in argument values with
-    /// the previous step's full result. Non-string values pass through.
-    private static func substitutePrev(_ args: [String: JSONValue], prev: JSONValue?) -> [String: Value] {
+    /// Substitute `$prev_result` or a path such as `$prev_result.stdout` /
+    /// `$prev_result.content[0].text` in argument values. An unresolved path
+    /// fails the step before dispatch; it never silently becomes an empty body.
+    public static func substitutePrev(_ args: [String: JSONValue], prev: JSONValue?) throws -> [String: Value] {
         var out: [String: Value] = [:]
         for (k, v) in args {
-            if case .string(let s) = v, s == "$prev_result", let prev {
-                out[k] = prev.toMCP()
+            if case .string(let s) = v, s.hasPrefix("$prev_result") {
+                guard let prev else {
+                    throw JobsModuleError.invalidActionChain("argument '\(k)' references $prev_result before a previous step exists")
+                }
+                guard let resolved = resolvePrevPath(s, in: prev) else {
+                    throw JobsModuleError.invalidActionChain("argument '\(k)' could not resolve previous-result path '\(s)'")
+                }
+                out[k] = resolved.toMCP()
             } else {
                 out[k] = v.toMCP()
             }
         }
         return out
+    }
+
+    private enum PrevPathComponent: Equatable {
+        case key(String)
+        case index(Int)
+    }
+
+    private static func resolvePrevPath(_ token: String, in root: JSONValue) -> JSONValue? {
+        guard token.hasPrefix("$prev_result") else { return nil }
+        let suffix = String(token.dropFirst("$prev_result".count))
+        if suffix.isEmpty { return root }
+        guard let components = parsePrevPath(suffix) else { return nil }
+
+        var current = root
+        for component in components {
+            switch (component, current) {
+            case (.key(let key), .object(let object)):
+                guard let next = object[key] else { return nil }
+                current = next
+            case (.index(let index), .array(let array)):
+                guard array.indices.contains(index) else { return nil }
+                current = array[index]
+            default:
+                return nil
+            }
+        }
+        return current
+    }
+
+    private static func parsePrevPath(_ suffix: String) -> [PrevPathComponent]? {
+        var components: [PrevPathComponent] = []
+        var index = suffix.startIndex
+
+        while index < suffix.endIndex {
+            if suffix[index] == "." {
+                index = suffix.index(after: index)
+                let start = index
+                while index < suffix.endIndex, suffix[index] != ".", suffix[index] != "[" {
+                    index = suffix.index(after: index)
+                }
+                guard start < index else { return nil }
+                components.append(.key(String(suffix[start..<index])))
+            } else if suffix[index] == "[" {
+                index = suffix.index(after: index)
+                let start = index
+                while index < suffix.endIndex, suffix[index] != "]" {
+                    index = suffix.index(after: index)
+                }
+                guard index < suffix.endIndex,
+                      let numeric = Int(suffix[start..<index]), numeric >= 0 else { return nil }
+                components.append(.index(numeric))
+                index = suffix.index(after: index)
+            } else {
+                return nil
+            }
+        }
+
+        return components.isEmpty ? nil : components
     }
 
     /// Reject action chains that would trigger auto-escalation in unattended

--- a/TheBridge/Modules/MessagesModule.swift
+++ b/TheBridge/Modules/MessagesModule.swift
@@ -466,24 +466,81 @@ public enum MessagesModule {
     /// Convert query result rows to MCP Value, applying extractText fallback on the text column.
     /// The raw `attributedBody` blob is excluded from output.
     private static func rowsToValue(_ rows: [[String: Any]], textKey: String = "text") -> Value {
+        let valueRows = rows.map { rowToValue($0, textKey: textKey) }
+        return .object(["rows": .array(valueRows), "count": .int(valueRows.count)])
+    }
+
+    private static func rowToValue(_ row: [String: Any], textKey: String) -> Value {
+        var result: [String: Value] = [:]
+        for (key, val) in row {
+            if key == "attributedBody" { continue }
+            if key == textKey {
+                let extracted = extractText(row: row, textKey: textKey)
+                result[key] = extracted.map { .string($0) } ?? .null
+            } else if let s = val as? String {
+                result[key] = .string(s)
+            } else if let i = val as? Int {
+                result[key] = .int(i)
+            } else if let d = val as? Double {
+                result[key] = .double(d)
+            } else {
+                result[key] = .null
+            }
+        }
+        return .object(result)
+    }
+
+    public static func attributionFields(
+        messagesDisplayName: String?,
+        handle: String?,
+        contact: ContactsModule.HandleAttribution?
+    ) -> [String: Value] {
+        if let displayName = messagesDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !displayName.isEmpty {
+            return [
+                "resolvedName": .string(displayName),
+                "attributionSource": .string("messages_chat_display_name"),
+                "attributionConfidence": .string("exact_chat_metadata"),
+                "attributionFailureReason": .null
+            ]
+        }
+        if let contact, let resolvedName = contact.resolvedName {
+            return [
+                "resolvedName": .string(resolvedName),
+                "attributionSource": .string(contact.source),
+                "attributionConfidence": .string(contact.confidence),
+                "attributionFailureReason": .null
+            ]
+        }
+        return [
+            "resolvedName": .null,
+            "attributionSource": .string(contact?.source ?? "none"),
+            "attributionConfidence": .string(contact?.confidence ?? "none"),
+            "attributionFailureReason": .string(
+                contact?.failureReason ?? (handle == nil ? "chat_has_no_resolvable_handle" : "no_attribution_available")
+            )
+        ]
+    }
+
+    private static func recentRowsToValue(_ rows: [[String: Any]]) -> Value {
         let valueRows: [Value] = rows.map { row in
-            var result: [String: Value] = [:]
-            for (key, val) in row {
-                // Never expose raw attributedBody blob to caller
-                if key == "attributedBody" { continue }
-                if key == textKey {
-                    // Apply text extraction with attributedBody fallback
-                    let extracted = extractText(row: row, textKey: textKey)
-                    result[key] = extracted.map { .string($0) } ?? .null
-                } else if let s = val as? String {
-                    result[key] = .string(s)
-                } else if let i = val as? Int {
-                    result[key] = .int(i)
-                } else if let d = val as? Double {
-                    result[key] = .double(d)
-                } else {
-                    result[key] = .null
-                }
+            var result: [String: Value]
+            if case .object(let object) = rowToValue(row, textKey: "last_message") {
+                result = object
+            } else {
+                result = [:]
+            }
+            let displayName = row["display_name"] as? String
+            let handle = row["chat_identifier"] as? String
+            let contact = (displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+                ? nil
+                : handle.map(ContactsModule.exactHandleAttributionIfAuthorized)
+            for (key, value) in attributionFields(
+                messagesDisplayName: displayName,
+                handle: handle,
+                contact: contact
+            ) {
+                result[key] = value
             }
             return .object(result)
         }
@@ -598,7 +655,7 @@ public enum MessagesModule {
             name: "messages_recent",
             module: moduleName,
             tier: .open,
-            description: "List the N most recently active Messages conversations (chats, not individual messages).",
+            description: "List the N most recently active Messages conversations with explicit attribution provenance. Blank chat names get a best-effort exact Contacts lookup when Contacts permission is already granted; loose name inference is never used.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -638,7 +695,7 @@ public enum MessagesModule {
                     LIMIT ?1
                     """
                 let rows = try performQuery(sql, params: [String(limit)])
-                return rowsToValue(rows, textKey: "last_message")
+                return recentRowsToValue(rows)
             }
         ))
 
@@ -693,7 +750,7 @@ public enum MessagesModule {
             name: "messages_content",
             module: moduleName,
             tier: .open,
-            description: "Fetch a single message by its Messages DB ROWID (full text + metadata).",
+            description: "Fetch one message by Messages DB ROWID, including attachment metadata when present. Attachment bytes are not auto-extracted.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -723,7 +780,35 @@ public enum MessagesModule {
                     WHERE m.ROWID = ?1
                     """
                 let rows = try performQuery(sql, params: [String(msgId)])
-                return rowsToValue(rows)
+                guard case .object(var result) = rowsToValue(rows) else {
+                    return rowsToValue(rows)
+                }
+                do {
+                    let attachmentSQL = """
+                        SELECT a.ROWID AS attachment_id,
+                               a.filename AS file_path,
+                               a.mime_type,
+                               a.transfer_name
+                        FROM attachment a
+                        JOIN message_attachment_join maj ON maj.attachment_id = a.ROWID
+                        WHERE maj.message_id = ?1
+                        ORDER BY a.ROWID ASC
+                        """
+                    let attachmentRows = try performQuery(attachmentSQL, params: [String(msgId)])
+                    if case .object(let attachmentResult) = rawRowsToValue(attachmentRows),
+                       case .array(let attachments) = attachmentResult["rows"] {
+                        result["attachments"] = .array(attachments)
+                        result["attachmentCount"] = .int(attachments.count)
+                    }
+                    result["attachmentMode"] = .string("metadata_only")
+                    result["attachmentLimitation"] = .string("Attachment bytes are not returned automatically; file_path is provided when Messages stored one locally.")
+                } catch {
+                    result["attachments"] = .array([])
+                    result["attachmentCount"] = .int(0)
+                    result["attachmentMode"] = .string("metadata_unavailable")
+                    result["attachmentLimitation"] = .string("Attachment metadata query failed: \(error.localizedDescription)")
+                }
+                return .object(result)
             }
         ))
 

--- a/TheBridge/Modules/NotionModule.swift
+++ b/TheBridge/Modules/NotionModule.swift
@@ -106,6 +106,35 @@ public enum NotionModule {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Block-level write responses include their parent when the touched block
+    /// is directly under a page. Evict both the explicit target (which may be a
+    /// page id for top-level appends) and any returned page/block parent; the
+    /// eviction helper itself ignores ids that are not configured skill pages.
+    public static func skillCacheEvictionCandidates(
+        targetId: String,
+        responseJSON: [String: Any]? = nil
+    ) -> [String] {
+        var candidates = [targetId]
+        guard let parent = responseJSON?["parent"] as? [String: Any] else { return candidates }
+        for key in ["page_id", "block_id"] {
+            if let parentId = parent[key] as? String {
+                candidates.append(parentId)
+            }
+        }
+        var seen: Set<String> = []
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    private static func evictSkillBodyCache(
+        targetId: String,
+        responseJSON: [String: Any]? = nil
+    ) async {
+        for candidate in skillCacheEvictionCandidates(targetId: targetId, responseJSON: responseJSON) {
+            await SkillBodyCacheEviction.evictIfConfiguredSkillPage(candidate)
+            await RegistryRowCache.shared.evictPageEverywhere(pageId: candidate)
+        }
+    }
+
     /// Register all NotionModule tools on the given router.
     /// Lazily initializes NotionClientRegistry on first tool invocation.
     public static func register(on router: ToolRouter) async {
@@ -352,6 +381,7 @@ public enum NotionModule {
                 let url = resultJSON["url"] as? String ?? ""
 
                 await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+                await RegistryRowCache.shared.evictPageEverywhere(pageId: pageId)
 
                 return .object([
                     "success": .bool(true),
@@ -712,6 +742,8 @@ public enum NotionModule {
                         return .object(["error": .string("Failed to parse append response")])
                     }
 
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: results.first)
+
                     var resultItems: [Value] = []
                     for block in results {
                         let bid = block["id"] as? String ?? ""
@@ -742,6 +774,8 @@ public enum NotionModule {
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object(["error": .string("Failed to parse append response")])
                     }
+
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
 
                     // The markdown endpoint doesn't return a per-block results
                     // array like PATCH /blocks/{id}/children does; report what
@@ -809,6 +843,7 @@ public enum NotionModule {
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object(["error": .string("Failed to parse delete response")])
                     }
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
                     return .object([
                         "success": .bool(true),
                         "id": .string(json["id"] as? String ?? blockId),
@@ -824,6 +859,7 @@ public enum NotionModule {
                     do {
                         let data = try await client.deleteBlock(blockId: blockId)
                         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                        await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
                         deleted += 1
                         results.append(.object([
                             "id": .string((json?["id"] as? String) ?? blockId),
@@ -855,11 +891,12 @@ public enum NotionModule {
             name: "notion_page_markdown_read",
             module: moduleName,
             tier: .open,
-            description: "Read a Notion page body as plain markdown only — no properties, no block IDs. Use when you just need the text.",
+            description: "Read a Notion page body as plain markdown only — no properties or block IDs. Optional section returns one heading slice; a miss returns a compact heading index instead of the full page.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "pageId": .object(["type": .string("string"), "description": .string("Notion page ID")]),
+                    "section": .object(["type": .string("string"), "description": .string("Optional markdown heading to return, case-insensitive and without # markers.")]),
                     "workspace": workspaceParam
                 ]),
                 "required": .array([.string("pageId")])
@@ -873,12 +910,24 @@ public enum NotionModule {
                 let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
                 let data = try await client.getPageMarkdown(pageId: pageId)
 
-                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                    let text = String(data: data, encoding: .utf8) ?? ""
-                    return .object(["markdown": .string(text)])
+                let markdown = SkillsModule.skillMarkdownString(fromMarkdownJSON: data)
+                if case .string(let section)? = args["section"] {
+                    if let slice = SkillsModule.extractMarkdownSection(markdown, section: section) {
+                        return .object([
+                            "markdown": .string(slice),
+                            "section": .string(section),
+                            "sectionMatched": .bool(true)
+                        ])
+                    }
+                    let headings = SkillsModule.markdownHeadings(markdown)
+                    return .object([
+                        "markdown": .string(SkillsModule.sectionMissMarkdown(requested: section, markdown: markdown)),
+                        "section": .string(section),
+                        "sectionMatched": .bool(false),
+                        "annotation": .string("section-not-found"),
+                        "availableSections": .array(headings.prefix(100).map(Value.string))
+                    ])
                 }
-
-                let markdown = json["markdown"] as? String ?? String(data: data, encoding: .utf8) ?? ""
                 return .object(["markdown": .string(markdown)])
             }
         ))
@@ -981,6 +1030,7 @@ public enum NotionModule {
                 _ = try await client.replacePageMarkdown(pageId: pageId, markdown: editedMarkdown)
 
                 await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+                await RegistryRowCache.shared.evictPageEverywhere(pageId: pageId)
 
                 let totalReplacements = editResults.reduce(0) { $0 + $1.replacements }
                 return .object([
@@ -1390,6 +1440,8 @@ public enum NotionModule {
                 guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
                     return .object(["error": .string("Failed to parse update response")])
                 }
+
+                await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
 
                 let id = json["id"] as? String ?? ""
                 let type = json["type"] as? String ?? ""

--- a/TheBridge/Modules/Registry/RegistryModels.swift
+++ b/TheBridge/Modules/Registry/RegistryModels.swift
@@ -211,7 +211,41 @@ public struct RegistryConfig: Codable, Sendable, Equatable {
 
     /// Entity lookup by key.
     public func entity(_ key: String) -> RegistryEntity? {
-        entities.first { $0.key == key }
+        if let direct = entities.first(where: { $0.key == key }) { return direct }
+
+        // PACKETS was historically registered as `session` on some installs,
+        // while packet contracts and registry_hydrate call it `packet`.
+        // Prefer `packet`; preserve `session` as a compatibility alias only
+        // when the entity's display name proves it is the PACKETS source.
+        if key == "packet",
+           let legacy = entities.first(where: {
+               $0.key == "session" && $0.displayName.lowercased().contains("packet")
+           }) {
+            return RegistryEntity(
+                key: "packet",
+                displayName: legacy.displayName,
+                dataSourceId: legacy.dataSourceId,
+                workspace: legacy.workspace,
+                properties: legacy.properties,
+                cacheTTLSeconds: legacy.cacheTTLSeconds,
+                hasBody: legacy.hasBody
+            )
+        }
+        if key == "session",
+           let canonical = entities.first(where: {
+               $0.key == "packet" && $0.displayName.lowercased().contains("packet")
+           }) {
+            return RegistryEntity(
+                key: "session",
+                displayName: canonical.displayName,
+                dataSourceId: canonical.dataSourceId,
+                workspace: canonical.workspace,
+                properties: canonical.properties,
+                cacheTTLSeconds: canonical.cacheTTLSeconds,
+                hasBody: canonical.hasBody
+            )
+        }
+        return nil
     }
 
     /// Upsert an entity by key (replace-in-place or append).

--- a/TheBridge/Modules/Registry/RegistryRowCache.swift
+++ b/TheBridge/Modules/Registry/RegistryRowCache.swift
@@ -108,6 +108,31 @@ public actor RegistryRowCache {
         try? FileManager.default.removeItem(at: Self.entityDir(entity))
     }
 
+    /// Evict one Notion page id from every configured/entity cache directory.
+    /// Direct notion_* writes do not know which Registry entity owns a page;
+    /// scanning the shallow entity directories keeps post-write reads honest.
+    @discardableResult
+    public func evictPageEverywhere(pageId: String) -> [String] {
+        let root = BridgePaths.applicationSupport(.registryCache)
+        let fm = FileManager.default
+        guard let entityNames = try? fm.contentsOfDirectory(atPath: root.path) else { return [] }
+        var evicted: [String] = []
+        for entityName in entityNames.sorted() {
+            let candidate = root
+                .appendingPathComponent(entityName, isDirectory: true)
+                .appendingPathComponent("\(Self.safeComponent(CachedRow.normalize(pageId))).json")
+            guard fm.fileExists(atPath: candidate.path) else { continue }
+            do {
+                try fm.removeItem(at: candidate)
+                evicted.append(entityName)
+            } catch {
+                // Cache eviction is a best-effort freshness hint. A failed
+                // removal remains visible to forceRefresh and normal TTL.
+            }
+        }
+        return evicted
+    }
+
     /// Increment the persisted `callCount` and return the new value (0 when
     /// no entry). The read-bump-write runs inside the actor, so concurrent
     /// ticks can't lose an increment. Drives the revalidation cadence.

--- a/TheBridge/Modules/RunningReportJob.swift
+++ b/TheBridge/Modules/RunningReportJob.swift
@@ -60,7 +60,7 @@ public enum RunningReportJob {
     /// operator-pending banner for the Strava data source. NO fabricated numbers.
     /// When the operator wires a data source, they replace this one step (e.g.
     /// with an `http_fetch` of their Strava activities + a formatter) — the
-    /// delivery step downstream is unchanged because it reads `$prev_result`.
+    /// delivery step downstream is unchanged because it reads `$prev_result.stdout`.
     static let reportBuilderScript = """
     cat <<'REPORT'
     🏃 Morning Running Report — $(date '+%a %b %-d')
@@ -79,7 +79,7 @@ public enum RunningReportJob {
     """
 
     /// The default action chain: build the report text, then deliver it as an
-    /// iMessage. Step 2 reads `$prev_result` (the report builder's stdout).
+    /// iMessage. Step 2 extracts the report builder's stdout explicitly.
     public static func defaultActionChain(recipient: String = selfHandlePlaceholder) -> [ActionStep] {
         [
             // Step 0 — build the running summary text (honest scaffold).
@@ -96,7 +96,7 @@ public enum RunningReportJob {
                 tool: "messages_send",
                 arguments: [
                     "recipient": .string(recipient),
-                    "body": .string("$prev_result"),
+                    "body": .string("$prev_result.stdout"),
                     "confirm": .string("SEND")
                 ],
                 onFail: .continue

--- a/TheBridge/Modules/Skills/SkillsModuleDoctrine.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleDoctrine.swift
@@ -19,9 +19,9 @@ extension SkillsModule {
     /// subsection (deeper level) is included in its parent's slice; a
     /// sibling or shallower heading terminates it.
     ///
-    /// Returns `nil` when no heading matches — the caller then falls back
-    /// to the full body and annotates the envelope so the result is never
-    /// silently empty.
+    /// Returns `nil` when no heading matches — callers return a compact
+    /// heading index rather than the full body, so a typo cannot trigger the
+    /// same oversized response the section selector was meant to avoid.
     public static func extractMarkdownSection(_ markdown: String, section rawSection: String) -> String? {
         let target = rawSection
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -93,6 +93,40 @@ extension SkillsModule {
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return slice
+    }
+
+    /// Return addressable markdown headings while ignoring fenced-code lines.
+    /// Used for bounded section-miss responses and by notion_page_markdown_read.
+    public static func markdownHeadings(_ markdown: String) -> [String] {
+        let lines = markdown.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        var headings: [String] = []
+        var inFence = false
+        for rawLine in lines {
+            let line = rawLine.drop(while: { $0 == " " })
+            if line.hasPrefix("```") || line.hasPrefix("~~~") {
+                inFence.toggle()
+                continue
+            }
+            guard !inFence else { continue }
+            var hashes = 0
+            for character in line {
+                if character == "#" { hashes += 1 } else { break }
+            }
+            guard (1...6).contains(hashes) else { continue }
+            let remainder = line.dropFirst(hashes)
+            guard remainder.first == " " else { continue }
+            let title = remainder.trimmingCharacters(in: .whitespaces)
+            if !title.isEmpty { headings.append(title) }
+        }
+        return headings
+    }
+
+    public static func sectionMissMarkdown(requested: String, markdown: String) -> String {
+        let headings = markdownHeadings(markdown)
+        let available = headings.isEmpty
+            ? "(no markdown headings found)"
+            : headings.prefix(100).map { "- \($0)" }.joined(separator: "\n")
+        return "Section not found: \(requested)\n\nAvailable sections:\n\(available)"
     }
 
     // MARK: - cmd-w4: /markdown body retrieval + mention resolution
@@ -332,12 +366,61 @@ extension SkillsModule {
         cachedIdentity: CachedSkillBody? = nil
     ) -> Value {
         guard case .object(var dict) = value else { return value }
+        let version = cachedIdentity?.version ?? CachedSkillBody.propertyString("Version", in: flattenedProperties)
+        let status = cachedIdentity?.status ?? CachedSkillBody.propertyString("Status", in: flattenedProperties)
+        let maturity = cachedIdentity?.maturity ?? CachedSkillBody.propertyString("Maturity", in: flattenedProperties)
         dict["uuid"] = .string(CachedSkillBody.canonicalUUID(pageId))
         dict["slug"] = .string(cachedIdentity?.slug ?? CachedSkillBody.propertyString("Slug", in: flattenedProperties))
-        dict["version"] = .string(cachedIdentity?.version ?? CachedSkillBody.propertyString("Version", in: flattenedProperties))
-        dict["status"] = .string(cachedIdentity?.status ?? CachedSkillBody.propertyString("Status", in: flattenedProperties))
-        dict["maturity"] = .string(cachedIdentity?.maturity ?? CachedSkillBody.propertyString("Maturity", in: flattenedProperties))
+        dict["version"] = .string(version)
+        dict["status"] = .string(status)
+        dict["maturity"] = .string(maturity)
+        dict["authoritativeMetadataSource"] = .string("notion_properties")
+
+        if case .string(let content) = dict["content"] {
+            let propertyValues = ["version": version, "status": status, "maturity": maturity]
+            var fields: [Value] = []
+            for field in ["version", "status", "maturity"] {
+                guard let bodyValue = bodyMetadataValue(field: field, markdown: content),
+                      let propertyValue = propertyValues[field],
+                      !propertyValue.isEmpty,
+                      bodyValue.caseInsensitiveCompare(propertyValue) != .orderedSame else { continue }
+                fields.append(.object([
+                    "field": .string(field),
+                    "body": .string(bodyValue),
+                    "property": .string(propertyValue)
+                ]))
+            }
+            if !fields.isEmpty {
+                dict["metadataDrift"] = .object([
+                    "detected": .bool(true),
+                    "authoritativeSource": .string("notion_properties"),
+                    "fields": .array(fields),
+                    "warning": .string("Skill body metadata differs from Notion properties; routing uses the property-backed envelope values.")
+                ])
+            }
+        }
         return .object(dict)
+    }
+
+    /// Extract a simple `Version:`, `Status:`, or `Maturity:` declaration
+    /// from the first part of a skill body. This is diagnostic only: Notion
+    /// properties remain the routing-authoritative metadata source.
+    public static func bodyMetadataValue(field: String, markdown: String) -> String? {
+        let wanted = field.lowercased() + ":"
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false).prefix(120) {
+            var line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            while let first = line.first, "->*#` ".contains(first) {
+                line.removeFirst()
+                line = line.trimmingCharacters(in: .whitespaces)
+            }
+            line = line.replacingOccurrences(of: "**", with: "")
+                .replacingOccurrences(of: "`", with: "")
+            guard line.lowercased().hasPrefix(wanted) else { continue }
+            let value = String(line.dropFirst(wanted.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return nil
     }
 
     /// Public, network-free entry point mirroring `buildSkillResult` but

--- a/TheBridge/Modules/Skills/SkillsModuleSpecialists.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleSpecialists.swift
@@ -117,6 +117,21 @@ extension SkillsModule {
 
         // Intent ranking → confident / disambiguate / none.
         if let intent = intent {
+            // An exact canonical parent with no specialist roster is already
+            // resolved. Intent cannot route anywhere, so do not mislabel the
+            // authoritative parent body as low-confidence.
+            if allSpecialists.isEmpty {
+                let parentEnvelope = await Self.buildFileSkillResult(parent)
+                return Self.annotateFileEnvelope(
+                    parentEnvelope,
+                    parentName: parentName,
+                    annotation: nil,
+                    resolvedPath: nil,
+                    score: 1.0,
+                    reason: "exact canonical name; no specialists configured",
+                    siblingTitles: []
+                )
+            }
             let candidates: [SkillIntentCandidate] = allSpecialists.map { s in
                 var aliases: [String] = []
                 if case .array(let arr) = s.frontmatter["aliases"] { aliases = arr }
@@ -247,6 +262,19 @@ extension SkillsModule {
         // `childPages` already holds only curated specialists.
         let childPages = await Self.listNotionChildPages(client: client, pageId: parentPageId)
         let siblingTitles = childPages.map { $0.title }
+
+        // Intent on an exact canonical parent that has no curated specialists
+        // is a definitive parent fetch, not a routing failure.
+        if parsedPath.child == nil, intent != nil, childPages.isEmpty {
+            return SpecialistDispatch(
+                resolvedSpecialist: nil,
+                resolvedPath: nil,
+                annotation: nil,
+                matchScore: 1.0,
+                matchReason: "exact canonical name; no specialists configured",
+                siblingTitles: []
+            )
+        }
 
         if let childName = parsedPath.child {
             let needle = childName.lowercased()
@@ -550,8 +578,8 @@ extension SkillsModule {
     /// `section` (the requested name) + `sectionMatched: true` so the agent
     /// knows the body is a partial slice. When the section was requested but
     /// no heading matched, records `annotation: "section-not-found"` plus
-    /// the requested name and `sectionMatched: false` — the full body is
-    /// returned (never silently empty). No-op when no section was requested.
+    /// the requested name and `sectionMatched: false` — a compact heading
+    /// index is returned instead of the full body. No-op when no section was requested.
     ///
     /// Pure + nonisolated: mutates only its own envelope copy.
     nonisolated static func annotateSection(
@@ -575,7 +603,7 @@ extension SkillsModule {
     /// `content` markdown to the requested heading, recomputes the honest
     /// `blockCount` (non-empty line count), and stamps the section
     /// annotation. No section requested → returns the envelope untouched.
-    /// No match → full content kept + `section-not-found` annotation.
+    /// No match → compact heading index + `section-not-found` annotation.
     ///
     /// Pure + nonisolated: reads/writes only its own envelope copy.
     nonisolated static func applySectionToEnvelope(
@@ -599,6 +627,10 @@ extension SkillsModule {
             dict["blockCount"] = .int(nonEmptyLineCount)
             return Self.annotateSection(.object(dict), requested: section, matched: true, missed: false)
         }
+        let headings = Self.markdownHeadings(content)
+        dict["content"] = .string(Self.sectionMissMarkdown(requested: section, markdown: content))
+        dict["availableSections"] = .array(headings.prefix(100).map(Value.string))
+        dict["blockCount"] = .int(headings.isEmpty ? 1 : headings.count + 2)
         return Self.annotateSection(.object(dict), requested: section, matched: false, missed: true)
     }
 

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -194,8 +194,8 @@ public enum SkillsModule {
 
             GRANULAR FETCH: pass `section="<heading>"` to return ONLY that heading's \
             slice instead of the whole body — use this when you need one part of a \
-            large skill and want to stay under token caps. No match → full body + a \
-            `section-not-found` annotation.
+            large skill and want to stay under token caps. No match → compact heading \
+            index + a `section-not-found` annotation.
             """,
             inputSchema: .object([
                 "type": .string("object"),
@@ -226,7 +226,7 @@ public enum SkillsModule {
                     ]),
                     "section": .object([
                         "type": .string("string"),
-                        "description": .string("Optional heading name to return ONLY that section's slice (case-insensitive, '#' markers ignored) instead of the whole body — a granular partial fetch to avoid blowing token caps. Nested subsections are included; a sibling/shallower heading ends the slice. No match → full body + a `section-not-found` annotation.")
+                        "description": .string("Optional heading name to return ONLY that section's slice (case-insensitive, '#' markers ignored) instead of the whole body — a granular partial fetch to avoid blowing token caps. Nested subsections are included; a sibling/shallower heading ends the slice. No match → compact heading index + a `section-not-found` annotation.")
                     ]),
                     "fields": .object([
                         "type": .string("array"),
@@ -553,13 +553,20 @@ public enum SkillsModule {
                     // fb-resultsize: when a `section` is requested, slice the
                     // rendered markdown down to that heading's content before
                     // mention-resolution + envelope build — a granular partial
-                    // fetch. No match → full body, and we record it so the
-                    // envelope carries a `section-not-found` annotation.
+                    // fetch. No match → a compact heading index, and we record
+                    // it so the envelope carries a `section-not-found` annotation.
                     let sectionBody = sectionArg.flatMap {
                         Self.extractMarkdownSection(rawMarkdown, section: $0)
                     }
-                    let bodyForEnvelope = sectionBody ?? rawMarkdown
                     let sectionMissed = (sectionArg != nil) && (sectionBody == nil)
+                    let bodyForEnvelope: String
+                    if let sectionBody {
+                        bodyForEnvelope = sectionBody
+                    } else if let sectionArg {
+                        bodyForEnvelope = Self.sectionMissMarkdown(requested: sectionArg, markdown: rawMarkdown)
+                    } else {
+                        bodyForEnvelope = rawMarkdown
+                    }
 
                     // Skill-body <mention-page> tags now render as
                     // [Title](url) via the shared MentionResolver (cmd-w2),

--- a/TheBridge/Notion/NotionModels.swift
+++ b/TheBridge/Notion/NotionModels.swift
@@ -28,6 +28,9 @@ public enum NotionClientError: Error, LocalizedError, Sendable {
         case .maxRetriesExceeded:
             return "Max retries exceeded"
         case .httpError(let code, let body):
+            if code == 401 {
+                return "HTTP 401: Notion authorization failed. Reauthorize or replace the token in The Bridge Settings > Connections, then run notion_token_introspect before retrying the write. Response: \(String(body.prefix(300)))"
+            }
             return "HTTP \(code): \(String(body.prefix(500)))"
         case .decodingError(let msg):
             return "Decoding error: \(msg)"

--- a/TheBridgeTests/FetchSkillPropertiesTests.swift
+++ b/TheBridgeTests/FetchSkillPropertiesTests.swift
@@ -443,7 +443,8 @@ func runFetchSkillPropertiesTests() async {
         "summary", "triggerPhrases", "antiTriggerPhrases"
     ]
     let additiveEnvelopeKeys: Set<String> = [
-        "properties", "uuid", "slug", "version", "status", "maturity"
+        "properties", "uuid", "slug", "version", "status", "maturity",
+        "authoritativeMetadataSource"
     ]
 
     await test("cu-sa (d): legacy keys byte-identical empty↔populated; doctrine identity is additive") {
@@ -686,5 +687,28 @@ func runFetchSkillPropertiesTests() async {
             default: throw TestError.assertion("real fixture produced a non-modelled Value for `\(k)`: \(v)")
             }
         }
+    }
+
+    await test("fetch_skill surfaces body/property metadata drift with one authoritative source") {
+        let result = await SkillsModule.buildSkillResultForTesting(
+            name: "close-agent",
+            title: "Close Agent",
+            url: "https://www.notion.so/example",
+            markdownJSONOrText: "**Version:** 3.3.2\n**Status:** Proven\n\n# Closeout",
+            pageProperties: [
+                "Version": richText("3.3.1"),
+                "Status": statusProp("Testing")
+            ]
+        ) { _ in nil }
+        guard case .object(let envelope) = result,
+              case .object(let drift) = envelope["metadataDrift"],
+              case .array(let fields) = drift["fields"] else {
+            throw TestError.assertion("expected structured metadata drift warning")
+        }
+        try expect(envelope["version"] == .string("3.3.1"))
+        try expect(envelope["status"] == .string("Testing"))
+        try expect(envelope["authoritativeMetadataSource"] == .string("notion_properties"))
+        try expect(drift["detected"] == .bool(true))
+        try expect(fields.count == 2)
     }
 }

--- a/TheBridgeTests/MessagesModuleTests.swift
+++ b/TheBridgeTests/MessagesModuleTests.swift
@@ -105,6 +105,35 @@ func runMessagesModuleTests() async {
         }
     }
 
+    await test("messages_recent attribution prefers Messages metadata over Contacts") {
+        let fields = MessagesModule.attributionFields(
+            messagesDisplayName: "Scott",
+            handle: "+16055550123",
+            contact: .init(resolvedName: "Different Contact", source: "contacts_exact_handle", confidence: "exact", failureReason: nil)
+        )
+        try expect(fields["resolvedName"] == .string("Scott"))
+        try expect(fields["attributionSource"] == .string("messages_chat_display_name"))
+        try expect(fields["attributionFailureReason"] == .null)
+    }
+
+    await test("messages_recent attribution uses exact Contacts result and exposes failure reason") {
+        let resolved = MessagesModule.attributionFields(
+            messagesDisplayName: nil,
+            handle: "+16055550123",
+            contact: .init(resolvedName: "Known Person", source: "contacts_exact_handle", confidence: "exact", failureReason: nil)
+        )
+        try expect(resolved["resolvedName"] == .string("Known Person"))
+        try expect(resolved["attributionConfidence"] == .string("exact"))
+
+        let unresolved = MessagesModule.attributionFields(
+            messagesDisplayName: nil,
+            handle: "+16055550123",
+            contact: .init(resolvedName: nil, source: "contacts", confidence: "none", failureReason: "no_exact_contact_match")
+        )
+        try expect(unresolved["resolvedName"] == .null)
+        try expect(unresolved["attributionFailureReason"] == .string("no_exact_contact_match"))
+    }
+
     // messages_send rejects without confirm
     await test("messages_send rejects without confirm='SEND'") {
         let result = try await router.dispatch(

--- a/TheBridgeTests/NotionModuleTests.swift
+++ b/TheBridgeTests/NotionModuleTests.swift
@@ -213,6 +213,32 @@ func runNotionModuleTests() async {
         }
     }
 
+    await test("notion_page_markdown_read schema exposes bounded section selector") {
+        let tools = await router.registrations(forModule: "notion")
+        guard let tool = tools.first(where: { $0.name == "notion_page_markdown_read" }),
+              case .object(let schema) = tool.inputSchema,
+              case .object(let properties) = schema["properties"] else {
+            throw TestError.assertion("Missing notion_page_markdown_read schema")
+        }
+        try expect(properties["section"] != nil)
+    }
+
+    await test("block-level writes derive configured-skill cache eviction candidates") {
+        let candidates = NotionModule.skillCacheEvictionCandidates(
+            targetId: "child-block",
+            responseJSON: ["parent": ["type": "page_id", "page_id": "skill-page"]]
+        )
+        try expect(candidates == ["child-block", "skill-page"])
+        let direct = NotionModule.skillCacheEvictionCandidates(targetId: "skill-page")
+        try expect(direct == ["skill-page"])
+    }
+
+    await test("Notion 401 errors carry a concrete reauthorization path") {
+        let message = NotionClientError.httpError(401, "unauthorized").localizedDescription
+        try expect(message.contains("Settings > Connections"))
+        try expect(message.contains("notion_token_introspect"))
+    }
+
 
     await test("notion_comments_create rejects missing text") {
         do {

--- a/TheBridgeTests/RegistryConfigTests.swift
+++ b/TheBridgeTests/RegistryConfigTests.swift
@@ -28,6 +28,36 @@ private func withTempRegistryStore(_ body: (RegistryConfigStore, URL) async thro
 func runRegistryConfigTests() async {
     print("\n\u{1F5C3}\u{FE0F} Data-Source Registry — Config (model + store)")
 
+    await test("RegistryConfig: packet is canonical with session compatibility alias") {
+        let legacy = RegistryEntity(
+            key: "session",
+            displayName: "PACKETS",
+            dataSourceId: "packets-ds",
+            properties: [],
+            cacheTTLSeconds: 3600,
+            hasBody: true
+        )
+        let legacyConfig = RegistryConfig(entities: [legacy])
+        try expect(legacyConfig.entity("packet")?.key == "packet")
+        try expect(legacyConfig.entity("packet")?.dataSourceId == "packets-ds")
+
+        let canonical = RegistryEntity(
+            key: "packet",
+            displayName: legacy.displayName,
+            dataSourceId: legacy.dataSourceId,
+            properties: legacy.properties,
+            cacheTTLSeconds: legacy.cacheTTLSeconds,
+            hasBody: legacy.hasBody
+        )
+        let canonicalConfig = RegistryConfig(entities: [canonical])
+        try expect(canonicalConfig.entity("session")?.key == "session")
+
+        var actualSession = legacy
+        actualSession.displayName = "Sessions"
+        try expect(RegistryConfig(entities: [actualSession]).entity("packet") == nil,
+                   "a real Sessions entity must never be mistaken for PACKETS")
+    }
+
     // MARK: - Seed model
 
     await test("Seed: Skills is entity #1 with the expected shape") {

--- a/TheBridgeTests/RegistryRowCacheTests.swift
+++ b/TheBridgeTests/RegistryRowCacheTests.swift
@@ -130,6 +130,21 @@ func runRegistryRowCacheTests() async {
         }
     }
 
+    await test("RowCache: direct Notion write evicts the same page across every entity") {
+        try await withTempHomeRows { _ in
+            let cache = RegistryRowCache()
+            let pageId = "aaaa1111111111111111111111111111"
+            try await cache.write(sampleRow(entity: "skill", pageId: pageId, title: "Skill"))
+            try await cache.write(sampleRow(entity: "packet", pageId: pageId, title: "Packet"))
+            try await cache.write(sampleRow(entity: "contact", pageId: "bbbb1111111111111111111111111111", title: "Other"))
+            let evicted = await cache.evictPageEverywhere(pageId: pageId)
+            try expect(evicted == ["packet", "skill"], "stable entity receipt, got \(evicted)")
+            try expect(await cache.read(entity: "skill", pageId: pageId) == nil)
+            try expect(await cache.read(entity: "packet", pageId: pageId) == nil)
+            try expect(await cache.read(entity: "contact", pageId: "bbbb1111111111111111111111111111") != nil)
+        }
+    }
+
     await test("RowCache: incrementCallCount bumps persisted counter; 0 when absent") {
         try await withTempHomeRows { _ in
             let cache = RegistryRowCache()

--- a/TheBridgeTests/ResultSizeControlsTests.swift
+++ b/TheBridgeTests/ResultSizeControlsTests.swift
@@ -76,9 +76,17 @@ func runResultSizeControlsTests() async {
         try expect(a == b, "case/whitespace variants should resolve identically")
     }
 
-    await test("fb-resultsize (1): no match → nil (caller falls back to full body)") {
+    await test("fb-resultsize (1): no match → nil for caller-controlled bounded response") {
         try expect(SkillsModule.extractMarkdownSection(doc, section: "Nonexistent") == nil,
                    "unknown heading must return nil, not an empty/wrong slice")
+    }
+
+    await test("fb-resultsize (1): section miss response is compact and lists real headings") {
+        let miss = SkillsModule.sectionMissMarkdown(requested: "Nonexistent", markdown: doc)
+        try expect(miss.contains("Section not found: Nonexistent"))
+        try expect(miss.contains("- Setup") && miss.contains("- Usage"))
+        try expect(!miss.contains("Setup line one."), "miss must not echo the oversized full body")
+        try expect(SkillsModule.markdownHeadings(doc) == ["Overview", "Setup", "Prereqs", "Usage", "Teardown"])
     }
 
     await test("fb-resultsize (1): empty section name → nil (no-op)") {

--- a/TheBridgeTests/SchedulerResilienceTests.swift
+++ b/TheBridgeTests/SchedulerResilienceTests.swift
@@ -448,7 +448,7 @@ func runSchedulerResilienceTests() async {
         try expect(job.actionChain.count == 2, "expected build-report + send-iMessage steps")
     }
 
-    await test("FirstJob: action chain is report-builder → iMessage with $prev_result wiring") {
+    await test("FirstJob: action chain is report-builder → iMessage with $prev_result.stdout wiring") {
         let chain = RunningReportJob.defaultActionChain()
         // Step 0 builds the report text.
         try expect(chain[0].tool == "shell_exec", "step 0 builds the running summary")
@@ -457,11 +457,38 @@ func runSchedulerResilienceTests() async {
         try expect(chain[1].tool == "messages_send", "step 1 delivers via iMessage")
         try expect(chain[1].onFail == .continue, "an un-wired placeholder records a failed send, not an abort")
         if case .string(let body)? = chain[1].arguments["body"] {
-            try expect(body == "$prev_result", "delivery body must read the previous step's report output")
+            try expect(body == "$prev_result.stdout", "delivery body must extract the previous step's stdout")
         } else { try expect(false, "messages_send must have a 'body'") }
         if case .string(let confirm)? = chain[1].arguments["confirm"] {
             try expect(confirm == "SEND", "unattended messages_send requires confirm: SEND")
         } else { try expect(false, "messages_send must carry the SEND gate") }
+    }
+
+    await test("Jobs: previous-result path extracts object fields and array members") {
+        let previous: JSONValue = .object([
+            "stdout": .string("report text"),
+            "content": .array([.object(["text": .string("nested text")])])
+        ])
+        let substituted = try JobsManager.substitutePrev([
+            "body": .string("$prev_result.stdout"),
+            "nested": .string("$prev_result.content[0].text"),
+            "whole": .string("$prev_result")
+        ], prev: previous)
+        try expect(substituted["body"] == .string("report text"))
+        try expect(substituted["nested"] == .string("nested text"))
+        try expect(substituted["whole"] == previous.toMCP())
+    }
+
+    await test("Jobs: unresolved previous-result paths fail closed before dispatch") {
+        do {
+            _ = try JobsManager.substitutePrev(
+                ["body": .string("$prev_result.missing")],
+                prev: .object(["stdout": .string("present")])
+            )
+            throw TestError.assertion("Expected unresolved path failure")
+        } catch let error as JobsModuleError {
+            try expect(String(describing: error).contains("could not resolve"))
+        }
     }
 
     await test("FirstJob: chain passes the same unattended validation as createJob") {

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -125,21 +125,18 @@ Source: `TheBridge/Modules/GitModule.swift`.
 
 ---
 
-## Not yet available
-
-These were referenced in friction reports as *proposals*. They are **not registered in
-the codebase** as of this writing — do not call them. Confirm with a fresh grep before
-relying on any of them later.
+## Availability notes
 
 - **`swift_build` / `swift_test`** — a first-class build/test wrapper has been *requested*
-  (`AGENT_FEEDBACK.md` 2026-05-10) but has **not landed**. Until it does, use
-  `bg_process_start` with `swift build` / `make test`.
-- **`bridge_settings_navigate(section)` / `bridge_focus_settings`** — proposed in
-  `AGENT_FEEDBACK.md` (2026-06-04) to make on-device Settings verification deterministic.
-  They **do not exist**. Today, on-device verification of the menu-bar app requires a
-  System Events re-`set frontmost` + `AXRaise` before each `screen_capture`, and note the
-  coordinate-space mismatch (AX reports logical points; `screen_capture` returns device
-  pixels) when computing `mouse_click` targets.
+  (`AGENT_FEEDBACK.md` 2026-05-10) but is intentionally replaced by the current
+  `bg_run` → `bg_poll` → optional `bg_kill` surface for long builds and tests.
+- **`bridge_settings_navigate(section)` / `bridge_open_settings` /
+  `bridge_focus_settings` are registered.** Use the open/focus helpers before
+  Settings screenshots; they verify the target app/window rather than reporting
+  coordinate-only success.
+- After changing branches across tool-surface commits, run **`make test-clean`**.
+  After any install/relaunch, reconnect MCP clients so they re-run initialize and
+  `tools/list`; an already-open client's descriptor cache is not live proof.
 
 ---
 

--- a/docs/operator/agent-feedback-audit-2026-07-17.md
+++ b/docs/operator/agent-feedback-audit-2026-07-17.md
@@ -1,0 +1,105 @@
+# Agent feedback disposition audit — 2026-07-17
+
+This audit closes the historical `AGENT_FEEDBACK.md` backlog without treating
+old observations as current defects. Every entry was checked against current
+`origin/main`, the open review branches, current tests, or its owning system.
+The original prose remains recoverable from git history.
+
+## Implemented in `codex/feedback-v4`
+
+| Feedback cluster | Resolution |
+|---|---|
+| Job `$prev_result` whole-object/blank-body failure | Added fail-closed `$prev_result.stdout` and indexed paths such as `$prev_result.content[0].text`; corrected the seeded running-report job. |
+| Test-floor log loss | Failed runs now retain the complete log under `~/Library/Logs/TheBridge/test-floor-failures`, print the stable path, and extract failure rows from the full output. The first validation run in this branch proved the retained-log path against a real failing assertion. |
+| Worktree cache contamination | Added `make test-clean`; operator guidance now names it for branch changes that alter the tool surface. |
+| Stale client catalog after install | Install banners and the playbook now require reconnect plus fresh `initialize`/`tools/list`. |
+| Oversized `fetch_skill` / markdown section misses | Section misses return a bounded heading index instead of the full body; `notion_page_markdown_read` now supports the same section contract; fenced code headings are ignored. |
+| Skill cache stale after writes | Successful page and block mutations evict affected skill bodies; page writes also evict the same page from every registry entity cache. An explicit invalidation tool was considered and rejected because correct automatic write-through invalidation removes the operator burden without expanding the public surface. |
+| Exact skill marked low-confidence / contradictory metadata | An exact canonical parent with no specialist roster is no longer marked low-confidence. Notion properties are named as the authoritative metadata source and body/property version, status, or maturity drift is returned as a structured warning. |
+| PACKETS exposed only as `session` | `packet` is canonical with a guarded `session` compatibility alias; a real Sessions data source is never misclassified. |
+| Recent Messages identity guess | `messages_recent` returns resolved name, source, confidence, and failure reason; it uses Messages metadata first and only attempts exact-handle Contacts lookup when permission already exists. Loose name inference is prohibited. |
+| Attachment-only Messages | `messages_content` returns attachment id, local path, MIME type, transfer name, count, mode, and a typed metadata-only limitation; bytes are never silently extracted. |
+| Invalid Notion token remediation | HTTP 401 guidance now points to Settings > Connections and `notion_token_introspect`. |
+| Operator docs drift | Corrected background-process, settings-tool, clean-test, install, and reconnect guidance. |
+
+## Verified already resolved on current main
+
+These entries required no duplicate code change:
+
+- Notion aliases and write ergonomics: comment `content` alias and chunking,
+  query data-source alias, blocks append aliases, bulk delete, create-body
+  materialization guidance, `appendKeys`, and projected registry identity.
+- Local tool correctness: shell PATH and `bg_run`/`bg_poll`/`bg_kill`, credential
+  sentinel detection, calendar parsing, Reminders/Calendar permission rows,
+  `bridge_focus_settings`, screen app identity, stale-PID AX errors, main-actor AX
+  execution, child/byte traversal caps, and coordinate-safe AX-path clicking.
+- Connection and governance: resumable session contract, registration gate,
+  `connections_reset`, same-session governance propagation tests, origin-aware
+  initialization, OAuth boot-order self-heal, git SHA/dirty provenance, and
+  dirty/non-main install guards.
+- Delivery and routing: messages send confirmation, fields identity retention,
+  routing archive/canonical precedence, routing cache refresh surfaces, tool
+  annotation audit, counter-collision checks, and packet/worktree playbook rules.
+- Security approval behavior: module-scoped Always Allow, coalesced prompts,
+  90-second timeout, time-sensitive delivery, visible/revocable grants, and
+  `neverAutoApprove` protection for destructive tools.
+
+## Considered and intentionally not implemented here
+
+These are handled by ownership or design disposition, not silently left open.
+
+### Client or host owned
+
+Client auto-reinitialize, cached tool descriptors, raw oversized-result dump
+format, dynamic UI click coordinates, the AskUserQuestion cap, spoken model
+identity, and capability claims are MCP client/host behavior. The Bridge now
+provides reconnect/reset primitives, current provenance, bounded responses, and
+explicit install instructions; it cannot force a third-party client to refresh
+or change its runtime self-description.
+
+### External service or another repository
+
+Google Drive connector authorization/CloudStorage writes, kup.solutions portal
+schema/deploy polling/dead-route status, GitHub stacked-PR detection, and macOS
+27 mouse-driver behavior belong to their respective connector, website, GitHub,
+or OS/driver owners. No Bridge code change can truthfully close them.
+
+### Live workspace doctrine or workflow data
+
+Stale `project-keepr` route text, close-agent path text, specialist relation
+content, packet lifecycle status, active-telemetry pointers, and initializer
+roster warnings depend on live Notion skill/standing-order data. They must be
+corrected through the governed skill/doctrine owner, not by baking a second
+copy into this repo. Current Bridge surfaces expose the detailed roster,
+telemetry event reference, cache refresh, and registry force-refresh needed for
+that owner to reconcile them.
+
+### Correct fail-closed behavior or low-evidence observations
+
+Malformed Notion table rows rejecting atomically, destructive delete approval
+timeouts, exact relation validation, TCC denial, and no-contact/no-message
+results are correct fail-closed outcomes. `job_delete` denial versus timeout was
+considered; the security boundary intentionally exposes one rejection result so
+callers do not infer notification-delivery internals or auto-retry a destructive
+operation. One-off transport drops and intermittent calendar updates have no
+current reproducible defect and retain the existing retry-once guidance.
+
+### Material product expansions outside the locked proposal
+
+Messages reactions, first-class Google Drive mutation, Memory Process UI
+redesign, voice-curator settings tools, service-by-port management, automatic
+packet lifecycle transitions, and richer telemetry continuation are valid
+product ideas, but each changes product scope or safety semantics. They were
+reviewed and not smuggled into the stabilization release. The source log is
+preserved in git history if the product owner chooses to contract any of them.
+
+## Verification contract
+
+- No open GitHub issues existed at audit time.
+- PR #106 and PR #107 were inspected separately; neither is merged without a
+  review decision.
+- Every changed behavior above has a focused regression test or a source-level
+  contract test.
+- Full `make test-floor`, integration-branch release build, installed MCP smoke,
+  and git/worktree reconciliation are required before this audit is considered
+  complete.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2290,3 +2290,11 @@ set -euo pipefail
 # mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
 # redaction, and client name/version attribution. Measured 3207 passed, 0
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
+# Agent-feedback reconciliation (2026-07-17): +11 net-new tests cover job
+# previous-result paths and fail-closed misses, Messages attribution provenance,
+# bounded skill/Notion section misses, skill metadata drift, block/page cache
+# eviction, cross-entity registry cache eviction, packet/session compatibility,
+# and actionable Notion 401 guidance. Measured 3218 passed, 0 failed on the
+# origin/main-based feedback worktree. FLOOR 3207 -> 3218. A deliberately
+# failing precursor also proved complete-log retention to the stable evidence
+# directory before its assertion was corrected.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3218}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."
@@ -17,6 +17,21 @@ swift build -c debug
 
 LOG="$(mktemp -t bridge-test-floor.XXXXXX)"
 trap 'rm -f "$LOG"' EXIT
+
+# A failing run is evidence, not disposable noise. Copy the complete log to a
+# stable operator-visible directory before the temporary file is cleaned up,
+# then print both the path and every explicit failure row found anywhere in the
+# log (not merely the tail). Tests/CI may override this location.
+FAILURE_DIR="${BRIDGE_TEST_FAILURE_DIR:-${HOME}/Library/Logs/TheBridge/test-floor-failures}"
+retain_failure_log() {
+  mkdir -p "$FAILURE_DIR"
+  RETAINED_LOG="${FAILURE_DIR}/test-floor-$(date -u +%Y%m%dT%H%M%SZ)-$$.log"
+  cp "$LOG" "$RETAINED_LOG"
+  echo "::notice::test-floor-gate: complete failure log retained at $RETAINED_LOG"
+  echo "--- failure rows from complete test output ---"
+  grep -aE '(^|[[:space:]])❌|::error::|error:' "$RETAINED_LOG" || echo "(no explicit failure row found; inspect the retained complete log)"
+  echo "--- end failure rows ---"
+}
 
 # Watchdog: cap the test binary at DEADLINE seconds (default 1500 = 25 min;
 # local run is ~5 min, CI macos-26 is ~3x slower). Override with
@@ -72,6 +87,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # kept as a defensive fallback in case a future change reintroduces an alarm.)
   if [ "$RC" -eq 137 ] || [ "$RC" -eq 142 ] || [ "$RC" -eq 14 ]; then
     echo "::error::test-floor-gate: test binary exceeded ${DEADLINE}s watchdog and was killed"
+    retain_failure_log
     echo "--- last 60 lines of test output (so you can see which test hung) ---"
     tail -60 "$LOG" || true
     echo "--- end of test output tail ---"
@@ -79,6 +95,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   fi
   if [ "$RC" -ne 0 ]; then
     echo "::error::test-floor-gate: test binary exited with code $RC (non-zero, non-timeout)"
+    retain_failure_log
     echo "--- last 60 lines of test output ---"
     tail -60 "$LOG" || true
     echo "--- end of test output tail ---"
@@ -95,6 +112,7 @@ done
 LINE="$(tr -d '\000-\010\013\014\016-\037' < "$LOG" | grep -aE 'Results: [0-9]+ passed, [0-9]+ failed, [0-9]+ total' | tail -1 || true)"
 if [ -z "$LINE" ]; then
   echo "::error::test-floor-gate: no 'Results:' summary line after ${ATTEMPTS} attempts"
+  retain_failure_log
   exit 2
 fi
 
@@ -103,11 +121,13 @@ FAILED="$(printf '%s\n' "$LINE" | sed -E 's/^Results: [0-9]+ passed, ([0-9]+) fa
 
 if [ "$FAILED" -ne 0 ]; then
   echo "::error::test-floor-gate: ${FAILED} failing test(s) — green bar broken"
+  retain_failure_log
   exit 1
 fi
 
 if [ "$PASSED" -lt "$FLOOR" ]; then
   echo "::error::test-floor-gate: passed=${PASSED} is BELOW floor=${FLOOR} — tests were removed or disabled. If this drop is intentional, lower the floor in scripts/test-floor-gate.sh in the same change and record why."
+  retain_failure_log
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

- implements the actionable in-repo feedback gaps across jobs, skills, Notion cache invalidation, registry aliases, Messages attribution/attachments, troubleshooting, and test-floor diagnostics
- adds a durable disposition audit for all reviewed `AGENT_FEEDBACK.md` items
- adds `make test-clean`, install/reconnect guidance, and corrected operator playbook entries
- raises the exact test floor to 3,218

## Why

The feedback inbox mixed current defects, already-shipped behavior, external/client constraints, and product expansion ideas. The root problem was lack of a verified disposition plus several concrete reliability gaps.

## Impact

The actionable Bridge-owned gaps are covered by tests and the audit keeps external or intentionally deferred items explicit instead of treating them as shipped behavior.

## Validation

- `make test-floor`: 3,218 passed, 0 failed; floor 3,218
- `swift build -c debug`: green
- retained-failure-log path was exercised by an intentional failing assertion before the final green run
- `git diff --check`: green

## Review boundary

Draft / REVIEW. Do not merge without an explicit review decision.