### PR TITLE
Add read-only calls_recent tool

### DIFF
--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -442,7 +442,9 @@ public enum BridgeConstants {
     /// PKT-1120 Tool Ergonomics (2026-07-14): +2
     ///   (voice_memo_settings_get + voice_memo_settings_set; voice family).
     ///   203 + 2 = 205.
-    public static let staticFeatureModuleToolCount = 205
+    /// Bridge v4 stabilization Wave 1 (2026-07-17): +1 calls_recent.
+    ///   205 + 1 = 206.
+    public static let staticFeatureModuleToolCount = 206
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -471,5 +473,6 @@ public enum BridgeConstants {
     /// Voice Memos curator (2026-06-24): + voice family = 29.
     /// Local Ollama (2026-06-24): + ollama family = 30.
     /// PKT-1061 (2026-06-29): + commands family = 31.
-    public static let staticFeatureModuleFamilyCount = 31
+    /// Bridge v4 stabilization Wave 1 (2026-07-17): + calls family = 32.
+    public static let staticFeatureModuleFamilyCount = 32
 }

--- a/TheBridge/Modules/CallHistoryModule.swift
+++ b/TheBridge/Modules/CallHistoryModule.swift
@@ -1,0 +1,424 @@
+// CallHistoryModule.swift — Bridge v4 stabilization · calls_recent Wave 1
+// TheBridge · Modules
+//
+// Read-only access to the local macOS CallHistoryDB store. This module never
+// mutates the database, never joins Contacts, and never claims that a number
+// belongs to a person. The raw ZNAME column is intentionally neither selected
+// nor exposed.
+
+import Foundation
+import SQLite3
+import MCP
+
+public enum CallHistoryDirection: String, Sendable, CaseIterable {
+    case inbound
+    case outbound
+    case all
+}
+
+public struct CallHistoryQuery: Sendable, Equatable {
+    public let limit: Int
+    public let since: Date?
+    public let number: String?
+    public let direction: CallHistoryDirection
+
+    public init(limit: Int, since: Date?, number: String?, direction: CallHistoryDirection) {
+        self.limit = limit
+        self.since = since
+        self.number = number
+        self.direction = direction
+    }
+}
+
+public struct CallHistoryRawRecord: Sendable, Equatable {
+    public let primaryKey: Int64
+    public let uniqueID: String?
+    public let date: Date
+    public let durationSeconds: Double
+    public let address: String?
+    public let originated: Bool
+    public let answered: Bool
+    public let callType: Int
+    public let serviceProvider: String?
+
+    public init(
+        primaryKey: Int64,
+        uniqueID: String?,
+        date: Date,
+        durationSeconds: Double,
+        address: String?,
+        originated: Bool,
+        answered: Bool,
+        callType: Int,
+        serviceProvider: String?
+    ) {
+        self.primaryKey = primaryKey
+        self.uniqueID = uniqueID
+        self.date = date
+        self.durationSeconds = durationSeconds
+        self.address = address
+        self.originated = originated
+        self.answered = answered
+        self.callType = callType
+        self.serviceProvider = serviceProvider
+    }
+}
+
+public enum CallHistoryReadError: Error, Sendable, Equatable {
+    case unavailable(String)
+    case unsupportedSchema(missingColumns: [String])
+    case queryFailed(String)
+}
+
+public enum CallHistoryModule {
+    public static let moduleName = "calls"
+    public static let defaultLimit = 20
+    public static let maximumLimit = 100
+
+    public static let requiredColumns: Set<String> = [
+        "Z_PK", "ZUNIQUE_ID", "ZDATE", "ZDURATION", "ZADDRESS",
+        "ZORIGINATED", "ZANSWERED", "ZCALLTYPE", "ZSERVICE_PROVIDER"
+    ]
+
+    public static var defaultDatabasePath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/CallHistoryDB/CallHistory.storedata")
+            .path
+    }
+
+    private static func makeISO8601() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
+
+    public static func normalizePhoneNumber(_ value: String) -> String {
+        String(value.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) })
+    }
+
+    public static func parseQuery(_ arguments: Value) throws -> CallHistoryQuery {
+        let args: [String: Value]
+        if case .object(let object) = arguments {
+            args = object
+        } else {
+            args = [:]
+        }
+
+        let requestedLimit: Int
+        if let value = args["limit"] {
+            guard case .int(let limit) = value, limit > 0 else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'limit' must be a positive integer"
+                )
+            }
+            requestedLimit = limit
+        } else {
+            requestedLimit = defaultLimit
+        }
+
+        let since: Date?
+        if let value = args["since"] {
+            guard case .string(let raw) = value else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'since' must be an ISO-8601 timestamp string"
+                )
+            }
+            let fractional = makeISO8601()
+            let ordinary = ISO8601DateFormatter()
+            guard let parsed = fractional.date(from: raw) ?? ordinary.date(from: raw) else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'since' must be a valid ISO-8601 timestamp"
+                )
+            }
+            since = parsed
+        } else {
+            since = nil
+        }
+
+        let number: String?
+        if let value = args["number"] {
+            guard case .string(let raw) = value else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'number' must be a phone-number string"
+                )
+            }
+            let normalized = normalizePhoneNumber(raw)
+            guard !normalized.isEmpty else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'number' must contain at least one decimal digit"
+                )
+            }
+            number = normalized
+        } else {
+            number = nil
+        }
+
+        let direction: CallHistoryDirection
+        if let value = args["direction"] {
+            guard case .string(let raw) = value,
+                  let parsed = CallHistoryDirection(rawValue: raw.lowercased()) else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'direction' must be inbound, outbound, or all"
+                )
+            }
+            direction = parsed
+        } else {
+            direction = .all
+        }
+
+        return CallHistoryQuery(
+            limit: min(requestedLimit, maximumLimit),
+            since: since,
+            number: number,
+            direction: direction
+        )
+    }
+
+    public static func filteredRecords(
+        _ records: [CallHistoryRawRecord],
+        query: CallHistoryQuery
+    ) -> [CallHistoryRawRecord] {
+        records
+            .filter { record in
+                if let since = query.since, record.date < since { return false }
+                if query.direction == .inbound, record.originated { return false }
+                if query.direction == .outbound, !record.originated { return false }
+                if let number = query.number {
+                    guard let address = record.address else { return false }
+                    return normalizePhoneNumber(address) == number
+                }
+                return true
+            }
+            .sorted { lhs, rhs in
+                if lhs.date == rhs.date { return lhs.primaryKey > rhs.primaryKey }
+                return lhs.date > rhs.date
+            }
+            .prefix(query.limit)
+            .map { $0 }
+    }
+
+    public static func response(
+        arguments: Value,
+        databasePath: String = defaultDatabasePath,
+        reader: (String) throws -> [CallHistoryRawRecord] = readDatabase
+    ) throws -> Value {
+        let query = try parseQuery(arguments)
+
+        do {
+            let records = filteredRecords(try reader(databasePath), query: query)
+            let iso = makeISO8601()
+            let calls: [Value] = records.map { record in
+                let identifier = record.uniqueID.flatMap { $0.isEmpty ? nil : $0 } ?? String(record.primaryKey)
+                return .object([
+                    "id": .string(identifier),
+                    "startedAt": .string(iso.string(from: record.date)),
+                    "durationSeconds": .double(record.durationSeconds),
+                    "number": record.address.map(Value.string) ?? .null,
+                    "normalizedNumber": record.address.map(normalizePhoneNumber).map(Value.string) ?? .null,
+                    "direction": .string(record.originated ? CallHistoryDirection.outbound.rawValue : CallHistoryDirection.inbound.rawValue),
+                    "answered": .bool(record.answered),
+                    "callType": .int(record.callType),
+                    "serviceProvider": record.serviceProvider.map(Value.string) ?? .null
+                ])
+            }
+
+            var filters: [String: Value] = [
+                "limit": .int(query.limit),
+                "direction": .string(query.direction.rawValue)
+            ]
+            filters["since"] = query.since.map { .string(iso.string(from: $0)) } ?? .null
+            filters["number"] = query.number.map(Value.string) ?? .null
+
+            return .object([
+                "success": .bool(true),
+                "source": .string("CallHistoryDB"),
+                "identityResolved": .bool(false),
+                "filters": .object(filters),
+                "count": .int(calls.count),
+                "calls": .array(calls)
+            ])
+        } catch CallHistoryReadError.unavailable(let detail) {
+            return errorResponse(
+                code: "full_disk_access_required",
+                message: "The Bridge could not read the local CallHistory database.",
+                remediation: "Grant Full Disk Access to The Bridge in System Settings > Privacy & Security > Full Disk Access, then relaunch the app.",
+                details: detail
+            )
+        } catch CallHistoryReadError.unsupportedSchema(let missing) {
+            return errorResponse(
+                code: "unsupported_call_history_schema",
+                message: "This macOS CallHistoryDB schema is not supported; no partial or empty result was returned.",
+                remediation: "Update The Bridge or report the missing schema columns before relying on call data.",
+                details: "Missing columns: \(missing.sorted().joined(separator: ", "))",
+                missingColumns: missing.sorted()
+            )
+        } catch CallHistoryReadError.queryFailed(let detail) {
+            return errorResponse(
+                code: "call_history_query_failed",
+                message: "The Bridge could not query the local CallHistory database.",
+                remediation: "Retry once. If the error persists, report the schema and query error to The Bridge developer.",
+                details: detail
+            )
+        }
+    }
+
+    private static func errorResponse(
+        code: String,
+        message: String,
+        remediation: String,
+        details: String,
+        missingColumns: [String]? = nil
+    ) -> Value {
+        var error: [String: Value] = [
+            "code": .string(code),
+            "message": .string(message),
+            "remediation": .string(remediation),
+            "details": .string(details)
+        ]
+        if let missingColumns {
+            error["missingColumns"] = .array(missingColumns.map(Value.string))
+        }
+        return .object([
+            "success": .bool(false),
+            "source": .string("CallHistoryDB"),
+            "identityResolved": .bool(false),
+            "error": .object(error)
+        ])
+    }
+
+    public static func readDatabase(at path: String) throws -> [CallHistoryRawRecord] {
+        var database: OpaquePointer?
+        let openResult = sqlite3_open_v2(path, &database, SQLITE_OPEN_READONLY, nil)
+        guard openResult == SQLITE_OK, let database else {
+            let detail = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unable to open database"
+            if let database { sqlite3_close(database) }
+            throw CallHistoryReadError.unavailable(detail)
+        }
+        defer { sqlite3_close(database) }
+
+        let columns = try schemaColumns(database: database)
+        let missing = requiredColumns.subtracting(columns)
+        guard missing.isEmpty else {
+            throw CallHistoryReadError.unsupportedSchema(missingColumns: missing.sorted())
+        }
+
+        let sql = """
+            SELECT Z_PK, ZUNIQUE_ID, ZDATE, ZDURATION, ZADDRESS,
+                   ZORIGINATED, ZANSWERED, ZCALLTYPE, ZSERVICE_PROVIDER
+            FROM ZCALLRECORD
+            ORDER BY ZDATE DESC, Z_PK DESC
+            """
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var records: [CallHistoryRawRecord] = []
+        while true {
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else {
+                throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+            }
+
+            records.append(CallHistoryRawRecord(
+                primaryKey: sqlite3_column_int64(statement, 0),
+                uniqueID: stringColumn(statement, index: 1),
+                date: Date(timeIntervalSinceReferenceDate: sqlite3_column_double(statement, 2)),
+                durationSeconds: sqlite3_column_double(statement, 3),
+                address: stringColumn(statement, index: 4),
+                originated: sqlite3_column_int(statement, 5) != 0,
+                answered: sqlite3_column_int(statement, 6) != 0,
+                callType: Int(sqlite3_column_int64(statement, 7)),
+                serviceProvider: stringColumn(statement, index: 8)
+            ))
+        }
+        return records
+    }
+
+    private static func schemaColumns(database: OpaquePointer) throws -> Set<String> {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, "PRAGMA table_info(ZCALLRECORD)", -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var columns: Set<String> = []
+        while true {
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else {
+                throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+            }
+            if let name = stringColumn(statement, index: 1) { columns.insert(name) }
+        }
+        return columns
+    }
+
+    private static func stringColumn(_ statement: OpaquePointer, index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let bytes = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: bytes)
+    }
+
+    public static func register(on router: ToolRouter) async {
+        await router.register(ToolRegistration(
+            name: "calls_recent",
+            module: moduleName,
+            tier: .open,
+            description: "Read recent macOS call-history records newest-first. Supports bounded time, normalized-number, and direction filters. Returns phone records only; it never resolves or claims contact identity.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "minimum": .int(1),
+                        "maximum": .int(maximumLimit),
+                        "description": .string("Maximum records to return (default 20, hard maximum 100).")
+                    ]),
+                    "since": .object([
+                        "type": .string("string"),
+                        "format": .string("date-time"),
+                        "description": .string("Only calls at or after this ISO-8601 timestamp.")
+                    ]),
+                    "number": .object([
+                        "type": .string("string"),
+                        "description": .string("Exact phone filter after removing all non-decimal characters; no contact identity lookup is performed.")
+                    ]),
+                    "direction": .object([
+                        "type": .string("string"),
+                        "enum": .array(CallHistoryDirection.allCases.map { .string($0.rawValue) }),
+                        "description": .string("Filter inbound, outbound, or all calls (default all).")
+                    ])
+                ]),
+                "required": .array([]),
+                "additionalProperties": .bool(false)
+            ]),
+            metadata: ToolMetadata(
+                title: "Calls: Recent",
+                whenToUse: [
+                    "reviewing recent inbound or outbound call records on this Mac",
+                    "checking whether a normalized phone number appears in local call history"
+                ],
+                whenNotToUse: [
+                    "identifying who owns a phone number (use contacts_resolve_handle separately)",
+                    "dialing, messaging, drafting, recording, or modifying call history"
+                ],
+                relatedTools: ["contacts_resolve_handle", "messages_chat"]
+            ),
+            handler: { arguments in
+                try response(arguments: arguments)
+            }
+        ))
+    }
+}

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -40,6 +40,7 @@ public enum BridgeModuleRegistry {
         await FileModule.register(on: router)
         await registerSession(router)
         await MessagesModule.register(on: router)
+        await CallHistoryModule.register(on: router)      // Bridge v4 Wave 1: calls_recent read-only CallHistoryDB projection
         await MailModule.register(on: router)
         await NotesModule.register(on: router)
         await SystemModule.register(on: router)

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -129,6 +129,7 @@ public enum ToolAnnotationCatalog {
         // (alias kept; old + new are both live for one cycle).
         "clipboard_read": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "clipboard_write": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "calls_recent": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "code_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "connections_capabilities": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "connections_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),

--- a/TheBridgeTests/CallHistoryModuleTests.swift
+++ b/TheBridgeTests/CallHistoryModuleTests.swift
@@ -1,0 +1,222 @@
+// CallHistoryModuleTests.swift — Bridge v4 stabilization · calls_recent Wave 1
+
+import Foundation
+import MCP
+import SQLite3
+import TheBridgeLib
+
+private func callRecord(
+    id: Int64,
+    seconds: TimeInterval,
+    number: String?,
+    outbound: Bool
+) -> CallHistoryRawRecord {
+    CallHistoryRawRecord(
+        primaryKey: id,
+        uniqueID: "call-\(id)",
+        date: Date(timeIntervalSince1970: seconds),
+        durationSeconds: Double(id),
+        address: number,
+        originated: outbound,
+        answered: id.isMultiple(of: 2),
+        callType: Int(id),
+        serviceProvider: "provider"
+    )
+}
+
+private func object(_ value: Value) throws -> [String: Value] {
+    guard case .object(let result) = value else {
+        throw TestError.assertion("Expected object response")
+    }
+    return result
+}
+
+func runCallHistoryModuleTests() async {
+    print("\n☎️ CallHistoryModule Tests")
+
+    let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+    await CallHistoryModule.register(on: router)
+
+    await test("calls_recent registers as one open-tier calls tool") {
+        let tools = await router.registrations(forModule: "calls")
+        try expect(tools.count == 1)
+        try expect(tools.first?.name == "calls_recent")
+        try expect(tools.first?.tier == .open)
+    }
+
+    await test("calls_recent schema exposes every locked Wave 1 filter") {
+        let registrations = await router.registrations(forModule: "calls")
+        guard let tool = registrations.first(where: { $0.name == "calls_recent" }) else {
+            throw TestError.assertion("Missing calls_recent registration")
+        }
+        guard case .object(let schema) = tool.inputSchema,
+              case .object(let properties) = schema["properties"] else {
+            throw TestError.assertion("Missing input properties")
+        }
+        try expect(Set(properties.keys) == Set(["limit", "since", "number", "direction"]))
+        guard case .object(let direction) = properties["direction"],
+              case .array(let values) = direction["enum"] else {
+            throw TestError.assertion("Missing direction enum")
+        }
+        try expect(Set(values) == Set([.string("inbound"), .string("outbound"), .string("all")]))
+    }
+
+    await test("calls_recent annotation is read-only, ungated, and time-dependent") {
+        guard let annotation = ToolAnnotationCatalog.annotations(for: "calls_recent") else {
+            throw TestError.assertion("Missing calls_recent annotation")
+        }
+        try expect(annotation.readOnlyHint)
+        try expect(!annotation.destructiveHint)
+        try expect(!annotation.idempotentHint)
+        try expect(!annotation.requiresConfirmation)
+        try expect(annotation.openWorld)
+    }
+
+    await test("phone normalization removes punctuation without resolving identity") {
+        try expect(CallHistoryModule.normalizePhoneNumber("+1 (605) 555-0123") == "16055550123")
+        try expect(CallHistoryModule.normalizePhoneNumber("abc") == "")
+    }
+
+    await test("query parser defaults and hard-clamps the limit") {
+        let defaults = try CallHistoryModule.parseQuery(.object([:]))
+        try expect(defaults.limit == 20)
+        try expect(defaults.direction == .all)
+        let clamped = try CallHistoryModule.parseQuery(.object(["limit": .int(1_000)]))
+        try expect(clamped.limit == 100)
+    }
+
+    await test("query parser rejects invalid limit, since, number, and direction") {
+        for args: Value in [
+            .object(["limit": .int(0)]),
+            .object(["since": .string("yesterday-ish")]),
+            .object(["number": .string("no digits")]),
+            .object(["direction": .string("sideways")])
+        ] {
+            do {
+                _ = try CallHistoryModule.parseQuery(args)
+                throw TestError.assertion("Expected invalid arguments")
+            } catch is ToolRouterError {
+                // Expected.
+            }
+        }
+    }
+
+    let records = [
+        callRecord(id: 1, seconds: 100, number: "+1 (605) 555-0100", outbound: false),
+        callRecord(id: 2, seconds: 300, number: "+1 605 555 0200", outbound: true),
+        callRecord(id: 3, seconds: 200, number: "16055550100", outbound: true)
+    ]
+
+    await test("records are newest-first and limit is applied after sorting") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 2, since: nil, number: nil, direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [2, 3])
+    }
+
+    await test("since filter is inclusive") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: Date(timeIntervalSince1970: 200), number: nil, direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [2, 3])
+    }
+
+    await test("normalized-number filter is exact and formatting-insensitive") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: "16055550100", direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [3, 1])
+    }
+
+    await test("direction filters distinguish inbound, outbound, and all") {
+        let inbound = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .inbound)
+        )
+        let outbound = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .outbound)
+        )
+        let all = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .all)
+        )
+        try expect(inbound.map(\.primaryKey) == [1])
+        try expect(outbound.map(\.primaryKey) == [2, 3])
+        try expect(all.map(\.primaryKey) == [2, 3, 1])
+    }
+
+    await test("successful response is structured and makes no identity claim") {
+        let value = try CallHistoryModule.response(
+            arguments: .object(["limit": .int(1)]),
+            databasePath: "/fixture",
+            reader: { _ in records }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(true))
+        try expect(result["identityResolved"] == .bool(false))
+        guard case .array(let calls) = result["calls"],
+              case .object(let first) = calls.first else {
+            throw TestError.assertion("Missing calls array")
+        }
+        try expect(first["id"] == .string("call-2"))
+        try expect(first["name"] == nil)
+        try expect(first["resolvedName"] == nil)
+    }
+
+    await test("database denial returns structured Full Disk Access guidance") {
+        let value = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/denied",
+            reader: { _ in throw CallHistoryReadError.unavailable("authorization denied") }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(false))
+        guard case .object(let error) = result["error"] else {
+            throw TestError.assertion("Missing error object")
+        }
+        try expect(error["code"] == .string("full_disk_access_required"))
+        guard case .string(let remediation) = error["remediation"] else {
+            throw TestError.assertion("Missing remediation")
+        }
+        try expect(remediation.contains("Full Disk Access"))
+    }
+
+    await test("schema drift fails explicitly instead of returning an empty success") {
+        let value = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/fixture",
+            reader: { _ in throw CallHistoryReadError.unsupportedSchema(missingColumns: ["ZDATE", "ZADDRESS"]) }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(false))
+        try expect(result["calls"] == nil)
+        guard case .object(let error) = result["error"],
+              case .array(let missing) = error["missingColumns"] else {
+            throw TestError.assertion("Missing structured schema error")
+        }
+        try expect(Set(missing) == Set([.string("ZADDRESS"), .string("ZDATE")]))
+    }
+
+    await test("real SQLite adapter rejects an incompatible fixture schema") {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calls-recent-schema-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("CallHistory.storedata").path
+        var database: OpaquePointer?
+        try expect(sqlite3_open(path, &database) == SQLITE_OK)
+        defer { if let database { sqlite3_close(database) } }
+        try expect(sqlite3_exec(database, "CREATE TABLE ZCALLRECORD (Z_PK INTEGER)", nil, nil, nil) == SQLITE_OK)
+        do {
+            _ = try CallHistoryModule.readDatabase(at: path)
+            throw TestError.assertion("Expected unsupported schema")
+        } catch CallHistoryReadError.unsupportedSchema(let missing) {
+            try expect(missing.contains("ZDATE"))
+            try expect(missing.contains("ZADDRESS"))
+        }
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -646,6 +646,7 @@ await runDataSourcesViewModelTests() // Data-Source Registry W4: Settings pane s
 await runRegistryEdgeCaseTests()     // Data-Source Registry: adversarial edge cases (codec chunking, pagination, cache concurrency, config race, writer)
 await runRegistryHydrationTests()    // Packet Runner v1 (FR-1/§8.3): packet-registry-v1 one-hop hydration envelope (primary+body+relations+provenance+warnings)
 await runMessagesModuleTests()
+await runCallHistoryModuleTests()      // Bridge v4 Wave 1: calls_recent filters, schema/FDA errors, annotations
 await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
 await runVoiceMemoSuiteAuditTests()  // Voice memo suite audit (PKT-MEM-122)
 await runMailModuleTests()           // PKT-961 (v3.7·H): mail_* Apple Mail module (mock seam; send-guard)

--- a/docs/operator/calls-recent.md
+++ b/docs/operator/calls-recent.md
@@ -1,0 +1,42 @@
+# `calls_recent` operator guide
+
+`calls_recent` is The Bridge's read-only view of the local macOS CallHistoryDB.
+It returns phone records; it does not resolve a number to a person and does not
+modify call history.
+
+## Usage
+
+```json
+{
+  "limit": 20,
+  "since": "2026-07-17T00:00:00Z",
+  "number": "+1 (605) 555-0123",
+  "direction": "outbound"
+}
+```
+
+Every field is optional. `limit` defaults to 20 and is capped at 100.
+`direction` accepts `inbound`, `outbound`, or `all`. The number filter removes
+non-decimal characters and then requires an exact normalized match. Results are
+newest-first.
+
+The response includes `identityResolved: false`. Call direction, answered
+state, duration, and service-provider metadata are call facts only; none proves
+who owns the number.
+
+## Full Disk Access
+
+If the database cannot be opened, the tool returns
+`full_disk_access_required` with remediation instead of an empty list. Grant
+Full Disk Access to The Bridge in **System Settings > Privacy & Security > Full
+Disk Access**, relaunch The Bridge, reconnect MCP clients, and retry.
+
+An incompatible database returns `unsupported_call_history_schema` with the
+missing columns. Do not treat that response as evidence that there were no
+calls.
+
+## Scope boundary
+
+Wave 1 intentionally stops at read-only call truth. Prospect matching, outreach
+writes, dialing, message drafts, and next-action recommendations belong to later
+reviewed waves in `PKT-CALL-001`; they are not implied by this tool.

--- a/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
+++ b/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
@@ -1,0 +1,354 @@
+# PKT-CALL-001 — Prospecting Call Tools Suite (7)
+
+**Slug:** `pkt-call-001-prospecting-call-tools`
+**Execution Class:** REVIEW-FIRST
+**Status:** REVIEW — Wave 1 implemented; Waves 2–3 deliberately deferred
+**Priority:** 80
+**Classification:** Standard (suite) · sequential waves inside one packet
+**SKILLS:** orchestrator · executor · mac-keepr · people-keepr (consumer contract)
+**PROJECT:** The Bridge (platform tools) · related ops: KUP Solutions prospecting
+**Agent Type:** Implementation (Bridge MCP tools)
+
+**Orchestrator source:** `focus-keepr/orchestrator` v7.1.x (packet architect protocol)
+**Origin session:** 2026-07-16 — Prospect Execute + CallHistory recon
+
+---
+
+## Goal Contract
+
+**Outcome:** Seven Bridge MCP tools ship so an agent can read Mac call history, log prospecting call touches into PROSPECTS/OUTREACH, run a Prospect Execute loop, join call+Messages timelines, prep dials, follow up after VM, and recommend next best actions — without inventing CONTACTS or auto-sending.
+
+**Scope (in):**
+1. `calls_recent` — read CallHistoryDB
+2. `log_call_touch` — write OUTREACH + update PROSPECT from a call or operator claim
+3. `prospect_execute_loop` — boot / tick / close for a Prospect block
+4. `handle_timeline` — calls + Messages (+ optional mail later) for one handle
+5. `dial_prep` — brief + talk track + open `tel:` via Phone
+6. `vm_followup` — draft SMS/email after VM; wrong-number fork
+7. `next_best_action` — call vs text vs pause vs warm intro for one prospect or queue
+
+**Scope (out):**
+- Call recording / live transcription
+- Auto-dial spam or unattended mass dialing
+- Auto-send SMS/email without operator confirm
+- Auto-create CONTACT / CLIENT (conversion remains create+dispose with human or explicit GO)
+- Treating CallHistory “answered” as full Phone Verified identity
+- AppleScript Phone recents (dead end — use CallHistoryDB)
+- iOS-only private APIs
+
+**Constraints:**
+- Local-first: CallHistory path `~/Library/Application Support/CallHistoryDB/CallHistory.storedata`
+- TCC: Full Disk Access for The Bridge if required on some macOS versions
+- Governance: read tools open/notify; write/log notify; send paths request + confirm
+- Conversion law (ops): never move DS rows; create downstream + Status=Converted on source
+- Tool count / floor gate: bump `staticFeatureModuleToolCount` + `make test-floor`
+- Prefer shared primitives over one-off VoiceMemo-style triple round trips
+
+**Success Criteria:**
+1. All seven tools registered in ToolAnnotationCatalog with governance tiers
+2. `calls_recent` returns Jeff-class rows (e.g. outbound unanswered ~74s to 6128403028 when present in history)
+3. `log_call_touch` creates OUTREACH linked to PROSPECT and updates Last Touched / Next Action
+4. `prospect_execute_loop` boot returns Top queue + unlogged dials since `since`
+5. `handle_timeline` merges call + messages for a known number without inventing contacts
+6. `dial_prep` opens Phone with `tel:` (system default Phone.app)
+7. `vm_followup` returns draft text only (no send) unless confirm path used
+8. `next_best_action` returns ranked options with reasons grounded in history
+9. Unit/integration tests for parse/normalize/match; floor green
+10. Operator brief documents how Prospect Execute uses the suite
+
+**Verification:**
+- `make test` / `make test-floor` green
+- Live MCP smoke: `calls_recent` limit 10; match Jeff if in DB
+- Live smoke: `log_call_touch` dryRun then real against a test PROSPECT
+- Manual: dial_prep opens Phone; no Google Voice handler required
+- Docs: AGENTS.md or operator packet note updated
+
+**Execution Class:** REVIEW-FIRST
+Ship to reviewable PR stack + smoke evidence; operator GO before merge to main / release.
+
+**Review Requirement:**
+- Reviewer: Isaiah (or Bridge code owner)
+- Artifact: PR(s) + smoke transcript + tool catalog entries
+- Decisions: Approve merge · Request changes · Park
+
+**Failure / Stop Conditions:**
+- CallHistory unreadable after FDA granted → BLOCKED with exact TCC steps
+- Schema drift in ZCALLRECORD without adapter → REVIEW with mapping gap
+- Any path that would auto-send or auto-convert CONTACT → stop, fix design
+- Ambiguous multi-match prospect for a number → no silent write; return ambiguous
+
+**Output / Brief Contract:**
+- PR description with tool list + tiers
+- Operator one-pager: Prospect Execute with tools
+- Packet Runner Output sections filled on completion
+
+## GOAL_CONDITION
+
+Ship seven Bridge MCP tools (`calls_recent`, `log_call_touch`, `prospect_execute_loop`, `handle_timeline`, `dial_prep`, `vm_followup`, `next_best_action`) so Prospect Execute can read Mac CallHistory, log touches to PROSPECTS/OUTREACH, and recommend next actions within scope, proven by test-floor green and live MCP smoke on CallHistory + a PROSPECT row; REVIEW-FIRST before release; stop if FDA/schema blocks or auto-send/auto-convert would be required.
+
+---
+
+## Current System State & Context
+
+**Proven on operator Mac (2026-07-16):**
+- CallHistory SQLite readable at `CallHistoryDB/CallHistory.storedata`
+- Columns usable: ZDATE, ZDURATION, ZORIGINATED, ZANSWERED, ZADDRESS, ZNAME, ZSERVICE_PROVIDER, ZORIGINATINGDEVICENAME
+- Jeff O’Neill (6128403028): outbound, unanswered, ~74s VM-class duration logged same day
+- PROSPECTS registry entity `prospect` bound to DS `97a4ae02-…`
+- OUTREACH has PROSPECT relation; Status/Outcome include Voicemail
+- Messages tools exist (`messages_chat`, `messages_recent`, …)
+- Phone.app opens via `open -a Phone tel:…`; system `tel:` should be Phone (not Google Voice)
+- No Bridge `calls_*` tools today
+
+**Ops doctrine:**
+- Invent PROSPECTS only after verification gate
+- Contact = quality relationship; Client = paid
+- Convert = create + dispose (Status=Converted), never move/delete
+- Prospect Execute Top 5 from trades Excel + open PROSPECTS
+
+**Context relevance list:**
+- This packet + Bridge repo `Sources/` Mac/Registry modules
+- `docs/operator/packets/PKT-MEM-135-…` as pattern for new tools
+- Prospect aura invent/convert law
+- Sales strategy pipeline / conversion law
+
+---
+
+## Material decisions (recommended defaults — operator may override)
+
+| ID | Decision | Recommended | Impact if otherwise |
+|---|---|---|---|
+| D1 | Module home | New **Calls** feature surface under Mac tooling (or MacModule extension), not Notion-only | Wrong module → messy ownership |
+| D2 | Packet shape | **One suite packet**, sequential waves W1→W3 (not 7 micro-packets) | More packets → more runner overhead |
+| D3 | FDA | Document FDA requirement; fail with actionable error if DB unreadable | Silent empty lists mislead agents |
+| D4 | Number match | Normalize to digits; match last-10 US; multi-prospect → ambiguous error | Wrong person logged |
+| D5 | Auto Phone Verified | **Never** set true from unanswered/VM; optional suggest after answered + duration ≥ threshold | False identity claims |
+| D6 | Sends | `vm_followup` drafts only unless existing messages_send confirm path | Accidental customer SMS |
+
+**Assumed GO on D1–D6 unless operator objects before QUEUE.**
+
+---
+
+## Decomposition / Waves (sequential)
+
+### Wave 1 — Call truth (unblocks all)
+**Tools:** `calls_recent`
+**Deliverables:** Reader for CallHistory.storedata; filters limit/since/number/direction; ToolAnnotationCatalog; tests with fixture DB or mocked rows; FDA error path.
+
+### Wave 2 — Log + block loop
+**Tools:** `log_call_touch`, `prospect_execute_loop`
+**Depends on:** Wave 1
+**Deliverables:**
+- `log_call_touch`: input call id or {number, at, outcome claim}; resolve PROSPECT; create OUTREACH; update Last Touched / Next Action; dryRun
+- `prospect_execute_loop`: mode boot|tick|close; boot = queue + recent calls; tick = unlogged dials since; close = digest + scoreboard
+
+### Wave 3 — Context, prep, recovery, judgment
+**Tools:** `handle_timeline`, `dial_prep`, `vm_followup`, `next_best_action`
+**Depends on:** Wave 1–2
+**Deliverables:**
+- Timeline merge calls + messages_chat/recent
+- dial_prep: registry prospect brief + open tel
+- vm_followup: draft only
+- next_best_action: ranked options with evidence fields
+
+**Merge points:** shared phone normalize + CallHistory reader + prospect match helper (extract once in W1, reuse W2–W3).
+
+---
+
+## Definition of Done (checklist)
+
+### Wave 1
+- [x] `calls_recent` implemented and registered
+- [x] Returns newest-first rows with stable field names
+- [x] Filters: limit, since, number (normalized), direction
+- [x] Unreadable DB → structured error with FDA hint
+- [x] Tests + floor bump
+
+### Wave 2
+- [ ] `log_call_touch` dryRun + write paths
+- [ ] OUTREACH linked to PROSPECT when relation exists
+- [ ] Does not set Phone Verified on VM/unanswered
+- [ ] `prospect_execute_loop` boot/tick/close
+- [ ] Tick lists unlogged outbound calls matched to prospects
+- [ ] Tests + floor bump
+
+### Wave 3
+- [ ] `handle_timeline` for a handle
+- [ ] `dial_prep` returns brief + opens Phone (or returns tel URL if open fails)
+- [ ] `vm_followup` draft body + optional Ready OUTREACH without send
+- [ ] `next_best_action` returns ≥1 ranked option with reason
+- [ ] Operator brief markdown in repo
+- [ ] Tests + floor bump
+- [ ] REVIEW artifact ready for merge GO
+
+---
+
+## Required Capabilities
+
+- `repo:the-bridge` — Swift MCP tool modules, tests, annotations, version/floor
+- Local filesystem read: CallHistoryDB (operator machine)
+- Bridge registry: `prospect` read/write; Notion OUTREACH create via existing paths
+- messages_* read for timeline (existing)
+
+## Prohibited Actions
+
+- No merge to main without REVIEW GO
+- No production deploy from this packet
+- No messages_send / mail_send without operator confirm:'SEND'
+- No bulk invent CONTACTS from call history
+- No deletion of CallHistory or prospect rows
+- No secret values in packet or logs
+
+---
+
+## Replay and Recovery
+
+1. **Detect prior work:** tools exist in catalog + tests green + Version/floor comments dated PKT-CALL-001
+2. **Stable keys:** tool names exact as listed; CallHistory reader module path documented
+3. **Safe resume:** land waves in order; if W2 mid-flight, do not start W3 tools depending on missing APIs
+4. **Unsafe:** partial catalog registration without tests → REVIEW before more tools
+
+---
+
+## Review Contract
+
+| Item | Value |
+|---|---|
+| Who | Isaiah / Bridge owner |
+| Artifact | PR stack + smoke notes + this packet Output section |
+| Approve | Merge + optional release notes |
+| Request changes | List gaps; keep branch |
+| Park | Leave Draft/REVIEW with reason |
+
+---
+
+## Brief Contract (operator-facing after ship)
+
+1. How to run Prospect Execute with the suite
+2. What CallHistory can/can’t prove (identity)
+3. FDA one-liner if empty results
+4. Continuity note: Mac vs iPhone call chooser is OS UX, not tool failure
+
+---
+
+## Dependencies
+
+| Depends on | State |
+|---|---|
+| CallHistoryDB present on operator Mac | Available (verified 2026-07-16) |
+| PROSPECTS + OUTREACH live | Available |
+| Messages tools | Available |
+| tel: → Phone.app | Operator preference (fixed once; re-check if Chrome steals handler) |
+
+**Blocked by:** none hard. Soft: FDA if tool returns empty erroneously.
+
+---
+
+## Tool contracts (authoritative for implementers)
+
+### 1. `calls_recent`
+```
+in:  { limit?: number, since?: ISO8601, number?: string, direction?: "inbound"|"outbound"|"all" }
+out: { calls: [{ id, at, number, name?, originated, answered, durationSec, service?, device? }], source: "CallHistoryDB" }
+tier: open | notify
+```
+
+### 2. `log_call_touch`
+```
+in:  { callId?: string, number?: string, at?: ISO8601, outcome: "Connected"|"Voicemail"|"No answer"|"Wrong number"|"Booked", prospectId?: string, dryRun?: bool, nextAction?: string }
+out: { outreachId?, prospectId?, updated: string[], suggestions?: string[] }
+tier: notify (write)
+```
+
+### 3. `prospect_execute_loop`
+```
+in:  { mode: "boot"|"tick"|"close", since?: ISO8601, brand?: string }
+out: boot → { queue, recentCalls, openProspects }; tick → { unloggedCalls, suggestions }; close → { scoreboard, digest }
+tier: open/notify
+```
+
+### 4. `handle_timeline`
+```
+in:  { number: string, limit?: number }
+out: { events: [{ at, channel: "call"|"message", summary, ref }] }
+tier: open
+```
+
+### 5. `dial_prep`
+```
+in:  { prospectId: string, openPhone?: bool }
+out: { brief, talkTrack, telUrl, opened?: bool }
+tier: notify if opens Phone
+```
+
+### 6. `vm_followup`
+```
+in:  { prospectId: string, channel?: "Text"|"Email", createOutreachDraft?: bool }
+out: { draftBody, subject?, outreachId? }
+tier: notify if writes draft row; never send
+```
+
+### 7. `next_best_action`
+```
+in:  { prospectId?: string, queue?: bool }
+out: { actions: [{ rank, action, reason, evidence[] }] }
+tier: open
+```
+
+---
+
+## Packet Runner Output
+
+### Current Canonical Result
+
+Wave 1 is implemented on `codex/calls-recent` for review. `calls_recent` reads
+CallHistoryDB through a read-only SQLite connection, supports the four locked
+filters, returns newest-first structured records, and explicitly reports that
+no contact identity was resolved. It does not select or expose CallHistory's
+name column.
+
+Verification on 2026-07-17:
+
+- Operator DB preflight: read-only open, required schema, and sample SELECT all
+  succeeded under The Bridge's installed FDA identity.
+- Hermetic suite: 3221 passed, 0 failed; floor 3207 → 3221.
+- Structured error tests: FDA denial and unsupported schema both fail visibly;
+  neither degrades to an empty-success result.
+- Live installed MCP smoke remains the final review-integration gate because
+  the currently installed app predates this branch.
+
+Waves 2–3 are not part of the approved stabilization scope and remain unchecked.
+Recommended next step after Wave 1 review: extract the normalized-number helper
+into a shared Calls primitive, then implement `log_call_touch` with dry-run and
+ambiguous-prospect fail-closed behavior before adding any higher-level loop.
+
+### Artifact Manifest
+
+- **Canonical mission surface:** [PACKETS · PKT-CALL-001](https://app.notion.com/p/PKT-CALL-001-Prospecting-Call-Tools-Suite-7-39fcbb58889e81cb9c9cca1dfee73cc6)
+- DOCS dual `pkt-call-001` **deleted** 2026-07-16 (standing order: Packet Mission Surface)
+- Repo mirror only (not a second SSOT)
+
+- This file: `docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md`
+- Notion packet page: https://app.notion.com/p/PKT-CALL-001-Prospecting-Call-Tools-Suite-7-39fcbb58889e81cb9c9cca1dfee73cc6
+
+### Exceptional History
+
+- 2026-07-16: Scoped via orchestrator protocol from seven-tool consolidation; CallHistory recon confirmed readable; Jeff VM call present in DB.
+- 2026-07-17: Stabilization scope locked to Wave 1 only. Implemented and tested
+  `calls_recent`; retained Waves 2–3 as future review work rather than silently
+  expanding the branch.
+
+---
+
+## Fresh-Agent Test
+
+A fresh executor with this packet + Bridge repo can implement Wave 1 without asking material questions (path, schema columns, and tool names are specified). Waves 2–3 reuse Wave 1 helpers. Operator review required before merge (REVIEW-FIRST).
+
+## Autonomy Gate
+
+- Material decisions D1–D6 recommended and assumed
+- Execution Class set
+- Verification named
+- No customer auto-send
+- PROJECT relation: The Bridge (set on Notion row)
+- Ready for QUEUE after operator confirms D1–D6 (or silence = accept defaults)

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2290,3 +2290,9 @@ set -euo pipefail
 # mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
 # redaction, and client name/version attribution. Measured 3207 passed, 0
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
+# PKT-CALL-001 Wave 1 (2026-07-17): +14 hermetic CallHistory tests cover
+# calls_recent registration/tier/schema/annotations, phone normalization,
+# limit/since/number/direction filters, newest-first ordering, identity-free
+# output, actionable Full Disk Access failure, explicit schema-drift failure,
+# and an incompatible SQLite fixture. Measured 3221 passed, 0 failed on the
+# origin/main-based calls worktree. FLOOR 3207 -> 3221.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3221}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."


### PR DESCRIPTION
## What changed

- adds the read-only `calls_recent(limit?, since?, number?, direction?)` MCP tool
- reads CallHistoryDB newest-first without exposing contact-name identity claims
- returns structured Full Disk Access, schema, validation, and query errors
- registers read-only annotations, module counts, operator documentation, and packet evidence

## Why

Prospecting workflows need a safe, local call-history primitive before any write or automation tools are considered. This PR intentionally implements Wave 1 only; the remaining six proposal tools stay deferred for separate review.

## Impact

Operators can inspect recent call records with normalized phone filtering and explicit provenance. The tool never mutates CallHistoryDB and reports `identityResolved: false`.

## Validation

- `make test-floor`: 3,221 passed, 0 failed; floor 3,221
- read-only preflight confirmed the installed app can open CallHistoryDB and required schema columns exist
- live installed MCP smoke is recorded after the review-integration install

## Review boundary

Draft / REVIEW. Do not merge without an explicit review decision.