### PR TITLE
Integrate Bridge v4 candidate lineage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    # Workflow-level safety net. Cap the whole job at 45 minutes so a
+    # Workflow-level safety net. Cap the whole job at 60 minutes so a
     # hanging test (or a Swift toolchain stall on the GHA runner) fails
     # fast instead of riding the 6h default to cancellation. Locally
-    # the suite runs in <10min; 45min gives headroom for FluidAudio
-    # (Parakeet) fetch+compile on the macos runner's slower IO.
-    timeout-minutes: 45
+    # the suite runs in <10min; 60min gives headroom for FluidAudio
+    # (Parakeet) fetch+compile plus the full floor on the macos runner's
+    # slower IO.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,9 +39,10 @@ jobs:
 
       - name: Build release
         # Per-step timeout — Swift release build on macos-26 with strict
-        # concurrency + FluidAudio (Parakeet) fetch takes ~20min on GHA;
-        # 25min cap catches a stuck compile without burning the job budget.
-        timeout-minutes: 25
+        # concurrency + FluidAudio (Parakeet) fetch can exceed 25min on GHA;
+        # PR #107 reached the final link step before that cap killed it. A 35min
+        # cap keeps a bounded failure while allowing a healthy cold build.
+        timeout-minutes: 35
         run: make build
 
       - name: Run test suite + floor gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased — Notion Views read + comment reply fidelity — 2026-07-15
+
+- **Feature** — `notion_views_list` and `notion_view_get` wrap the Notion Views
+  API (`GET /v1/views`, `GET /v1/views/{id}`) so agents can discover and inspect
+  table/board/chart/calendar views that already exist on KEEP OS data sources.
+- **Fix** — `notion_comment_create` accepts `discussionId` for true thread
+  replies (POST body uses `discussion_id`, not `parent`). Exactly one of
+  `pageId` / `discussionId`. Voice-memo `pageId`+`text` path unchanged.
+- **Fix** — `notion_discussion_create` description no longer claims to be the
+  reply tool; it starts a new page-level thread (same as `pageId` create).
+- **Docs** — `notion_search` notes that API filter object types are `page` |
+  `data_source` only (not `database`) under Notion-Version 2026-03-11.
+- **Counts** — static feature tools 205 → 207; test floor 3207 → 3213.
+
 ## v3.9.9 (build 80) — Remote shell and control-plane parity — 2026-07-10
 
 - **Fix** — the Wave 1 remote control-plane preference now defaults OFF instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@
   `data_source` only (not `database`) under Notion-Version 2026-03-11.
 - **Counts** — static feature tools 205 → 207; test floor 3207 → 3213.
 
+## Unreleased — Voice Memo Reliability (list + receipts + identity projection) — 2026-07-15
+
+- **Fix** — `FieldsFilter` retains `id` / `entity` / `title` on projected registry
+  rows by default (`includeIdentity: true`) so `registry_find`/`list` projections
+  stay usable for follow-on writes without a second unprojected lookup.
+- **Feature** — `voice_memo_list` supports dateFrom/dateTo, hasTranscript,
+  transcriptContains, sort, limit/cursor pagination, and a `health` block
+  (curator job status + unprocessed/pending-review backlog).
+- **Feature** — `voice_memo_commit` returns structured receipts:
+  `memoState` / `intentState` / `completedIntents` / `remainingIntents` / `write`
+  while preserving legacy ok/memoId/intentKind/detail/markedProcessed fields.
+
 ## v3.9.9 (build 80) — Remote shell and control-plane parity — 2026-07-10
 
 - **Fix** — the Wave 1 remote control-plane preference now defaults OFF instead

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SPARKLE_ARTIFACT_DIR = $(BUILD_DIR)/artifacts/sparkle/Sparkle
 SPARKLE_FRAMEWORK = $(SPARKLE_ARTIFACT_DIR)/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework
 SPARKLE_TOOLS_DIR = $(SPARKLE_ARTIFACT_DIR)/bin
 
-.PHONY: debug build test test-floor check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree inject-license-key inject-remote-access
+.PHONY: debug build test test-floor test-clean check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree inject-license-key inject-remote-access
 
 # ── Debug Build ────────────────────────────────────────────────
 debug:
@@ -129,6 +129,14 @@ test:
 # Used by CI so a shrunk/disabled suite fails. Floor provenance lives in
 # scripts/test-floor-gate.sh.
 test-floor:
+	./scripts/test-floor-gate.sh
+
+# Branch/tool-surface switch verification: clear every SwiftPM object before
+# running the same locked floor gate. Use when a worktree changes branches or
+# cherry-picks a module-registration change; prevents stale tools from a prior
+# HEAD surviving in .build and producing a false surface-audit failure.
+test-clean:
+	swift package clean
 	./scripts/test-floor-gate.sh
 
 # PKT-1115: detect duplicate monotonic counter/FLOOR claims across open PRs.
@@ -327,6 +335,7 @@ install: check-clean-tree check-stale-build notarize
 	@killall Dock 2>/dev/null || true
 	$(VERIFY_INSTALL)
 	@echo "✅ Installed: /Applications/The Bridge.app"
+	@echo "🔌 Reconnect every MCP client after relaunch so it re-runs initialize + tools/list."
 
 # v1.7.0: Copy-only install (no notarize dep, no killall) (F3)
 install-copy: check-clean-tree check-stale-build sign
@@ -340,6 +349,7 @@ install-copy: check-clean-tree check-stale-build sign
 	$(VERIFY_INSTALL)
 	@echo "Installed: /Applications/The Bridge.app"
 	@echo "Restart The Bridge manually to pick up changes."
+	@echo "Reconnect every MCP client after relaunch so it re-runs initialize + tools/list."
 
 # Alias for agents / remote MCP sessions: same as install-copy (no notarize; does not kill The Bridge).
 install-agent-safe: install-copy

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -442,7 +442,10 @@ public enum BridgeConstants {
     /// PKT-1120 Tool Ergonomics (2026-07-14): +2
     ///   (voice_memo_settings_get + voice_memo_settings_set; voice family).
     ///   203 + 2 = 205.
-    public static let staticFeatureModuleToolCount = 205
+    /// Notion Views read + comment reply (2026-07-15): +2
+    ///   (notion_views_list + notion_view_get; notion family). Comment path
+    ///   gains discussionId reply (no new tool). 205 + 2 = 207.
+    public static let staticFeatureModuleToolCount = 207
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -445,7 +445,9 @@ public enum BridgeConstants {
     /// Notion Views read + comment reply (2026-07-15): +2
     ///   (notion_views_list + notion_view_get; notion family). Comment path
     ///   gains discussionId reply (no new tool). 205 + 2 = 207.
-    public static let staticFeatureModuleToolCount = 207
+    /// Bridge v4 stabilization Wave 1 (2026-07-17): +1 calls_recent.
+    ///   207 + 1 = 208.
+    public static let staticFeatureModuleToolCount = 208
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.
@@ -474,5 +476,6 @@ public enum BridgeConstants {
     /// Voice Memos curator (2026-06-24): + voice family = 29.
     /// Local Ollama (2026-06-24): + ollama family = 30.
     /// PKT-1061 (2026-06-29): + commands family = 31.
-    public static let staticFeatureModuleFamilyCount = 31
+    /// Bridge v4 stabilization Wave 1 (2026-07-17): + calls family = 32.
+    public static let staticFeatureModuleFamilyCount = 32
 }

--- a/TheBridge/Modules/CalendarModule.swift
+++ b/TheBridge/Modules/CalendarModule.swift
@@ -57,12 +57,29 @@ public struct CalendarInfo: Sendable, Equatable {
     public let title: String
     public let isDefault: Bool
     public let allowsModify: Bool
+    public let calendarType: String
+    public let sourceIdentifier: String?
+    public let sourceTitle: String?
+    public let sourceType: String?
 
-    public init(id: String, title: String, isDefault: Bool, allowsModify: Bool) {
+    public init(
+        id: String,
+        title: String,
+        isDefault: Bool,
+        allowsModify: Bool,
+        calendarType: String = "unknown",
+        sourceIdentifier: String? = nil,
+        sourceTitle: String? = nil,
+        sourceType: String? = nil
+    ) {
         self.id = id
         self.title = title
         self.isDefault = isDefault
         self.allowsModify = allowsModify
+        self.calendarType = calendarType
+        self.sourceIdentifier = sourceIdentifier
+        self.sourceTitle = sourceTitle
+        self.sourceType = sourceType
     }
 }
 
@@ -372,6 +389,30 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
         )
     }
 
+
+    private static func calendarTypeName(_ type: EKCalendarType) -> String {
+        switch type {
+        case .local: return "local"
+        case .calDAV: return "caldav"
+        case .exchange: return "exchange"
+        case .subscription: return "subscription"
+        case .birthday: return "birthday"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private static func sourceTypeName(_ type: EKSourceType) -> String {
+        switch type {
+        case .local: return "local"
+        case .exchange: return "exchange"
+        case .calDAV: return "caldav"
+        case .mobileMe: return "mobileme"
+        case .subscribed: return "subscribed"
+        case .birthdays: return "birthdays"
+        @unknown default: return "unknown"
+        }
+    }
+
     public func calendars() async throws -> [CalendarInfo] {
         try await ensureAccess()
         return store.calendars(for: .event).map { cal in
@@ -380,7 +421,11 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
                 title: cal.title,
                 isDefault: cal.calendarIdentifier
                     == store.defaultCalendarForNewEvents?.calendarIdentifier,
-                allowsModify: cal.allowsContentModifications
+                allowsModify: cal.allowsContentModifications,
+                calendarType: Self.calendarTypeName(cal.type),
+                sourceIdentifier: cal.source?.sourceIdentifier,
+                sourceTitle: cal.source?.title,
+                sourceType: cal.source.map { Self.sourceTypeName($0.sourceType) }
             )
         }
     }

--- a/TheBridge/Modules/CalendarModule.swift
+++ b/TheBridge/Modules/CalendarModule.swift
@@ -250,9 +250,11 @@ public enum CalendarModuleError: LocalizedError, Equatable {
 /// timezone-qualified strings, naive local wall-clock (`2026-06-03T09:00:00`),
 /// and date-only (`2026-06-03`) anchored to the user's local time zone.
 public enum CalendarISOParsing {
-    private static func makeISO() -> ISO8601DateFormatter {
+    private static func makeISO(fractionalSeconds: Bool = false) -> ISO8601DateFormatter {
         let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
+        f.formatOptions = fractionalSeconds
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
         return f
     }
 
@@ -273,7 +275,8 @@ public enum CalendarISOParsing {
     }
 
     public static func parse(_ iso: String) throws -> Date {
-        if let date = makeISO().date(from: iso) {
+        if let date = makeISO(fractionalSeconds: true).date(from: iso)
+            ?? makeISO().date(from: iso) {
             return date
         }
         if let date = makeNaiveLocal().date(from: iso) {

--- a/TheBridge/Modules/CalendarModule.swift
+++ b/TheBridge/Modules/CalendarModule.swift
@@ -78,6 +78,14 @@ public struct CalendarEvent: Sendable, Equatable {
     public var calendarTitle: String
     public var location: String?
     public var notes: String?
+    public var timeZoneIdentifier: String?
+    public var externalId: String?
+    public var organizer: String?
+    public var attendees: [String]
+    public var conferenceURL: String?
+    public var lastModified: String?
+    public var isRecurring: Bool
+    public var isDetached: Bool
 
     public init(
         id: String,
@@ -88,7 +96,15 @@ public struct CalendarEvent: Sendable, Equatable {
         calendarId: String,
         calendarTitle: String,
         location: String?,
-        notes: String?
+        notes: String?,
+        timeZoneIdentifier: String? = nil,
+        externalId: String? = nil,
+        organizer: String? = nil,
+        attendees: [String] = [],
+        conferenceURL: String? = nil,
+        lastModified: String? = nil,
+        isRecurring: Bool = false,
+        isDetached: Bool = false
     ) {
         self.id = id
         self.title = title
@@ -99,6 +115,14 @@ public struct CalendarEvent: Sendable, Equatable {
         self.calendarTitle = calendarTitle
         self.location = location
         self.notes = notes
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.externalId = externalId
+        self.organizer = organizer
+        self.attendees = attendees
+        self.conferenceURL = conferenceURL
+        self.lastModified = lastModified
+        self.isRecurring = isRecurring
+        self.isDetached = isDetached
     }
 }
 
@@ -127,6 +151,7 @@ public struct CalendarEventDraft: Sendable {
     public var calendarId: String?
     public var location: String?
     public var notes: String?
+    public var timeZoneIdentifier: String?
 
     public init(
         title: String? = nil,
@@ -135,7 +160,8 @@ public struct CalendarEventDraft: Sendable {
         allDay: Bool? = nil,
         calendarId: String? = nil,
         location: String? = nil,
-        notes: String? = nil
+        notes: String? = nil,
+        timeZoneIdentifier: String? = nil
     ) {
         self.title = title
         self.start = start
@@ -144,6 +170,7 @@ public struct CalendarEventDraft: Sendable {
         self.calendarId = calendarId
         self.location = location
         self.notes = notes
+        self.timeZoneIdentifier = timeZoneIdentifier
     }
 }
 
@@ -157,9 +184,19 @@ public protocol CalendarStoring: Sendable {
     func ensureAccess() async throws
     func calendars() async throws -> [CalendarInfo]
     func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent]
+    /// Provider-backed direct lookup. Implementations must query their durable
+    /// calendar store; process-local caches are not authoritative.
+    func event(id: String) async throws -> CalendarEvent?
     func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent
     func update(id: String, _ draft: CalendarEventDraft) async throws -> CalendarEvent
     func delete(id: String) async throws
+}
+
+
+public extension CalendarStoring {
+    /// Compatibility default for non-production test seams. Production EventKit
+    /// overrides this with `EKEventStore.event(withIdentifier:)`.
+    func event(id: String) async throws -> CalendarEvent? { nil }
 }
 
 // MARK: - Errors
@@ -305,6 +342,14 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
         try CalendarISOParsing.parse(iso)
     }
 
+    private func participantLabel(_ participant: EKParticipant?) -> String? {
+        guard let participant else { return nil }
+        let url = participant.url.absoluteString
+        if !url.isEmpty { return url }
+        if let name = participant.name, !name.isEmpty { return name }
+        return nil
+    }
+
     private func toEvent(_ e: EKEvent) -> CalendarEvent {
         CalendarEvent(
             id: e.eventIdentifier ?? "",
@@ -315,7 +360,15 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
             calendarId: e.calendar?.calendarIdentifier ?? "",
             calendarTitle: e.calendar?.title ?? "",
             location: e.location,
-            notes: e.notes
+            notes: e.notes,
+            timeZoneIdentifier: e.timeZone?.identifier,
+            externalId: e.calendarItemExternalIdentifier,
+            organizer: participantLabel(e.organizer),
+            attendees: (e.attendees ?? []).compactMap(participantLabel),
+            conferenceURL: e.url?.absoluteString,
+            lastModified: dateToISO(e.lastModifiedDate),
+            isRecurring: !(e.recurrenceRules ?? []).isEmpty,
+            isDetached: e.isDetached
         )
     }
 
@@ -330,6 +383,12 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
                 allowsModify: cal.allowsContentModifications
             )
         }
+    }
+
+    public func event(id: String) async throws -> CalendarEvent? {
+        try await ensureAccess()
+        guard let event = store.event(withIdentifier: id) else { return nil }
+        return toEvent(event)
     }
 
     public func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
@@ -378,6 +437,7 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
         if let allDay = draft.allDay { event.isAllDay = allDay }
         if let location = draft.location { event.location = location }
         if let notes = draft.notes { event.notes = notes }
+        if let identifier = draft.timeZoneIdentifier { event.timeZone = TimeZone(identifier: identifier) }
         try store.save(event, span: .thisEvent, commit: true)
         return toEvent(event)
     }
@@ -398,6 +458,7 @@ public final class EventKitCalendarStore: CalendarStoring, @unchecked Sendable {
         if let allDay = draft.allDay { event.isAllDay = allDay }
         if let location = draft.location { event.location = location }
         if let notes = draft.notes { event.notes = notes }
+        if let identifier = draft.timeZoneIdentifier { event.timeZone = TimeZone(identifier: identifier) }
         if let calendarId = draft.calendarId {
             event.calendar = try resolveCalendar(calendarId)
         }
@@ -451,7 +512,7 @@ public enum CalendarModule {
             name: "calendar_events",
             module: moduleName,
             tier: .open,
-            description: "List calendar events within a date range. Requires start + end (ISO-8601); optional calendarId scopes to one calendar (default: all). Returns id, title, start, end, allDay, calendar, location, notes. `compact: true` trims each event to id/title/start/end; `limit` caps the count (default 50) to stay under token caps — `has_more`/`truncated` flag when the range held more. Read-only.",
+            description: "List calendar events within a date range. Requires start + end (ISO-8601); optional calendarId scopes to one calendar (default: all). Returns local event identity plus providerExternalId and itemURL when available. `compact: true` trims each event to id/title/start/end; `limit` caps the count (default 50) to stay under token caps — `has_more`/`truncated` flag when the range held more. Read-only.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -639,6 +700,14 @@ public enum CalendarModule {
         ]
         if let location = event.location { entry["location"] = .string(location) }
         if let notes = event.notes { entry["notes"] = .string(notes) }
+        if let timeZone = event.timeZoneIdentifier { entry["timeZone"] = .string(timeZone) }
+        if let externalId = event.externalId { entry["providerExternalId"] = .string(externalId) }
+        if let organizer = event.organizer { entry["organizer"] = .string(organizer) }
+        if !event.attendees.isEmpty { entry["attendees"] = .array(event.attendees.map(Value.string)) }
+        if let url = event.conferenceURL { entry["itemURL"] = .string(url) }
+        if let modified = event.lastModified { entry["lastModified"] = .string(modified) }
+        entry["isRecurring"] = .bool(event.isRecurring)
+        entry["isDetached"] = .bool(event.isDetached)
         return .object(entry)
     }
 

--- a/TheBridge/Modules/CallHistoryModule.swift
+++ b/TheBridge/Modules/CallHistoryModule.swift
@@ -1,0 +1,424 @@
+// CallHistoryModule.swift — Bridge v4 stabilization · calls_recent Wave 1
+// TheBridge · Modules
+//
+// Read-only access to the local macOS CallHistoryDB store. This module never
+// mutates the database, never joins Contacts, and never claims that a number
+// belongs to a person. The raw ZNAME column is intentionally neither selected
+// nor exposed.
+
+import Foundation
+import SQLite3
+import MCP
+
+public enum CallHistoryDirection: String, Sendable, CaseIterable {
+    case inbound
+    case outbound
+    case all
+}
+
+public struct CallHistoryQuery: Sendable, Equatable {
+    public let limit: Int
+    public let since: Date?
+    public let number: String?
+    public let direction: CallHistoryDirection
+
+    public init(limit: Int, since: Date?, number: String?, direction: CallHistoryDirection) {
+        self.limit = limit
+        self.since = since
+        self.number = number
+        self.direction = direction
+    }
+}
+
+public struct CallHistoryRawRecord: Sendable, Equatable {
+    public let primaryKey: Int64
+    public let uniqueID: String?
+    public let date: Date
+    public let durationSeconds: Double
+    public let address: String?
+    public let originated: Bool
+    public let answered: Bool
+    public let callType: Int
+    public let serviceProvider: String?
+
+    public init(
+        primaryKey: Int64,
+        uniqueID: String?,
+        date: Date,
+        durationSeconds: Double,
+        address: String?,
+        originated: Bool,
+        answered: Bool,
+        callType: Int,
+        serviceProvider: String?
+    ) {
+        self.primaryKey = primaryKey
+        self.uniqueID = uniqueID
+        self.date = date
+        self.durationSeconds = durationSeconds
+        self.address = address
+        self.originated = originated
+        self.answered = answered
+        self.callType = callType
+        self.serviceProvider = serviceProvider
+    }
+}
+
+public enum CallHistoryReadError: Error, Sendable, Equatable {
+    case unavailable(String)
+    case unsupportedSchema(missingColumns: [String])
+    case queryFailed(String)
+}
+
+public enum CallHistoryModule {
+    public static let moduleName = "calls"
+    public static let defaultLimit = 20
+    public static let maximumLimit = 100
+
+    public static let requiredColumns: Set<String> = [
+        "Z_PK", "ZUNIQUE_ID", "ZDATE", "ZDURATION", "ZADDRESS",
+        "ZORIGINATED", "ZANSWERED", "ZCALLTYPE", "ZSERVICE_PROVIDER"
+    ]
+
+    public static var defaultDatabasePath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/CallHistoryDB/CallHistory.storedata")
+            .path
+    }
+
+    private static func makeISO8601() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
+
+    public static func normalizePhoneNumber(_ value: String) -> String {
+        String(value.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) })
+    }
+
+    public static func parseQuery(_ arguments: Value) throws -> CallHistoryQuery {
+        let args: [String: Value]
+        if case .object(let object) = arguments {
+            args = object
+        } else {
+            args = [:]
+        }
+
+        let requestedLimit: Int
+        if let value = args["limit"] {
+            guard case .int(let limit) = value, limit > 0 else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'limit' must be a positive integer"
+                )
+            }
+            requestedLimit = limit
+        } else {
+            requestedLimit = defaultLimit
+        }
+
+        let since: Date?
+        if let value = args["since"] {
+            guard case .string(let raw) = value else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'since' must be an ISO-8601 timestamp string"
+                )
+            }
+            let fractional = makeISO8601()
+            let ordinary = ISO8601DateFormatter()
+            guard let parsed = fractional.date(from: raw) ?? ordinary.date(from: raw) else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'since' must be a valid ISO-8601 timestamp"
+                )
+            }
+            since = parsed
+        } else {
+            since = nil
+        }
+
+        let number: String?
+        if let value = args["number"] {
+            guard case .string(let raw) = value else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'number' must be a phone-number string"
+                )
+            }
+            let normalized = normalizePhoneNumber(raw)
+            guard !normalized.isEmpty else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'number' must contain at least one decimal digit"
+                )
+            }
+            number = normalized
+        } else {
+            number = nil
+        }
+
+        let direction: CallHistoryDirection
+        if let value = args["direction"] {
+            guard case .string(let raw) = value,
+                  let parsed = CallHistoryDirection(rawValue: raw.lowercased()) else {
+                throw ToolRouterError.invalidArguments(
+                    toolName: "calls_recent",
+                    reason: "'direction' must be inbound, outbound, or all"
+                )
+            }
+            direction = parsed
+        } else {
+            direction = .all
+        }
+
+        return CallHistoryQuery(
+            limit: min(requestedLimit, maximumLimit),
+            since: since,
+            number: number,
+            direction: direction
+        )
+    }
+
+    public static func filteredRecords(
+        _ records: [CallHistoryRawRecord],
+        query: CallHistoryQuery
+    ) -> [CallHistoryRawRecord] {
+        records
+            .filter { record in
+                if let since = query.since, record.date < since { return false }
+                if query.direction == .inbound, record.originated { return false }
+                if query.direction == .outbound, !record.originated { return false }
+                if let number = query.number {
+                    guard let address = record.address else { return false }
+                    return normalizePhoneNumber(address) == number
+                }
+                return true
+            }
+            .sorted { lhs, rhs in
+                if lhs.date == rhs.date { return lhs.primaryKey > rhs.primaryKey }
+                return lhs.date > rhs.date
+            }
+            .prefix(query.limit)
+            .map { $0 }
+    }
+
+    public static func response(
+        arguments: Value,
+        databasePath: String = defaultDatabasePath,
+        reader: (String) throws -> [CallHistoryRawRecord] = readDatabase
+    ) throws -> Value {
+        let query = try parseQuery(arguments)
+
+        do {
+            let records = filteredRecords(try reader(databasePath), query: query)
+            let iso = makeISO8601()
+            let calls: [Value] = records.map { record in
+                let identifier = record.uniqueID.flatMap { $0.isEmpty ? nil : $0 } ?? String(record.primaryKey)
+                return .object([
+                    "id": .string(identifier),
+                    "startedAt": .string(iso.string(from: record.date)),
+                    "durationSeconds": .double(record.durationSeconds),
+                    "number": record.address.map(Value.string) ?? .null,
+                    "normalizedNumber": record.address.map(normalizePhoneNumber).map(Value.string) ?? .null,
+                    "direction": .string(record.originated ? CallHistoryDirection.outbound.rawValue : CallHistoryDirection.inbound.rawValue),
+                    "answered": .bool(record.answered),
+                    "callType": .int(record.callType),
+                    "serviceProvider": record.serviceProvider.map(Value.string) ?? .null
+                ])
+            }
+
+            var filters: [String: Value] = [
+                "limit": .int(query.limit),
+                "direction": .string(query.direction.rawValue)
+            ]
+            filters["since"] = query.since.map { .string(iso.string(from: $0)) } ?? .null
+            filters["number"] = query.number.map(Value.string) ?? .null
+
+            return .object([
+                "success": .bool(true),
+                "source": .string("CallHistoryDB"),
+                "identityResolved": .bool(false),
+                "filters": .object(filters),
+                "count": .int(calls.count),
+                "calls": .array(calls)
+            ])
+        } catch CallHistoryReadError.unavailable(let detail) {
+            return errorResponse(
+                code: "full_disk_access_required",
+                message: "The Bridge could not read the local CallHistory database.",
+                remediation: "Grant Full Disk Access to The Bridge in System Settings > Privacy & Security > Full Disk Access, then relaunch the app.",
+                details: detail
+            )
+        } catch CallHistoryReadError.unsupportedSchema(let missing) {
+            return errorResponse(
+                code: "unsupported_call_history_schema",
+                message: "This macOS CallHistoryDB schema is not supported; no partial or empty result was returned.",
+                remediation: "Update The Bridge or report the missing schema columns before relying on call data.",
+                details: "Missing columns: \(missing.sorted().joined(separator: ", "))",
+                missingColumns: missing.sorted()
+            )
+        } catch CallHistoryReadError.queryFailed(let detail) {
+            return errorResponse(
+                code: "call_history_query_failed",
+                message: "The Bridge could not query the local CallHistory database.",
+                remediation: "Retry once. If the error persists, report the schema and query error to The Bridge developer.",
+                details: detail
+            )
+        }
+    }
+
+    private static func errorResponse(
+        code: String,
+        message: String,
+        remediation: String,
+        details: String,
+        missingColumns: [String]? = nil
+    ) -> Value {
+        var error: [String: Value] = [
+            "code": .string(code),
+            "message": .string(message),
+            "remediation": .string(remediation),
+            "details": .string(details)
+        ]
+        if let missingColumns {
+            error["missingColumns"] = .array(missingColumns.map(Value.string))
+        }
+        return .object([
+            "success": .bool(false),
+            "source": .string("CallHistoryDB"),
+            "identityResolved": .bool(false),
+            "error": .object(error)
+        ])
+    }
+
+    public static func readDatabase(at path: String) throws -> [CallHistoryRawRecord] {
+        var database: OpaquePointer?
+        let openResult = sqlite3_open_v2(path, &database, SQLITE_OPEN_READONLY, nil)
+        guard openResult == SQLITE_OK, let database else {
+            let detail = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unable to open database"
+            if let database { sqlite3_close(database) }
+            throw CallHistoryReadError.unavailable(detail)
+        }
+        defer { sqlite3_close(database) }
+
+        let columns = try schemaColumns(database: database)
+        let missing = requiredColumns.subtracting(columns)
+        guard missing.isEmpty else {
+            throw CallHistoryReadError.unsupportedSchema(missingColumns: missing.sorted())
+        }
+
+        let sql = """
+            SELECT Z_PK, ZUNIQUE_ID, ZDATE, ZDURATION, ZADDRESS,
+                   ZORIGINATED, ZANSWERED, ZCALLTYPE, ZSERVICE_PROVIDER
+            FROM ZCALLRECORD
+            ORDER BY ZDATE DESC, Z_PK DESC
+            """
+
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var records: [CallHistoryRawRecord] = []
+        while true {
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else {
+                throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+            }
+
+            records.append(CallHistoryRawRecord(
+                primaryKey: sqlite3_column_int64(statement, 0),
+                uniqueID: stringColumn(statement, index: 1),
+                date: Date(timeIntervalSinceReferenceDate: sqlite3_column_double(statement, 2)),
+                durationSeconds: sqlite3_column_double(statement, 3),
+                address: stringColumn(statement, index: 4),
+                originated: sqlite3_column_int(statement, 5) != 0,
+                answered: sqlite3_column_int(statement, 6) != 0,
+                callType: Int(sqlite3_column_int64(statement, 7)),
+                serviceProvider: stringColumn(statement, index: 8)
+            ))
+        }
+        return records
+    }
+
+    private static func schemaColumns(database: OpaquePointer) throws -> Set<String> {
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(database, "PRAGMA table_info(ZCALLRECORD)", -1, &statement, nil) == SQLITE_OK,
+              let statement else {
+            throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+        }
+        defer { sqlite3_finalize(statement) }
+
+        var columns: Set<String> = []
+        while true {
+            let step = sqlite3_step(statement)
+            if step == SQLITE_DONE { break }
+            guard step == SQLITE_ROW else {
+                throw CallHistoryReadError.queryFailed(String(cString: sqlite3_errmsg(database)))
+            }
+            if let name = stringColumn(statement, index: 1) { columns.insert(name) }
+        }
+        return columns
+    }
+
+    private static func stringColumn(_ statement: OpaquePointer, index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let bytes = sqlite3_column_text(statement, index) else { return nil }
+        return String(cString: bytes)
+    }
+
+    public static func register(on router: ToolRouter) async {
+        await router.register(ToolRegistration(
+            name: "calls_recent",
+            module: moduleName,
+            tier: .open,
+            description: "Read recent macOS call-history records newest-first. Supports bounded time, normalized-number, and direction filters. Returns phone records only; it never resolves or claims contact identity.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "minimum": .int(1),
+                        "maximum": .int(maximumLimit),
+                        "description": .string("Maximum records to return (default 20, hard maximum 100).")
+                    ]),
+                    "since": .object([
+                        "type": .string("string"),
+                        "format": .string("date-time"),
+                        "description": .string("Only calls at or after this ISO-8601 timestamp.")
+                    ]),
+                    "number": .object([
+                        "type": .string("string"),
+                        "description": .string("Exact phone filter after removing all non-decimal characters; no contact identity lookup is performed.")
+                    ]),
+                    "direction": .object([
+                        "type": .string("string"),
+                        "enum": .array(CallHistoryDirection.allCases.map { .string($0.rawValue) }),
+                        "description": .string("Filter inbound, outbound, or all calls (default all).")
+                    ])
+                ]),
+                "required": .array([]),
+                "additionalProperties": .bool(false)
+            ]),
+            metadata: ToolMetadata(
+                title: "Calls: Recent",
+                whenToUse: [
+                    "reviewing recent inbound or outbound call records on this Mac",
+                    "checking whether a normalized phone number appears in local call history"
+                ],
+                whenNotToUse: [
+                    "identifying who owns a phone number (use contacts_resolve_handle separately)",
+                    "dialing, messaging, drafting, recording, or modifying call history"
+                ],
+                relatedTools: ["contacts_resolve_handle", "messages_chat"]
+            ),
+            handler: { arguments in
+                try response(arguments: arguments)
+            }
+        ))
+    }
+}

--- a/TheBridge/Modules/ContactsModule.swift
+++ b/TheBridge/Modules/ContactsModule.swift
@@ -18,6 +18,76 @@ public enum ContactsModule {
 
     public static let moduleName = "contacts"
 
+    public struct HandleAttribution: Sendable, Equatable {
+        public let resolvedName: String?
+        public let source: String
+        public let confidence: String
+        public let failureReason: String?
+
+        public init(resolvedName: String?, source: String, confidence: String, failureReason: String?) {
+            self.resolvedName = resolvedName
+            self.source = source
+            self.confidence = confidence
+            self.failureReason = failureReason
+        }
+    }
+
+    /// Best-effort exact-handle lookup for Messages attribution. It never
+    /// prompts for Contacts access: messages_recent remains a passive read.
+    public static func exactHandleAttributionIfAuthorized(_ handle: String) -> HandleAttribution {
+        guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+            return HandleAttribution(
+                resolvedName: nil,
+                source: "contacts",
+                confidence: "unavailable",
+                failureReason: "contacts_permission_not_authorized"
+            )
+        }
+
+        let store = CNContactStore()
+        let predicate: NSPredicate
+        if handle.contains("@") {
+            predicate = CNContact.predicateForContacts(matchingEmailAddress: handle)
+        } else {
+            predicate = CNContact.predicateForContacts(matching: CNPhoneNumber(stringValue: toE164(handle) ?? handle))
+        }
+
+        do {
+            let contacts = try store.unifiedContacts(matching: predicate, keysToFetch: fullKeys)
+            guard contacts.count == 1, let contact = contacts.first else {
+                return HandleAttribution(
+                    resolvedName: nil,
+                    source: "contacts",
+                    confidence: contacts.isEmpty ? "none" : "ambiguous",
+                    failureReason: contacts.isEmpty ? "no_exact_contact_match" : "multiple_exact_contact_matches"
+                )
+            }
+            let name = CNContactFormatter.string(from: contact, style: .fullName)
+                ?? "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty else {
+                return HandleAttribution(
+                    resolvedName: nil,
+                    source: "contacts",
+                    confidence: "none",
+                    failureReason: "exact_contact_has_no_display_name"
+                )
+            }
+            return HandleAttribution(
+                resolvedName: name,
+                source: "contacts_exact_handle",
+                confidence: "exact",
+                failureReason: nil
+            )
+        } catch {
+            return HandleAttribution(
+                resolvedName: nil,
+                source: "contacts",
+                confidence: "unavailable",
+                failureReason: "contacts_query_failed"
+            )
+        }
+    }
+
     // MARK: - TCC Helper
 
     /// Ensures Contacts access is authorized or limited. Triggers TCC prompt if `.notDetermined`.

--- a/TheBridge/Modules/FieldsFilter.swift
+++ b/TheBridge/Modules/FieldsFilter.swift
@@ -26,10 +26,20 @@
 //    type is broken caller code, not a typo.
 //  - No max-length cap: a Set-lookup filter is O(1) per key, nothing here
 //    to defend against (Round 2 Decision 1).
+//  - Identity keys (Voice Memo Reliability / registry audit): when projecting
+//    a non-empty `fields` set, always re-attach any of `id` / `entity` /
+//    `title` that were present on the source envelope (`includeIdentity`
+//    default true). Follow-on relation/update calls need the row id even
+//    when the caller only projected display fields.
 
 import MCP
 
 public enum FieldsFilter {
+
+    /// Immutable envelope keys re-attached after a non-empty projection when
+    /// `includeIdentity` is true (default). Only keys that exist on the source
+    /// envelope are restored — skill envelopes without `id` are unaffected.
+    public static let identityKeys: [String] = ["id", "entity", "title"]
 
     /// Parse the raw `fields` argument (if present) into a validated
     /// `[String]`. Returns `nil` when the key is absent — the "omitted"
@@ -73,12 +83,17 @@ public enum FieldsFilter {
     ///   `propertiesKey` (case-insensitive) keeps the WHOLE map and wins
     ///   over any narrower dotted selection for the same key (permissive
     ///   union — Success Criteria #3).
+    /// - `includeIdentity` (default `true`) re-attaches any of
+    ///   `identityKeys` that exist on the source envelope after projection,
+    ///   so callers who only ask for `properties.status` still receive a
+    ///   usable `id` for follow-on writes.
     /// - Non-object `envelope` (defensive — every real caller passes
     ///   `.object`) is returned untouched.
     public static func project(
         _ envelope: Value,
         fields: [String]?,
-        propertiesKey: String = "properties"
+        propertiesKey: String = "properties",
+        includeIdentity: Bool = true
     ) -> Value {
         guard let fields, !fields.isEmpty else { return envelope }
         guard case .object(let dict) = envelope else { return envelope }
@@ -120,6 +135,14 @@ public enum FieldsFilter {
             }
             if topLevelKeys.contains(key) {
                 result[key] = value
+            }
+        }
+
+        if includeIdentity {
+            for identityKey in identityKeys {
+                if result[identityKey] == nil, let value = dict[identityKey] {
+                    result[identityKey] = value
+                }
             }
         }
         return .object(result)

--- a/TheBridge/Modules/JobsManager.swift
+++ b/TheBridge/Modules/JobsManager.swift
@@ -1321,8 +1321,9 @@ public actor JobsManager {
         var overall: ExecutionRecord.Status = .success
 
         for (idx, step) in job.actionChain.enumerated() {
-            let mcpArgs = Self.substitutePrev(step.arguments, prev: stepResults.last)
+            let previousResult = stepResults.last
             do {
+                let mcpArgs = try Self.substitutePrev(step.arguments, prev: previousResult)
                 let toolName = Self.canonicalActionToolName(step.tool)
                 let result = try await router.dispatch(toolName: toolName, arguments: .object(mcpArgs))
                 stepResults.append(JSONValue.fromMCP(result))
@@ -1342,6 +1343,7 @@ public actor JobsManager {
                     // One retry with a short backoff.
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
                     do {
+                        let mcpArgs = try Self.substitutePrev(step.arguments, prev: previousResult)
                         let toolName = Self.canonicalActionToolName(step.tool)
                         let result = try await router.dispatch(toolName: toolName, arguments: .object(mcpArgs))
                         stepResults[stepResults.count - 1] = JSONValue.fromMCP(result)
@@ -1416,18 +1418,83 @@ public actor JobsManager {
         throw JobsModuleError.invalidActionChain("missing required arg '\(key)'")
     }
 
-    /// Substitute the literal `"$prev_result"` token in argument values with
-    /// the previous step's full result. Non-string values pass through.
-    private static func substitutePrev(_ args: [String: JSONValue], prev: JSONValue?) -> [String: Value] {
+    /// Substitute `$prev_result` or a path such as `$prev_result.stdout` /
+    /// `$prev_result.content[0].text` in argument values. An unresolved path
+    /// fails the step before dispatch; it never silently becomes an empty body.
+    public static func substitutePrev(_ args: [String: JSONValue], prev: JSONValue?) throws -> [String: Value] {
         var out: [String: Value] = [:]
         for (k, v) in args {
-            if case .string(let s) = v, s == "$prev_result", let prev {
-                out[k] = prev.toMCP()
+            if case .string(let s) = v, s.hasPrefix("$prev_result") {
+                guard let prev else {
+                    throw JobsModuleError.invalidActionChain("argument '\(k)' references $prev_result before a previous step exists")
+                }
+                guard let resolved = resolvePrevPath(s, in: prev) else {
+                    throw JobsModuleError.invalidActionChain("argument '\(k)' could not resolve previous-result path '\(s)'")
+                }
+                out[k] = resolved.toMCP()
             } else {
                 out[k] = v.toMCP()
             }
         }
         return out
+    }
+
+    private enum PrevPathComponent: Equatable {
+        case key(String)
+        case index(Int)
+    }
+
+    private static func resolvePrevPath(_ token: String, in root: JSONValue) -> JSONValue? {
+        guard token.hasPrefix("$prev_result") else { return nil }
+        let suffix = String(token.dropFirst("$prev_result".count))
+        if suffix.isEmpty { return root }
+        guard let components = parsePrevPath(suffix) else { return nil }
+
+        var current = root
+        for component in components {
+            switch (component, current) {
+            case (.key(let key), .object(let object)):
+                guard let next = object[key] else { return nil }
+                current = next
+            case (.index(let index), .array(let array)):
+                guard array.indices.contains(index) else { return nil }
+                current = array[index]
+            default:
+                return nil
+            }
+        }
+        return current
+    }
+
+    private static func parsePrevPath(_ suffix: String) -> [PrevPathComponent]? {
+        var components: [PrevPathComponent] = []
+        var index = suffix.startIndex
+
+        while index < suffix.endIndex {
+            if suffix[index] == "." {
+                index = suffix.index(after: index)
+                let start = index
+                while index < suffix.endIndex, suffix[index] != ".", suffix[index] != "[" {
+                    index = suffix.index(after: index)
+                }
+                guard start < index else { return nil }
+                components.append(.key(String(suffix[start..<index])))
+            } else if suffix[index] == "[" {
+                index = suffix.index(after: index)
+                let start = index
+                while index < suffix.endIndex, suffix[index] != "]" {
+                    index = suffix.index(after: index)
+                }
+                guard index < suffix.endIndex,
+                      let numeric = Int(suffix[start..<index]), numeric >= 0 else { return nil }
+                components.append(.index(numeric))
+                index = suffix.index(after: index)
+            } else {
+                return nil
+            }
+        }
+
+        return components.isEmpty ? nil : components
     }
 
     /// Reject action chains that would trigger auto-escalation in unattended

--- a/TheBridge/Modules/MessagesModule.swift
+++ b/TheBridge/Modules/MessagesModule.swift
@@ -466,24 +466,81 @@ public enum MessagesModule {
     /// Convert query result rows to MCP Value, applying extractText fallback on the text column.
     /// The raw `attributedBody` blob is excluded from output.
     private static func rowsToValue(_ rows: [[String: Any]], textKey: String = "text") -> Value {
+        let valueRows = rows.map { rowToValue($0, textKey: textKey) }
+        return .object(["rows": .array(valueRows), "count": .int(valueRows.count)])
+    }
+
+    private static func rowToValue(_ row: [String: Any], textKey: String) -> Value {
+        var result: [String: Value] = [:]
+        for (key, val) in row {
+            if key == "attributedBody" { continue }
+            if key == textKey {
+                let extracted = extractText(row: row, textKey: textKey)
+                result[key] = extracted.map { .string($0) } ?? .null
+            } else if let s = val as? String {
+                result[key] = .string(s)
+            } else if let i = val as? Int {
+                result[key] = .int(i)
+            } else if let d = val as? Double {
+                result[key] = .double(d)
+            } else {
+                result[key] = .null
+            }
+        }
+        return .object(result)
+    }
+
+    public static func attributionFields(
+        messagesDisplayName: String?,
+        handle: String?,
+        contact: ContactsModule.HandleAttribution?
+    ) -> [String: Value] {
+        if let displayName = messagesDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !displayName.isEmpty {
+            return [
+                "resolvedName": .string(displayName),
+                "attributionSource": .string("messages_chat_display_name"),
+                "attributionConfidence": .string("exact_chat_metadata"),
+                "attributionFailureReason": .null
+            ]
+        }
+        if let contact, let resolvedName = contact.resolvedName {
+            return [
+                "resolvedName": .string(resolvedName),
+                "attributionSource": .string(contact.source),
+                "attributionConfidence": .string(contact.confidence),
+                "attributionFailureReason": .null
+            ]
+        }
+        return [
+            "resolvedName": .null,
+            "attributionSource": .string(contact?.source ?? "none"),
+            "attributionConfidence": .string(contact?.confidence ?? "none"),
+            "attributionFailureReason": .string(
+                contact?.failureReason ?? (handle == nil ? "chat_has_no_resolvable_handle" : "no_attribution_available")
+            )
+        ]
+    }
+
+    private static func recentRowsToValue(_ rows: [[String: Any]]) -> Value {
         let valueRows: [Value] = rows.map { row in
-            var result: [String: Value] = [:]
-            for (key, val) in row {
-                // Never expose raw attributedBody blob to caller
-                if key == "attributedBody" { continue }
-                if key == textKey {
-                    // Apply text extraction with attributedBody fallback
-                    let extracted = extractText(row: row, textKey: textKey)
-                    result[key] = extracted.map { .string($0) } ?? .null
-                } else if let s = val as? String {
-                    result[key] = .string(s)
-                } else if let i = val as? Int {
-                    result[key] = .int(i)
-                } else if let d = val as? Double {
-                    result[key] = .double(d)
-                } else {
-                    result[key] = .null
-                }
+            var result: [String: Value]
+            if case .object(let object) = rowToValue(row, textKey: "last_message") {
+                result = object
+            } else {
+                result = [:]
+            }
+            let displayName = row["display_name"] as? String
+            let handle = row["chat_identifier"] as? String
+            let contact = (displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+                ? nil
+                : handle.map(ContactsModule.exactHandleAttributionIfAuthorized)
+            for (key, value) in attributionFields(
+                messagesDisplayName: displayName,
+                handle: handle,
+                contact: contact
+            ) {
+                result[key] = value
             }
             return .object(result)
         }
@@ -598,7 +655,7 @@ public enum MessagesModule {
             name: "messages_recent",
             module: moduleName,
             tier: .open,
-            description: "List the N most recently active Messages conversations (chats, not individual messages).",
+            description: "List the N most recently active Messages conversations with explicit attribution provenance. Blank chat names get a best-effort exact Contacts lookup when Contacts permission is already granted; loose name inference is never used.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -638,7 +695,7 @@ public enum MessagesModule {
                     LIMIT ?1
                     """
                 let rows = try performQuery(sql, params: [String(limit)])
-                return rowsToValue(rows, textKey: "last_message")
+                return recentRowsToValue(rows)
             }
         ))
 
@@ -693,7 +750,7 @@ public enum MessagesModule {
             name: "messages_content",
             module: moduleName,
             tier: .open,
-            description: "Fetch a single message by its Messages DB ROWID (full text + metadata).",
+            description: "Fetch one message by Messages DB ROWID, including attachment metadata when present. Attachment bytes are not auto-extracted.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -723,7 +780,35 @@ public enum MessagesModule {
                     WHERE m.ROWID = ?1
                     """
                 let rows = try performQuery(sql, params: [String(msgId)])
-                return rowsToValue(rows)
+                guard case .object(var result) = rowsToValue(rows) else {
+                    return rowsToValue(rows)
+                }
+                do {
+                    let attachmentSQL = """
+                        SELECT a.ROWID AS attachment_id,
+                               a.filename AS file_path,
+                               a.mime_type,
+                               a.transfer_name
+                        FROM attachment a
+                        JOIN message_attachment_join maj ON maj.attachment_id = a.ROWID
+                        WHERE maj.message_id = ?1
+                        ORDER BY a.ROWID ASC
+                        """
+                    let attachmentRows = try performQuery(attachmentSQL, params: [String(msgId)])
+                    if case .object(let attachmentResult) = rawRowsToValue(attachmentRows),
+                       case .array(let attachments) = attachmentResult["rows"] {
+                        result["attachments"] = .array(attachments)
+                        result["attachmentCount"] = .int(attachments.count)
+                    }
+                    result["attachmentMode"] = .string("metadata_only")
+                    result["attachmentLimitation"] = .string("Attachment bytes are not returned automatically; file_path is provided when Messages stored one locally.")
+                } catch {
+                    result["attachments"] = .array([])
+                    result["attachmentCount"] = .int(0)
+                    result["attachmentMode"] = .string("metadata_unavailable")
+                    result["attachmentLimitation"] = .string("Attachment metadata query failed: \(error.localizedDescription)")
+                }
+                return .object(result)
             }
         ))
 

--- a/TheBridge/Modules/NotionModule.swift
+++ b/TheBridge/Modules/NotionModule.swift
@@ -106,6 +106,35 @@ public enum NotionModule {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Block-level write responses include their parent when the touched block
+    /// is directly under a page. Evict both the explicit target (which may be a
+    /// page id for top-level appends) and any returned page/block parent; the
+    /// eviction helper itself ignores ids that are not configured skill pages.
+    public static func skillCacheEvictionCandidates(
+        targetId: String,
+        responseJSON: [String: Any]? = nil
+    ) -> [String] {
+        var candidates = [targetId]
+        guard let parent = responseJSON?["parent"] as? [String: Any] else { return candidates }
+        for key in ["page_id", "block_id"] {
+            if let parentId = parent[key] as? String {
+                candidates.append(parentId)
+            }
+        }
+        var seen: Set<String> = []
+        return candidates.filter { seen.insert($0).inserted }
+    }
+
+    private static func evictSkillBodyCache(
+        targetId: String,
+        responseJSON: [String: Any]? = nil
+    ) async {
+        for candidate in skillCacheEvictionCandidates(targetId: targetId, responseJSON: responseJSON) {
+            await SkillBodyCacheEviction.evictIfConfiguredSkillPage(candidate)
+            await RegistryRowCache.shared.evictPageEverywhere(pageId: candidate)
+        }
+    }
+
     /// Register all NotionModule tools on the given router.
     /// Lazily initializes NotionClientRegistry on first tool invocation.
     public static func register(on router: ToolRouter) async {
@@ -352,6 +381,7 @@ public enum NotionModule {
                 let url = resultJSON["url"] as? String ?? ""
 
                 await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+                await RegistryRowCache.shared.evictPageEverywhere(pageId: pageId)
 
                 return .object([
                     "success": .bool(true),
@@ -712,6 +742,8 @@ public enum NotionModule {
                         return .object(["error": .string("Failed to parse append response")])
                     }
 
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: results.first)
+
                     var resultItems: [Value] = []
                     for block in results {
                         let bid = block["id"] as? String ?? ""
@@ -742,6 +774,8 @@ public enum NotionModule {
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object(["error": .string("Failed to parse append response")])
                     }
+
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
 
                     // The markdown endpoint doesn't return a per-block results
                     // array like PATCH /blocks/{id}/children does; report what
@@ -809,6 +843,7 @@ public enum NotionModule {
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object(["error": .string("Failed to parse delete response")])
                     }
+                    await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
                     return .object([
                         "success": .bool(true),
                         "id": .string(json["id"] as? String ?? blockId),
@@ -824,6 +859,7 @@ public enum NotionModule {
                     do {
                         let data = try await client.deleteBlock(blockId: blockId)
                         let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                        await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
                         deleted += 1
                         results.append(.object([
                             "id": .string((json?["id"] as? String) ?? blockId),
@@ -855,11 +891,12 @@ public enum NotionModule {
             name: "notion_page_markdown_read",
             module: moduleName,
             tier: .open,
-            description: "Read a Notion page body as plain markdown only — no properties, no block IDs. Use when you just need the text.",
+            description: "Read a Notion page body as plain markdown only — no properties or block IDs. Optional section returns one heading slice; a miss returns a compact heading index instead of the full page.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "pageId": .object(["type": .string("string"), "description": .string("Notion page ID")]),
+                    "section": .object(["type": .string("string"), "description": .string("Optional markdown heading to return, case-insensitive and without # markers.")]),
                     "workspace": workspaceParam
                 ]),
                 "required": .array([.string("pageId")])
@@ -873,12 +910,24 @@ public enum NotionModule {
                 let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
                 let data = try await client.getPageMarkdown(pageId: pageId)
 
-                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                    let text = String(data: data, encoding: .utf8) ?? ""
-                    return .object(["markdown": .string(text)])
+                let markdown = SkillsModule.skillMarkdownString(fromMarkdownJSON: data)
+                if case .string(let section)? = args["section"] {
+                    if let slice = SkillsModule.extractMarkdownSection(markdown, section: section) {
+                        return .object([
+                            "markdown": .string(slice),
+                            "section": .string(section),
+                            "sectionMatched": .bool(true)
+                        ])
+                    }
+                    let headings = SkillsModule.markdownHeadings(markdown)
+                    return .object([
+                        "markdown": .string(SkillsModule.sectionMissMarkdown(requested: section, markdown: markdown)),
+                        "section": .string(section),
+                        "sectionMatched": .bool(false),
+                        "annotation": .string("section-not-found"),
+                        "availableSections": .array(headings.prefix(100).map(Value.string))
+                    ])
                 }
-
-                let markdown = json["markdown"] as? String ?? String(data: data, encoding: .utf8) ?? ""
                 return .object(["markdown": .string(markdown)])
             }
         ))
@@ -981,6 +1030,7 @@ public enum NotionModule {
                 _ = try await client.replacePageMarkdown(pageId: pageId, markdown: editedMarkdown)
 
                 await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+                await RegistryRowCache.shared.evictPageEverywhere(pageId: pageId)
 
                 let totalReplacements = editResults.reduce(0) { $0 + $1.replacements }
                 return .object([
@@ -1403,6 +1453,8 @@ public enum NotionModule {
                 guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
                     return .object(["error": .string("Failed to parse update response")])
                 }
+
+                await Self.evictSkillBodyCache(targetId: blockId, responseJSON: json)
 
                 let id = json["id"] as? String ?? ""
                 let type = json["type"] as? String ?? ""

--- a/TheBridge/Modules/NotionModule.swift
+++ b/TheBridge/Modules/NotionModule.swift
@@ -130,7 +130,7 @@ public enum NotionModule {
             name: "notion_search",
             module: moduleName,
             tier: .open,
-            description: "Keyword-search a Notion workspace for pages and data sources. Returns IDs + titles; no semantic ranking.",
+            description: "Keyword-search a Notion workspace for pages and data sources. Returns IDs + titles; no semantic ranking. Under Notion-Version 2026-03-11 the search filter object type (not exposed here) accepts only page or data_source — not database.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -1052,57 +1052,70 @@ public enum NotionModule {
             name: "notion_comment_create",
             module: moduleName,
             tier: .notify,
-            description: "Post a top-level inline-only markdown comment on a Notion page. Text over Notion's 2000-character per-run limit is auto-chunked into sequential comments preserving order. For threaded replies use notion_discussion_create.",
+            description: "Post an inline-only comment on a Notion page (pageId) OR reply in an existing discussion thread (discussionId). Exactly one of pageId/discussionId. Text over Notion's 2000-character per-run limit is auto-chunked into sequential comments preserving order (replies re-use the same discussionId).",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "pageId": .object(["type": .string("string"), "description": .string("Page ID to comment on")]),
+                    "pageId": .object(["type": .string("string"), "description": .string("Page ID for a new top-level page comment. Mutually exclusive with discussionId.")]),
+                    "discussionId": .object(["type": .string("string"), "description": .string("Existing discussion thread ID for a reply. Mutually exclusive with pageId. Obtain from notion_comments_list or a prior create's discussionId.")]),
                     "text": .object(["type": .string("string"), "description": .string("Comment text content")]),
                     "content": .object(["type": .string("string"), "description": .string("Alias for 'text' — comment text content. If both are supplied, 'text' wins.")]),
                     "workspace": workspaceParam
                 ]),
-                "required": .array([.string("pageId")])
+                "required": .array([.string("text")])
             ]),
             metadata: ToolMetadata(
                 title: "Notion: Create Comment",
-                whenToUse: ["posting a short inline comment on a page"],
-                whenNotToUse: ["threaded replies (use notion_discussion_create)",
+                whenToUse: ["posting a short inline comment on a page",
+                            "replying to an existing discussion via discussionId"],
+                whenNotToUse: ["starting a named new thread (use notion_discussion_create for the same page-level start, or pageId here)",
                                "long code/text (use notion_blocks_append with autoChunk:true)"],
                 relatedTools: ["notion_discussion_create", "notion_comments_list"]
             ),
             handler: { arguments in
-                guard case .object(let args) = arguments,
-                      case .string(let pageId) = args["pageId"] else {
-                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'pageId' or 'text'")
+                guard case .object(let args) = arguments else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing arguments")
+                }
+                let pageId: String? = { if case .string(let p) = args["pageId"] { return p }; return nil }()
+                let discussionIdArg: String? = {
+                    if case .string(let d) = args["discussionId"] { return d }
+                    return nil
+                }()
+                let hasPage = !(pageId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                let hasDiscussion = !(discussionIdArg?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                guard hasPage != hasDiscussion else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notion_comment_create",
+                        reason: "exactly one of 'pageId' or 'discussionId' is required"
+                    )
                 }
                 // 'content' is an alias for 'text' — agents reach for 'content'
-                // as the generic term first (documented friction: schema
-                // mismatch cost a failed call before the correct 'text' shape
-                // was discovered). 'text' wins if both are supplied.
+                // as the generic term first. 'text' wins if both are supplied.
                 let text: String
                 if case .string(let t) = args["text"] {
                     text = t
                 } else if case .string(let c) = args["content"] {
                     text = c
                 } else {
-                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'pageId' or 'text'")
+                    throw ToolRouterError.invalidArguments(toolName: "notion_comment_create", reason: "missing 'text'")
                 }
 
                 let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
 
-                // FB-3: Auto-chunk into sequential <=2000-char comments preserving order,
-                // instead of hard-rejecting. Notion enforces a 2000-character per-run limit;
-                // post one comment per chunk and report all created IDs in order.
+                // FB-3: Auto-chunk into sequential <=2000-char comments preserving order.
+                // For replies, every chunk uses the same discussionId so they stay in-thread.
                 let chunks = NotionModule.chunkCommentText(text, maxChars: 2000)
 
                 var ids: [Value] = []
-                // PKT-MEM-136: surface the Notion `discussion_id` the first posted chunk
-                // started, so callers (e.g. VoiceMemoProcessor.executeComment) can log it
-                // to a durable ledger without a second round trip. Additive — every other
-                // key/shape is byte-for-byte unchanged.
-                var discussionId = ""
+                // PKT-MEM-136: surface discussion_id so VoiceMemoProcessor can ledger it.
+                var discussionIdOut = discussionIdArg ?? ""
                 for chunk in chunks {
-                    let data = try await client.createComment(pageId: pageId, text: chunk)
+                    let data: Data
+                    if hasDiscussion {
+                        data = try await client.createComment(pageId: nil, discussionId: discussionIdArg, text: chunk)
+                    } else {
+                        data = try await client.createComment(pageId: pageId, discussionId: nil, text: chunk)
+                    }
                     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                         return .object([
                             "success": .bool(false),
@@ -1113,8 +1126,8 @@ public enum NotionModule {
                         ])
                     }
                     ids.append(.string(json["id"] as? String ?? ""))
-                    if discussionId.isEmpty {
-                        discussionId = json["discussion_id"] as? String ?? ""
+                    if discussionIdOut.isEmpty {
+                        discussionIdOut = json["discussion_id"] as? String ?? ""
                     }
                 }
 
@@ -1124,7 +1137,7 @@ public enum NotionModule {
                     "id": ids.first ?? .string(""),
                     "ids": .array(ids),
                     "chunks": .int(chunks.count),
-                    "discussionId": .string(discussionId)
+                    "discussionId": .string(discussionIdOut)
                 ])
             }
         ))
@@ -1705,7 +1718,7 @@ public enum NotionModule {
             name: "notion_discussion_create",
             module: moduleName,
             tier: .notify,
-            description: "Start a new threaded discussion on a Notion page (accepts compressed URLs, UUIDs, or full Notion URLs). Initial comment is inline-only markdown and preflights Notion's 2000-character rich_text run limit.",
+            description: "Start a NEW top-level discussion on a Notion page (same as notion_comment_create with pageId — not a reply). For replies, pass discussionId to notion_comment_create. Accepts compressed URLs, UUIDs, or full Notion URLs. Initial comment is inline-only markdown and preflights Notion's 2000-character rich_text run limit.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -1747,6 +1760,133 @@ public enum NotionModule {
                     "success": .bool(true),
                     "id": .string(id),
                     "discussionId": .string(discussionId)
+                ])
+            }
+        ))
+
+        // MARK: 24. notion_views_list – open (Views API)
+        await router.register(ToolRegistration(
+            name: "notion_views_list",
+            module: moduleName,
+            tier: .open,
+            description: "List database views for a database_id and/or data_source_id (Notion Views API). List results are often id-only references — use notion_view_get for filter/sorts/configuration. At least one of databaseId or dataSourceId is required.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "databaseId": .object(["type": .string("string"), "description": .string("Database container ID — lists views on that database.")]),
+                    "dataSourceId": .object(["type": .string("string"), "description": .string("Data source ID — lists views over that collection (including linked views).")]),
+                    "pageSize": .object(["type": .string("integer"), "description": .string("Max results (default 100, max 100).")]),
+                    "startCursor": .object(["type": .string("string"), "description": .string("Pagination cursor from a prior next_cursor.")]),
+                    "workspace": workspaceParam
+                ]),
+                "required": .array([])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notion: List Views",
+                whenToUse: ["discovering board/table/chart views on a database or data source"],
+                whenNotToUse: ["reading one view's filter/sorts (use notion_view_get)",
+                               "querying rows (use notion_query)"],
+                relatedTools: ["notion_view_get", "notion_database_get", "notion_datasource_get", "notion_query"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_views_list", reason: "missing arguments")
+                }
+                let databaseId: String? = { if case .string(let d) = args["databaseId"] { return d }; return nil }()
+                let dataSourceId: String? = { if case .string(let d) = args["dataSourceId"] { return d }; return nil }()
+                let hasDB = !(databaseId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                let hasDS = !(dataSourceId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                guard hasDB || hasDS else {
+                    throw ToolRouterError.invalidArguments(
+                        toolName: "notion_views_list",
+                        reason: "at least one of 'databaseId' or 'dataSourceId' is required"
+                    )
+                }
+                let pageSize: Int = { if case .int(let ps) = args["pageSize"] { return min(max(ps, 1), 100) }; return 100 }()
+                let startCursor: String? = { if case .string(let c) = args["startCursor"] { return c }; return nil }()
+
+                let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
+                let data = try await client.listViews(
+                    databaseId: hasDB ? databaseId : nil,
+                    dataSourceId: hasDS ? dataSourceId : nil,
+                    startCursor: startCursor,
+                    pageSize: pageSize
+                )
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return .object(["error": .string("Failed to parse views list response")])
+                }
+                let results = (json["results"] as? [[String: Any]]) ?? []
+                var items: [Value] = []
+                for row in results {
+                    let id = row["id"] as? String ?? ""
+                    let object = row["object"] as? String ?? "view"
+                    let name = row["name"] as? String
+                    let type = row["type"] as? String
+                    var entry: [String: Value] = [
+                        "id": .string(id),
+                        "object": .string(object)
+                    ]
+                    if let name { entry["name"] = .string(name) }
+                    if let type { entry["type"] = .string(type) }
+                    items.append(.object(entry))
+                }
+                let hasMore = json["has_more"] as? Bool ?? false
+                var out: [String: Value] = [
+                    "success": .bool(true),
+                    "count": .int(items.count),
+                    "has_more": .bool(hasMore),
+                    "results": .array(items)
+                ]
+                if let next = json["next_cursor"] as? String {
+                    out["next_cursor"] = .string(next)
+                }
+                return .object(out)
+            }
+        ))
+
+        // MARK: 25. notion_view_get – open (Views API)
+        await router.register(ToolRegistration(
+            name: "notion_view_get",
+            module: moduleName,
+            tier: .open,
+            description: "Retrieve one Notion database view by ID — name, type, filter, sorts, quick_filters, and configuration (table/board/chart/etc.). Use after notion_views_list.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "viewId": .object(["type": .string("string"), "description": .string("View ID (with or without dashes).")]),
+                    "workspace": workspaceParam
+                ]),
+                "required": .array([.string("viewId")])
+            ]),
+            metadata: ToolMetadata(
+                title: "Notion: Get View",
+                whenToUse: ["reading a view's filters, sorts, and layout configuration"],
+                whenNotToUse: ["listing views (use notion_views_list)",
+                               "querying rows of a data source (use notion_query)"],
+                relatedTools: ["notion_views_list", "notion_query", "notion_database_get"]
+            ),
+            handler: { arguments in
+                guard case .object(let args) = arguments,
+                      case .string(let viewId) = args["viewId"], !viewId.isEmpty else {
+                    throw ToolRouterError.invalidArguments(toolName: "notion_view_get", reason: "missing 'viewId'")
+                }
+                let client = try await registryHolder.getClient(workspace: extractWorkspace(args))
+                let data = try await client.getView(viewId: viewId)
+                guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    return .object(["error": .string("Failed to parse view response")])
+                }
+                // Pass through the full view object as JSON string for nested filter/config fidelity,
+                // plus a few top-level convenience fields.
+                let raw = String(data: data, encoding: .utf8) ?? "{}"
+                return .object([
+                    "success": .bool(true),
+                    "id": .string(json["id"] as? String ?? viewId),
+                    "object": .string(json["object"] as? String ?? "view"),
+                    "name": .string(json["name"] as? String ?? ""),
+                    "type": .string(json["type"] as? String ?? ""),
+                    "data_source_id": .string(json["data_source_id"] as? String ?? ""),
+                    "url": .string(json["url"] as? String ?? ""),
+                    "view": .string(raw)
                 ])
             }
         ))

--- a/TheBridge/Modules/Registry/RegistryGateway.swift
+++ b/TheBridge/Modules/Registry/RegistryGateway.swift
@@ -24,6 +24,29 @@ public enum RegistryGatewayError: Error, LocalizedError, Equatable {
     }
 }
 
+public enum RegistryRowResponseDecoder {
+    public static func decode(_ data: Data, context: String) throws -> NotionRow {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw RegistryGatewayError.invalidResponse("\(context) is not a JSON object")
+        }
+        return try decode(object, context: context)
+    }
+
+    public static func decode(_ object: [String: Any], context: String) throws -> NotionRow {
+        guard let id = object["id"] as? String, !id.isEmpty else {
+            throw RegistryGatewayError.invalidResponse("\(context) is missing a nonempty page id")
+        }
+        guard object["properties"] is [String: Any] else {
+            throw RegistryGatewayError.invalidResponse("\(context) is missing a properties object for page \(id)")
+        }
+        let row = RegistryRowDecoder.row(from: object)
+        guard !row.id.isEmpty else {
+            throw RegistryGatewayError.invalidResponse("\(context) decoded an empty page id")
+        }
+        return row
+    }
+}
+
 public enum RegistryQueryResponseDecoder {
     public static func decode(_ data: Data) throws -> (rows: [NotionRow], nextCursor: String?) {
         guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -40,7 +63,10 @@ public enum RegistryQueryResponseDecoder {
         } else {
             next = nil
         }
-        return (results.map { RegistryRowDecoder.row(from: $0) }, next)
+        let rows = try results.enumerated().map { index, object in
+            try RegistryRowResponseDecoder.decode(object, context: "Notion query result[\(index)]")
+        }
+        return (rows, next)
     }
 }
 
@@ -116,24 +142,22 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
     public func page(pageId: String, workspace: String?) async throws -> NotionRow {
         let c = try await client(workspace)
         let data = try await limiter.throttled { try await c.getPage(pageId: pageId) }
-        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
-        return RegistryRowDecoder.row(from: obj)
+        return try RegistryRowResponseDecoder.decode(data, context: "Notion page response")
     }
 
     public func create(dataSourceId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
         let c = try await client(workspace)
         let data = try await limiter.throttled {
-            try await c.createPage(parentId: dataSourceId, parentType: "data_source_id", properties: Self.createBody(fields))
+            try await c.createPage(parentId: dataSourceId, parentType: "data_source_id", properties: try Self.createBody(fields))
         }
-        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
-        return RegistryRowDecoder.row(from: obj)
+        return try RegistryRowResponseDecoder.decode(data, context: "Notion create response")
     }
 
     public func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
         let c = try await client(workspace)
-        let data = try await limiter.throttled { try await c.updatePage(pageId: pageId, properties: Self.updateBody(fields)) }
-        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
-        return RegistryRowDecoder.row(from: obj)
+        let body = try Self.updateBody(fields)
+        let data = try await limiter.throttled { try await c.updatePage(pageId: pageId, properties: body) }
+        return try RegistryRowResponseDecoder.decode(data, context: "Notion update response")
     }
 
     public func archive(pageId: String, workspace: String?) async throws {
@@ -186,15 +210,15 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
     /// The body for `NotionClient.createPage(properties:)`, which WRAPS the
     /// passed dict under `{"parent":…, "properties": <dict>}` itself — so this
     /// passes the RAW property envelope (no `properties` wrapper here).
-    public static func createBody(_ fields: [BoundField]) -> Data {
-        (try? JSONSerialization.data(withJSONObject: encodeEnvelope(fields))) ?? Data("{}".utf8)
+    public static func createBody(_ fields: [BoundField]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: encodeEnvelope(fields))
     }
 
     /// The body for `NotionClient.updatePage(properties:)`, which sends its arg
     /// AS the PATCH body UNWRAPPED — so the `{"properties": …}` wrapper MUST be
     /// added here. (Asymmetry with createPage; a missing wrapper makes Notion
     /// silently ignore the write — the live-smoke bug this fixes.)
-    public static func updateBody(_ fields: [BoundField]) -> Data {
-        (try? JSONSerialization.data(withJSONObject: ["properties": encodeEnvelope(fields)])) ?? Data("{}".utf8)
+    public static func updateBody(_ fields: [BoundField]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["properties": encodeEnvelope(fields)])
     }
 }

--- a/TheBridge/Modules/Registry/RegistryGateway.swift
+++ b/TheBridge/Modules/Registry/RegistryGateway.swift
@@ -15,8 +15,10 @@ import Foundation
 import MCP
 
 public protocol RegistryNotionGateway: Sendable {
+    var supportsAuthoritativeFiltering: Bool { get }
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema
     func query(dataSourceId: String, workspace: String?, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?)
+    func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?)
     func page(pageId: String, workspace: String?) async throws -> NotionRow
     func create(dataSourceId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow
     func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow
@@ -26,8 +28,18 @@ public protocol RegistryNotionGateway: Sendable {
 }
 
 public extension RegistryNotionGateway {
+    var supportsAuthoritativeFiltering: Bool { false }
+
     func query(dataSourceId: String, workspace: String?) async throws -> [NotionRow] {
         try await query(dataSourceId: dataSourceId, workspace: workspace, pageSize: 100, startCursor: nil).rows
+    }
+
+    /// Default compatibility path for test gateways. LiveRegistryGateway overrides
+    /// this and sends the filter to Notion. The default never claims server-side
+    /// filtering; callers that require a live authoritative lookup should use a
+    /// gateway implementation that overrides this method.
+    func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
+        try await query(dataSourceId: dataSourceId, workspace: workspace, pageSize: pageSize, startCursor: startCursor)
     }
 }
 
@@ -55,6 +67,21 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
         let c = try await client(workspace)
         let data = try await limiter.throttled {
             try await c.queryDataSource(dataSourceId: dataSourceId, pageSize: pageSize, startCursor: startCursor)
+        }
+        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        let results = (obj["results"] as? [[String: Any]]) ?? []
+        let rows = results.map { RegistryRowDecoder.row(from: $0) }
+        let next = (obj["has_more"] as? Bool == true) ? (obj["next_cursor"] as? String) : nil
+        return (rows, next)
+    }
+
+    public func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
+        let c = try await client(workspace)
+        let data = try await limiter.throttled {
+            try await c.queryDataSource(
+                dataSourceId: dataSourceId, filter: filter,
+                pageSize: pageSize, startCursor: startCursor
+            )
         }
         let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
         let results = (obj["results"] as? [[String: Any]]) ?? []

--- a/TheBridge/Modules/Registry/RegistryGateway.swift
+++ b/TheBridge/Modules/Registry/RegistryGateway.swift
@@ -14,6 +14,36 @@
 import Foundation
 import MCP
 
+public enum RegistryGatewayError: Error, LocalizedError, Equatable {
+    case invalidResponse(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let reason): return "registry gateway response invalid: \(reason)"
+        }
+    }
+}
+
+public enum RegistryQueryResponseDecoder {
+    public static func decode(_ data: Data) throws -> (rows: [NotionRow], nextCursor: String?) {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let results = object["results"] as? [[String: Any]],
+              let hasMore = object["has_more"] as? Bool else {
+            throw RegistryGatewayError.invalidResponse("Notion query response is missing results or has_more")
+        }
+        let next: String?
+        if hasMore {
+            guard let cursor = object["next_cursor"] as? String, !cursor.isEmpty else {
+                throw RegistryGatewayError.invalidResponse("Notion query response has_more=true without next_cursor")
+            }
+            next = cursor
+        } else {
+            next = nil
+        }
+        return (results.map { RegistryRowDecoder.row(from: $0) }, next)
+    }
+}
+
 public protocol RegistryNotionGateway: Sendable {
     var supportsAuthoritativeFiltering: Bool { get }
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema
@@ -46,6 +76,7 @@ public extension RegistryNotionGateway {
 /// Production gateway: `NotionClientRegistry` for the connection + the shared
 /// rate limiter for every call.
 public struct LiveRegistryGateway: RegistryNotionGateway {
+    public var supportsAuthoritativeFiltering: Bool { true }
     private let limiter: RegistryRateLimiter
 
     public init(limiter: RegistryRateLimiter = .shared) {
@@ -68,11 +99,7 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
         let data = try await limiter.throttled {
             try await c.queryDataSource(dataSourceId: dataSourceId, pageSize: pageSize, startCursor: startCursor)
         }
-        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
-        let results = (obj["results"] as? [[String: Any]]) ?? []
-        let rows = results.map { RegistryRowDecoder.row(from: $0) }
-        let next = (obj["has_more"] as? Bool == true) ? (obj["next_cursor"] as? String) : nil
-        return (rows, next)
+        return try RegistryQueryResponseDecoder.decode(data)
     }
 
     public func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
@@ -83,11 +110,7 @@ public struct LiveRegistryGateway: RegistryNotionGateway {
                 pageSize: pageSize, startCursor: startCursor
             )
         }
-        let obj = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
-        let results = (obj["results"] as? [[String: Any]]) ?? []
-        let rows = results.map { RegistryRowDecoder.row(from: $0) }
-        let next = (obj["has_more"] as? Bool == true) ? (obj["next_cursor"] as? String) : nil
-        return (rows, next)
+        return try RegistryQueryResponseDecoder.decode(data)
     }
 
     public func page(pageId: String, workspace: String?) async throws -> NotionRow {

--- a/TheBridge/Modules/Registry/RegistryModels.swift
+++ b/TheBridge/Modules/Registry/RegistryModels.swift
@@ -211,7 +211,41 @@ public struct RegistryConfig: Codable, Sendable, Equatable {
 
     /// Entity lookup by key.
     public func entity(_ key: String) -> RegistryEntity? {
-        entities.first { $0.key == key }
+        if let direct = entities.first(where: { $0.key == key }) { return direct }
+
+        // PACKETS was historically registered as `session` on some installs,
+        // while packet contracts and registry_hydrate call it `packet`.
+        // Prefer `packet`; preserve `session` as a compatibility alias only
+        // when the entity's display name proves it is the PACKETS source.
+        if key == "packet",
+           let legacy = entities.first(where: {
+               $0.key == "session" && $0.displayName.lowercased().contains("packet")
+           }) {
+            return RegistryEntity(
+                key: "packet",
+                displayName: legacy.displayName,
+                dataSourceId: legacy.dataSourceId,
+                workspace: legacy.workspace,
+                properties: legacy.properties,
+                cacheTTLSeconds: legacy.cacheTTLSeconds,
+                hasBody: legacy.hasBody
+            )
+        }
+        if key == "session",
+           let canonical = entities.first(where: {
+               $0.key == "packet" && $0.displayName.lowercased().contains("packet")
+           }) {
+            return RegistryEntity(
+                key: "session",
+                displayName: canonical.displayName,
+                dataSourceId: canonical.dataSourceId,
+                workspace: canonical.workspace,
+                properties: canonical.properties,
+                cacheTTLSeconds: canonical.cacheTTLSeconds,
+                hasBody: canonical.hasBody
+            )
+        }
+        return nil
     }
 
     /// Upsert an entity by key (replace-in-place or append).

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -129,7 +129,7 @@ public enum RegistryModule {
     /// Shared description snippet for the `fields` result-projection param,
     /// reused verbatim across all 6 tools (Round 2 Decision 4 — one
     /// mechanism, learned once, recognized everywhere).
-    static let fieldsParamDescriptionSuffix = " Optional `fields` (array of strings) narrows the returned row to only the requested top-level keys — e.g. [\"title\",\"properties.status\"] — instead of the full envelope. Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Omitted or [] → unchanged full response. Unknown keys/paths are silently absent, never an error. On write tools this NEVER filters the operation-status wrapper (created/updated/matchedId/bodyWrite/idempotentReplay/partialFailure/reason) — only the row payload."
+    static let fieldsParamDescriptionSuffix = " Optional `fields` (array of strings) narrows the returned row to only the requested top-level keys — e.g. [\"title\",\"properties.status\"] — instead of the full envelope. Bare \"properties\" keeps the whole properties map; a dotted \"properties.X\" sub-selects one property (case-insensitive). Identity keys (`id`, `entity`, `title`) are always retained when present so projected list/find rows remain usable for follow-on updates. Omitted or [] → unchanged full response. Unknown keys/paths are silently absent, never an error. On write tools this NEVER filters the operation-status wrapper (created/updated/matchedId/bodyWrite/idempotentReplay/partialFailure/reason) — only the row payload."
 
     static func fieldsParamSchema() -> Value {
         .object([

--- a/TheBridge/Modules/Registry/RegistryPropertyCodec.swift
+++ b/TheBridge/Modules/Registry/RegistryPropertyCodec.swift
@@ -81,6 +81,14 @@ public enum RegistryPropertyCodec {
         case "date":
             guard let d = property["date"] as? [String: Any],
                   let start = d["start"] as? String else { return .null }
+            let end = d["end"] as? String
+            let timeZone = d["time_zone"] as? String
+            if end != nil || timeZone != nil {
+                var range: [String: Value] = ["start": .string(start)]
+                if let end { range["end"] = .string(end) }
+                if let timeZone { range["timeZone"] = .string(timeZone) }
+                return .object(range)
+            }
             return .string(start)
 
         case "checkbox":
@@ -217,6 +225,17 @@ public enum RegistryPropertyCodec {
 
         case "date":
             if case .null = value { return ["date": NSNull()] }
+            if case .object(let range) = value,
+               case .string(let start)? = range["start"], !start.isEmpty {
+                var payload: [String: Any] = ["start": start]
+                if case .string(let end)? = range["end"], !end.isEmpty {
+                    payload["end"] = end
+                }
+                if case .string(let timeZone)? = range["timeZone"], !timeZone.isEmpty {
+                    payload["time_zone"] = timeZone
+                }
+                return ["date": payload]
+            }
             guard let s = stringy(value), !s.isEmpty else { return ["date": NSNull()] }
             return ["date": ["start": s]]
 

--- a/TheBridge/Modules/Registry/RegistryRowCache.swift
+++ b/TheBridge/Modules/Registry/RegistryRowCache.swift
@@ -108,6 +108,31 @@ public actor RegistryRowCache {
         try? FileManager.default.removeItem(at: Self.entityDir(entity))
     }
 
+    /// Evict one Notion page id from every configured/entity cache directory.
+    /// Direct notion_* writes do not know which Registry entity owns a page;
+    /// scanning the shallow entity directories keeps post-write reads honest.
+    @discardableResult
+    public func evictPageEverywhere(pageId: String) -> [String] {
+        let root = BridgePaths.applicationSupport(.registryCache)
+        let fm = FileManager.default
+        guard let entityNames = try? fm.contentsOfDirectory(atPath: root.path) else { return [] }
+        var evicted: [String] = []
+        for entityName in entityNames.sorted() {
+            let candidate = root
+                .appendingPathComponent(entityName, isDirectory: true)
+                .appendingPathComponent("\(Self.safeComponent(CachedRow.normalize(pageId))).json")
+            guard fm.fileExists(atPath: candidate.path) else { continue }
+            do {
+                try fm.removeItem(at: candidate)
+                evicted.append(entityName)
+            } catch {
+                // Cache eviction is a best-effort freshness hint. A failed
+                // removal remains visible to forceRefresh and normal TTL.
+            }
+        }
+        return evicted
+    }
+
     /// Increment the persisted `callCount` and return the new value (0 when
     /// no entry). The read-bump-write runs inside the actor, so concurrent
     /// ticks can't lose an increment. Drives the revalidation cadence.

--- a/TheBridge/Modules/RunningReportJob.swift
+++ b/TheBridge/Modules/RunningReportJob.swift
@@ -60,7 +60,7 @@ public enum RunningReportJob {
     /// operator-pending banner for the Strava data source. NO fabricated numbers.
     /// When the operator wires a data source, they replace this one step (e.g.
     /// with an `http_fetch` of their Strava activities + a formatter) — the
-    /// delivery step downstream is unchanged because it reads `$prev_result`.
+    /// delivery step downstream is unchanged because it reads `$prev_result.stdout`.
     static let reportBuilderScript = """
     cat <<'REPORT'
     🏃 Morning Running Report — $(date '+%a %b %-d')
@@ -79,7 +79,7 @@ public enum RunningReportJob {
     """
 
     /// The default action chain: build the report text, then deliver it as an
-    /// iMessage. Step 2 reads `$prev_result` (the report builder's stdout).
+    /// iMessage. Step 2 extracts the report builder's stdout explicitly.
     public static func defaultActionChain(recipient: String = selfHandlePlaceholder) -> [ActionStep] {
         [
             // Step 0 — build the running summary text (honest scaffold).
@@ -96,7 +96,7 @@ public enum RunningReportJob {
                 tool: "messages_send",
                 arguments: [
                     "recipient": .string(recipient),
-                    "body": .string("$prev_result"),
+                    "body": .string("$prev_result.stdout"),
                     "confirm": .string("SEND")
                 ],
                 onFail: .continue

--- a/TheBridge/Modules/Skills/SkillBodyCacheEviction.swift
+++ b/TheBridge/Modules/Skills/SkillBodyCacheEviction.swift
@@ -1,23 +1,161 @@
 // SkillBodyCacheEviction.swift — Bridge (Wave 3 FB)
-// Evict the persistent skill body cache when Notion writes touch a configured skill page.
+// Evict the persistent skill body cache when Notion writes touch a skill page.
 
 import Foundation
 
-public enum SkillBodyCacheEviction {
-    /// When `pageId` matches a skill configured in `SkillsManager`, evict its
-    /// body cache entry so the next `fetch_skill` re-reads from Notion.
-    public static func evictIfConfiguredSkillPage(_ rawPageId: String) async {
-        let normalized = NotionClient.normalizePageId(rawPageId)
-        guard normalized.count >= 32 else { return }
+public struct SkillCacheImpact: Sendable, Equatable {
+    public let pageId: String
+    public let parentPageIds: [String]
 
-        let isConfigured = await MainActor.run {
-            SkillsManager().skills.contains { skill in
+    public init(pageId: String, parentPageIds: [String]) {
+        self.pageId = pageId
+        self.parentPageIds = parentPageIds
+    }
+}
+
+
+public struct SkillCacheRefreshReceipt: Sendable, Equatable {
+    public let matchedSkillPage: Bool
+    public let bodyEvicted: Bool
+    public let routingRefreshAttempted: Bool
+    public let routingParentsExpected: Int
+    public let routingParentsRefreshed: Int
+
+    public var routingRefreshSucceeded: Bool {
+        routingRefreshAttempted && routingParentsExpected > 0
+            && routingParentsRefreshed == routingParentsExpected
+    }
+}
+
+public enum SkillBodyCacheEviction {
+    /// Pure classification used by tests and the live invalidation path.
+    /// A skill page is either a configured top-level parent or a curated
+    /// specialist already present in the routing cache.
+    public static func impact(
+        rawPageId: String,
+        configuredPageIds: [String],
+        cachedParents: [CachedParent]
+    ) -> SkillCacheImpact? {
+        let normalized = NotionClient.normalizePageId(rawPageId)
+        guard normalized.count >= 32 else { return nil }
+
+        let configured = Set(configuredPageIds.map(NotionClient.normalizePageId))
+        if configured.contains(normalized) {
+            return SkillCacheImpact(pageId: normalized, parentPageIds: [normalized])
+        }
+
+        let parents = cachedParents.compactMap { parent -> String? in
+            let isChild = parent.children.contains {
+                NotionClient.normalizePageId($0.id) == normalized
+            }
+            return isChild ? NotionClient.normalizePageId(parent.parentId) : nil
+        }
+        guard !parents.isEmpty else { return nil }
+        return SkillCacheImpact(
+            pageId: normalized,
+            parentPageIds: Array(Set(parents)).sorted()
+        )
+    }
+
+
+    public static func mergedMetadata(
+        currentSummary: String,
+        currentTriggers: [String],
+        currentAntiTriggers: [String],
+        pulled: SkillNotionPulledMetadata
+    ) -> SkillNotionPulledMetadata {
+        SkillNotionPulledMetadata(
+            summary: pulled.summary.isEmpty ? currentSummary : pulled.summary,
+            triggerPhrases: pulled.triggerPhrases.isEmpty ? currentTriggers : pulled.triggerPhrases,
+            antiTriggerPhrases: pulled.antiTriggerPhrases.isEmpty ? currentAntiTriggers : pulled.antiTriggerPhrases
+        )
+    }
+
+    /// When `pageId` matches a configured skill or cached specialist, evict
+    /// its body and refresh the parent routing cache. The refresh is best-
+    /// effort: eviction is the correctness boundary for `fetch_skill`, while
+    /// routing refresh heals summaries/aliases immediately when Notion access
+    /// is available.
+    @discardableResult
+    public static func evictIfConfiguredSkillPage(
+        _ rawPageId: String,
+        refreshRouting: Bool = true
+    ) async -> Bool {
+        await refreshReceipt(rawPageId, refreshRouting: refreshRouting).matchedSkillPage
+    }
+
+    public static func refreshReceipt(
+        _ rawPageId: String,
+        refreshRouting: Bool = true
+    ) async -> SkillCacheRefreshReceipt {
+        let configuredPageIds = await MainActor.run {
+            SkillsManager().skills.compactMap { skill -> String? in
                 let pid = skill.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !pid.isEmpty else { return false }
-                return NotionClient.normalizePageId(pid) == normalized
+                return pid.isEmpty ? nil : pid
             }
         }
-        guard isConfigured else { return }
-        await SkillBodyCacheStore.shared.evict(pageId: normalized)
+        let cachedParents = await SkillsCacheReader.shared.readAll()
+        guard let affected = impact(
+            rawPageId: rawPageId,
+            configuredPageIds: configuredPageIds,
+            cachedParents: cachedParents
+        ) else {
+            return SkillCacheRefreshReceipt(
+                matchedSkillPage: false, bodyEvicted: false,
+                routingRefreshAttempted: false, routingParentsExpected: 0,
+                routingParentsRefreshed: 0
+            )
+        }
+
+        await SkillBodyCacheStore.shared.evict(pageId: affected.pageId)
+        await SkillCache.shared.clear()
+
+        guard refreshRouting, let client = try? NotionClient() else {
+            return SkillCacheRefreshReceipt(
+                matchedSkillPage: true, bodyEvicted: true,
+                routingRefreshAttempted: false,
+                routingParentsExpected: affected.parentPageIds.count,
+                routingParentsRefreshed: 0
+            )
+        }
+
+        var configuredSkills = SkillsModule.readAllSkills()
+        if let index = configuredSkills.firstIndex(where: {
+            NotionClient.normalizePageId($0.notionPageId) == affected.pageId
+        }), let pageData = try? await client.getPage(pageId: affected.pageId),
+           let pageJSON = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any],
+           let properties = pageJSON["properties"] as? [String: Any] {
+            let current = configuredSkills[index]
+            let pulled = SkillNotionMetadata.parsePulledMetadata(properties: properties)
+            let merged = mergedMetadata(
+                currentSummary: current.summary,
+                currentTriggers: current.triggerPhrases,
+                currentAntiTriggers: current.antiTriggerPhrases,
+                pulled: pulled
+            )
+            configuredSkills[index] = SkillsModule.SkillConfig(
+                name: current.name, source: current.source, enabled: current.enabled,
+                routingDiscoverable: current.routingDiscoverable, inCommandPalette: current.inCommandPalette,
+                summary: SkillMetadataLimits.clampedSummary(merged.summary),
+                triggerPhrases: SkillMetadataLimits.clampedPhraseList(merged.triggerPhrases),
+                antiTriggerPhrases: SkillMetadataLimits.clampedPhraseList(merged.antiTriggerPhrases),
+                url: current.url, platform: current.platform
+            )
+            SkillsModule.writeSkills(configuredSkills)
+        }
+
+        let source = await MainActor.run {
+            SkillsCacheWriter.ParentSource.fromSkillsManager(SkillsManager())
+        }
+        let expected = await source.load().count
+        let refreshed = await SkillsCacheWriter.shared.refreshAll(
+            source: source, enumerator: .live(client: client)
+        )
+        return SkillCacheRefreshReceipt(
+            matchedSkillPage: true, bodyEvicted: true,
+            routingRefreshAttempted: true, routingParentsExpected: expected,
+            routingParentsRefreshed: refreshed
+        )
     }
+
 }

--- a/TheBridge/Modules/Skills/SkillMutationTargetResolver.swift
+++ b/TheBridge/Modules/Skills/SkillMutationTargetResolver.swift
@@ -1,0 +1,170 @@
+// SkillMutationTargetResolver.swift — shared parent/specialist identity resolution
+//
+// Skill reads have long supported `parent/specialist` paths through
+// `fetch_skill`, while mutation tools historically looked only at configured
+// top-level SkillsManager rows. This pure resolver gives every mutation path
+// the same bounded identity surface: configured parents plus specialists that
+// are already present in the routing cache.
+
+import Foundation
+
+public struct SkillMutationConfiguredSkill: Sendable, Equatable {
+    public let name: String
+    public let pageId: String
+
+    public init(name: String, pageId: String) {
+        self.name = name
+        self.pageId = pageId
+    }
+}
+
+public struct SkillMutationTarget: Sendable, Equatable {
+    public enum Kind: String, Sendable, Equatable {
+        case configuredParent
+        case cachedSpecialist
+    }
+
+    public let kind: Kind
+    public let name: String
+    public let pageId: String
+    public let parentName: String?
+    public let parentPageId: String?
+    public let cachedSummary: String
+
+    public init(
+        kind: Kind,
+        name: String,
+        pageId: String,
+        parentName: String? = nil,
+        parentPageId: String? = nil,
+        cachedSummary: String = ""
+    ) {
+        self.kind = kind
+        self.name = name
+        self.pageId = pageId
+        self.parentName = parentName
+        self.parentPageId = parentPageId
+        self.cachedSummary = cachedSummary
+    }
+}
+
+public enum SkillMutationTargetResolution: Sendable, Equatable {
+    case found(SkillMutationTarget)
+    case notFound
+    case ambiguous([String])
+}
+
+public enum SkillMutationTargetResolver: Sendable {
+    public static func resolve(
+        _ rawName: String,
+        configured: [SkillMutationConfiguredSkill],
+        cachedParents: [CachedParent]
+    ) -> SkillMutationTargetResolution {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .notFound }
+
+        let pathParts = trimmed.split(separator: "/", maxSplits: 1).map(String.init)
+        if pathParts.count == 2 {
+            return resolvePath(
+                parent: pathParts[0], child: pathParts[1],
+                configured: configured, cachedParents: cachedParents
+            )
+        }
+
+        let wanted = normalize(trimmed)
+        if let parent = configured.first(where: { normalize($0.name) == wanted }) {
+            return .found(SkillMutationTarget(
+                kind: .configuredParent,
+                name: parent.name,
+                pageId: parent.pageId
+            ))
+        }
+
+        let childMatches = cachedParents.flatMap { parent in
+            parent.children.compactMap { child -> SkillMutationTarget? in
+                let names = [child.title] + child.aliases
+                guard names.contains(where: { normalize($0) == wanted }) else { return nil }
+                return SkillMutationTarget(
+                    kind: .cachedSpecialist,
+                    name: child.title,
+                    pageId: child.id,
+                    parentName: parent.parentTitle,
+                    parentPageId: parent.parentId,
+                    cachedSummary: child.summary
+                )
+            }
+        }
+        return unique(childMatches)
+    }
+
+    private static func resolvePath(
+        parent rawParent: String,
+        child rawChild: String,
+        configured: [SkillMutationConfiguredSkill],
+        cachedParents: [CachedParent]
+    ) -> SkillMutationTargetResolution {
+        let wantedParent = normalize(rawParent)
+        let wantedChild = normalize(rawChild)
+
+        let configuredParent = configured.first { normalize($0.name) == wantedParent }
+        let parentMatches = cachedParents.filter { parent in
+            normalize(parent.parentTitle) == wantedParent
+                || configuredParent.map { CachedSkillBody.normalize($0.pageId) }
+                    == CachedSkillBody.normalize(parent.parentId)
+        }
+        guard !parentMatches.isEmpty else { return .notFound }
+
+        let childMatches = parentMatches.flatMap { parent in
+            parent.children.compactMap { child -> SkillMutationTarget? in
+                let names = [child.title] + child.aliases
+                guard names.contains(where: { normalize($0) == wantedChild }) else { return nil }
+                return SkillMutationTarget(
+                    kind: .cachedSpecialist,
+                    name: child.title,
+                    pageId: child.id,
+                    parentName: parent.parentTitle,
+                    parentPageId: parent.parentId,
+                    cachedSummary: child.summary
+                )
+            }
+        }
+        return unique(childMatches)
+    }
+
+    private static func unique(_ matches: [SkillMutationTarget]) -> SkillMutationTargetResolution {
+        let deduped = Dictionary(grouping: matches, by: { CachedSkillBody.normalize($0.pageId) })
+            .compactMap { $0.value.first }
+        if deduped.count == 1, let only = deduped.first { return .found(only) }
+        if deduped.count > 1 {
+            let labels = deduped.map { target in
+                if let parent = target.parentName { return "\(parent)/\(target.name)" }
+                return target.name
+            }.sorted()
+            return .ambiguous(labels)
+        }
+        return .notFound
+    }
+
+    private static func normalize(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if value.hasPrefix("sk ") { value.removeFirst(3) }
+        value = value.replacingOccurrences(of: "_", with: "-")
+        value = value.replacingOccurrences(of: " ", with: "-")
+        while value.contains("--") { value = value.replacingOccurrences(of: "--", with: "-") }
+        return value.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+extension SkillsModule {
+    static func resolveMutationTarget(named name: String) async -> SkillMutationTargetResolution {
+        let configured = readAllSkills().compactMap { skill -> SkillMutationConfiguredSkill? in
+            let pageId = skill.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pageId.isEmpty else { return nil }
+            return SkillMutationConfiguredSkill(name: skill.name, pageId: pageId)
+        }
+        let cachedParents = await SkillsCacheReader.shared.readAll()
+        return SkillMutationTargetResolver.resolve(
+            name, configured: configured, cachedParents: cachedParents
+        )
+    }
+}

--- a/TheBridge/Modules/Skills/SkillsModuleDoctrine.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleDoctrine.swift
@@ -19,9 +19,9 @@ extension SkillsModule {
     /// subsection (deeper level) is included in its parent's slice; a
     /// sibling or shallower heading terminates it.
     ///
-    /// Returns `nil` when no heading matches — the caller then falls back
-    /// to the full body and annotates the envelope so the result is never
-    /// silently empty.
+    /// Returns `nil` when no heading matches — callers return a compact
+    /// heading index rather than the full body, so a typo cannot trigger the
+    /// same oversized response the section selector was meant to avoid.
     public static func extractMarkdownSection(_ markdown: String, section rawSection: String) -> String? {
         let target = rawSection
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -93,6 +93,40 @@ extension SkillsModule {
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return slice
+    }
+
+    /// Return addressable markdown headings while ignoring fenced-code lines.
+    /// Used for bounded section-miss responses and by notion_page_markdown_read.
+    public static func markdownHeadings(_ markdown: String) -> [String] {
+        let lines = markdown.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        var headings: [String] = []
+        var inFence = false
+        for rawLine in lines {
+            let line = rawLine.drop(while: { $0 == " " })
+            if line.hasPrefix("```") || line.hasPrefix("~~~") {
+                inFence.toggle()
+                continue
+            }
+            guard !inFence else { continue }
+            var hashes = 0
+            for character in line {
+                if character == "#" { hashes += 1 } else { break }
+            }
+            guard (1...6).contains(hashes) else { continue }
+            let remainder = line.dropFirst(hashes)
+            guard remainder.first == " " else { continue }
+            let title = remainder.trimmingCharacters(in: .whitespaces)
+            if !title.isEmpty { headings.append(title) }
+        }
+        return headings
+    }
+
+    public static func sectionMissMarkdown(requested: String, markdown: String) -> String {
+        let headings = markdownHeadings(markdown)
+        let available = headings.isEmpty
+            ? "(no markdown headings found)"
+            : headings.prefix(100).map { "- \($0)" }.joined(separator: "\n")
+        return "Section not found: \(requested)\n\nAvailable sections:\n\(available)"
     }
 
     // MARK: - cmd-w4: /markdown body retrieval + mention resolution
@@ -332,12 +366,61 @@ extension SkillsModule {
         cachedIdentity: CachedSkillBody? = nil
     ) -> Value {
         guard case .object(var dict) = value else { return value }
+        let version = cachedIdentity?.version ?? CachedSkillBody.propertyString("Version", in: flattenedProperties)
+        let status = cachedIdentity?.status ?? CachedSkillBody.propertyString("Status", in: flattenedProperties)
+        let maturity = cachedIdentity?.maturity ?? CachedSkillBody.propertyString("Maturity", in: flattenedProperties)
         dict["uuid"] = .string(CachedSkillBody.canonicalUUID(pageId))
         dict["slug"] = .string(cachedIdentity?.slug ?? CachedSkillBody.propertyString("Slug", in: flattenedProperties))
-        dict["version"] = .string(cachedIdentity?.version ?? CachedSkillBody.propertyString("Version", in: flattenedProperties))
-        dict["status"] = .string(cachedIdentity?.status ?? CachedSkillBody.propertyString("Status", in: flattenedProperties))
-        dict["maturity"] = .string(cachedIdentity?.maturity ?? CachedSkillBody.propertyString("Maturity", in: flattenedProperties))
+        dict["version"] = .string(version)
+        dict["status"] = .string(status)
+        dict["maturity"] = .string(maturity)
+        dict["authoritativeMetadataSource"] = .string("notion_properties")
+
+        if case .string(let content) = dict["content"] {
+            let propertyValues = ["version": version, "status": status, "maturity": maturity]
+            var fields: [Value] = []
+            for field in ["version", "status", "maturity"] {
+                guard let bodyValue = bodyMetadataValue(field: field, markdown: content),
+                      let propertyValue = propertyValues[field],
+                      !propertyValue.isEmpty,
+                      bodyValue.caseInsensitiveCompare(propertyValue) != .orderedSame else { continue }
+                fields.append(.object([
+                    "field": .string(field),
+                    "body": .string(bodyValue),
+                    "property": .string(propertyValue)
+                ]))
+            }
+            if !fields.isEmpty {
+                dict["metadataDrift"] = .object([
+                    "detected": .bool(true),
+                    "authoritativeSource": .string("notion_properties"),
+                    "fields": .array(fields),
+                    "warning": .string("Skill body metadata differs from Notion properties; routing uses the property-backed envelope values.")
+                ])
+            }
+        }
         return .object(dict)
+    }
+
+    /// Extract a simple `Version:`, `Status:`, or `Maturity:` declaration
+    /// from the first part of a skill body. This is diagnostic only: Notion
+    /// properties remain the routing-authoritative metadata source.
+    public static func bodyMetadataValue(field: String, markdown: String) -> String? {
+        let wanted = field.lowercased() + ":"
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false).prefix(120) {
+            var line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            while let first = line.first, "->*#` ".contains(first) {
+                line.removeFirst()
+                line = line.trimmingCharacters(in: .whitespaces)
+            }
+            line = line.replacingOccurrences(of: "**", with: "")
+                .replacingOccurrences(of: "`", with: "")
+            guard line.lowercased().hasPrefix(wanted) else { continue }
+            let value = String(line.dropFirst(wanted.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }
+        return nil
     }
 
     /// Public, network-free entry point mirroring `buildSkillResult` but

--- a/TheBridge/Modules/Skills/SkillsModuleRegistration.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleRegistration.swift
@@ -248,40 +248,111 @@ extension SkillsModule {
                         ])
                     }
                 } else if dict["summary"] != nil || dict["triggerPhrases"] != nil || dict["antiTriggerPhrases"] != nil {
-                    let hasSummary = dict["summary"] != nil
-                    let hasTrig = dict["triggerPhrases"] != nil
-                    let hasAnti = dict["antiTriggerPhrases"] != nil
-                    guard hasSummary || hasTrig || hasAnti else {
-                        throw ToolRouterError.invalidArguments(
-                            toolName: "skill_update",
-                            reason: "set_metadata requires at least one of: summary, triggerPhrases, antiTriggerPhrases"
+                    let resolution = await resolveMutationTarget(named: name)
+                    switch resolution {
+                    case .notFound:
+                        return .object([
+                            "success": .bool(false), "action": .string("set_metadata"),
+                            "message": .string("Skill not found in configured parents or the curated specialist routing cache.")
+                        ])
+                    case .ambiguous(let candidates):
+                        return .object([
+                            "success": .bool(false), "action": .string("set_metadata"),
+                            "message": .string("Skill name is ambiguous; use an explicit parent/specialist path."),
+                            "candidates": .array(candidates.map(Value.string))
+                        ])
+                    case .found(let target) where target.kind == .configuredParent:
+                        var skills = readAllSkills()
+                        let wanted = CachedSkillBody.normalize(target.pageId)
+                        guard let idx = skills.firstIndex(where: {
+                            CachedSkillBody.normalize($0.notionPageId) == wanted
+                        }) else {
+                            return .object(["success": .bool(false), "action": .string("set_metadata"), "message": .string("Configured skill row not found.")])
+                        }
+                        let cur = skills[idx]
+                        let newSummary: String = {
+                            if case .string(let value) = dict["summary"] {
+                                return SkillMetadataLimits.clampedSummary(value)
+                            }
+                            return cur.summary
+                        }()
+                        let newTrig: [String] = {
+                            if let value = dict["triggerPhrases"] {
+                                return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(value))
+                            }
+                            return cur.triggerPhrases
+                        }()
+                        let newAnti: [String] = {
+                            if let value = dict["antiTriggerPhrases"] {
+                                return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(value))
+                            }
+                            return cur.antiTriggerPhrases
+                        }()
+                        skills[idx] = SkillConfig(
+                            name: cur.name, source: cur.source, enabled: cur.enabled,
+                            routingDiscoverable: cur.routingDiscoverable, inCommandPalette: cur.inCommandPalette,
+                            summary: newSummary, triggerPhrases: newTrig, antiTriggerPhrases: newAnti,
+                            url: cur.url, platform: cur.platform
                         )
+                        writeSkills(skills)
+                        return .object([
+                            "success": .bool(true), "action": .string("set_metadata"),
+                            "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                            "message": .string("Configured skill metadata updated locally. Use skill_sync_notion push to publish it to Notion.")
+                        ])
+                    case .found(let target):
+                        do {
+                            let client = try NotionClient()
+                            let pageData = try await client.getPage(pageId: target.pageId)
+                            guard let pageJSON = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any],
+                                  let properties = pageJSON["properties"] as? [String: Any] else {
+                                return .object(["success": .bool(false), "action": .string("set_metadata"), "message": .string("Failed to parse specialist Notion page.")])
+                            }
+                            let current = SkillNotionMetadata.parsePulledMetadata(properties: properties)
+                            let summary: String = {
+                                if case .string(let value) = dict["summary"] {
+                                    return SkillMetadataLimits.clampedSummary(value)
+                                }
+                                return current.summary
+                            }()
+                            let triggers: [String] = {
+                                if let value = dict["triggerPhrases"] {
+                                    return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(value))
+                                }
+                                return current.triggerPhrases
+                            }()
+                            let antiTriggers: [String] = {
+                                if let value = dict["antiTriggerPhrases"] {
+                                    return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(value))
+                                }
+                                return current.antiTriggerPhrases
+                            }()
+                            let patch = try SkillNotionMetadata.buildPagePropertiesPatchData(
+                                summary: summary,
+                                triggerPhrases: triggers,
+                                antiTriggerPhrases: antiTriggers
+                            )
+                            _ = try await client.updatePage(pageId: target.pageId, properties: patch)
+                            let cache = await SkillBodyCacheEviction.refreshReceipt(target.pageId)
+                            let resolvedPath = [target.parentName, target.name].compactMap { $0 }.joined(separator: "/")
+                            return .object([
+                                "success": .bool(true), "action": .string("set_metadata"),
+                                "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                                "resolvedPath": .string(resolvedPath),
+                                "bodyEvicted": .bool(cache.bodyEvicted),
+                                "routingRefreshAttempted": .bool(cache.routingRefreshAttempted),
+                                "routingRefreshSucceeded": .bool(cache.routingRefreshSucceeded),
+                                "routingParentsExpected": .int(cache.routingParentsExpected),
+                                "routingParentsRefreshed": .int(cache.routingParentsRefreshed),
+                                "message": .string("Specialist metadata updated in Notion; cache evidence is reported separately.")
+                            ])
+                        } catch {
+                            return .object([
+                                "success": .bool(false), "action": .string("set_metadata"),
+                                "error": .string(error.localizedDescription)
+                            ])
+                        }
                     }
-                    var skills = readAllSkills()
-                    guard let idx = skills.firstIndex(where: { $0.name.lowercased() == name.lowercased() }) else {
-                        return .object(["success": .bool(false), "action": .string("set_metadata"), "message": .string("Skill not found.")])
-                    }
-                    let cur = skills[idx]
-                    let newSummary: String = {
-                        if case .string(let s) = dict["summary"] { return SkillMetadataLimits.clampedSummary(s) }
-                        return cur.summary
-                    }()
-                    let newTrig: [String] = {
-                        if let v = dict["triggerPhrases"] { return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(v)) }
-                        return cur.triggerPhrases
-                    }()
-                    let newAnti: [String] = {
-                        if let v = dict["antiTriggerPhrases"] { return SkillMetadataLimits.clampedPhraseList(Self.parseStringArrayValue(v)) }
-                        return cur.antiTriggerPhrases
-                    }()
-                    skills[idx] = SkillConfig(
-                        name: cur.name, source: cur.source, enabled: cur.enabled,
-                        routingDiscoverable: cur.routingDiscoverable, inCommandPalette: cur.inCommandPalette,
-                        summary: newSummary, triggerPhrases: newTrig, antiTriggerPhrases: newAnti,
-                        url: cur.url, platform: cur.platform
-                    )
-                    writeSkills(skills)
-                    return .object(["success": .bool(true), "action": .string("set_metadata"), "name": .string(name), "message": .string("Metadata updated.")])
                 } else if dict["visibility"] != nil {
                     guard let vis = parseVisibilityArg(dict) else {
                         throw ToolRouterError.invalidArguments(
@@ -383,15 +454,80 @@ extension SkillsModule {
                         toolName: "skill_sync_notion"
                     )
                 }
-                guard let skill = lookupSkill(named: name) else {
-                    return .object(["success": .bool(false), "action": .string(actionLabel), "message": .string("Skill not found.")])
+                let resolution = await resolveMutationTarget(named: name)
+                let target: SkillMutationTarget
+                switch resolution {
+                case .notFound:
+                    return .object([
+                        "success": .bool(false), "action": .string(actionLabel),
+                        "message": .string("Skill not found in configured parents or the curated specialist routing cache.")
+                    ])
+                case .ambiguous(let candidates):
+                    return .object([
+                        "success": .bool(false), "action": .string(actionLabel),
+                        "message": .string("Skill name is ambiguous; use an explicit parent/specialist path."),
+                        "candidates": .array(candidates.map { .string($0) })
+                    ])
+                case .found(let resolved):
+                    target = resolved
                 }
-                let pageId = skill.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                let pageId = target.pageId.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard NotionPageRef.isValidStoredPageId(pageId) else {
-                    return .object(["success": .bool(false), "action": .string(actionLabel), "message": .string("Skill has an invalid Notion page id — fix in Settings → Skills.")])
+                    return .object([
+                        "success": .bool(false), "action": .string(actionLabel),
+                        "message": .string("Skill has an invalid Notion page id — fix the parent routing relation or Settings → Skills.")
+                    ])
                 }
                 do {
                     let client = try NotionClient()
+                    if target.kind == .cachedSpecialist {
+                        if isPush {
+                            return .object([
+                                "success": .bool(false), "action": .string(actionLabel),
+                                "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                                "message": .string("Cached specialists have no independent local metadata row to push. Use skill_update with the explicit parent/specialist path; it writes the child page directly and refreshes both caches.")
+                            ])
+                        }
+
+                        let pageData = try await client.getPage(pageId: pageId)
+                        guard let pageJSON = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any],
+                              let properties = pageJSON["properties"] as? [String: Any] else {
+                            return .object([
+                                "success": .bool(false), "action": .string(actionLabel),
+                                "message": .string("Failed to parse specialist Notion page.")
+                            ])
+                        }
+                        let pulled = SkillNotionMetadata.parsePulledMetadata(properties: properties)
+                        let cache = await SkillBodyCacheEviction.refreshReceipt(pageId)
+                        let resolvedPath = [target.parentName, target.name].compactMap { $0 }.joined(separator: "/")
+                        return .object([
+                            "success": .bool(true), "action": .string(actionLabel),
+                            "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                            "resolvedPath": .string(resolvedPath),
+                            "summary": .string(pulled.summary),
+                            "triggerPhrases": .array(pulled.triggerPhrases.map { .string($0) }),
+                            "antiTriggerPhrases": .array(pulled.antiTriggerPhrases.map { .string($0) }),
+                            "bodyEvicted": .bool(cache.bodyEvicted),
+                            "routingRefreshAttempted": .bool(cache.routingRefreshAttempted),
+                            "routingRefreshSucceeded": .bool(cache.routingRefreshSucceeded),
+                            "routingParentsExpected": .int(cache.routingParentsExpected),
+                            "routingParentsRefreshed": .int(cache.routingParentsRefreshed),
+                            "message": .string("Specialist metadata read from Notion; cache evidence is reported separately.")
+                        ])
+                    }
+
+                    var skills = readAllSkills()
+                    let wanted = CachedSkillBody.normalize(pageId)
+                    guard let idx = skills.firstIndex(where: {
+                        CachedSkillBody.normalize($0.notionPageId) == wanted
+                    }) else {
+                        return .object([
+                            "success": .bool(false), "action": .string(actionLabel),
+                            "message": .string("Configured skill row not found.")
+                        ])
+                    }
+                    let skill = skills[idx]
                     if isPush {
                         let patch = try SkillNotionMetadata.buildPagePropertiesPatchData(
                             summary: skill.summary,
@@ -399,42 +535,53 @@ extension SkillsModule {
                             antiTriggerPhrases: skill.antiTriggerPhrases
                         )
                         _ = try await client.updatePage(pageId: pageId, properties: patch)
-                        return .object(["success": .bool(true), "action": .string(actionLabel), "name": .string(name), "message": .string("Notion page properties updated from MCP metadata.")])
+                        let cache = await SkillBodyCacheEviction.refreshReceipt(pageId)
+                        return .object([
+                            "success": .bool(true), "action": .string(actionLabel),
+                            "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                            "bodyEvicted": .bool(cache.bodyEvicted),
+                            "routingRefreshAttempted": .bool(cache.routingRefreshAttempted),
+                            "routingRefreshSucceeded": .bool(cache.routingRefreshSucceeded),
+                            "routingParentsExpected": .int(cache.routingParentsExpected),
+                            "routingParentsRefreshed": .int(cache.routingParentsRefreshed),
+                            "message": .string("Notion page properties updated; cache evidence is reported separately.")
+                        ])
                     } else {
                         let pageData = try await client.getPage(pageId: pageId)
                         guard let pageJSON = try? JSONSerialization.jsonObject(with: pageData) as? [String: Any],
                               let properties = pageJSON["properties"] as? [String: Any] else {
-                            return .object(["success": .bool(false), "action": .string(actionLabel), "message": .string("Failed to parse Notion page.")])
+                            return .object([
+                                "success": .bool(false), "action": .string(actionLabel),
+                                "message": .string("Failed to parse Notion page.")
+                            ])
                         }
                         // SSOT = Notion. Read the REAL columns
                         // (Description, Activation Examples, Anti-Triggers).
-                        // GATE-SAFE: an empty Notion value never
-                        // overwrites a non-empty local value, so a pull can no
-                        // longer blank metadata (the historical phantom-column
-                        // bug). See SkillNotionMetadata.parsePulledMetadata.
+                        // Empty values remain gate-safe no-ops for configured
+                        // parent rows.
                         let pulled = SkillNotionMetadata.parsePulledMetadata(properties: properties)
-                        var skills = readAllSkills()
-                        guard let idx = skills.firstIndex(where: { $0.name.lowercased() == name.lowercased() }) else {
-                            return .object(["success": .bool(false), "action": .string(actionLabel), "message": .string("Skill not found.")])
-                        }
-                        let cur = skills[idx]
                         let newSummary = pulled.summary.isEmpty
-                            ? cur.summary
+                            ? skill.summary
                             : SkillMetadataLimits.clampedSummary(pulled.summary)
                         let trig = pulled.triggerPhrases.isEmpty
-                            ? cur.triggerPhrases
+                            ? skill.triggerPhrases
                             : SkillMetadataLimits.clampedPhraseList(pulled.triggerPhrases)
                         let anti = pulled.antiTriggerPhrases.isEmpty
-                            ? cur.antiTriggerPhrases
+                            ? skill.antiTriggerPhrases
                             : SkillMetadataLimits.clampedPhraseList(pulled.antiTriggerPhrases)
                         skills[idx] = SkillConfig(
-                            name: cur.name, source: cur.source, enabled: cur.enabled,
-                            routingDiscoverable: cur.routingDiscoverable, inCommandPalette: cur.inCommandPalette,
+                            name: skill.name, source: skill.source, enabled: skill.enabled,
+                            routingDiscoverable: skill.routingDiscoverable, inCommandPalette: skill.inCommandPalette,
                             summary: newSummary, triggerPhrases: trig, antiTriggerPhrases: anti,
-                            url: cur.url, platform: cur.platform
+                            url: skill.url, platform: skill.platform
                         )
                         writeSkills(skills)
-                        return .object(["success": .bool(true), "action": .string(actionLabel), "name": .string(name), "message": .string("MCP metadata updated from Notion (Description-sourced; empty fields preserved).")])
+                        await SkillBodyCacheStore.shared.evict(pageId: pageId)
+                        return .object([
+                            "success": .bool(true), "action": .string(actionLabel),
+                            "name": .string(target.name), "targetKind": .string(target.kind.rawValue),
+                            "message": .string("MCP metadata updated from Notion (Description-sourced; empty fields preserved); body cache evicted.")
+                        ])
                     }
                 } catch let error as NotionClientError {
                     return .object(["success": .bool(false), "action": .string(actionLabel), "error": .string(error.localizedDescription)])

--- a/TheBridge/Modules/Skills/SkillsModuleSpecialists.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleSpecialists.swift
@@ -117,6 +117,21 @@ extension SkillsModule {
 
         // Intent ranking → confident / disambiguate / none.
         if let intent = intent {
+            // An exact canonical parent with no specialist roster is already
+            // resolved. Intent cannot route anywhere, so do not mislabel the
+            // authoritative parent body as low-confidence.
+            if allSpecialists.isEmpty {
+                let parentEnvelope = await Self.buildFileSkillResult(parent)
+                return Self.annotateFileEnvelope(
+                    parentEnvelope,
+                    parentName: parentName,
+                    annotation: nil,
+                    resolvedPath: nil,
+                    score: 1.0,
+                    reason: "exact canonical name; no specialists configured",
+                    siblingTitles: []
+                )
+            }
             let candidates: [SkillIntentCandidate] = allSpecialists.map { s in
                 var aliases: [String] = []
                 if case .array(let arr) = s.frontmatter["aliases"] { aliases = arr }
@@ -247,6 +262,19 @@ extension SkillsModule {
         // `childPages` already holds only curated specialists.
         let childPages = await Self.listNotionChildPages(client: client, pageId: parentPageId)
         let siblingTitles = childPages.map { $0.title }
+
+        // Intent on an exact canonical parent that has no curated specialists
+        // is a definitive parent fetch, not a routing failure.
+        if parsedPath.child == nil, intent != nil, childPages.isEmpty {
+            return SpecialistDispatch(
+                resolvedSpecialist: nil,
+                resolvedPath: nil,
+                annotation: nil,
+                matchScore: 1.0,
+                matchReason: "exact canonical name; no specialists configured",
+                siblingTitles: []
+            )
+        }
 
         if let childName = parsedPath.child {
             let needle = childName.lowercased()
@@ -550,8 +578,8 @@ extension SkillsModule {
     /// `section` (the requested name) + `sectionMatched: true` so the agent
     /// knows the body is a partial slice. When the section was requested but
     /// no heading matched, records `annotation: "section-not-found"` plus
-    /// the requested name and `sectionMatched: false` — the full body is
-    /// returned (never silently empty). No-op when no section was requested.
+    /// the requested name and `sectionMatched: false` — a compact heading
+    /// index is returned instead of the full body. No-op when no section was requested.
     ///
     /// Pure + nonisolated: mutates only its own envelope copy.
     nonisolated static func annotateSection(
@@ -575,7 +603,7 @@ extension SkillsModule {
     /// `content` markdown to the requested heading, recomputes the honest
     /// `blockCount` (non-empty line count), and stamps the section
     /// annotation. No section requested → returns the envelope untouched.
-    /// No match → full content kept + `section-not-found` annotation.
+    /// No match → compact heading index + `section-not-found` annotation.
     ///
     /// Pure + nonisolated: reads/writes only its own envelope copy.
     nonisolated static func applySectionToEnvelope(
@@ -599,6 +627,10 @@ extension SkillsModule {
             dict["blockCount"] = .int(nonEmptyLineCount)
             return Self.annotateSection(.object(dict), requested: section, matched: true, missed: false)
         }
+        let headings = Self.markdownHeadings(content)
+        dict["content"] = .string(Self.sectionMissMarkdown(requested: section, markdown: content))
+        dict["availableSections"] = .array(headings.prefix(100).map(Value.string))
+        dict["blockCount"] = .int(headings.isEmpty ? 1 : headings.count + 2)
         return Self.annotateSection(.object(dict), requested: section, matched: false, missed: true)
     }
 

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -194,8 +194,8 @@ public enum SkillsModule {
 
             GRANULAR FETCH: pass `section="<heading>"` to return ONLY that heading's \
             slice instead of the whole body — use this when you need one part of a \
-            large skill and want to stay under token caps. No match → full body + a \
-            `section-not-found` annotation.
+            large skill and want to stay under token caps. No match → compact heading \
+            index + a `section-not-found` annotation.
             """,
             inputSchema: .object([
                 "type": .string("object"),
@@ -226,7 +226,7 @@ public enum SkillsModule {
                     ]),
                     "section": .object([
                         "type": .string("string"),
-                        "description": .string("Optional heading name to return ONLY that section's slice (case-insensitive, '#' markers ignored) instead of the whole body — a granular partial fetch to avoid blowing token caps. Nested subsections are included; a sibling/shallower heading ends the slice. No match → full body + a `section-not-found` annotation.")
+                        "description": .string("Optional heading name to return ONLY that section's slice (case-insensitive, '#' markers ignored) instead of the whole body — a granular partial fetch to avoid blowing token caps. Nested subsections are included; a sibling/shallower heading ends the slice. No match → compact heading index + a `section-not-found` annotation.")
                     ]),
                     "fields": .object([
                         "type": .string("array"),
@@ -553,13 +553,20 @@ public enum SkillsModule {
                     // fb-resultsize: when a `section` is requested, slice the
                     // rendered markdown down to that heading's content before
                     // mention-resolution + envelope build — a granular partial
-                    // fetch. No match → full body, and we record it so the
-                    // envelope carries a `section-not-found` annotation.
+                    // fetch. No match → a compact heading index, and we record
+                    // it so the envelope carries a `section-not-found` annotation.
                     let sectionBody = sectionArg.flatMap {
                         Self.extractMarkdownSection(rawMarkdown, section: $0)
                     }
-                    let bodyForEnvelope = sectionBody ?? rawMarkdown
                     let sectionMissed = (sectionArg != nil) && (sectionBody == nil)
+                    let bodyForEnvelope: String
+                    if let sectionBody {
+                        bodyForEnvelope = sectionBody
+                    } else if let sectionArg {
+                        bodyForEnvelope = Self.sectionMissMarkdown(requested: sectionArg, markdown: rawMarkdown)
+                    } else {
+                        bodyForEnvelope = rawMarkdown
+                    }
 
                     // Skill-body <mention-page> tags now render as
                     // [Title](url) via the shared MentionResolver (cmd-w2),

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -11,7 +11,7 @@ import MCP
 // MARK: - Skill Cache
 
 /// Cache entry for a fetched skill page.
-private struct CachedSkill: Sendable {
+struct CachedSkill: Sendable {
     let content: Value
     let fetchedAt: Date
 
@@ -22,6 +22,7 @@ private struct CachedSkill: Sendable {
 
 /// Thread-safe actor cache for fetched skill content.
 actor SkillCache {
+    static let shared = SkillCache()
     private var cache: [String: CachedSkill] = [:]
 
     func get(_ key: String) -> Value? {
@@ -149,7 +150,7 @@ public enum SkillsModule {
     /// Register the `fetch_skill` tool on the given router.
     public static func register(on router: ToolRouter) async {
 
-        let cache = SkillCache()
+        let cache = SkillCache.shared
 
         // fetch_skill — open tier
         // PKT-907: now accepts slash-delimited paths (`"parent/child"`)

--- a/TheBridge/Modules/Time/CalendarRegistryCoordinatorTrust.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryCoordinatorTrust.swift
@@ -1,0 +1,169 @@
+// CalendarRegistryCoordinatorTrust.swift — filesystem trust boundary for the disabled pairing coordinator
+
+import CryptoKit
+import Darwin
+import Foundation
+
+package enum CalendarRegistryCoordinatorTrustError: Error, LocalizedError, Equatable {
+    case unsafe(String)
+
+    package var errorDescription: String? {
+        switch self {
+        case .unsafe(let reason): return "calendar-registry coordinator is unsafe: \(reason)"
+        }
+    }
+}
+
+package struct CalendarRegistryFilesystemIdentity: Sendable, Equatable {
+    package let resolvedPath: String
+    package let device: UInt64
+    package let inode: UInt64
+
+    package var namespace: String {
+        let canonical = "\(device):\(inode):\(resolvedPath)"
+        return "local-" + SHA256.hash(data: Data(canonical.utf8))
+            .prefix(12).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+package enum CalendarRegistryCoordinatorTrust {
+    private static let ownerOnlyDirectory = mode_t(S_IRWXU)
+    private static let ownerOnlyFile = mode_t(S_IRUSR | S_IWUSR)
+
+    package static func prepareDirectory(_ requestedURL: URL) throws -> (url: URL, identity: CalendarRegistryFilesystemIdentity) {
+        let standardized = requestedURL.standardizedFileURL
+        try rejectSymlinkComponents(standardized)
+        let resolved = standardized.resolvingSymlinksInPath()
+        try FileManager.default.createDirectory(
+            at: resolved,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: Int(ownerOnlyDirectory))]
+        )
+        var info = stat()
+        guard lstat(resolved.path, &info) == 0 else { throw failure("lstat directory \(resolved.path)") }
+        guard (info.st_mode & S_IFMT) == S_IFDIR else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("not a directory: \(resolved.path)")
+        }
+        guard info.st_uid == geteuid() else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("directory is not owned by the current user: \(resolved.path)")
+        }
+        guard chmod(resolved.path, ownerOnlyDirectory) == 0 else { throw failure("chmod directory \(resolved.path)") }
+        var verified = stat()
+        guard lstat(resolved.path, &verified) == 0,
+              (verified.st_mode & S_IFMT) == S_IFDIR,
+              verified.st_uid == geteuid(),
+              (verified.st_mode & 0o077) == 0 else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("directory permissions or identity changed: \(resolved.path)")
+        }
+        let values = try resolved.resourceValues(forKeys: [.volumeIsLocalKey])
+        guard values.volumeIsLocal == true else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("coordinator volume is not local: \(resolved.path)")
+        }
+        var backupValues = URLResourceValues()
+        backupValues.isExcludedFromBackup = true
+        var mutable = resolved
+        try? mutable.setResourceValues(backupValues)
+        return (resolved, identity(path: resolved.path, info: verified))
+    }
+
+    package static func prepareRegularFile(_ requestedURL: URL) throws -> CalendarRegistryFilesystemIdentity {
+        let url = requestedURL.standardizedFileURL
+        let fd = Darwin.open(url.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, ownerOnlyFile)
+        guard fd >= 0 else { throw failure("open file \(url.path)") }
+        defer { _ = close(fd) }
+        var info = stat()
+        guard fstat(fd, &info) == 0 else { throw failure("fstat file \(url.path)") }
+        try validateRegular(info, path: url.path)
+        guard fchmod(fd, ownerOnlyFile) == 0 else { throw failure("chmod file \(url.path)") }
+        guard fsync(fd) == 0 else { throw failure("fsync file \(url.path)") }
+        return identity(path: url.path, info: info)
+    }
+
+    package static func validateRegularFileIfPresent(_ requestedURL: URL) throws -> CalendarRegistryFilesystemIdentity? {
+        let url = requestedURL.standardizedFileURL
+        var info = stat()
+        if lstat(url.path, &info) != 0 {
+            if errno == ENOENT { return nil }
+            throw failure("lstat file \(url.path)")
+        }
+        try validateRegular(info, path: url.path)
+        guard chmod(url.path, ownerOnlyFile) == 0 else { throw failure("chmod file \(url.path)") }
+        var verified = stat()
+        guard lstat(url.path, &verified) == 0 else { throw failure("re-lstat file \(url.path)") }
+        try validateRegular(verified, path: url.path)
+        return identity(path: url.path, info: verified)
+    }
+
+    package static func requireStable(
+        _ expected: CalendarRegistryFilesystemIdentity,
+        actual: CalendarRegistryFilesystemIdentity,
+        label: String
+    ) throws {
+        guard expected.device == actual.device, expected.inode == actual.inode else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("\(label) device/inode changed during bootstrap")
+        }
+    }
+
+    package static func syncDirectory(_ requestedURL: URL) throws {
+        let url = requestedURL.standardizedFileURL
+        let fd = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_DIRECTORY)
+        guard fd >= 0 else { throw failure("open directory for fsync \(url.path)") }
+        defer { _ = close(fd) }
+        guard fsync(fd) == 0 else { throw failure("fsync directory \(url.path)") }
+    }
+
+
+    private static func rejectSymlinkComponents(_ url: URL) throws {
+        let standardized = url.standardizedFileURL
+        let anchors = [
+            FileManager.default.temporaryDirectory.standardizedFileURL,
+            FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL
+        ]
+        let anchor = anchors
+            .filter { standardized.path == $0.path || standardized.path.hasPrefix($0.path + "/") }
+            .max { $0.path.count < $1.path.count }
+            ?? URL(fileURLWithPath: "/", isDirectory: true)
+        let anchorPath = anchor.path == "/" ? "" : anchor.path
+        let relative = String(standardized.path.dropFirst(anchorPath.count))
+        var current = anchor.resolvingSymlinksInPath()
+        for component in relative.split(separator: "/").map(String.init) {
+            current.appendPathComponent(component)
+            var info = stat()
+            if lstat(current.path, &info) != 0 {
+                if errno == ENOENT { break }
+                throw failure("lstat path component \(current.path)")
+            }
+            if (info.st_mode & S_IFMT) == S_IFLNK {
+                throw CalendarRegistryCoordinatorTrustError.unsafe("symlinked path component: \(current.path)")
+            }
+        }
+    }
+
+    private static func validateRegular(_ info: stat, path: String) throws {
+        guard (info.st_mode & S_IFMT) == S_IFREG else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("not a regular file: \(path)")
+        }
+        guard info.st_uid == geteuid() else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("file is not owned by the current user: \(path)")
+        }
+        guard info.st_nlink == 1 else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("file link count is not one: \(path)")
+        }
+        guard (info.st_mode & 0o077) == 0 else {
+            throw CalendarRegistryCoordinatorTrustError.unsafe("file permissions expose group or other access: \(path)")
+        }
+    }
+
+    private static func identity(path: String, info: stat) -> CalendarRegistryFilesystemIdentity {
+        CalendarRegistryFilesystemIdentity(
+            resolvedPath: path,
+            device: UInt64(info.st_dev),
+            inode: UInt64(info.st_ino)
+        )
+    }
+
+    private static func failure(_ operation: String) -> CalendarRegistryCoordinatorTrustError {
+        let code = errno
+        return .unsafe("\(operation) errno=\(code): \(String(cString: strerror(code)))")
+    }
+}

--- a/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
@@ -79,47 +79,12 @@ public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProces
     public let coordinatorNamespace: String
 
     public init(rootURL: URL) throws {
-        let standardized = rootURL.standardizedFileURL
-        self.rootURL = standardized
-        self.coordinatorNamespace = "local-" + SHA256.hash(data: Data(standardized.path.utf8))
-            .prefix(12).map { String(format: "%02x", $0) }.joined()
-        try FileManager.default.createDirectory(
-            at: standardized,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
-        )
-        try Self.validateRoot(standardized)
-        var values = URLResourceValues()
-        values.isExcludedFromBackup = true
-        var mutable = standardized
-        try? mutable.setResourceValues(values)
-    }
-
-    private static func validateRoot(_ url: URL) throws {
-        var info = stat()
-        guard lstat(url.path, &info) == 0 else {
-            throw CalendarRegistryProcessLockError.storageFailure(
-                "lstat \(url.path) errno=\(errno): \(String(cString: strerror(errno)))"
-            )
-        }
-        guard (info.st_mode & S_IFMT) == S_IFDIR else {
-            throw CalendarRegistryProcessLockError.storageFailure("lock root is not a directory: \(url.path)")
-        }
-        guard info.st_uid == geteuid() else {
-            throw CalendarRegistryProcessLockError.storageFailure("lock root is not owned by the current user: \(url.path)")
-        }
-        if (info.st_mode & 0o077) != 0 {
-            guard chmod(url.path, mode_t(S_IRWXU)) == 0 else {
-                throw CalendarRegistryProcessLockError.storageFailure(
-                    "chmod lock root errno=\(errno): \(String(cString: strerror(errno)))"
-                )
-            }
-            var repaired = stat()
-            guard lstat(url.path, &repaired) == 0, (repaired.st_mode & 0o077) == 0 else {
-                throw CalendarRegistryProcessLockError.storageFailure(
-                    "lock root permissions remain unsafe after repair: \(url.path)"
-                )
-            }
+        do {
+            let prepared = try CalendarRegistryCoordinatorTrust.prepareDirectory(rootURL)
+            self.rootURL = prepared.url
+            self.coordinatorNamespace = prepared.identity.namespace
+        } catch {
+            throw CalendarRegistryProcessLockError.storageFailure(error.localizedDescription)
         }
     }
 
@@ -171,22 +136,55 @@ public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProces
             )
         }
 
-        let owner = "pid=\(ProcessInfo.processInfo.processIdentifier) key=\(idempotencyKey)\n"
-        if ftruncate(fd, 0) != 0 || owner.withCString({ write(fd, $0, strlen($0)) }) < 0 {
+        guard ftruncate(fd, 0) == 0, lseek(fd, 0, SEEK_SET) >= 0 else {
             let captured = errno
+            _ = flock(fd, LOCK_UN)
+            _ = close(fd)
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "reset lock owner file errno=\(captured): \(String(cString: strerror(captured)))"
+            )
+        }
+        let owner = "pid=\(ProcessInfo.processInfo.processIdentifier) lock=\(url.lastPathComponent)\n"
+        var writeError: Int32 = 0
+        let wroteAll = owner.utf8CString.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            var offset = 0
+            let count = max(0, raw.count - 1)
+            while offset < count {
+                let written = Darwin.write(fd, base.advanced(by: offset), count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    writeError = errno
+                    return false
+                }
+                if written == 0 {
+                    writeError = EIO
+                    return false
+                }
+                offset += written
+            }
+            return true
+        }
+        if !wroteAll {
+            let captured = writeError == 0 ? EIO : writeError
             _ = flock(fd, LOCK_UN)
             _ = close(fd)
             throw CalendarRegistryProcessLockError.storageFailure(
                 "write lock owner errno=\(captured): \(String(cString: strerror(captured)))"
             )
         }
-        guard fsync(fd) == 0 else {
-            let captured = errno
+        do {
+            guard fsync(fd) == 0 else {
+                throw CalendarRegistryProcessLockError.storageFailure(
+                    "fsync lock owner errno=\(errno): \(String(cString: strerror(errno)))"
+                )
+            }
+            try CalendarRegistryCoordinatorTrust.syncDirectory(rootURL)
+        } catch {
             _ = flock(fd, LOCK_UN)
             _ = close(fd)
-            throw CalendarRegistryProcessLockError.storageFailure(
-                "fsync lock owner errno=\(captured): \(String(cString: strerror(captured)))"
-            )
+            if let lockError = error as? CalendarRegistryProcessLockError { throw lockError }
+            throw CalendarRegistryProcessLockError.storageFailure(error.localizedDescription)
         }
         return FileCalendarRegistryProcessLockHandle(
             idempotencyKey: idempotencyKey,

--- a/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
@@ -1,0 +1,180 @@
+// CalendarRegistryProcessLock.swift — process-shared ownership for calendar-registry effects
+
+import CryptoKit
+import Darwin
+import Foundation
+
+public enum CalendarRegistryProcessLockError: Error, LocalizedError, Equatable {
+    case operationActive(String)
+    case storageFailure(String)
+    case releaseFailure(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .operationActive(let key):
+            return "calendar-registry operation is already active in another process: \(key)"
+        case .storageFailure(let reason):
+            return "calendar-registry process lock failed: \(reason)"
+        case .releaseFailure(let reason):
+            return "calendar-registry process lock release failed: \(reason)"
+        }
+    }
+}
+
+public protocol CalendarRegistryProcessLockHandle: AnyObject, Sendable {
+    var idempotencyKey: String { get }
+    func release() throws
+}
+
+public protocol CalendarRegistryProcessLocking: Sendable {
+    func acquire(idempotencyKey: String) throws -> any CalendarRegistryProcessLockHandle
+}
+
+public final class FileCalendarRegistryProcessLockHandle: CalendarRegistryProcessLockHandle, @unchecked Sendable {
+    public let idempotencyKey: String
+    public let fileURL: URL
+
+    private let stateLock = NSLock()
+    private var descriptor: Int32
+
+    fileprivate init(idempotencyKey: String, fileURL: URL, descriptor: Int32) {
+        self.idempotencyKey = idempotencyKey
+        self.fileURL = fileURL
+        self.descriptor = descriptor
+    }
+
+    public func release() throws {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard descriptor >= 0 else { return }
+        let fd = descriptor
+        descriptor = -1
+        var failures: [String] = []
+        if flock(fd, LOCK_UN) != 0 {
+            failures.append("flock unlock errno=\(errno): \(String(cString: strerror(errno)))")
+        }
+        if close(fd) != 0 {
+            failures.append("close errno=\(errno): \(String(cString: strerror(errno)))")
+        }
+        if !failures.isEmpty {
+            throw CalendarRegistryProcessLockError.releaseFailure(failures.joined(separator: " | "))
+        }
+    }
+
+    deinit {
+        stateLock.lock()
+        let fd = descriptor
+        descriptor = -1
+        stateLock.unlock()
+        if fd >= 0 {
+            _ = flock(fd, LOCK_UN)
+            _ = close(fd)
+        }
+    }
+}
+
+public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProcessLocking, Sendable {
+    public let rootURL: URL
+
+    public init(rootURL: URL) throws {
+        self.rootURL = rootURL.standardizedFileURL
+        try FileManager.default.createDirectory(
+            at: self.rootURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutable = self.rootURL
+        try? mutable.setResourceValues(values)
+    }
+
+    public func lockURL(idempotencyKey: String) -> URL {
+        let digest = SHA256.hash(data: Data(idempotencyKey.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return rootURL.appendingPathComponent("\(digest).lock", isDirectory: false)
+    }
+
+    public func acquire(idempotencyKey: String) throws -> any CalendarRegistryProcessLockHandle {
+        guard !idempotencyKey.isEmpty else {
+            throw CalendarRegistryProcessLockError.storageFailure("idempotency key is empty")
+        }
+        let url = lockURL(idempotencyKey: idempotencyKey)
+        let flags = O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW
+        let fd = Darwin.open(url.path, flags, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else {
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "open \(url.path) errno=\(errno): \(String(cString: strerror(errno)))"
+            )
+        }
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            let captured = errno
+            _ = close(fd)
+            if captured == EWOULDBLOCK || captured == EAGAIN {
+                throw CalendarRegistryProcessLockError.operationActive(idempotencyKey)
+            }
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "flock \(url.path) errno=\(captured): \(String(cString: strerror(captured)))"
+            )
+        }
+
+        let owner = "pid=\(ProcessInfo.processInfo.processIdentifier) key=\(idempotencyKey)\n"
+        if ftruncate(fd, 0) != 0 || owner.withCString({ write(fd, $0, strlen($0)) }) < 0 {
+            let captured = errno
+            _ = flock(fd, LOCK_UN)
+            _ = close(fd)
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "write lock owner errno=\(captured): \(String(cString: strerror(captured)))"
+            )
+        }
+        _ = fsync(fd)
+        return FileCalendarRegistryProcessLockHandle(
+            idempotencyKey: idempotencyKey,
+            fileURL: url,
+            descriptor: fd
+        )
+    }
+}
+
+public final class InMemoryCalendarRegistryProcessLockCoordinator: CalendarRegistryProcessLocking, @unchecked Sendable {
+    public static let shared = InMemoryCalendarRegistryProcessLockCoordinator()
+
+    private let stateLock = NSLock()
+    private var active: Set<String> = []
+
+    public init() {}
+
+    public func acquire(idempotencyKey: String) throws -> any CalendarRegistryProcessLockHandle {
+        stateLock.lock()
+        let inserted = active.insert(idempotencyKey).inserted
+        stateLock.unlock()
+        guard inserted else { throw CalendarRegistryProcessLockError.operationActive(idempotencyKey) }
+        return InMemoryHandle(idempotencyKey: idempotencyKey) { [weak self] key in
+            self?.stateLock.lock()
+            self?.active.remove(key)
+            self?.stateLock.unlock()
+        }
+    }
+
+    private final class InMemoryHandle: CalendarRegistryProcessLockHandle, @unchecked Sendable {
+        let idempotencyKey: String
+        private let stateLock = NSLock()
+        private var releaseBody: (@Sendable (String) -> Void)?
+
+        init(idempotencyKey: String, releaseBody: @escaping @Sendable (String) -> Void) {
+            self.idempotencyKey = idempotencyKey
+            self.releaseBody = releaseBody
+        }
+
+        func release() throws {
+            stateLock.lock()
+            let body = releaseBody
+            releaseBody = nil
+            stateLock.unlock()
+            body?(idempotencyKey)
+        }
+
+        deinit { try? release() }
+    }
+}

--- a/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryProcessLock.swift
@@ -27,6 +27,7 @@ public protocol CalendarRegistryProcessLockHandle: AnyObject, Sendable {
 }
 
 public protocol CalendarRegistryProcessLocking: Sendable {
+    var coordinatorNamespace: String { get }
     func acquire(idempotencyKey: String) throws -> any CalendarRegistryProcessLockHandle
 }
 
@@ -75,18 +76,51 @@ public final class FileCalendarRegistryProcessLockHandle: CalendarRegistryProces
 
 public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProcessLocking, Sendable {
     public let rootURL: URL
+    public let coordinatorNamespace: String
 
     public init(rootURL: URL) throws {
-        self.rootURL = rootURL.standardizedFileURL
+        let standardized = rootURL.standardizedFileURL
+        self.rootURL = standardized
+        self.coordinatorNamespace = "local-" + SHA256.hash(data: Data(standardized.path.utf8))
+            .prefix(12).map { String(format: "%02x", $0) }.joined()
         try FileManager.default.createDirectory(
-            at: self.rootURL,
+            at: standardized,
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: 0o700]
         )
+        try Self.validateRoot(standardized)
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
-        var mutable = self.rootURL
+        var mutable = standardized
         try? mutable.setResourceValues(values)
+    }
+
+    private static func validateRoot(_ url: URL) throws {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else {
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "lstat \(url.path) errno=\(errno): \(String(cString: strerror(errno)))"
+            )
+        }
+        guard (info.st_mode & S_IFMT) == S_IFDIR else {
+            throw CalendarRegistryProcessLockError.storageFailure("lock root is not a directory: \(url.path)")
+        }
+        guard info.st_uid == geteuid() else {
+            throw CalendarRegistryProcessLockError.storageFailure("lock root is not owned by the current user: \(url.path)")
+        }
+        if (info.st_mode & 0o077) != 0 {
+            guard chmod(url.path, mode_t(S_IRWXU)) == 0 else {
+                throw CalendarRegistryProcessLockError.storageFailure(
+                    "chmod lock root errno=\(errno): \(String(cString: strerror(errno)))"
+                )
+            }
+            var repaired = stat()
+            guard lstat(url.path, &repaired) == 0, (repaired.st_mode & 0o077) == 0 else {
+                throw CalendarRegistryProcessLockError.storageFailure(
+                    "lock root permissions remain unsafe after repair: \(url.path)"
+                )
+            }
+        }
     }
 
     public func lockURL(idempotencyKey: String) -> URL {
@@ -106,6 +140,24 @@ public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProces
         guard fd >= 0 else {
             throw CalendarRegistryProcessLockError.storageFailure(
                 "open \(url.path) errno=\(errno): \(String(cString: strerror(errno)))"
+            )
+        }
+        var info = stat()
+        guard fstat(fd, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == geteuid(),
+              info.st_nlink == 1 else {
+            let captured = errno
+            _ = close(fd)
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "unsafe lock file \(url.path) errno=\(captured): \(String(cString: strerror(captured)))"
+            )
+        }
+        guard fchmod(fd, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            let captured = errno
+            _ = close(fd)
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "chmod lock file errno=\(captured): \(String(cString: strerror(captured)))"
             )
         }
         guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
@@ -128,7 +180,14 @@ public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProces
                 "write lock owner errno=\(captured): \(String(cString: strerror(captured)))"
             )
         }
-        _ = fsync(fd)
+        guard fsync(fd) == 0 else {
+            let captured = errno
+            _ = flock(fd, LOCK_UN)
+            _ = close(fd)
+            throw CalendarRegistryProcessLockError.storageFailure(
+                "fsync lock owner errno=\(captured): \(String(cString: strerror(captured)))"
+            )
+        }
         return FileCalendarRegistryProcessLockHandle(
             idempotencyKey: idempotencyKey,
             fileURL: url,
@@ -140,10 +199,13 @@ public struct FileCalendarRegistryProcessLockCoordinator: CalendarRegistryProces
 public final class InMemoryCalendarRegistryProcessLockCoordinator: CalendarRegistryProcessLocking, @unchecked Sendable {
     public static let shared = InMemoryCalendarRegistryProcessLockCoordinator()
 
+    public let coordinatorNamespace: String
     private let stateLock = NSLock()
     private var active: Set<String> = []
 
-    public init() {}
+    public init(coordinatorNamespace: String = "in-memory-test") {
+        self.coordinatorNamespace = coordinatorNamespace
+    }
 
     public func acquire(idempotencyKey: String) throws -> any CalendarRegistryProcessLockHandle {
         stateLock.lock()

--- a/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
@@ -30,6 +30,9 @@ public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatab
 public enum CalendarRegistrySyncComposition {
     public static let enableEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC"
     public static let allowedCalendarsEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_ALLOWED_CALENDARS"
+    public static let canonicalCoordinatorDirectory = BridgePaths.applicationSupport(.registry)
+    public static let canonicalLedgerURL = canonicalCoordinatorDirectory
+        .appendingPathComponent("calendar-registry-transactions.sqlite3")
 
     public static func featureState(environment: [String: String]) -> CalendarRegistrySyncFeatureState {
         environment[enableEnvironmentKey] == "1"
@@ -42,9 +45,7 @@ public enum CalendarRegistrySyncComposition {
         registryGateway: any RegistryNotionGateway,
         calendarStore: any CalendarStoring,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        allowedCalendarIds: Set<String>? = nil,
-        ledgerURL: URL = BridgePaths.applicationSupport(.registry)
-            .appendingPathComponent("calendar-registry-transactions.sqlite3")
+        allowedCalendarIds: Set<String>? = nil
     ) throws -> CalendarRegistrySyncEngine {
         guard featureState(environment: environment) == .enabledForPrivateSmoke else {
             throw CalendarRegistrySyncCompositionError.disabled
@@ -63,8 +64,8 @@ public enum CalendarRegistrySyncComposition {
         guard !allowlist.isEmpty else {
             throw CalendarRegistrySyncCompositionError.missingAllowedCalendars
         }
-        let standardizedLedger = ledgerURL.standardizedFileURL
-        let parent = standardizedLedger.deletingLastPathComponent()
+        let standardizedLedger = canonicalLedgerURL.standardizedFileURL
+        let parent = canonicalCoordinatorDirectory.standardizedFileURL
         let values = try parent.resourceValues(forKeys: [.volumeIsLocalKey])
         guard values.volumeIsLocal == true else {
             throw CalendarRegistrySyncCompositionError.unsupportedCoordinatorLocation(parent.path)

--- a/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
@@ -1,0 +1,56 @@
+// CalendarRegistrySyncComposition.swift — disabled internal assembly boundary
+
+import Foundation
+
+public enum CalendarRegistrySyncFeatureState: Sendable, Equatable {
+    case disabled(reason: String)
+    case enabledForPrivateSmoke
+}
+
+public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatable {
+    case disabled
+    case missingBindings([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .disabled:
+            return "Calendar–Registry Sync is disabled; no public tool or production activation exists"
+        case .missingBindings(let keys):
+            return "schedule registry is missing required bindings: \(keys.joined(separator: ", "))"
+        }
+    }
+}
+
+public enum CalendarRegistrySyncComposition {
+    public static let enableEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC"
+
+    public static func featureState(environment: [String: String]) -> CalendarRegistrySyncFeatureState {
+        environment[enableEnvironmentKey] == "1"
+            ? .enabledForPrivateSmoke
+            : .disabled(reason: "set only for an isolated private smoke fixture")
+    }
+
+    public static func build(
+        entity: RegistryEntity,
+        registryGateway: any RegistryNotionGateway,
+        calendarStore: any CalendarStoring,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        journalURL: URL = BridgePaths.applicationSupport(.registry)
+            .appendingPathComponent("calendar-registry-transactions.json")
+    ) throws -> CalendarRegistrySyncEngine {
+        guard featureState(environment: environment) == .enabledForPrivateSmoke else {
+            throw CalendarRegistrySyncCompositionError.disabled
+        }
+        let missing = CalendarRegistrySyncEngine.requiredScheduleCanonicalFields
+            .filter { entity.property($0)?.isBound != true }
+            .sorted()
+        guard missing.isEmpty else {
+            throw CalendarRegistrySyncCompositionError.missingBindings(missing)
+        }
+        return CalendarRegistrySyncEngine(
+            registry: NotionTimeInstanceRegistryStore(entity: entity, gateway: registryGateway),
+            calendar: CalendarStoringSyncProvider(store: calendarStore),
+            transactions: try JSONCalendarRegistryTransactionStore(url: journalURL)
+        )
+    }
+}

--- a/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
@@ -10,6 +10,7 @@ public enum CalendarRegistrySyncFeatureState: Sendable, Equatable {
 public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatable {
     case disabled
     case missingBindings([String])
+    case missingAllowedCalendars
 
     public var errorDescription: String? {
         switch self {
@@ -17,12 +18,15 @@ public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatab
             return "Calendar–Registry Sync is disabled; no public tool or production activation exists"
         case .missingBindings(let keys):
             return "schedule registry is missing required bindings: \(keys.joined(separator: ", "))"
+        case .missingAllowedCalendars:
+            return "an explicit private-smoke calendar allowlist is required"
         }
     }
 }
 
 public enum CalendarRegistrySyncComposition {
     public static let enableEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC"
+    public static let allowedCalendarsEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_ALLOWED_CALENDARS"
 
     public static func featureState(environment: [String: String]) -> CalendarRegistrySyncFeatureState {
         environment[enableEnvironmentKey] == "1"
@@ -35,8 +39,9 @@ public enum CalendarRegistrySyncComposition {
         registryGateway: any RegistryNotionGateway,
         calendarStore: any CalendarStoring,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        journalURL: URL = BridgePaths.applicationSupport(.registry)
-            .appendingPathComponent("calendar-registry-transactions.json")
+        allowedCalendarIds: Set<String>? = nil,
+        ledgerURL: URL = BridgePaths.applicationSupport(.registry)
+            .appendingPathComponent("calendar-registry-transactions.sqlite3")
     ) throws -> CalendarRegistrySyncEngine {
         guard featureState(environment: environment) == .enabledForPrivateSmoke else {
             throw CalendarRegistrySyncCompositionError.disabled
@@ -47,10 +52,21 @@ public enum CalendarRegistrySyncComposition {
         guard missing.isEmpty else {
             throw CalendarRegistrySyncCompositionError.missingBindings(missing)
         }
+        let parsed = Set((environment[allowedCalendarsEnvironmentKey] ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })
+        let allowlist = allowedCalendarIds ?? parsed
+        guard !allowlist.isEmpty else {
+            throw CalendarRegistrySyncCompositionError.missingAllowedCalendars
+        }
         return CalendarRegistrySyncEngine(
             registry: NotionTimeInstanceRegistryStore(entity: entity, gateway: registryGateway),
-            calendar: CalendarStoringSyncProvider(store: calendarStore),
-            transactions: try JSONCalendarRegistryTransactionStore(url: journalURL)
+            calendar: CalendarStoringSyncProvider(
+                store: calendarStore,
+                allowlistedCalendarIds: allowlist
+            ),
+            transactions: try SQLiteCalendarRegistryTransactionStore(url: ledgerURL)
         )
     }
 }

--- a/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
@@ -31,8 +31,9 @@ public enum CalendarRegistrySyncComposition {
     public static let enableEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC"
     public static let allowedCalendarsEnvironmentKey = "BRIDGE_INTERNAL_CALENDAR_REGISTRY_ALLOWED_CALENDARS"
     public static let canonicalCoordinatorDirectory = BridgePaths.applicationSupport(.registry)
+        .appendingPathComponent("calendar-registry-coordinator", isDirectory: true)
     public static let canonicalLedgerURL = canonicalCoordinatorDirectory
-        .appendingPathComponent("calendar-registry-transactions.sqlite3")
+        .appendingPathComponent("transactions.sqlite3")
 
     public static func featureState(environment: [String: String]) -> CalendarRegistrySyncFeatureState {
         environment[enableEnvironmentKey] == "1"
@@ -64,13 +65,18 @@ public enum CalendarRegistrySyncComposition {
         guard !allowlist.isEmpty else {
             throw CalendarRegistrySyncCompositionError.missingAllowedCalendars
         }
-        let standardizedLedger = canonicalLedgerURL.standardizedFileURL
-        let parent = canonicalCoordinatorDirectory.standardizedFileURL
-        let values = try parent.resourceValues(forKeys: [.volumeIsLocalKey])
-        guard values.volumeIsLocal == true else {
-            throw CalendarRegistrySyncCompositionError.unsupportedCoordinatorLocation(parent.path)
+        let parent: URL
+        do {
+            parent = try CalendarRegistryCoordinatorTrust.prepareDirectory(
+                canonicalCoordinatorDirectory
+            ).url
+        } catch {
+            throw CalendarRegistrySyncCompositionError.unsupportedCoordinatorLocation(
+                "\(canonicalCoordinatorDirectory.path): \(error.localizedDescription)"
+            )
         }
-        let lockRoot = parent.appendingPathComponent("calendar-registry-locks", isDirectory: true)
+        let standardizedLedger = parent.appendingPathComponent("transactions.sqlite3")
+        let lockRoot = parent.appendingPathComponent("locks", isDirectory: true)
         return CalendarRegistrySyncEngine(
             registry: NotionTimeInstanceRegistryStore(entity: entity, gateway: registryGateway),
             calendar: CalendarStoringSyncProvider(

--- a/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncComposition.swift
@@ -11,6 +11,7 @@ public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatab
     case disabled
     case missingBindings([String])
     case missingAllowedCalendars
+    case unsupportedCoordinatorLocation(String)
 
     public var errorDescription: String? {
         switch self {
@@ -20,6 +21,8 @@ public enum CalendarRegistrySyncCompositionError: Error, LocalizedError, Equatab
             return "schedule registry is missing required bindings: \(keys.joined(separator: ", "))"
         case .missingAllowedCalendars:
             return "an explicit private-smoke calendar allowlist is required"
+        case .unsupportedCoordinatorLocation(let path):
+            return "calendar-registry coordinator must use a verified local filesystem: \(path)"
         }
     }
 }
@@ -60,13 +63,21 @@ public enum CalendarRegistrySyncComposition {
         guard !allowlist.isEmpty else {
             throw CalendarRegistrySyncCompositionError.missingAllowedCalendars
         }
+        let standardizedLedger = ledgerURL.standardizedFileURL
+        let parent = standardizedLedger.deletingLastPathComponent()
+        let values = try parent.resourceValues(forKeys: [.volumeIsLocalKey])
+        guard values.volumeIsLocal == true else {
+            throw CalendarRegistrySyncCompositionError.unsupportedCoordinatorLocation(parent.path)
+        }
+        let lockRoot = parent.appendingPathComponent("calendar-registry-locks", isDirectory: true)
         return CalendarRegistrySyncEngine(
             registry: NotionTimeInstanceRegistryStore(entity: entity, gateway: registryGateway),
             calendar: CalendarStoringSyncProvider(
                 store: calendarStore,
                 allowlistedCalendarIds: allowlist
             ),
-            transactions: try SQLiteCalendarRegistryTransactionStore(url: ledgerURL)
+            transactions: try SQLiteCalendarRegistryTransactionStore(url: standardizedLedger),
+            processLocks: try FileCalendarRegistryProcessLockCoordinator(rootURL: lockRoot)
         )
     }
 }

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -575,6 +575,27 @@ public enum CalendarRegistryRouteClassifier {
     }
 }
 
+/// Package-scoped crash-injection seam for proving forward recovery across
+/// durable writes and the EventKit external effect. Production composition uses
+/// the no-op default; no public tool or runtime setting can select a checkpoint.
+package enum CalendarRegistryDurableCheckpoint: String, CaseIterable, Sendable {
+    case claimPersisted
+    case registryAuthorizationPersisted
+    case createInvocationHeartbeatPersisted
+    case createInvocationRegistryPersisted
+    case createInvocationLedgerPersisted
+    case calendarCreateReturned
+    case calendarIdentityLedgerPersisted
+    case pairIdentityHeartbeatPersisted
+    case pairIdentityRegistryPersisted
+    case pairIdentityLedgerPersisted
+    case syncEvidenceHeartbeatPersisted
+    case syncEvidenceRegistryPersisted
+    case syncEvidenceLedgerPersisted
+    case completionLedgerPersisted
+    case completionLeaseReleased
+}
+
 public actor CalendarRegistrySyncEngine {
     private let registry: any TimeInstanceRegistryStoring
     private let calendar: any CalendarSyncProviding
@@ -586,6 +607,7 @@ public actor CalendarRegistrySyncEngine {
     private let makeLeaseToken: @Sendable () -> String
     private let makeCreateInvocationId: @Sendable () -> String
     private let makeSyncWriterToken: @Sendable () -> String
+    private let durableCheckpoint: @Sendable (CalendarRegistryDurableCheckpoint) -> Void
     private let leaseDuration: TimeInterval
 
     package init(
@@ -599,6 +621,7 @@ public actor CalendarRegistrySyncEngine {
         makeLeaseToken: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
         makeCreateInvocationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
         makeSyncWriterToken: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
+        durableCheckpoint: @Sendable @escaping (CalendarRegistryDurableCheckpoint) -> Void = { _ in },
         leaseDuration: TimeInterval = 600
     ) {
         self.registry = registry
@@ -611,6 +634,7 @@ public actor CalendarRegistrySyncEngine {
         self.makeLeaseToken = makeLeaseToken
         self.makeCreateInvocationId = makeCreateInvocationId
         self.makeSyncWriterToken = makeSyncWriterToken
+        self.durableCheckpoint = durableCheckpoint
         self.leaseDuration = leaseDuration
     }
 
@@ -697,6 +721,7 @@ public actor CalendarRegistrySyncEngine {
             leaseDuration: leaseDuration,
             exclusiveProcessLockHeld: true
         )
+        durableCheckpoint(.claimPersisted)
         let stageBefore = transaction.stage
         let fencingToken = transaction.leaseToken
         var record: TimeInstanceRecord?
@@ -736,6 +761,7 @@ public actor CalendarRegistrySyncEngine {
                     transaction.lastError = nil
                     transaction.partialEffects.append("strictly authorized pre-existing Notion EVENT \(request.registryEventId)")
                     transaction = try await transactions.save(transaction)
+                    durableCheckpoint(.registryAuthorizationPersisted)
                     evidence.append("Notion authority and admissibility were proven before EventKit access")
 
                 case .registryAuthorized:
@@ -767,7 +793,9 @@ public actor CalendarRegistrySyncEngine {
                     authorized.syncWriterToken = writerToken
                     authorized.registryUpdatedAt = clock()
                     try await heartbeat(&transaction)
+                    durableCheckpoint(.createInvocationHeartbeatPersisted)
                     authorized = try await registry.savePairing(authorized, expectedRevision: authorized.registryRevision)
+                    durableCheckpoint(.createInvocationRegistryPersisted)
                     try assertWriterEvidence(
                         authorized, expectedInvocationId: invocationId,
                         expectedWriterToken: writerToken, expectedSyncRevision: authorized.syncRevision
@@ -781,6 +809,7 @@ public actor CalendarRegistrySyncEngine {
                     transaction.stage = .createInvocationPersisted
                     transaction.partialEffects.append("persisted Create Invocation ID \(invocationId) before EventKit create")
                     transaction = try await transactions.save(transaction)
+                    durableCheckpoint(.createInvocationLedgerPersisted)
                     createAuthorizedThisAttempt = true
 
                 case .createInvocationPersisted, .calendarEffectUnknown:
@@ -826,6 +855,7 @@ public actor CalendarRegistrySyncEngine {
                             operationFingerprint: request.manifest.fingerprint,
                             createInvocationId: invocationId
                         ))
+                        durableCheckpoint(.calendarCreateReturned)
                         try assertCalendarMatchesManifest(created, request: request, createInvocationId: invocationId)
                         try setCalendarIdentity(created, on: &transaction)
                         calendarItem = created
@@ -833,6 +863,7 @@ public actor CalendarRegistrySyncEngine {
                         transaction.lastError = nil
                         transaction.partialEffects.append("invoked EventKit create once for \(invocationId) and identified \(created.localEventId)")
                         transaction = try await transactions.save(transaction)
+                        durableCheckpoint(.calendarIdentityLedgerPersisted)
                         calendarFields.append(contentsOf: [
                             "title", "start", "end", "timeZone", "calendarId", "location", "notes",
                             "syncKey", "operationFingerprint", "createInvocationId"
@@ -858,7 +889,9 @@ public actor CalendarRegistrySyncEngine {
                     pair.syncWriterToken = makeSyncWriterToken()
                     pair.registryUpdatedAt = clock()
                     try await heartbeat(&transaction)
+                    durableCheckpoint(.pairIdentityHeartbeatPersisted)
                     pair = try await registry.savePairing(pair, expectedRevision: record?.registryRevision)
+                    durableCheckpoint(.pairIdentityRegistryPersisted)
                     try assertWriterEvidence(
                         pair, expectedInvocationId: transaction.createInvocationId,
                         expectedWriterToken: pair.syncWriterToken, expectedSyncRevision: pair.syncRevision
@@ -872,6 +905,7 @@ public actor CalendarRegistrySyncEngine {
                     transaction.stage = .pairIdentityPersisted
                     transaction.partialEffects.append("persisted immutable pair identity to Notion")
                     transaction = try await transactions.save(transaction)
+                    durableCheckpoint(.pairIdentityLedgerPersisted)
                     pairPersisted = true
 
                 case .pairIdentityPersisted:
@@ -910,9 +944,11 @@ public actor CalendarRegistrySyncEngine {
                     syncedRecord.syncRevision += 1
                     syncedRecord.syncWriterToken = makeSyncWriterToken()
                     try await heartbeat(&transaction)
+                    durableCheckpoint(.syncEvidenceHeartbeatPersisted)
                     syncedRecord = try await registry.savePairing(
                         syncedRecord, expectedRevision: preliminary.record.registryRevision
                     )
+                    durableCheckpoint(.syncEvidenceRegistryPersisted)
                     try assertWriterEvidence(
                         syncedRecord, expectedInvocationId: transaction.createInvocationId,
                         expectedWriterToken: syncedRecord.syncWriterToken,
@@ -926,6 +962,7 @@ public actor CalendarRegistrySyncEngine {
                     transaction.stage = .syncEvidencePersisted
                     transaction.lastError = nil
                     transaction = try await transactions.save(transaction)
+                    durableCheckpoint(.syncEvidenceLedgerPersisted)
 
                 case .syncEvidencePersisted:
                     guard let recordId = transaction.registryEventId,
@@ -945,6 +982,7 @@ public actor CalendarRegistrySyncEngine {
                     transaction.lastVerifiedAt = final.record.lastSyncedAt
                     transaction.lastError = nil
                     transaction = try await transactions.save(transaction)
+                    durableCheckpoint(.completionLedgerPersisted)
 
                 case .complete:
                     guard let recordId = transaction.registryEventId,
@@ -957,6 +995,7 @@ public actor CalendarRegistrySyncEngine {
                         expectedCreateInvocationId: transaction.createInvocationId
                     )
                     let released = try await transactions.release(transaction)
+                    durableCheckpoint(.completionLeaseReleased)
                     return makeReceipt(
                         succeeded: true, infrastructureFault: false, ledgerPersisted: true,
                         notionPersisted: notionOutcomePersisted, pairPersisted: true,
@@ -1208,116 +1247,6 @@ public actor CalendarRegistrySyncEngine {
         }
         try assertCalendarMatchesManifest(item, request: request, createInvocationId: transaction.createInvocationId)
         return item
-    }
-
-    private func adoptExistingCalendarIdentity(
-        from record: TimeInstanceRecord,
-        into transaction: inout CalendarRegistryTransaction
-    ) throws {
-        for (name, existing, candidate) in [
-            ("calendar event id", transaction.calendarEventId, record.calendarEventId),
-            ("calendar id", transaction.calendarId, record.calendarId),
-            ("provider external id", transaction.providerExternalId, record.providerExternalId)
-        ] where existing?.isEmpty == false && candidate?.isEmpty == false && existing != candidate {
-            throw CalendarRegistrySyncError.identityConflict("ledger and Notion \(name) differ")
-        }
-        transaction.calendarEventId = transaction.calendarEventId ?? record.calendarEventId
-        transaction.calendarId = transaction.calendarId ?? record.calendarId
-        transaction.providerExternalId = transaction.providerExternalId ?? record.providerExternalId
-    }
-
-    private func resolveOrCreateCalendar(
-        request: RegistryFirstTimeInstanceRequest,
-        record: TimeInstanceRecord,
-        transaction: inout CalendarRegistryTransaction,
-        fieldsWritten: inout [String]
-    ) async throws -> ExternalCalendarItem {
-        let priorEvidence = [
-            transaction.calendarEventId, transaction.providerExternalId,
-            record.calendarEventId, record.providerExternalId
-        ].contains { $0?.isEmpty == false }
-        let query = CalendarRecoveryQuery(
-            localEventId: transaction.calendarEventId ?? record.calendarEventId,
-            providerExternalId: transaction.providerExternalId ?? record.providerExternalId,
-            syncKey: request.idempotencyKey,
-            operationFingerprint: request.manifest.fingerprint,
-            calendarId: request.calendarId,
-            title: request.title,
-            start: request.start,
-            end: request.end
-        )
-        let recovered = try await calendar.recover(query)
-        if recovered.count > 1 {
-            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map { $0.localEventId })
-        }
-        if let existing = recovered.first {
-            try assertCalendarMatchesManifest(existing, request: request)
-            try setCalendarIdentity(existing, on: &transaction)
-            transaction.stage = .calendarIdentified
-            if !transaction.partialEffects.contains("recovered calendar event \(existing.localEventId)") {
-                transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
-            }
-            transaction = try await transactions.save(transaction)
-            return existing
-        }
-
-        if transaction.stage == .createInvocationPersisted || transaction.stage == .calendarEffectUnknown {
-            if transaction.stage == .createInvocationPersisted {
-                transaction.stage = .calendarEffectUnknown
-                transaction.lastError = "calendar create intent exists but recovery found no unique item"
-                transaction = try await transactions.save(transaction)
-            }
-            throw CalendarRegistrySyncError.calendarEffectUnknown(
-                "no unique EventKit item was recovered; automatic recreation is prohibited"
-            )
-        }
-        if priorEvidence {
-            throw CalendarRegistrySyncError.identityConflict(
-                "prior calendar identity exists but no unique provider item could be recovered"
-            )
-        }
-        guard transaction.stage == .registryAuthorized else {
-            throw CalendarRegistrySyncError.identityConflict(
-                "calendar create is allowed only immediately after registry verification"
-            )
-        }
-
-        transaction.stage = .createInvocationPersisted
-        transaction.lastError = nil
-        transaction.partialEffects.append("persisted EventKit create intent")
-        transaction = try await transactions.save(transaction)
-        try Task.checkCancellation()
-
-        do {
-            let created = try await calendar.create(ExternalCalendarDraft(
-                title: request.title,
-                start: request.start,
-                end: request.end,
-                timeZoneIdentifier: request.timeZoneIdentifier,
-                calendarId: request.calendarId,
-                location: request.location,
-                notes: request.notes,
-                syncKey: request.idempotencyKey,
-                operationFingerprint: request.manifest.fingerprint,
-                createInvocationId: transaction.createInvocationId ?? ""
-            ))
-            try assertCalendarMatchesManifest(created, request: request)
-            try setCalendarIdentity(created, on: &transaction)
-            transaction.stage = .calendarIdentified
-            transaction.partialEffects.append("created calendar event \(created.localEventId)")
-            transaction = try await transactions.save(transaction)
-            fieldsWritten.append(contentsOf: [
-                "title", "start", "end", "timeZone", "calendarId", "location", "notes",
-                "syncKey", "operationFingerprint"
-            ])
-            return created
-        } catch {
-            transaction.stage = .calendarEffectUnknown
-            transaction.lastError = error.localizedDescription
-            do { transaction = try await transactions.save(transaction) }
-            catch { throw error }
-            throw CalendarRegistrySyncError.calendarEffectUnknown(error.localizedDescription)
-        }
     }
 
     private func setCalendarIdentity(

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -1,9 +1,7 @@
-// CalendarRegistrySyncEngine.swift — disabled-by-default registry-first pairing core
+// CalendarRegistrySyncEngine.swift — disabled registry-first recovery core
 //
-// Scope is intentionally narrow: one private, non-recurring, timed EventKit
-// event paired with one Notion EVENT. Calendar-first import, recurrence,
-// destructive rollback, attendees, RSVP writes, and public MCP registration are
-// outside this implementation.
+// Scope: one caller-classified, private, non-recurring, timed EventKit item
+// paired with one Notion EVENT. No public tool registration or activation.
 
 import Foundation
 import MCP
@@ -64,14 +62,19 @@ public struct ExternalCalendarItem: Sendable, Equatable {
     public var providerExternalId: String?
     public var itemURL: String?
     public var syncKey: String?
+    public var operationFingerprint: String?
     public var title: String
     public var start: Date
     public var end: Date
     public var timeZoneIdentifier: String
     public var location: String?
     public var notes: String?
+    public var organizer: String?
+    public var attendees: [String]
     public var updatedAt: Date
     public var isRecurring: Bool
+    public var isAllDay: Bool
+    public var isDetached: Bool
 
     public init(
         provider: String,
@@ -80,14 +83,19 @@ public struct ExternalCalendarItem: Sendable, Equatable {
         providerExternalId: String? = nil,
         itemURL: String? = nil,
         syncKey: String? = nil,
+        operationFingerprint: String? = nil,
         title: String,
         start: Date,
         end: Date,
-        timeZoneIdentifier: String = TimeZone.current.identifier,
+        timeZoneIdentifier: String,
         location: String? = nil,
         notes: String? = nil,
+        organizer: String? = nil,
+        attendees: [String] = [],
         updatedAt: Date,
-        isRecurring: Bool = false
+        isRecurring: Bool = false,
+        isAllDay: Bool = false,
+        isDetached: Bool = false
     ) {
         self.provider = provider
         self.calendarId = calendarId
@@ -95,14 +103,19 @@ public struct ExternalCalendarItem: Sendable, Equatable {
         self.providerExternalId = providerExternalId
         self.itemURL = itemURL
         self.syncKey = syncKey
+        self.operationFingerprint = operationFingerprint
         self.title = title
         self.start = start
         self.end = end
         self.timeZoneIdentifier = timeZoneIdentifier
         self.location = location
         self.notes = notes
+        self.organizer = organizer
+        self.attendees = attendees
         self.updatedAt = updatedAt
         self.isRecurring = isRecurring
+        self.isAllDay = isAllDay
+        self.isDetached = isDetached
     }
 }
 
@@ -111,20 +124,22 @@ public struct ExternalCalendarDraft: Sendable, Equatable {
     public var start: Date
     public var end: Date
     public var timeZoneIdentifier: String
-    public var calendarId: String?
+    public var calendarId: String
     public var location: String?
     public var notes: String?
     public var syncKey: String
+    public var operationFingerprint: String
 
     public init(
         title: String,
         start: Date,
         end: Date,
         timeZoneIdentifier: String,
-        calendarId: String? = nil,
+        calendarId: String,
         location: String? = nil,
         notes: String? = nil,
-        syncKey: String
+        syncKey: String,
+        operationFingerprint: String
     ) {
         self.title = title
         self.start = start
@@ -134,6 +149,7 @@ public struct ExternalCalendarDraft: Sendable, Equatable {
         self.location = location
         self.notes = notes
         self.syncKey = syncKey
+        self.operationFingerprint = operationFingerprint
     }
 }
 
@@ -141,7 +157,8 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
     public var localEventId: String?
     public var providerExternalId: String?
     public var syncKey: String
-    public var calendarId: String?
+    public var operationFingerprint: String
+    public var calendarId: String
     public var title: String
     public var start: Date
     public var end: Date
@@ -150,7 +167,8 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
         localEventId: String? = nil,
         providerExternalId: String? = nil,
         syncKey: String,
-        calendarId: String?,
+        operationFingerprint: String,
+        calendarId: String,
         title: String,
         start: Date,
         end: Date
@@ -158,10 +176,39 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
         self.localEventId = localEventId
         self.providerExternalId = providerExternalId
         self.syncKey = syncKey
+        self.operationFingerprint = operationFingerprint
         self.calendarId = calendarId
         self.title = title
         self.start = start
         self.end = end
+    }
+}
+
+public struct CalendarQualification: Sendable, Equatable {
+    public var calendarId: String
+    public var title: String
+    public var allowsModify: Bool
+    public var explicitlyAllowlisted: Bool
+    public var calendarType: String
+    public var sourceType: String?
+    public var qualifiedForPrivateSmoke: Bool
+
+    public init(
+        calendarId: String,
+        title: String,
+        allowsModify: Bool,
+        explicitlyAllowlisted: Bool,
+        calendarType: String,
+        sourceType: String?,
+        qualifiedForPrivateSmoke: Bool
+    ) {
+        self.calendarId = calendarId
+        self.title = title
+        self.allowsModify = allowsModify
+        self.explicitlyAllowlisted = explicitlyAllowlisted
+        self.calendarType = calendarType
+        self.sourceType = sourceType
+        self.qualifiedForPrivateSmoke = qualifiedForPrivateSmoke
     }
 }
 
@@ -175,6 +222,7 @@ public struct TimeInstanceRecord: Sendable, Equatable {
     public var notes: String?
     public var lifecycleStatus: String
     public var syncKey: String
+    public var operationFingerprint: String
     public var calendarProvider: String?
     public var calendarId: String?
     public var calendarEventId: String?
@@ -199,6 +247,7 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         notes: String? = nil,
         lifecycleStatus: String = "Propose",
         syncKey: String,
+        operationFingerprint: String,
         calendarProvider: String? = nil,
         calendarId: String? = nil,
         calendarEventId: String? = nil,
@@ -222,6 +271,7 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         self.notes = notes
         self.lifecycleStatus = lifecycleStatus
         self.syncKey = syncKey
+        self.operationFingerprint = operationFingerprint
         self.calendarProvider = calendarProvider
         self.calendarId = calendarId
         self.calendarEventId = calendarEventId
@@ -247,12 +297,28 @@ public enum RegistryLookupSource: String, Sendable, Equatable {
     case staleCache
 }
 
+public struct RegistryUnresolvedIdentity: Sendable, Equatable {
+    public var pageId: String
+    public var operationFingerprint: String?
+
+    public init(pageId: String, operationFingerprint: String?) {
+        self.pageId = pageId
+        self.operationFingerprint = operationFingerprint
+    }
+}
+
 public struct RegistryIdentityLookup: Sendable, Equatable {
     public var records: [TimeInstanceRecord]
+    public var unresolvedIdentities: [RegistryUnresolvedIdentity]
     public var source: RegistryLookupSource
 
-    public init(records: [TimeInstanceRecord], source: RegistryLookupSource) {
+    public init(
+        records: [TimeInstanceRecord],
+        unresolvedIdentities: [RegistryUnresolvedIdentity] = [],
+        source: RegistryLookupSource
+    ) {
         self.records = records
+        self.unresolvedIdentities = unresolvedIdentities
         self.source = source
     }
 }
@@ -267,7 +333,7 @@ public struct PartialRegistryCreateError: Error, LocalizedError, Sendable, Equat
     }
 
     public var errorDescription: String? {
-        "Notion created EVENT \(pageId) but the follow-up property update failed: \(message)"
+        "Notion created identity envelope \(pageId) but the semantic PATCH failed: \(message)"
     }
 }
 
@@ -275,10 +341,12 @@ public protocol TimeInstanceRegistryStoring: Sendable {
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup
     func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord?
     func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
+    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord
     func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
 }
 
 public protocol CalendarSyncProviding: Sendable {
+    func qualify(calendarId: String) async throws -> CalendarQualification
     func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem
     func item(id: String) async throws -> ExternalCalendarItem?
     func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem]
@@ -290,7 +358,7 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
     public var start: Date
     public var end: Date
     public var timeZoneIdentifier: String
-    public var calendarId: String?
+    public var calendarId: String
     public var location: String?
     public var notes: String?
     public var semantics: TimeInstanceSemantics
@@ -300,8 +368,8 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
         title: String,
         start: Date,
         end: Date,
-        timeZoneIdentifier: String = TimeZone.current.identifier,
-        calendarId: String? = nil,
+        timeZoneIdentifier: String,
+        calendarId: String,
         location: String? = nil,
         notes: String? = nil,
         semantics: TimeInstanceSemantics
@@ -327,18 +395,23 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
             location: location,
             notes: notes,
             eventClass: semantics.eventClass.rawValue,
+            meetingType: semantics.meetingType,
             primaryBlockId: semantics.primaryBlockId,
             blockIds: semantics.blockIds,
             projectIds: semantics.projectIds,
             contactIds: semantics.contactIds
-        )
+        ).canonicalized
     }
 }
 
 public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
     public var succeeded: Bool
+    public var infrastructureFault: Bool
+    public var recoveryStatePersisted: Bool
+    public var registryFailureStatePersisted: Bool
     public var operationId: String
     public var idempotencyKey: String
+    public var operationFingerprint: String
     public var stageBefore: CalendarRegistryTransactionStage
     public var stageAfter: CalendarRegistryTransactionStage
     public var record: TimeInstanceRecord?
@@ -353,23 +426,39 @@ public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
 
 public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
     case invalidTimeRange
+    case invalidTimeZone(String)
     case missingPrimaryBlock
-    case missingIdempotencyKey
+    case invalidIdempotencyKey
+    case missingCalendarId
+    case calendarNotQualified(String)
     case ambiguousRegistryIdentity([String])
+    case undecodableRegistryIdentity([String])
     case ambiguousCalendarIdentity([String])
     case degradedRegistryLookup
     case recurringEventUnsupported
+    case allDayEventUnsupported
+    case detachedEventUnsupported
+    case participantConsequencesUnsupported
+    case identityConflict(String)
     case verificationFailed(String)
 
     public var errorDescription: String? {
         switch self {
         case .invalidTimeRange: return "scheduled end must be after scheduled start"
+        case .invalidTimeZone(let value): return "invalid timezone identifier: \(value)"
         case .missingPrimaryBlock: return "Primary BLOCK is required"
-        case .missingIdempotencyKey: return "a stable idempotency key is required"
+        case .invalidIdempotencyKey: return "idempotency key must be 1–128 characters using letters, digits, period, underscore, colon, or hyphen"
+        case .missingCalendarId: return "an explicit allowlisted calendar ID is required"
+        case .calendarNotQualified(let reason): return "calendar is not qualified for a private smoke: \(reason)"
         case .ambiguousRegistryIdentity(let ids): return "multiple registry EVENTS matched: \(ids.joined(separator: ", "))"
+        case .undecodableRegistryIdentity(let ids): return "matching registry EVENTS could not be decoded safely: \(ids.joined(separator: ", "))"
         case .ambiguousCalendarIdentity(let ids): return "multiple calendar events matched: \(ids.joined(separator: ", "))"
         case .degradedRegistryLookup: return "registry identity lookup was not live; creation refused"
         case .recurringEventUnsupported: return "recurring events are outside the registry-first v1 slice"
+        case .allDayEventUnsupported: return "all-day events are outside the registry-first v1 slice"
+        case .detachedEventUnsupported: return "detached recurring occurrences are outside the registry-first v1 slice"
+        case .participantConsequencesUnsupported: return "attendee or organizer consequences are outside the registry-first v1 slice"
+        case .identityConflict(let reason): return "calendar-registry identity conflict: \(reason)"
         case .verificationFailed(let reason): return "paired verification failed: \(reason)"
         }
     }
@@ -432,20 +521,28 @@ public actor CalendarRegistrySyncEngine {
             return receipt
         } catch let conflict as CalendarRegistryTransactionStoreError {
             let existing = try? await transactions.get(idempotencyKey: request.idempotencyKey)
+            let isConflict: Bool
+            if case .idempotencyConflict = conflict { isConflict = true } else { isConflict = false }
             await operationGate.release(request.idempotencyKey)
             return CalendarRegistrySyncReceipt(
                 succeeded: false,
+                infrastructureFault: !isConflict,
+                recoveryStatePersisted: existing != nil,
+                registryFailureStatePersisted: false,
                 operationId: existing?.operationId ?? "",
                 idempotencyKey: request.idempotencyKey,
+                operationFingerprint: request.manifest.fingerprint,
                 stageBefore: existing?.stage ?? .prepared,
-                stageAfter: .conflict,
+                stageAfter: isConflict ? .conflict : .recoverableError,
                 record: nil,
                 calendarItem: nil,
                 registryFieldsWritten: [],
                 calendarFieldsWritten: [],
                 verificationEvidence: [],
                 partialEffects: existing?.partialEffects ?? [],
-                recoveryAction: "use a new idempotency key for a materially different manifest",
+                recoveryAction: isConflict
+                    ? "use a new idempotency key for a materially different manifest"
+                    : "inspect the SQLite recovery ledger before retrying",
                 discrepancy: conflict.localizedDescription
             )
         } catch {
@@ -457,12 +554,12 @@ public actor CalendarRegistrySyncEngine {
     private func performRegistryFirstCreate(
         _ request: RegistryFirstTimeInstanceRequest
     ) async throws -> CalendarRegistrySyncReceipt {
-        let now = clock()
+        let fingerprint = request.manifest.fingerprint
         var transaction = try await transactions.claim(
             idempotencyKey: request.idempotencyKey,
-            manifestFingerprint: request.manifest.fingerprint,
+            manifestFingerprint: fingerprint,
             operationId: makeOperationId(),
-            now: now
+            now: clock()
         )
         let stageBefore = transaction.stage
         var record: TimeInstanceRecord?
@@ -472,23 +569,36 @@ public actor CalendarRegistrySyncEngine {
         var evidence: [String] = []
 
         do {
+            let qualification = try await calendar.qualify(calendarId: request.calendarId)
+            guard qualification.qualifiedForPrivateSmoke else {
+                throw CalendarRegistrySyncError.calendarNotQualified(
+                    "calendar must be explicitly allowlisted, writable, local, and non-subscribed"
+                )
+            }
+            evidence.append("qualified explicit private-smoke calendar \(qualification.calendarId)")
+
             record = try await resolveOrCreateRegistry(
                 request: request, transaction: &transaction, fieldsWritten: &registryFields
             )
             calendarItem = try await resolveOrCreateCalendar(
-                request: request, transaction: &transaction, fieldsWritten: &calendarFields
+                request: request,
+                record: record!,
+                transaction: &transaction,
+                fieldsWritten: &calendarFields
             )
 
             guard var pair = record, let calendarItem else {
                 throw CalendarRegistrySyncError.verificationFailed("pair resolution returned an empty surface")
             }
-            apply(calendarItem, to: &pair)
+            try assertCalendarMatchesManifest(calendarItem, request: request)
+            applyIdentity(calendarItem, to: &pair)
             pair.syncState = .pendingCreate
             pair.lastSyncError = nil
             pair.registryUpdatedAt = clock()
             pair = try await registry.save(pair)
             record = pair
             registryFields.append(contentsOf: Self.pairingFieldNames)
+
             transaction.registryEventId = pair.id
             transaction.stage = .pairPersisted
             transaction.updatedAt = clock()
@@ -498,7 +608,7 @@ public actor CalendarRegistrySyncEngine {
             let verified = try await verify(
                 request: request, recordId: pair.id, calendarEventId: calendarItem.localEventId
             )
-            evidence = verified.evidence
+            evidence.append(contentsOf: verified.evidence)
             var verifiedRecord = verified.record
             verifiedRecord.syncState = .synced
             verifiedRecord.lastSyncedAt = clock()
@@ -513,27 +623,33 @@ public actor CalendarRegistrySyncEngine {
             transaction.lastError = nil
             try await transactions.save(transaction)
 
-            guard let finalRecord = try await registry.get(id: verifiedRecord.id, forceRefresh: true),
-                  finalRecord.syncState == .synced,
-                  let finalItem = try await calendar.item(id: verified.item.localEventId)
-            else {
-                throw CalendarRegistrySyncError.verificationFailed("final fresh read did not confirm Synced state")
+            let final = try await verify(
+                request: request,
+                recordId: verifiedRecord.id,
+                calendarEventId: verified.item.localEventId
+            )
+            guard final.record.syncState == .synced else {
+                throw CalendarRegistrySyncError.verificationFailed("final Notion read did not retain Synced state")
             }
 
             transaction.stage = .synced
             transaction.lastVerifiedAt = clock()
             transaction.updatedAt = clock()
             try await transactions.save(transaction)
-            evidence.append("final fresh reads confirm one Synced EVENT and one calendar item")
+            evidence.append("final fresh reads repeated the complete manifest and pair comparison")
 
             return CalendarRegistrySyncReceipt(
                 succeeded: true,
+                infrastructureFault: false,
+                recoveryStatePersisted: true,
+                registryFailureStatePersisted: true,
                 operationId: transaction.operationId,
                 idempotencyKey: transaction.idempotencyKey,
+                operationFingerprint: fingerprint,
                 stageBefore: stageBefore,
                 stageAfter: transaction.stage,
-                record: finalRecord,
-                calendarItem: finalItem,
+                record: final.record,
+                calendarItem: final.item,
                 registryFieldsWritten: Array(Set(registryFields)).sorted(),
                 calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
                 verificationEvidence: evidence,
@@ -544,33 +660,41 @@ public actor CalendarRegistrySyncEngine {
         } catch {
             if let partial = error as? PartialRegistryCreateError {
                 transaction.registryEventId = partial.pageId
-                transaction.partialEffects.append("Notion EVENT created: \(partial.pageId)")
+                transaction.partialEffects.append("Notion identity envelope exists: \(partial.pageId)")
             }
-            transaction.stage = error is CalendarRegistryTransactionStoreError
-                ? .conflict : .recoverableError
-            if let syncError = error as? CalendarRegistrySyncError {
-                switch syncError {
-                case .ambiguousRegistryIdentity, .ambiguousCalendarIdentity:
-                    transaction.stage = .conflict
-                default:
-                    break
-                }
-            }
+            transaction.stage = Self.isConflict(error) ? .conflict : .recoverableError
             transaction.lastError = error.localizedDescription
             transaction.updatedAt = clock()
-            try? await transactions.save(transaction)
 
+            var ledgerError: Error?
+            do { try await transactions.save(transaction) }
+            catch { ledgerError = error }
+
+            var registryError: Error?
             if var failed = record {
                 failed.syncState = transaction.stage == .conflict ? .conflict : .error
                 failed.lastSyncError = error.localizedDescription
                 failed.registryUpdatedAt = clock()
-                record = try? await registry.save(failed)
+                do { record = try await registry.save(failed) }
+                catch { registryError = error }
             }
+
+            let persisted = ledgerError == nil
+            let registryPersisted = record == nil ? false : registryError == nil
+            let combined = [
+                error.localizedDescription,
+                ledgerError.map { "recovery ledger write failed: \($0.localizedDescription)" },
+                registryError.map { "registry failure-state write failed: \($0.localizedDescription)" }
+            ].compactMap { $0 }.joined(separator: " | ")
 
             return CalendarRegistrySyncReceipt(
                 succeeded: false,
+                infrastructureFault: !persisted,
+                recoveryStatePersisted: persisted,
+                registryFailureStatePersisted: registryPersisted,
                 operationId: transaction.operationId,
                 idempotencyKey: transaction.idempotencyKey,
+                operationFingerprint: fingerprint,
                 stageBefore: stageBefore,
                 stageAfter: transaction.stage,
                 record: record,
@@ -579,37 +703,16 @@ public actor CalendarRegistrySyncEngine {
                 calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
                 verificationEvidence: evidence,
                 partialEffects: transaction.partialEffects,
-                recoveryAction: "retry with the same idempotency key; the journal will resume from \(transaction.stage.rawValue)",
-                discrepancy: error.localizedDescription
+                recoveryAction: persisted
+                    ? "retry with the same idempotency key; resume from \(transaction.stage.rawValue)"
+                    : "do not retry automatically; inspect Notion by Sync Key and Calendar by Bridge metadata before reconstructing the ledger",
+                discrepancy: combined
             )
         }
     }
 
-    private func resolveOrCreateRegistry(
-        request: RegistryFirstTimeInstanceRequest,
-        transaction: inout CalendarRegistryTransaction,
-        fieldsWritten: inout [String]
-    ) async throws -> TimeInstanceRecord {
-        if let id = transaction.registryEventId,
-           let existing = try await registry.get(id: id, forceRefresh: true) {
-            return existing
-        }
-
-        let lookup = try await registry.findBySyncKey(request.idempotencyKey)
-        guard lookup.source == .live else { throw CalendarRegistrySyncError.degradedRegistryLookup }
-        if lookup.records.count > 1 {
-            throw CalendarRegistrySyncError.ambiguousRegistryIdentity(lookup.records.map(\.id))
-        }
-        if let existing = lookup.records.first {
-            transaction.registryEventId = existing.id
-            transaction.stage = .registryCreated
-            transaction.updatedAt = clock()
-            transaction.partialEffects.append("reused existing Notion EVENT \(existing.id)")
-            try await transactions.save(transaction)
-            return existing
-        }
-
-        var created = TimeInstanceRecord(
+    private func desiredRecord(_ request: RegistryFirstTimeInstanceRequest) -> TimeInstanceRecord {
+        TimeInstanceRecord(
             title: request.title,
             scheduledStart: request.start,
             scheduledEnd: request.end,
@@ -617,39 +720,101 @@ public actor CalendarRegistrySyncEngine {
             location: request.location,
             notes: request.notes,
             syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
             semantics: request.semantics,
             schedulingAuthority: .registry,
             syncState: .pendingCreate,
             registryUpdatedAt: clock()
         )
+    }
+
+    private func resolveOrCreateRegistry(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: inout CalendarRegistryTransaction,
+        fieldsWritten: inout [String]
+    ) async throws -> TimeInstanceRecord {
+        let desired = desiredRecord(request)
+        if let id = transaction.registryEventId {
+            if let existing = try await registry.get(id: id, forceRefresh: true) {
+                try assertRegistryMatchesManifest(existing, request: request)
+                return existing
+            }
+            let repaired = try await registry.repair(id: id, from: desired)
+            try assertRegistryMatchesManifest(repaired, request: request)
+            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
+            return repaired
+        }
+
+        let lookup = try await registry.findBySyncKey(request.idempotencyKey)
+        guard lookup.source == .live else { throw CalendarRegistrySyncError.degradedRegistryLookup }
+        let totalMatches = lookup.records.count + lookup.unresolvedIdentities.count
+        if totalMatches > 1 {
+            throw CalendarRegistrySyncError.ambiguousRegistryIdentity(
+                lookup.records.map(\.id) + lookup.unresolvedIdentities.map(\.pageId)
+            )
+        }
+        if let unresolved = lookup.unresolvedIdentities.first {
+            guard unresolved.operationFingerprint == request.manifest.fingerprint else {
+                throw CalendarRegistrySyncError.identityConflict(
+                    "partial Notion EVENT fingerprint differs or is missing"
+                )
+            }
+            let repaired = try await registry.repair(id: unresolved.pageId, from: desired)
+            transaction.registryEventId = repaired.id
+            transaction.stage = .registryCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("repaired partial Notion EVENT \(repaired.id)")
+            try await transactions.save(transaction)
+            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
+            return repaired
+        }
+        if let existing = lookup.records.first {
+            try assertRegistryMatchesManifest(existing, request: request)
+            transaction.registryEventId = existing.id
+            transaction.calendarEventId = existing.calendarEventId
+            transaction.calendarId = existing.calendarId
+            transaction.providerExternalId = existing.providerExternalId
+            transaction.stage = .registryCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("reused existing Notion EVENT \(existing.id)")
+            try await transactions.save(transaction)
+            return existing
+        }
+
         do {
-            created = try await registry.create(created)
+            let created = try await registry.create(desired)
+            transaction.registryEventId = created.id
+            transaction.stage = .registryCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("created Notion EVENT \(created.id)")
+            try await transactions.save(transaction)
+            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
+            return created
         } catch let partial as PartialRegistryCreateError {
             transaction.registryEventId = partial.pageId
             transaction.stage = .registryCreated
             transaction.updatedAt = clock()
-            transaction.partialEffects.append("Notion EVENT created before follow-up PATCH failure: \(partial.pageId)")
-            try? await transactions.save(transaction)
+            transaction.partialEffects.append("Notion identity envelope created before semantic PATCH failure: \(partial.pageId)")
+            try await transactions.save(transaction)
             throw partial
         }
-        transaction.registryEventId = created.id
-        transaction.stage = .registryCreated
-        transaction.updatedAt = clock()
-        transaction.partialEffects.append("created Notion EVENT \(created.id)")
-        try await transactions.save(transaction)
-        fieldsWritten.append(contentsOf: Self.semanticFieldNames)
-        return created
     }
 
     private func resolveOrCreateCalendar(
         request: RegistryFirstTimeInstanceRequest,
+        record: TimeInstanceRecord,
         transaction: inout CalendarRegistryTransaction,
         fieldsWritten: inout [String]
     ) async throws -> ExternalCalendarItem {
+        let priorEvidence = [
+            transaction.calendarEventId, transaction.providerExternalId,
+            record.calendarEventId, record.providerExternalId
+        ].contains { $0?.isEmpty == false }
         let query = CalendarRecoveryQuery(
-            localEventId: transaction.calendarEventId,
-            providerExternalId: transaction.providerExternalId,
+            localEventId: transaction.calendarEventId ?? record.calendarEventId,
+            providerExternalId: transaction.providerExternalId ?? record.providerExternalId,
             syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
             calendarId: request.calendarId,
             title: request.title,
             start: request.start,
@@ -660,7 +825,7 @@ public actor CalendarRegistrySyncEngine {
             throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map(\.localEventId))
         }
         if let existing = recovered.first {
-            guard !existing.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
+            try assertCalendarMatchesManifest(existing, request: request)
             transaction.calendarEventId = existing.localEventId
             transaction.calendarId = existing.calendarId
             transaction.providerExternalId = existing.providerExternalId
@@ -669,6 +834,11 @@ public actor CalendarRegistrySyncEngine {
             transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
             try await transactions.save(transaction)
             return existing
+        }
+        if priorEvidence {
+            throw CalendarRegistrySyncError.identityConflict(
+                "prior calendar identity exists but no unique provider item could be recovered"
+            )
         }
 
         let created = try await calendar.create(ExternalCalendarDraft(
@@ -679,9 +849,10 @@ public actor CalendarRegistrySyncEngine {
             calendarId: request.calendarId,
             location: request.location,
             notes: request.notes,
-            syncKey: request.idempotencyKey
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint
         ))
-        guard !created.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
+        try assertCalendarMatchesManifest(created, request: request)
         transaction.calendarEventId = created.localEventId
         transaction.calendarId = created.calendarId
         transaction.providerExternalId = created.providerExternalId
@@ -689,7 +860,10 @@ public actor CalendarRegistrySyncEngine {
         transaction.updatedAt = clock()
         transaction.partialEffects.append("created calendar event \(created.localEventId)")
         try await transactions.save(transaction)
-        fieldsWritten.append(contentsOf: ["title", "start", "end", "timeZone", "calendarId", "location", "notes", "syncKey"])
+        fieldsWritten.append(contentsOf: [
+            "title", "start", "end", "timeZone", "calendarId", "location", "notes",
+            "syncKey", "operationFingerprint"
+        ])
         return created
     }
 
@@ -704,20 +878,12 @@ public actor CalendarRegistrySyncEngine {
         guard let item = try await calendar.item(id: calendarEventId) else {
             throw CalendarRegistrySyncError.verificationFailed("calendar item missing after write")
         }
-        guard !item.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
-        guard record.syncKey == request.idempotencyKey, item.syncKey == request.idempotencyKey else {
-            throw CalendarRegistrySyncError.verificationFailed("idempotency identity differs between surfaces")
-        }
-        guard record.title == item.title,
-              abs(record.scheduledStart.timeIntervalSince(item.start)) < 1,
-              abs(record.scheduledEnd.timeIntervalSince(item.end)) < 1
-        else {
-            throw CalendarRegistrySyncError.verificationFailed("title or scheduled range differs")
-        }
+        try assertRegistryMatchesManifest(record, request: request)
+        try assertCalendarMatchesManifest(item, request: request)
         guard record.calendarEventId == item.localEventId,
-              record.calendarId == item.calendarId
-        else {
-            throw CalendarRegistrySyncError.verificationFailed("pair identity is not persisted in Notion")
+              record.calendarId == item.calendarId,
+              record.providerExternalId == item.providerExternalId else {
+            throw CalendarRegistrySyncError.verificationFailed("pair identity is not persisted consistently")
         }
         return (
             record,
@@ -725,36 +891,110 @@ public actor CalendarRegistrySyncEngine {
             [
                 "fresh Notion read confirmed EVENT \(record.id)",
                 "provider read confirmed calendar event \(item.localEventId)",
-                "Sync Key, title, start, end, calendar ID, and event ID match"
+                "Sync Key, operation fingerprint, title, start, end, timezone, calendar ID, event ID, and event shape match the immutable manifest"
             ]
         )
     }
 
     private func validate(_ request: RegistryFirstTimeInstanceRequest) throws {
-        guard !request.idempotencyKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw CalendarRegistrySyncError.missingIdempotencyKey
+        let pattern = #"^[A-Za-z0-9._:-]{1,128}$"#
+        guard request.idempotencyKey.range(of: pattern, options: .regularExpression) != nil else {
+            throw CalendarRegistrySyncError.invalidIdempotencyKey
         }
         guard request.end > request.start else { throw CalendarRegistrySyncError.invalidTimeRange }
+        guard TimeZone(identifier: request.timeZoneIdentifier) != nil else {
+            throw CalendarRegistrySyncError.invalidTimeZone(request.timeZoneIdentifier)
+        }
+        guard !request.calendarId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CalendarRegistrySyncError.missingCalendarId
+        }
         guard !request.semantics.primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw CalendarRegistrySyncError.missingPrimaryBlock
         }
+        if let notes = request.notes,
+           notes.contains(CalendarRegistryCalendarMetadata.beginMarker) ||
+           notes.contains(CalendarRegistryCalendarMetadata.endMarker) {
+            throw CalendarRegistrySyncError.identityConflict("caller notes contain reserved Bridge metadata markers")
+        }
     }
 
-    private func apply(_ item: ExternalCalendarItem, to record: inout TimeInstanceRecord) {
+    private func assertRegistryMatchesManifest(
+        _ record: TimeInstanceRecord,
+        request: RegistryFirstTimeInstanceRequest
+    ) throws {
+        let fingerprint = request.manifest.fingerprint
+        guard record.syncKey == request.idempotencyKey else {
+            throw CalendarRegistrySyncError.identityConflict("Notion Sync Key differs")
+        }
+        guard !record.operationFingerprint.isEmpty,
+              record.operationFingerprint == fingerprint else {
+            throw CalendarRegistrySyncError.identityConflict("Notion operation fingerprint differs or is missing")
+        }
+        guard record.title == request.title,
+              abs(record.scheduledStart.timeIntervalSince(request.start)) < 1,
+              abs(record.scheduledEnd.timeIntervalSince(request.end)) < 1,
+              record.timeZoneIdentifier == request.timeZoneIdentifier,
+              record.location == request.location,
+              record.notes == request.notes,
+              record.semantics == request.semantics else {
+            throw CalendarRegistrySyncError.identityConflict("Notion semantic state differs from the immutable manifest")
+        }
+        if let calendarId = record.calendarId, calendarId != request.calendarId {
+            throw CalendarRegistrySyncError.identityConflict("Notion calendar ID differs from the immutable manifest")
+        }
+    }
+
+    private func assertCalendarMatchesManifest(
+        _ item: ExternalCalendarItem,
+        request: RegistryFirstTimeInstanceRequest
+    ) throws {
+        if item.isRecurring { throw CalendarRegistrySyncError.recurringEventUnsupported }
+        if item.isAllDay { throw CalendarRegistrySyncError.allDayEventUnsupported }
+        if item.isDetached { throw CalendarRegistrySyncError.detachedEventUnsupported }
+        if item.organizer != nil || !item.attendees.isEmpty {
+            throw CalendarRegistrySyncError.participantConsequencesUnsupported
+        }
+        guard item.syncKey == request.idempotencyKey,
+              item.operationFingerprint == request.manifest.fingerprint else {
+            throw CalendarRegistrySyncError.identityConflict("calendar metadata identity differs or is missing")
+        }
+        guard item.title == request.title,
+              abs(item.start.timeIntervalSince(request.start)) < 1,
+              abs(item.end.timeIntervalSince(request.end)) < 1,
+              item.timeZoneIdentifier == request.timeZoneIdentifier,
+              item.calendarId == request.calendarId,
+              item.location == request.location,
+              item.notes == request.notes else {
+            throw CalendarRegistrySyncError.identityConflict("calendar state differs from the immutable manifest")
+        }
+    }
+
+    private func applyIdentity(_ item: ExternalCalendarItem, to record: inout TimeInstanceRecord) {
         record.calendarProvider = item.provider
         record.calendarId = item.calendarId
         record.calendarEventId = item.localEventId
         record.providerExternalId = item.providerExternalId
         record.calendarItemURL = item.itemURL
-        record.scheduledStart = item.start
-        record.scheduledEnd = item.end
-        record.timeZoneIdentifier = item.timeZoneIdentifier
         record.calendarUpdatedAt = item.updatedAt
+    }
+
+    private static func isConflict(_ error: Error) -> Bool {
+        if let sync = error as? CalendarRegistrySyncError {
+            switch sync {
+            case .ambiguousRegistryIdentity, .undecodableRegistryIdentity,
+                 .ambiguousCalendarIdentity, .identityConflict:
+                return true
+            default:
+                return false
+            }
+        }
+        if case CalendarRegistryTransactionStoreError.idempotencyConflict = error { return true }
+        return false
     }
 
     private static func syncFingerprint(record: TimeInstanceRecord, item: ExternalCalendarItem) -> String {
         let canonical = [
-            record.syncKey, item.calendarId, item.localEventId,
+            record.syncKey, record.operationFingerprint, item.calendarId, item.localEventId,
             item.providerExternalId ?? "", item.title,
             CalendarRegistryISO.string(item.start), CalendarRegistryISO.string(item.end),
             item.timeZoneIdentifier, record.semantics.primaryBlockId,
@@ -764,9 +1004,10 @@ public actor CalendarRegistrySyncEngine {
     }
 
     private static let semanticFieldNames = [
-        "title", "date", "status", "syncKey", "eventClass", "meetingType",
-        "primaryBlock", "blocks", "projects", "contacts", "schedulingAuthority",
-        "syncState", "registryUpdatedAt", "scheduledDuration", "calendarLocation", "description"
+        "title", "date", "status", "syncKey", "operationFingerprint", "eventClass",
+        "meetingType", "primaryBlock", "blocks", "projects", "contacts",
+        "schedulingAuthority", "syncState", "registryUpdatedAt", "scheduledDuration",
+        "calendarLocation", "description"
     ]
 
     private static let pairingFieldNames = [
@@ -775,71 +1016,182 @@ public actor CalendarRegistrySyncEngine {
     ]
 }
 
+// MARK: - Versioned calendar metadata
+
+public enum CalendarRegistryCalendarMetadata {
+    public static let beginMarker = "--- BRIDGE-CALENDAR-REGISTRY v1 ---"
+    public static let endMarker = "--- END BRIDGE-CALENDAR-REGISTRY ---"
+
+    public struct Identity: Sendable, Equatable {
+        public var syncKey: String
+        public var operationFingerprint: String
+
+        public init(syncKey: String, operationFingerprint: String) {
+            self.syncKey = syncKey
+            self.operationFingerprint = operationFingerprint
+        }
+    }
+
+    public static func append(to notes: String?, identity: Identity) throws -> String {
+        if let notes,
+           notes.contains(beginMarker) || notes.contains(endMarker) {
+            throw CalendarRegistrySyncError.identityConflict("notes already contain reserved Bridge metadata")
+        }
+        let block = [
+            beginMarker,
+            "Sync-Key: \(identity.syncKey)",
+            "Operation-Fingerprint: \(identity.operationFingerprint)",
+            endMarker
+        ].joined(separator: "\n")
+        guard let notes, !notes.isEmpty else { return block }
+        return notes + "\n\n" + block
+    }
+
+    public static func userNotes(from notes: String?) throws -> String? {
+        guard let notes else { return nil }
+        guard let begin = notes.range(of: beginMarker),
+              let end = notes.range(of: endMarker),
+              begin.upperBound <= end.lowerBound else {
+            if notes.contains(beginMarker) || notes.contains(endMarker) {
+                throw CalendarRegistrySyncError.identityConflict("calendar contains malformed Bridge metadata")
+            }
+            return notes.isEmpty ? nil : notes
+        }
+        _ = try parse(notes)
+        var cleaned = notes
+        let removal = begin.lowerBound..<end.upperBound
+        cleaned.removeSubrange(removal)
+        cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    public static func parse(_ notes: String?) throws -> Identity? {
+        guard let notes else { return nil }
+        let beginCount = notes.components(separatedBy: beginMarker).count - 1
+        let endCount = notes.components(separatedBy: endMarker).count - 1
+        if beginCount == 0 && endCount == 0 { return nil }
+        guard beginCount == 1, endCount == 1,
+              let begin = notes.range(of: beginMarker),
+              let end = notes.range(of: endMarker),
+              begin.upperBound <= end.lowerBound else {
+            throw CalendarRegistrySyncError.identityConflict("calendar contains malformed or duplicate Bridge metadata")
+        }
+        let body = notes[begin.upperBound..<end.lowerBound]
+        var syncKey: String?
+        var fingerprint: String?
+        for raw in body.split(whereSeparator: \.isNewline) {
+            let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("Sync-Key:") {
+                guard syncKey == nil else {
+                    throw CalendarRegistrySyncError.identityConflict("calendar contains duplicate Sync-Key metadata")
+                }
+                syncKey = String(line.dropFirst("Sync-Key:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("Operation-Fingerprint:") {
+                guard fingerprint == nil else {
+                    throw CalendarRegistrySyncError.identityConflict("calendar contains duplicate fingerprint metadata")
+                }
+                fingerprint = String(line.dropFirst("Operation-Fingerprint:".count)).trimmingCharacters(in: .whitespaces)
+            }
+        }
+        guard let syncKey, let fingerprint, !syncKey.isEmpty, fingerprint.count == 64 else {
+            throw CalendarRegistrySyncError.identityConflict("calendar Bridge metadata is incomplete")
+        }
+        return Identity(syncKey: syncKey, operationFingerprint: fingerprint)
+    }
+}
+
 // MARK: - EventKit adapter
 
 public actor CalendarStoringSyncProvider: CalendarSyncProviding {
     private let store: any CalendarStoring
     private let providerName: String
+    private let allowlistedCalendarIds: Set<String>
     private let clock: @Sendable () -> Date
-    private var cache: [String: ExternalCalendarItem] = [:]
 
     public init(
         store: any CalendarStoring,
         providerName: String = "Apple Calendar",
+        allowlistedCalendarIds: Set<String>,
         clock: @Sendable @escaping () -> Date = { Date() }
     ) {
         self.store = store
         self.providerName = providerName
+        self.allowlistedCalendarIds = allowlistedCalendarIds
         self.clock = clock
     }
 
+    public func qualify(calendarId: String) async throws -> CalendarQualification {
+        guard let info = try await store.calendars().first(where: { $0.id == calendarId }) else {
+            throw CalendarModuleError.calendarNotFound(calendarId)
+        }
+        let allowlisted = allowlistedCalendarIds.contains(calendarId)
+        let local = info.calendarType == "local" && (info.sourceType == nil || info.sourceType == "local")
+        return CalendarQualification(
+            calendarId: info.id,
+            title: info.title,
+            allowsModify: info.allowsModify,
+            explicitlyAllowlisted: allowlisted,
+            calendarType: info.calendarType,
+            sourceType: info.sourceType,
+            qualifiedForPrivateSmoke: allowlisted && info.allowsModify && local
+        )
+    }
+
     public func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
+        let qualification = try await qualify(calendarId: draft.calendarId)
+        guard qualification.qualifiedForPrivateSmoke else {
+            throw CalendarRegistrySyncError.calendarNotQualified(draft.calendarId)
+        }
+        let notes = try CalendarRegistryCalendarMetadata.append(
+            to: draft.notes,
+            identity: .init(
+                syncKey: draft.syncKey,
+                operationFingerprint: draft.operationFingerprint
+            )
+        )
         let event = try await store.create(CalendarEventDraft(
             title: draft.title,
             start: Self.iso(draft.start),
             end: Self.iso(draft.end),
+            allDay: false,
             calendarId: draft.calendarId,
             location: draft.location,
-            notes: Self.notes(draft.notes, syncKey: draft.syncKey),
+            notes: notes,
             timeZoneIdentifier: draft.timeZoneIdentifier
         ))
-        let item = try map(event)
-        cache[item.localEventId] = item
-        return item
+        return try map(event)
     }
 
     public func item(id: String) async throws -> ExternalCalendarItem? {
-        guard let event = try await store.event(id: id) else {
-            cache[id] = nil
-            return nil
-        }
-        let item = try map(event)
-        cache[id] = item
-        return item
+        guard let event = try await store.event(id: id) else { return nil }
+        return try map(event)
     }
 
     public func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
         if let id = query.localEventId, let direct = try await item(id: id) {
             return [direct]
         }
-        let lower = query.start.addingTimeInterval(-86_400)
-        let upper = query.end.addingTimeInterval(86_400)
+        let lower = query.start.addingTimeInterval(-30 * 86_400)
+        let upper = query.end.addingTimeInterval(30 * 86_400)
         let events = try await store.events(CalendarEventQuery(
-            start: Self.iso(lower), end: Self.iso(upper), calendarId: query.calendarId
+            start: Self.iso(lower), end: Self.iso(upper), calendarId: nil
         ))
         let mapped = try events.map(map)
-        let nonRecurring = mapped.filter { !$0.isRecurring }
+        let eligible = mapped.filter { !$0.isRecurring && !$0.isAllDay && !$0.isDetached }
 
-        let bySyncKey = nonRecurring.filter { $0.syncKey == query.syncKey }
-        if !bySyncKey.isEmpty { return bySyncKey }
+        let byIdentity = eligible.filter {
+            $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
+        }
+        if !byIdentity.isEmpty { return byIdentity }
 
         if let external = query.providerExternalId {
-            let byExternal = nonRecurring.filter { $0.providerExternalId == external }
+            let byExternal = eligible.filter { $0.providerExternalId == external }
             if !byExternal.isEmpty { return byExternal }
         }
 
-        return nonRecurring.filter {
-            $0.title.caseInsensitiveCompare(query.title) == .orderedSame
+        return eligible.filter {
+            $0.calendarId == query.calendarId
+                && $0.title.caseInsensitiveCompare(query.title) == .orderedSame
                 && abs($0.start.timeIntervalSince(query.start)) < 1
                 && abs($0.end.timeIntervalSince(query.end)) < 1
         }
@@ -847,23 +1199,30 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
 
     private func map(_ event: CalendarEvent) throws -> ExternalCalendarItem {
         guard let start = try? CalendarISOParsing.parse(event.start),
-              let end = try? CalendarISOParsing.parse(event.end)
-        else { throw CalendarModuleError.invalidDate("\(event.start) – \(event.end)") }
+              let end = try? CalendarISOParsing.parse(event.end) else {
+            throw CalendarModuleError.invalidDate("\(event.start) – \(event.end)")
+        }
+        let metadata = try CalendarRegistryCalendarMetadata.parse(event.notes)
         return ExternalCalendarItem(
             provider: providerName,
             calendarId: event.calendarId,
             localEventId: event.id,
             providerExternalId: event.externalId,
             itemURL: event.conferenceURL,
-            syncKey: Self.syncKey(from: event.notes),
+            syncKey: metadata?.syncKey,
+            operationFingerprint: metadata?.operationFingerprint,
             title: event.title,
             start: start,
             end: end,
-            timeZoneIdentifier: TimeZone.current.identifier,
+            timeZoneIdentifier: event.timeZoneIdentifier ?? "",
             location: event.location,
-            notes: event.notes,
+            notes: try CalendarRegistryCalendarMetadata.userNotes(from: event.notes),
+            organizer: event.organizer,
+            attendees: event.attendees,
             updatedAt: event.lastModified.flatMap { try? CalendarISOParsing.parse($0) } ?? clock(),
-            isRecurring: event.isRecurring
+            isRecurring: event.isRecurring,
+            isAllDay: event.allDay,
+            isDetached: event.isDetached
         )
     }
 
@@ -871,22 +1230,6 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.string(from: date)
-    }
-
-    private static func notes(_ notes: String?, syncKey: String) -> String {
-        let marker = "Bridge Sync Key: \(syncKey)"
-        guard let notes, !notes.isEmpty else { return marker }
-        if notes.contains(marker) { return notes }
-        return notes + "\n\n" + marker
-    }
-
-    private static func syncKey(from notes: String?) -> String? {
-        guard let notes else { return nil }
-        let prefix = "Bridge Sync Key:"
-        guard let line = notes.split(whereSeparator: \.isNewline)
-            .first(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix(prefix) })
-        else { return nil }
-        return line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
@@ -917,8 +1260,9 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             "rich_text": ["equals": syncKey]
         ]
         let filter = try JSONSerialization.data(withJSONObject: filterObject)
-        var cursor: String? = nil
+        var cursor: String?
         var records: [TimeInstanceRecord] = []
+        var unresolved: [RegistryUnresolvedIdentity] = []
         repeat {
             let result = try await gateway.query(
                 dataSourceId: entity.dataSourceId,
@@ -927,23 +1271,30 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
                 pageSize: 100,
                 startCursor: cursor
             )
-            records.append(contentsOf: result.rows.compactMap { row in
-                let cached = CachedRow(
-                    entity: entity.key,
-                    pageId: row.id,
-                    title: RegistryReader.project(row, entity: entity).title,
-                    url: row.url,
-                    properties: RegistryReader.project(row, entity: entity).properties,
-                    lastEditedTime: row.lastEditedTime,
-                    writtenAt: Date(),
-                    ttlSeconds: entity.cacheTTLSeconds,
-                    callCount: 1
-                )
-                return Self.decode(cached)
-            })
+            for row in result.rows {
+                let cached = Self.cached(row, entity: entity)
+                if let record = Self.decode(cached) {
+                    records.append(record)
+                } else {
+                    let fingerprint: String?
+                    if case .object(let properties) = cached.properties {
+                        fingerprint = Self.string(properties["operationFingerprint"])
+                    } else {
+                        fingerprint = nil
+                    }
+                    unresolved.append(RegistryUnresolvedIdentity(
+                        pageId: row.id,
+                        operationFingerprint: fingerprint
+                    ))
+                }
+            }
             cursor = result.nextCursor
         } while cursor != nil
-        return RegistryIdentityLookup(records: records, source: .live)
+        return RegistryIdentityLookup(
+            records: records,
+            unresolvedIdentities: unresolved,
+            source: .live
+        )
     }
 
     public func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
@@ -952,24 +1303,31 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
     }
 
     public func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        let resolved = RegistryWriter.resolve(fields(record), entity: entity)
-        if !resolved.unknown.isEmpty {
-            throw RegistryWriter.RegistryWriteError.unknownFields(entity: entity.key, keys: resolved.unknown)
+        let all = try resolvedFields(record)
+        let identityNames = Set(["title", "syncKey", "operationFingerprint", "syncState"].compactMap {
+            entity.property($0)?.notionName
+        })
+        let identity = all.filter { identityNames.contains($0.notionName) }
+        let rest = all.filter { !identityNames.contains($0.notionName) }
+        guard identity.count == identityNames.count else {
+            throw RegistryWriter.RegistryWriteError.notFullyBound(
+                entity: entity.key,
+                unbound: ["title", "syncKey", "operationFingerprint", "syncState"]
+            )
         }
-        if !resolved.unbound.isEmpty {
-            throw RegistryWriter.RegistryWriteError.notFullyBound(entity: entity.key, unbound: resolved.unbound)
-        }
-        let titleFields = resolved.fields.filter(\.isTitle)
-        let rest = resolved.fields.filter { !$0.isTitle }
         let created = try await gateway.create(
             dataSourceId: entity.dataSourceId,
             workspace: entity.workspace,
-            fields: titleFields.isEmpty ? resolved.fields : titleFields
+            fields: identity
         )
         _ = await RegistryReader.store(created, entity: entity, into: reader.cache)
-        if !titleFields.isEmpty, !rest.isEmpty {
+        if !rest.isEmpty {
             do {
-                _ = try await gateway.update(pageId: created.id, workspace: entity.workspace, fields: rest)
+                _ = try await gateway.update(
+                    pageId: created.id,
+                    workspace: entity.workspace,
+                    fields: rest
+                )
             } catch {
                 throw PartialRegistryCreateError(pageId: created.id, message: error.localizedDescription)
             }
@@ -980,13 +1338,37 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         return fresh
     }
 
+    public func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        var repair = record
+        repair.id = id
+        _ = try await writer.update(entity: entity, pageId: id, fields: fields(repair))
+        guard let fresh = try await get(id: id, forceRefresh: true) else {
+            throw CalendarRegistrySyncError.verificationFailed("repaired Notion EVENT could not be decoded")
+        }
+        return fresh
+    }
+
     public func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
         _ = try await writer.update(entity: entity, pageId: record.id, fields: fields(record))
-        return record
+        guard let fresh = try await get(id: record.id, forceRefresh: true) else {
+            throw CalendarRegistrySyncError.verificationFailed("updated Notion EVENT could not be read back")
+        }
+        return fresh
+    }
+
+    private func resolvedFields(_ record: TimeInstanceRecord) throws -> [BoundField] {
+        let resolved = RegistryWriter.resolve(fields(record), entity: entity)
+        if !resolved.unknown.isEmpty {
+            throw RegistryWriter.RegistryWriteError.unknownFields(entity: entity.key, keys: resolved.unknown)
+        }
+        if !resolved.unbound.isEmpty {
+            throw RegistryWriter.RegistryWriteError.notFullyBound(entity: entity.key, unbound: resolved.unbound)
+        }
+        return resolved.fields
     }
 
     private func fields(_ record: TimeInstanceRecord) -> [String: Value] {
-        var out: [String: Value] = [
+        [
             "title": .string(record.title),
             "date": .object([
                 "start": .string(CalendarRegistryISO.string(record.scheduledStart)),
@@ -995,6 +1377,7 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             ]),
             "status": .string(record.lifecycleStatus),
             "syncKey": .string(record.syncKey),
+            "operationFingerprint": .string(record.operationFingerprint),
             "eventClass": .string(record.semantics.eventClass.rawValue),
             "primaryBlock": .array([.string(record.semantics.primaryBlockId)]),
             "blocks": .array(record.semantics.blockIds.map(Value.string)),
@@ -1010,26 +1393,38 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             "calendarProvider": Self.nullable(record.calendarProvider),
             "calendarId": Self.nullable(record.calendarId),
             "calendarEventId": Self.nullable(record.calendarEventId),
+            "providerExternalId": Self.nullable(record.providerExternalId),
             "calendarUrl": Self.nullable(record.calendarItemURL),
             "meetingType": Self.nullable(record.semantics.meetingType),
             "lastSyncError": Self.nullable(record.lastSyncError),
             "lastSyncedAt": Self.nullableDate(record.lastSyncedAt),
             "calendarUpdatedAt": Self.nullableDate(record.calendarUpdatedAt)
         ]
-        if entity.property("providerExternalId") != nil {
-            out["providerExternalId"] = Self.nullable(record.providerExternalId)
-        }
-        return out
+    }
+
+    private static func cached(_ row: NotionRow, entity: RegistryEntity) -> CachedRow {
+        let projected = RegistryReader.project(row, entity: entity)
+        return CachedRow(
+            entity: entity.key,
+            pageId: row.id,
+            title: projected.title,
+            url: row.url,
+            properties: projected.properties,
+            lastEditedTime: row.lastEditedTime,
+            writtenAt: Date(),
+            ttlSeconds: entity.cacheTTLSeconds,
+            callCount: 1
+        )
     }
 
     private static func decode(_ row: CachedRow) -> TimeInstanceRecord? {
         guard case .object(let properties) = row.properties,
               let range = dateRange(properties["date"]),
               let syncKey = string(properties["syncKey"]),
+              let fingerprint = string(properties["operationFingerprint"]),
               let primaryBlock = strings(properties["primaryBlock"]).first,
               let eventClassRaw = string(properties["eventClass"]),
-              let eventClass = TimeInstanceEventClass(rawValue: eventClassRaw)
-        else { return nil }
+              let eventClass = TimeInstanceEventClass(rawValue: eventClassRaw) else { return nil }
         let authority = TimeInstanceSchedulingAuthority(
             rawValue: string(properties["schedulingAuthority"]) ?? ""
         ) ?? .registry
@@ -1046,6 +1441,7 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             notes: string(properties["description"]),
             lifecycleStatus: string(properties["status"]) ?? "Propose",
             syncKey: syncKey,
+            operationFingerprint: fingerprint,
             calendarProvider: string(properties["calendarProvider"]),
             calendarId: string(properties["calendarId"]),
             calendarEventId: string(properties["calendarEventId"]),
@@ -1095,29 +1491,22 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
     }
 
     private static func dateRange(_ value: Value?) -> (start: Date, end: Date, timeZone: String)? {
-        if case .object(let object)? = value,
-           case .string(let startString)? = object["start"],
-           case .string(let endString)? = object["end"],
-           let start = CalendarRegistryISO.date(startString),
-           let end = CalendarRegistryISO.date(endString) {
-            let timeZone: String
-            if case .string(let identifier)? = object["timeZone"] { timeZone = identifier }
-            else { timeZone = TimeZone.current.identifier }
-            return (start, end, timeZone)
-        }
-        if let startString = string(value), let start = CalendarRegistryISO.date(startString) {
-            return (start, start, TimeZone.current.identifier)
-        }
-        return nil
+        guard case .object(let object)? = value,
+              case .string(let startString)? = object["start"],
+              case .string(let endString)? = object["end"],
+              case .string(let timeZone)? = object["timeZone"],
+              let start = CalendarRegistryISO.date(startString),
+              let end = CalendarRegistryISO.date(endString) else { return nil }
+        return (start, end, timeZone)
     }
 }
 
 public extension CalendarRegistrySyncEngine {
     static let requiredScheduleCanonicalFields: Set<String> = [
-        "syncKey", "calendarProvider", "calendarId", "calendarEventId",
-        "providerExternalId", "calendarUrl", "eventClass", "meetingType",
-        "primaryBlock", "schedulingAuthority", "syncState", "lastSyncedAt",
-        "registryUpdatedAt", "calendarUpdatedAt", "syncHash", "lastSyncError",
-        "scheduledDuration", "calendarLocation"
+        "syncKey", "operationFingerprint", "calendarProvider", "calendarId",
+        "calendarEventId", "providerExternalId", "calendarUrl", "eventClass",
+        "meetingType", "primaryBlock", "schedulingAuthority", "syncState",
+        "lastSyncedAt", "registryUpdatedAt", "calendarUpdatedAt", "syncHash",
+        "lastSyncError", "scheduledDuration", "calendarLocation"
     ]
 }

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -245,6 +245,7 @@ public struct TimeInstanceRecord: Sendable, Equatable {
     public var calendarUpdatedAt: Date?
     public var syncHash: String
     public var lastSyncError: String?
+    public var registryRevision: String?
 
     public init(
         id: String = "",
@@ -269,7 +270,8 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         registryUpdatedAt: Date,
         calendarUpdatedAt: Date? = nil,
         syncHash: String = "",
-        lastSyncError: String? = nil
+        lastSyncError: String? = nil,
+        registryRevision: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -294,6 +296,7 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         self.calendarUpdatedAt = calendarUpdatedAt
         self.syncHash = syncHash
         self.lastSyncError = lastSyncError
+        self.registryRevision = registryRevision
     }
 
     public var scheduledDurationMinutes: Double {
@@ -359,7 +362,7 @@ public protocol TimeInstanceRegistryStoring: Sendable {
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup
     func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead
     func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord?
-    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
+    func savePairing(_ record: TimeInstanceRecord, expectedRevision: String?) async throws -> TimeInstanceRecord
 }
 
 public protocol CalendarSyncProviding: Sendable {
@@ -439,6 +442,8 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
             notes: notes,
             eventClass: semantics.eventClass.rawValue,
             meetingType: semantics.meetingType,
+            schedulingAuthority: TimeInstanceSchedulingAuthority.registry.rawValue,
+            expectedInitialSyncState: TimeInstanceSyncState.pendingCreate.rawValue,
             primaryBlockId: semantics.primaryBlockId,
             blockIds: semantics.blockIds,
             projectIds: semantics.projectIds,
@@ -469,6 +474,11 @@ public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
     public var partialEffects: [String]
     public var recoveryAction: String?
     public var discrepancy: String?
+    public var coordinatorNamespace: String? = nil
+    public var registryIdentityCount: Int? = nil
+    public var calendarIdentityCount: Int? = nil
+    public var finalRegistryRevision: String? = nil
+    public var attemptId: String? = nil
 }
 
 public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
@@ -548,11 +558,11 @@ public actor CalendarRegistrySyncEngine {
     private let makeLeaseToken: @Sendable () -> String
     private let leaseDuration: TimeInterval
 
-    public init(
+    package init(
         registry: any TimeInstanceRegistryStoring,
         calendar: any CalendarSyncProviding,
         transactions: any CalendarRegistryTransactionStoring,
-        processLocks: any CalendarRegistryProcessLocking = InMemoryCalendarRegistryProcessLockCoordinator.shared,
+        processLocks: any CalendarRegistryProcessLocking,
         operationGate: CalendarRegistryOperationGate = .shared,
         clock: @Sendable @escaping () -> Date = { Date() },
         makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
@@ -575,6 +585,7 @@ public actor CalendarRegistrySyncEngine {
     ) async throws -> CalendarRegistrySyncReceipt {
         let request = rawRequest.canonicalized
         try validate(request)
+        let attemptId = makeOperationId()
         try await operationGate.acquire(request.idempotencyKey)
 
         let processLock: any CalendarRegistryProcessLockHandle
@@ -582,14 +593,24 @@ public actor CalendarRegistrySyncEngine {
             processLock = try processLocks.acquire(idempotencyKey: request.idempotencyKey)
         } catch let error as CalendarRegistryProcessLockError {
             await operationGate.release(request.idempotencyKey)
-            return Self.processLockFailureReceipt(request: request, error: error)
+            var receipt = Self.processLockFailureReceipt(request: request, error: error)
+            receipt.attemptId = attemptId
+            receipt.coordinatorNamespace = processLocks.coordinatorNamespace
+            return receipt
         } catch {
             await operationGate.release(request.idempotencyKey)
             throw error
         }
 
         do {
-            var receipt = try await performRegistryFirstCreate(request)
+            var receipt = try await performRegistryFirstCreate(request, attemptId: attemptId)
+            receipt.attemptId = attemptId
+            receipt.coordinatorNamespace = processLocks.coordinatorNamespace
+            receipt.finalRegistryRevision = receipt.record?.registryRevision
+            if receipt.succeeded {
+                receipt.registryIdentityCount = 1
+                receipt.calendarIdentityCount = 1
+            }
             do {
                 try processLock.release()
             } catch {
@@ -605,12 +626,16 @@ public actor CalendarRegistrySyncEngine {
             let existing = try? await transactions.get(idempotencyKey: request.idempotencyKey)
             let releaseError = Result { try processLock.release() }.failure
             await operationGate.release(request.idempotencyKey)
-            return Self.storeFailureReceipt(
+            var receipt = Self.storeFailureReceipt(
                 request: request,
                 storeError: storeError,
                 existing: existing,
                 processReleaseError: releaseError
             )
+            receipt.attemptId = attemptId
+            receipt.coordinatorNamespace = processLocks.coordinatorNamespace
+            receipt.finalRegistryRevision = receipt.record?.registryRevision
+            return receipt
         } catch {
             let releaseError = Result { try processLock.release() }.failure
             await operationGate.release(request.idempotencyKey)
@@ -624,10 +649,11 @@ public actor CalendarRegistrySyncEngine {
     }
 
     private func performRegistryFirstCreate(
-        _ request: RegistryFirstTimeInstanceRequest
+        _ request: RegistryFirstTimeInstanceRequest,
+        attemptId: String
     ) async throws -> CalendarRegistrySyncReceipt {
         let fingerprint = request.manifest.fingerprint
-        let operationId = makeOperationId()
+        let operationId = attemptId
         var transaction = try await transactions.claim(
             idempotencyKey: request.idempotencyKey,
             manifestFingerprint: fingerprint,
@@ -688,7 +714,7 @@ public actor CalendarRegistrySyncEngine {
                     succeeded: true,
                     infrastructureFault: false,
                     recoveryStatePersisted: true,
-                    registryFailureStatePersisted: true,
+                    registryFailureStatePersisted: false,
                     operationId: transaction.operationId,
                     idempotencyKey: transaction.idempotencyKey,
                     operationFingerprint: fingerprint,
@@ -773,7 +799,7 @@ public actor CalendarRegistrySyncEngine {
             pair.lastSyncError = nil
             pair.registryUpdatedAt = clock()
             try await heartbeat(&transaction)
-            pair = try await registry.save(pair)
+            pair = try await registry.savePairing(pair, expectedRevision: record?.registryRevision)
             record = pair
             registryFields.append(contentsOf: Self.pairingFieldNames)
 
@@ -797,7 +823,7 @@ public actor CalendarRegistrySyncEngine {
             verifiedRecord.lastSyncError = nil
             verifiedRecord.syncHash = expectedHash
             try await heartbeat(&transaction)
-            verifiedRecord = try await registry.save(verifiedRecord)
+            verifiedRecord = try await registry.savePairing(verifiedRecord, expectedRevision: verified.record.registryRevision)
 
             transaction.stage = .verified
             transaction.lastVerifiedAt = verifiedAt
@@ -822,7 +848,7 @@ public actor CalendarRegistrySyncEngine {
                     succeeded: true,
                     infrastructureFault: false,
                     recoveryStatePersisted: true,
-                    registryFailureStatePersisted: true,
+                    registryFailureStatePersisted: false,
                     operationId: transaction.operationId,
                     idempotencyKey: transaction.idempotencyKey,
                     operationFingerprint: fingerprint,
@@ -846,7 +872,7 @@ public actor CalendarRegistrySyncEngine {
                     succeeded: false,
                     infrastructureFault: true,
                     recoveryStatePersisted: true,
-                    registryFailureStatePersisted: true,
+                    registryFailureStatePersisted: false,
                     operationId: transaction.operationId,
                     idempotencyKey: transaction.idempotencyKey,
                     operationFingerprint: fingerprint,
@@ -889,7 +915,7 @@ public actor CalendarRegistrySyncEngine {
                     failed.syncState = targetStage == .conflict ? .conflict : .error
                     failed.lastSyncError = error.localizedDescription
                     failed.registryUpdatedAt = clock()
-                    record = try await registry.save(failed)
+                    record = try await registry.savePairing(failed, expectedRevision: failed.registryRevision)
                 } catch {
                     registryError = error
                 }
@@ -976,6 +1002,8 @@ public actor CalendarRegistrySyncEngine {
         }
         try assertRegistryMatchesManifest(direct, request: request)
         try assertRegistryMatchesManifest(queried, request: request)
+        try assertRegistryAdmissibleForPairing(direct, request: request, transaction: transaction)
+        try assertRegistryAdmissibleForPairing(queried, request: request, transaction: transaction)
 
         transaction.registryEventId = request.registryEventId
         try adoptExistingCalendarIdentity(from: direct, into: &transaction)
@@ -1140,6 +1168,35 @@ public actor CalendarRegistrySyncEngine {
               record.providerExternalId == item.providerExternalId else {
             throw CalendarRegistrySyncError.verificationFailed("authoritative pair identity is not persisted consistently")
         }
+
+        let registryLookup = try await registry.findBySyncKey(request.idempotencyKey)
+        guard registryLookup.source == .live, registryLookup.unresolvedIdentities.isEmpty else {
+            throw CalendarRegistrySyncError.verificationFailed(
+                "final registry uniqueness lookup was degraded or undecodable"
+            )
+        }
+        guard registryLookup.records.count == 1, registryLookup.records.first?.id == record.id else {
+            throw CalendarRegistrySyncError.verificationFailed(
+                "final registry uniqueness proof did not resolve exactly one supplied EVENT"
+            )
+        }
+
+        let calendarMatches = try await calendar.recover(CalendarRecoveryQuery(
+            localEventId: item.localEventId,
+            providerExternalId: item.providerExternalId,
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            calendarId: request.calendarId,
+            title: request.title,
+            start: request.start,
+            end: request.end
+        ))
+        guard calendarMatches.count == 1, calendarMatches.first?.localEventId == item.localEventId else {
+            throw CalendarRegistrySyncError.verificationFailed(
+                "final calendar uniqueness proof did not resolve exactly one paired item"
+            )
+        }
+
         let recomputedHash = Self.syncFingerprint(record: record, item: item)
         if requireSyncedEvidence {
             guard record.syncState == .synced,
@@ -1163,7 +1220,8 @@ public actor CalendarRegistrySyncEngine {
             [
                 "fresh Notion read confirmed EVENT \(record.id)",
                 "provider read confirmed calendar event \(item.localEventId)",
-                "canonical manifest and authoritative pair identity match final reads"
+                "canonical manifest and authoritative pair identity match final reads",
+                "final uniqueness proof found one Notion EVENT and one EventKit item"
             ]
         )
     }
@@ -1205,6 +1263,9 @@ public actor CalendarRegistrySyncEngine {
               record.operationFingerprint == fingerprint else {
             throw CalendarRegistrySyncError.identityConflict("Notion operation fingerprint differs or is missing")
         }
+        guard record.schedulingAuthority == .registry else {
+            throw CalendarRegistrySyncError.identityConflict("Notion Scheduling Authority is not Registry")
+        }
         guard record.title == request.title,
               abs(record.scheduledStart.timeIntervalSince(request.start)) < 1,
               abs(record.scheduledEnd.timeIntervalSince(request.end)) < 1,
@@ -1216,6 +1277,64 @@ public actor CalendarRegistrySyncEngine {
         }
         if let calendarId = record.calendarId, calendarId != request.calendarId {
             throw CalendarRegistrySyncError.identityConflict("Notion calendar ID differs from the canonical manifest")
+        }
+    }
+
+    private func assertRegistryAdmissibleForPairing(
+        _ record: TimeInstanceRecord,
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: CalendarRegistryTransaction
+    ) throws {
+        let providerPresent = record.calendarProvider?.isEmpty == false
+        let calendarIdPresent = record.calendarId?.isEmpty == false
+        let eventIdPresent = record.calendarEventId?.isEmpty == false
+        let externalPresent = record.providerExternalId?.isEmpty == false
+        let urlPresent = record.calendarItemURL?.isEmpty == false
+        let anyPairEvidence = providerPresent || calendarIdPresent || eventIdPresent || externalPresent || urlPresent
+        let completeCoreIdentity = providerPresent && calendarIdPresent && eventIdPresent
+
+        if !anyPairEvidence {
+            let resumableFailure = transaction.stage != .prepared && record.syncState == .error
+            guard record.syncState == .pendingCreate || resumableFailure else {
+                throw CalendarRegistrySyncError.identityConflict(
+                    "clean unpaired EVENT must be Pending Create; recovery Error requires an existing transaction"
+                )
+            }
+            guard record.syncHash.isEmpty, record.lastSyncedAt == nil, record.calendarUpdatedAt == nil else {
+                throw CalendarRegistrySyncError.identityConflict(
+                    "unpaired EVENT contains stale synchronization evidence"
+                )
+            }
+            return
+        }
+
+        guard completeCoreIdentity else {
+            throw CalendarRegistrySyncError.identityConflict(
+                "Notion EVENT contains a partial calendar identity"
+            )
+        }
+        guard record.calendarId == request.calendarId else {
+            throw CalendarRegistrySyncError.identityConflict(
+                "Notion EVENT is paired to a different calendar"
+            )
+        }
+        switch record.syncState {
+        case .pendingCreate, .error:
+            guard record.syncHash.isEmpty, record.lastSyncedAt == nil else {
+                throw CalendarRegistrySyncError.identityConflict(
+                    "non-Synced EVENT contains final synchronization evidence"
+                )
+            }
+        case .synced:
+            guard !record.syncHash.isEmpty, record.lastSyncedAt != nil else {
+                throw CalendarRegistrySyncError.identityConflict(
+                    "Synced EVENT is missing final synchronization evidence"
+                )
+            }
+        case .conflict, .detached:
+            throw CalendarRegistrySyncError.identityConflict(
+                "EVENT Sync State is not admissible for automatic pairing"
+            )
         }
     }
 
@@ -1553,9 +1672,11 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
     }
 
     public func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
+        var candidates: [String: ExternalCalendarItem] = [:]
         if let id = query.localEventId, let direct = try await item(id: id) {
-            return [direct]
+            candidates[direct.localEventId] = direct
         }
+
         let lower = query.start.addingTimeInterval(-30 * 86_400)
         let upper = query.end.addingTimeInterval(30 * 86_400)
         let events = try await store.events(CalendarEventQuery(
@@ -1575,23 +1696,19 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
             }
         }
 
-        let byIdentity = mapped.filter {
-            $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
+        for item in mapped {
+            let identityMatch = item.syncKey == query.syncKey
+                && item.operationFingerprint == query.operationFingerprint
+            let externalMatch = query.providerExternalId.map { item.providerExternalId == $0 } ?? false
+            let fallbackMatch = item.calendarId == query.calendarId
+                && item.title.caseInsensitiveCompare(query.title) == .orderedSame
+                && abs(item.start.timeIntervalSince(query.start)) < 1
+                && abs(item.end.timeIntervalSince(query.end)) < 1
+            if identityMatch || externalMatch || fallbackMatch {
+                candidates[item.localEventId] = item
+            }
         }
-        if !byIdentity.isEmpty { return byIdentity }
-
-        if let external = query.providerExternalId {
-            let byExternal = mapped.filter { $0.providerExternalId == external }
-            if !byExternal.isEmpty { return byExternal }
-        }
-
-        let eligible = mapped.filter { !$0.isRecurring && !$0.isAllDay && !$0.isDetached }
-        return eligible.filter {
-            $0.calendarId == query.calendarId
-                && $0.title.caseInsensitiveCompare(query.title) == .orderedSame
-                && abs($0.start.timeIntervalSince(query.start)) < 1
-                && abs($0.end.timeIntervalSince(query.end)) < 1
-        }
+        return candidates.values.sorted { $0.localEventId < $1.localEventId }
     }
 
     private static func matchesTargetEvidence(_ event: CalendarEvent, query: CalendarRecoveryQuery) -> Bool {
@@ -1816,8 +1933,26 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         return fresh
     }
 
-    public func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        _ = try await writer.update(entity: entity, pageId: record.id, fields: fields(record))
+    public func savePairing(
+        _ record: TimeInstanceRecord,
+        expectedRevision: String?
+    ) async throws -> TimeInstanceRecord {
+        guard let expectedRevision, !expectedRevision.isEmpty else {
+            throw CalendarRegistrySyncError.identityConflict("Notion revision evidence is missing before pairing write")
+        }
+        switch try await readIdentity(id: record.id, forceRefresh: true) {
+        case .decoded(let current):
+            guard current.registryRevision == expectedRevision else {
+                throw CalendarRegistrySyncError.identityConflict("Notion EVENT changed concurrently before pairing write")
+            }
+        case .partial:
+            throw CalendarRegistrySyncError.identityConflict("Notion EVENT became partial before pairing write")
+        case .missing:
+            throw CalendarRegistrySyncError.identityConflict("Notion EVENT disappeared before pairing write")
+        case .malformed(_, let reason):
+            throw CalendarRegistrySyncError.identityConflict("Notion EVENT became malformed before pairing write: \(reason)")
+        }
+        _ = try await writer.update(entity: entity, pageId: record.id, fields: pairingFields(record))
         guard let fresh = try await get(id: record.id, forceRefresh: true) else {
             throw CalendarRegistrySyncError.verificationFailed("updated Notion EVENT could not be read back")
         }
@@ -1833,6 +1968,22 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             throw RegistryWriter.RegistryWriteError.notFullyBound(entity: entity.key, unbound: resolved.unbound)
         }
         return resolved.fields
+    }
+
+    private func pairingFields(_ record: TimeInstanceRecord) -> [String: Value] {
+        [
+            "calendarProvider": Self.nullable(record.calendarProvider),
+            "calendarId": Self.nullable(record.calendarId),
+            "calendarEventId": Self.nullable(record.calendarEventId),
+            "providerExternalId": Self.nullable(record.providerExternalId),
+            "calendarUrl": Self.nullable(record.calendarItemURL),
+            "syncState": .string(record.syncState.rawValue),
+            "registryUpdatedAt": .string(CalendarRegistryISO.string(record.registryUpdatedAt)),
+            "syncHash": .string(record.syncHash),
+            "lastSyncError": Self.nullable(record.lastSyncError),
+            "lastSyncedAt": Self.nullableDate(record.lastSyncedAt),
+            "calendarUpdatedAt": Self.nullableDate(record.calendarUpdatedAt)
+        ]
     }
 
     private func fields(_ record: TimeInstanceRecord) -> [String: Value] {
@@ -1930,7 +2081,8 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
                 ?? CalendarRegistryISO.date(row.lastEditedTime) ?? .distantPast,
             calendarUpdatedAt: date(properties["calendarUpdatedAt"]),
             syncHash: string(properties["syncHash"]) ?? "",
-            lastSyncError: string(properties["lastSyncError"])
+            lastSyncError: string(properties["lastSyncError"]),
+            registryRevision: row.lastEditedTime
         )
     }
 

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -80,7 +80,7 @@ public struct ExternalCalendarItem: Sendable, Equatable {
     public var notes: String?
     public var organizer: String?
     public var attendees: [String]
-    public var updatedAt: Date
+    public var updatedAt: Date?
     public var isRecurring: Bool
     public var isAllDay: Bool
     public var isDetached: Bool
@@ -101,7 +101,7 @@ public struct ExternalCalendarItem: Sendable, Equatable {
         notes: String? = nil,
         organizer: String? = nil,
         attendees: [String] = [],
-        updatedAt: Date,
+        updatedAt: Date? = nil,
         isRecurring: Bool = false,
         isAllDay: Bool = false,
         isDetached: Bool = false
@@ -359,8 +359,6 @@ public protocol TimeInstanceRegistryStoring: Sendable {
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup
     func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead
     func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord?
-    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
-    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord
     func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
 }
 
@@ -373,6 +371,7 @@ public protocol CalendarSyncProviding: Sendable {
 
 public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
     public var idempotencyKey: String
+    public var registryEventId: String
     public var title: String
     public var start: Date
     public var end: Date
@@ -384,6 +383,7 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
 
     public init(
         idempotencyKey: String,
+        registryEventId: String,
         title: String,
         start: Date,
         end: Date,
@@ -394,6 +394,7 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
         semantics: TimeInstanceSemantics
     ) {
         self.idempotencyKey = idempotencyKey
+        self.registryEventId = registryEventId
         self.title = title
         self.start = start
         self.end = end
@@ -408,6 +409,7 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
         let manifest = self.manifest
         return RegistryFirstTimeInstanceRequest(
             idempotencyKey: idempotencyKey,
+            registryEventId: registryEventId.trimmingCharacters(in: .whitespacesAndNewlines),
             title: manifest.title,
             start: manifest.start,
             end: manifest.end,
@@ -475,6 +477,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
     case missingPrimaryBlock
     case invalidIdempotencyKey
     case missingCalendarId
+    case missingRegistryEventId
     case calendarNotQualified(String)
     case ambiguousRegistryIdentity([String])
     case undecodableRegistryIdentity([String])
@@ -484,6 +487,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
     case allDayEventUnsupported
     case detachedEventUnsupported
     case participantConsequencesUnsupported
+    case calendarEffectUnknown(String)
     case identityConflict(String)
     case verificationFailed(String)
 
@@ -494,6 +498,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
         case .missingPrimaryBlock: return "Primary BLOCK is required"
         case .invalidIdempotencyKey: return "idempotency key must be 1–128 characters using letters, digits, period, underscore, colon, or hyphen"
         case .missingCalendarId: return "an explicit allowlisted calendar ID is required"
+        case .missingRegistryEventId: return "a pre-existing Notion EVENT page ID is required"
         case .calendarNotQualified(let reason): return "calendar is not qualified for a private smoke: \(reason)"
         case .ambiguousRegistryIdentity(let ids): return "multiple registry EVENTS matched: \(ids.joined(separator: ", "))"
         case .undecodableRegistryIdentity(let ids): return "matching registry EVENTS could not be decoded safely: \(ids.joined(separator: ", "))"
@@ -503,6 +508,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
         case .allDayEventUnsupported: return "all-day events are outside the registry-first v1 slice"
         case .detachedEventUnsupported: return "detached recurring occurrences are outside the registry-first v1 slice"
         case .participantConsequencesUnsupported: return "attendee or organizer consequences are outside the registry-first v1 slice"
+        case .calendarEffectUnknown(let reason): return "calendar create effect is unknown; recovery only: \(reason)"
         case .identityConflict(let reason): return "calendar-registry identity conflict: \(reason)"
         case .verificationFailed(let reason): return "paired verification failed: \(reason)"
         }
@@ -532,9 +538,10 @@ public enum CalendarRegistryRouteClassifier {
 }
 
 public actor CalendarRegistrySyncEngine {
-    public let registry: any TimeInstanceRegistryStoring
-    public let calendar: any CalendarSyncProviding
-    public let transactions: any CalendarRegistryTransactionStoring
+    private let registry: any TimeInstanceRegistryStoring
+    private let calendar: any CalendarSyncProviding
+    private let transactions: any CalendarRegistryTransactionStoring
+    private let processLocks: any CalendarRegistryProcessLocking
     private let operationGate: CalendarRegistryOperationGate
     private let clock: @Sendable () -> Date
     private let makeOperationId: @Sendable () -> String
@@ -545,6 +552,7 @@ public actor CalendarRegistrySyncEngine {
         registry: any TimeInstanceRegistryStoring,
         calendar: any CalendarSyncProviding,
         transactions: any CalendarRegistryTransactionStoring,
+        processLocks: any CalendarRegistryProcessLocking = InMemoryCalendarRegistryProcessLockCoordinator.shared,
         operationGate: CalendarRegistryOperationGate = .shared,
         clock: @Sendable @escaping () -> Date = { Date() },
         makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
@@ -554,6 +562,7 @@ public actor CalendarRegistrySyncEngine {
         self.registry = registry
         self.calendar = calendar
         self.transactions = transactions
+        self.processLocks = processLocks
         self.operationGate = operationGate
         self.clock = clock
         self.makeOperationId = makeOperationId
@@ -567,49 +576,49 @@ public actor CalendarRegistrySyncEngine {
         let request = rawRequest.canonicalized
         try validate(request)
         try await operationGate.acquire(request.idempotencyKey)
+
+        let processLock: any CalendarRegistryProcessLockHandle
         do {
-            let receipt = try await performRegistryFirstCreate(request)
+            processLock = try processLocks.acquire(idempotencyKey: request.idempotencyKey)
+        } catch let error as CalendarRegistryProcessLockError {
+            await operationGate.release(request.idempotencyKey)
+            return Self.processLockFailureReceipt(request: request, error: error)
+        } catch {
+            await operationGate.release(request.idempotencyKey)
+            throw error
+        }
+
+        do {
+            var receipt = try await performRegistryFirstCreate(request)
+            do {
+                try processLock.release()
+            } catch {
+                receipt.succeeded = false
+                receipt.infrastructureFault = true
+                receipt.recoveryAction = "pair state is unchanged; inspect the process lock before retrying"
+                receipt.discrepancy = [receipt.discrepancy, error.localizedDescription]
+                    .compactMap { $0 }.joined(separator: " | ")
+            }
             await operationGate.release(request.idempotencyKey)
             return receipt
         } catch let storeError as CalendarRegistryTransactionStoreError {
             let existing = try? await transactions.get(idempotencyKey: request.idempotencyKey)
+            let releaseError = Result { try processLock.release() }.failure
             await operationGate.release(request.idempotencyKey)
-            let isConflict: Bool
-            let active: Bool
-            switch storeError {
-            case .idempotencyConflict: isConflict = true; active = false
-            case .operationActive: isConflict = false; active = true
-            default: isConflict = false; active = false
-            }
-            return CalendarRegistrySyncReceipt(
-                succeeded: false,
-                infrastructureFault: !isConflict && !active,
-                recoveryStatePersisted: existing != nil,
-                registryFailureStatePersisted: false,
-                operationId: existing?.operationId ?? "",
-                idempotencyKey: request.idempotencyKey,
-                operationFingerprint: request.manifest.fingerprint,
-                fencingToken: nil,
-                ledgerRevision: existing?.revision,
-                verifiedSyncHash: nil,
-                verifiedAt: nil,
-                stageBefore: existing?.stage ?? .prepared,
-                stageAfter: isConflict ? .conflict : (existing?.stage ?? .prepared),
-                record: nil,
-                calendarItem: nil,
-                registryFieldsWritten: [],
-                calendarFieldsWritten: [],
-                verificationEvidence: [],
-                partialEffects: existing?.partialEffects ?? [],
-                recoveryAction: active
-                    ? "another fenced worker owns this operation; retry after its lease ends"
-                    : (isConflict
-                        ? "use a new idempotency key for a materially different manifest"
-                        : "inspect the SQLite recovery ledger before retrying"),
-                discrepancy: storeError.localizedDescription
+            return Self.storeFailureReceipt(
+                request: request,
+                storeError: storeError,
+                existing: existing,
+                processReleaseError: releaseError
             )
         } catch {
+            let releaseError = Result { try processLock.release() }.failure
             await operationGate.release(request.idempotencyKey)
+            if let releaseError {
+                throw CalendarRegistryProcessLockError.releaseFailure(
+                    "operation failed: \(error.localizedDescription) | lock release failed: \(releaseError.localizedDescription)"
+                )
+            }
             throw error
         }
     }
@@ -619,14 +628,14 @@ public actor CalendarRegistrySyncEngine {
     ) async throws -> CalendarRegistrySyncReceipt {
         let fingerprint = request.manifest.fingerprint
         let operationId = makeOperationId()
-        let requestedFence = makeLeaseToken()
         var transaction = try await transactions.claim(
             idempotencyKey: request.idempotencyKey,
             manifestFingerprint: fingerprint,
             operationId: operationId,
             leaseOwner: operationId,
-            leaseToken: requestedFence,
-            leaseDuration: leaseDuration
+            leaseToken: makeLeaseToken(),
+            leaseDuration: leaseDuration,
+            exclusiveProcessLockHeld: true
         )
         let stageBefore = transaction.stage
         let fencingToken = transaction.leaseToken
@@ -658,7 +667,7 @@ public actor CalendarRegistrySyncEngine {
                 calendarFieldsWritten: [],
                 verificationEvidence: [],
                 partialEffects: transaction.partialEffects,
-                recoveryAction: "resolve the recorded conflict before automatic retry",
+                recoveryAction: Self.recoveryAction(for: stageBefore, persisted: true),
                 discrepancy: transaction.lastError ?? "transaction is not automatically resumable"
             )
         }
@@ -670,17 +679,10 @@ public actor CalendarRegistrySyncEngine {
                 let final = try await verify(
                     request: request,
                     recordId: recordId,
-                    calendarEventId: calendarEventId
+                    calendarEventId: calendarEventId,
+                    requireSyncedEvidence: true,
+                    expectedSyncedAt: transaction.lastVerifiedAt
                 )
-                guard final.record.syncState == .synced,
-                      !final.record.syncHash.isEmpty,
-                      let lastSyncedAt = final.record.lastSyncedAt else {
-                    throw CalendarRegistrySyncError.verificationFailed("existing Synced pair lacks durable evidence")
-                }
-                let expectedHash = Self.syncFingerprint(record: final.record, item: final.item)
-                guard final.record.syncHash == expectedHash else {
-                    throw CalendarRegistrySyncError.verificationFailed("existing Synced pair hash differs")
-                }
                 let released = try await transactions.release(transaction)
                 return CalendarRegistrySyncReceipt(
                     succeeded: true,
@@ -692,8 +694,8 @@ public actor CalendarRegistrySyncEngine {
                     operationFingerprint: fingerprint,
                     fencingToken: fencingToken,
                     ledgerRevision: released.revision,
-                    verifiedSyncHash: expectedHash,
-                    verifiedAt: lastSyncedAt,
+                    verifiedSyncHash: final.recomputedHash,
+                    verifiedAt: final.record.lastSyncedAt,
                     stageBefore: stageBefore,
                     stageAfter: .synced,
                     record: final.record,
@@ -732,10 +734,8 @@ public actor CalendarRegistrySyncEngine {
                     calendarFieldsWritten: [],
                     verificationEvidence: [],
                     partialEffects: transaction.partialEffects,
-                    recoveryAction: releaseError == nil
-                        ? "inspect the previously Synced pair before retrying"
-                        : "do not retry until the prior lease expires or the ledger is inspected",
-                    discrepancy: [error.localizedDescription, releaseError.map { "lease release failed: \($0.localizedDescription)" }]
+                    recoveryAction: Self.recoveryAction(for: transaction.stage, persisted: true),
+                    discrepancy: [error.localizedDescription, releaseError?.localizedDescription]
                         .compactMap { $0 }.joined(separator: " | ")
                 )
             }
@@ -751,9 +751,12 @@ public actor CalendarRegistrySyncEngine {
             }
             evidence.append("qualified explicit private-smoke calendar \(qualification.calendarId)")
 
-            record = try await resolveOrCreateRegistry(
-                request: request, transaction: &transaction, fieldsWritten: &registryFields
+            record = try await resolveExistingRegistry(
+                request: request,
+                transaction: &transaction
             )
+            evidence.append("verified pre-existing canonical Notion EVENT \(record!.id)")
+
             calendarItem = try await resolveOrCreateCalendar(
                 request: request,
                 record: record!,
@@ -765,33 +768,35 @@ public actor CalendarRegistrySyncEngine {
                 throw CalendarRegistrySyncError.verificationFailed("pair resolution returned an empty surface")
             }
             try assertCalendarMatchesManifest(calendarItem, request: request)
-            applyIdentity(calendarItem, to: &pair)
+            try applyIdentity(calendarItem, to: &pair)
             pair.syncState = .pendingCreate
             pair.lastSyncError = nil
             pair.registryUpdatedAt = clock()
-            try await fence(&transaction)
+            try await heartbeat(&transaction)
             pair = try await registry.save(pair)
             record = pair
             registryFields.append(contentsOf: Self.pairingFieldNames)
 
             transaction.registryEventId = pair.id
             transaction.stage = .pairPersisted
-            transaction.partialEffects.append("pair identity persisted to Notion EVENT")
+            transaction.partialEffects.append("pair identity persisted to pre-existing Notion EVENT")
             transaction = try await transactions.save(transaction)
 
             let verified = try await verify(
-                request: request, recordId: pair.id, calendarEventId: calendarItem.localEventId
+                request: request,
+                recordId: pair.id,
+                calendarEventId: calendarItem.localEventId
             )
             evidence.append(contentsOf: verified.evidence)
             var verifiedRecord = verified.record
             let verifiedAt = clock()
-            let expectedHash = Self.syncFingerprint(record: verifiedRecord, item: verified.item)
+            let expectedHash = verified.recomputedHash
             verifiedRecord.syncState = .synced
             verifiedRecord.lastSyncedAt = verifiedAt
             verifiedRecord.registryUpdatedAt = verifiedAt
             verifiedRecord.lastSyncError = nil
             verifiedRecord.syncHash = expectedHash
-            try await fence(&transaction)
+            try await heartbeat(&transaction)
             verifiedRecord = try await registry.save(verifiedRecord)
 
             transaction.stage = .verified
@@ -803,13 +808,13 @@ public actor CalendarRegistrySyncEngine {
                 request: request,
                 recordId: verifiedRecord.id,
                 calendarEventId: verified.item.localEventId,
-                expectedSyncHash: expectedHash,
+                requireSyncedEvidence: true,
                 expectedSyncedAt: verifiedAt
             )
             transaction.stage = .synced
             transaction.lastVerifiedAt = verifiedAt
             transaction = try await transactions.save(transaction)
-            evidence.append("final fresh reads confirmed the complete manifest, pair identity, Sync Hash, and Last Synced At")
+            evidence.append("final fresh reads recomputed Sync Hash and confirmed Last Synced At")
 
             do {
                 let released = try await transactions.release(transaction)
@@ -823,10 +828,10 @@ public actor CalendarRegistrySyncEngine {
                     operationFingerprint: fingerprint,
                     fencingToken: fencingToken,
                     ledgerRevision: released.revision,
-                    verifiedSyncHash: expectedHash,
-                    verifiedAt: verifiedAt,
+                    verifiedSyncHash: final.recomputedHash,
+                    verifiedAt: final.record.lastSyncedAt,
                     stageBefore: stageBefore,
-                    stageAfter: transaction.stage,
+                    stageAfter: .synced,
                     record: final.record,
                     calendarItem: final.item,
                     registryFieldsWritten: Array(Set(registryFields)).sorted(),
@@ -847,8 +852,8 @@ public actor CalendarRegistrySyncEngine {
                     operationFingerprint: fingerprint,
                     fencingToken: fencingToken,
                     ledgerRevision: transaction.revision,
-                    verifiedSyncHash: expectedHash,
-                    verifiedAt: verifiedAt,
+                    verifiedSyncHash: final.recomputedHash,
+                    verifiedAt: final.record.lastSyncedAt,
                     stageBefore: stageBefore,
                     stageAfter: transaction.stage,
                     record: final.record,
@@ -857,16 +862,18 @@ public actor CalendarRegistrySyncEngine {
                     calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
                     verificationEvidence: evidence,
                     partialEffects: transaction.partialEffects,
-                    recoveryAction: "pair is verified Synced; wait for lease expiry or inspect the ledger before retrying",
-                    discrepancy: "pair synchronized but lease release failed: \(error.localizedDescription)"
+                    recoveryAction: "pair is verified Synced; inspect the coordinator before retrying",
+                    discrepancy: "pair synchronized but SQLite lease release failed: \(error.localizedDescription)"
                 )
             }
         } catch {
-            if let partial = error as? PartialRegistryCreateError {
-                transaction.registryEventId = partial.pageId
-                transaction.partialEffects.append("Notion identity envelope exists: \(partial.pageId)")
+            let targetStage: CalendarRegistryTransactionStage
+            if transaction.stage == .calendarCreateIntent || transaction.stage == .calendarEffectUnknown {
+                targetStage = .calendarEffectUnknown
+            } else {
+                targetStage = Self.isConflict(error) ? .conflict : .recoverableError
             }
-            transaction.stage = Self.isConflict(error) ? .conflict : .recoverableError
+            transaction.stage = targetStage
             transaction.lastError = error.localizedDescription
 
             var ledgerError: Error?
@@ -879,7 +886,7 @@ public actor CalendarRegistrySyncEngine {
                 registryFailureWriteAttempted = true
                 do {
                     transaction = try await transactions.renew(transaction, leaseDuration: leaseDuration)
-                    failed.syncState = transaction.stage == .conflict ? .conflict : .error
+                    failed.syncState = targetStage == .conflict ? .conflict : .error
                     failed.lastSyncError = error.localizedDescription
                     failed.registryUpdatedAt = clock()
                     record = try await registry.save(failed)
@@ -899,7 +906,7 @@ public actor CalendarRegistrySyncEngine {
                 error.localizedDescription,
                 ledgerError.map { "recovery ledger write failed: \($0.localizedDescription)" },
                 registryError.map { "registry failure-state write failed: \($0.localizedDescription)" },
-                releaseError.map { "lease release failed: \($0.localizedDescription)" }
+                releaseError.map { "SQLite lease release failed: \($0.localizedDescription)" }
             ].compactMap { $0 }.joined(separator: " | ")
 
             return CalendarRegistrySyncReceipt(
@@ -915,122 +922,87 @@ public actor CalendarRegistrySyncEngine {
                 verifiedSyncHash: nil,
                 verifiedAt: nil,
                 stageBefore: stageBefore,
-                stageAfter: transaction.stage,
+                stageAfter: targetStage,
                 record: record,
                 calendarItem: calendarItem,
                 registryFieldsWritten: Array(Set(registryFields)).sorted(),
                 calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
                 verificationEvidence: evidence,
                 partialEffects: transaction.partialEffects,
-                recoveryAction: persisted
-                    ? "retry with the same idempotency key after the lease is released; resume from \(transaction.stage.rawValue)"
-                    : "do not retry automatically; inspect Notion by Sync Key and Calendar by Bridge metadata before reconstructing the ledger",
+                recoveryAction: Self.recoveryAction(for: targetStage, persisted: persisted),
                 discrepancy: combined
             )
         }
     }
 
-    private func fence(_ transaction: inout CalendarRegistryTransaction) async throws {
+    private func heartbeat(_ transaction: inout CalendarRegistryTransaction) async throws {
         try Task.checkCancellation()
         transaction = try await transactions.renew(transaction, leaseDuration: leaseDuration)
         try Task.checkCancellation()
     }
 
-    private func desiredRecord(_ request: RegistryFirstTimeInstanceRequest) -> TimeInstanceRecord {
-        TimeInstanceRecord(
-            title: request.title,
-            scheduledStart: request.start,
-            scheduledEnd: request.end,
-            timeZoneIdentifier: request.timeZoneIdentifier,
-            location: request.location,
-            notes: request.notes,
-            syncKey: request.idempotencyKey,
-            operationFingerprint: request.manifest.fingerprint,
-            semantics: request.semantics,
-            schedulingAuthority: .registry,
-            syncState: .pendingCreate,
-            registryUpdatedAt: clock()
-        )
-    }
-
-    private func resolveOrCreateRegistry(
+    private func resolveExistingRegistry(
         request: RegistryFirstTimeInstanceRequest,
-        transaction: inout CalendarRegistryTransaction,
-        fieldsWritten: inout [String]
+        transaction: inout CalendarRegistryTransaction
     ) async throws -> TimeInstanceRecord {
-        let desired = desiredRecord(request)
-        if let id = transaction.registryEventId {
-            switch try await registry.readIdentity(id: id, forceRefresh: true) {
-            case .decoded(let existing):
-                try assertRegistryMatchesManifest(existing, request: request)
-                return existing
-            case .partial(_, let syncKey, let operationFingerprint):
-                guard syncKey == request.idempotencyKey,
-                      operationFingerprint == request.manifest.fingerprint else {
-                    throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page identity differs or is missing")
-                }
-                try await fence(&transaction)
-                let repaired = try await registry.repair(id: id, from: desired)
-                try assertRegistryMatchesManifest(repaired, request: request)
-                fieldsWritten.append(contentsOf: Self.semanticFieldNames)
-                return repaired
-            case .missing:
-                throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page is missing; replacement creation refused")
-            case .malformed(_, let reason):
-                throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page is malformed: \(reason)")
-            }
+        if let existingId = transaction.registryEventId, existingId != request.registryEventId {
+            throw CalendarRegistrySyncError.identityConflict("ledger registry EVENT differs from the supplied page")
+        }
+
+        let direct: TimeInstanceRecord
+        switch try await registry.readIdentity(id: request.registryEventId, forceRefresh: true) {
+        case .decoded(let record): direct = record
+        case .partial:
+            throw CalendarRegistrySyncError.identityConflict("supplied Notion EVENT is partial; automatic repair is disabled")
+        case .missing:
+            throw CalendarRegistrySyncError.identityConflict("supplied Notion EVENT is missing")
+        case .malformed(_, let reason):
+            throw CalendarRegistrySyncError.identityConflict("supplied Notion EVENT is malformed: \(reason)")
         }
 
         let lookup = try await registry.findBySyncKey(request.idempotencyKey)
         guard lookup.source == .live else { throw CalendarRegistrySyncError.degradedRegistryLookup }
-        let totalMatches = lookup.records.count + lookup.unresolvedIdentities.count
-        if totalMatches > 1 {
-            throw CalendarRegistrySyncError.ambiguousRegistryIdentity(
-                lookup.records.map(\.id) + lookup.unresolvedIdentities.map(\.pageId)
-            )
+        guard lookup.unresolvedIdentities.isEmpty else {
+            throw CalendarRegistrySyncError.undecodableRegistryIdentity(lookup.unresolvedIdentities.map(\.pageId))
         }
-        if let unresolved = lookup.unresolvedIdentities.first {
-            guard unresolved.syncKey == request.idempotencyKey,
-                  unresolved.operationFingerprint == request.manifest.fingerprint else {
-                throw CalendarRegistrySyncError.identityConflict("partial Notion EVENT identity differs or is missing")
+        guard lookup.records.count == 1, let queried = lookup.records.first else {
+            if lookup.records.count > 1 {
+                throw CalendarRegistrySyncError.ambiguousRegistryIdentity(lookup.records.map(\.id))
             }
-            try await fence(&transaction)
-            let repaired = try await registry.repair(id: unresolved.pageId, from: desired)
-            transaction.registryEventId = repaired.id
-            transaction.stage = .registryCreated
-            transaction.partialEffects.append("repaired partial Notion EVENT \(repaired.id)")
-            transaction = try await transactions.save(transaction)
-            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
-            return repaired
+            throw CalendarRegistrySyncError.identityConflict("Sync Key query did not return the supplied pre-existing EVENT")
         }
-        if let existing = lookup.records.first {
-            try assertRegistryMatchesManifest(existing, request: request)
-            transaction.registryEventId = existing.id
-            transaction.calendarEventId = existing.calendarEventId
-            transaction.calendarId = existing.calendarId
-            transaction.providerExternalId = existing.providerExternalId
-            transaction.stage = .registryCreated
-            transaction.partialEffects.append("reused existing Notion EVENT \(existing.id)")
-            transaction = try await transactions.save(transaction)
-            return existing
+        guard queried.id == request.registryEventId, direct.id == request.registryEventId else {
+            throw CalendarRegistrySyncError.identityConflict("supplied EVENT differs from the unique Sync Key result")
         }
+        try assertRegistryMatchesManifest(direct, request: request)
+        try assertRegistryMatchesManifest(queried, request: request)
 
-        do {
-            try await fence(&transaction)
-            let created = try await registry.create(desired)
-            transaction.registryEventId = created.id
-            transaction.stage = .registryCreated
-            transaction.partialEffects.append("created Notion EVENT \(created.id)")
-            transaction = try await transactions.save(transaction)
-            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
-            return created
-        } catch let partial as PartialRegistryCreateError {
-            transaction.registryEventId = partial.pageId
-            transaction.stage = .registryCreated
-            transaction.partialEffects.append("Notion identity envelope created before semantic PATCH failure: \(partial.pageId)")
-            transaction = try await transactions.save(transaction)
-            throw partial
+        transaction.registryEventId = request.registryEventId
+        try adoptExistingCalendarIdentity(from: direct, into: &transaction)
+        if transaction.stage == .prepared || transaction.stage == .recoverableError {
+            transaction.stage = .registryVerified
         }
+        if !transaction.partialEffects.contains("verified pre-existing Notion EVENT \(request.registryEventId)") {
+            transaction.partialEffects.append("verified pre-existing Notion EVENT \(request.registryEventId)")
+        }
+        transaction = try await transactions.save(transaction)
+        return direct
+    }
+
+    private func adoptExistingCalendarIdentity(
+        from record: TimeInstanceRecord,
+        into transaction: inout CalendarRegistryTransaction
+    ) throws {
+        for (name, existing, candidate) in [
+            ("calendar event id", transaction.calendarEventId, record.calendarEventId),
+            ("calendar id", transaction.calendarId, record.calendarId),
+            ("provider external id", transaction.providerExternalId, record.providerExternalId)
+        ] where existing?.isEmpty == false && candidate?.isEmpty == false && existing != candidate {
+            throw CalendarRegistrySyncError.identityConflict("ledger and Notion \(name) differ")
+        }
+        transaction.calendarEventId = transaction.calendarEventId ?? record.calendarEventId
+        transaction.calendarId = transaction.calendarId ?? record.calendarId
+        transaction.providerExternalId = transaction.providerExternalId ?? record.providerExternalId
     }
 
     private func resolveOrCreateCalendar(
@@ -1059,53 +1031,101 @@ public actor CalendarRegistrySyncEngine {
         }
         if let existing = recovered.first {
             try assertCalendarMatchesManifest(existing, request: request)
-            transaction.calendarEventId = existing.localEventId
-            transaction.calendarId = existing.calendarId
-            transaction.providerExternalId = existing.providerExternalId
+            try setCalendarIdentity(existing, on: &transaction)
             transaction.stage = .calendarCreated
-            transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
+            if !transaction.partialEffects.contains("recovered calendar event \(existing.localEventId)") {
+                transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
+            }
             transaction = try await transactions.save(transaction)
             return existing
+        }
+
+        if transaction.stage == .calendarCreateIntent || transaction.stage == .calendarEffectUnknown {
+            if transaction.stage == .calendarCreateIntent {
+                transaction.stage = .calendarEffectUnknown
+                transaction.lastError = "calendar create intent exists but recovery found no unique item"
+                transaction = try await transactions.save(transaction)
+            }
+            throw CalendarRegistrySyncError.calendarEffectUnknown(
+                "no unique EventKit item was recovered; automatic recreation is prohibited"
+            )
         }
         if priorEvidence {
             throw CalendarRegistrySyncError.identityConflict(
                 "prior calendar identity exists but no unique provider item could be recovered"
             )
         }
+        guard transaction.stage == .registryVerified else {
+            throw CalendarRegistrySyncError.identityConflict(
+                "calendar create is allowed only immediately after registry verification"
+            )
+        }
 
-        try await fence(&transaction)
-        let created = try await calendar.create(ExternalCalendarDraft(
-            title: request.title,
-            start: request.start,
-            end: request.end,
-            timeZoneIdentifier: request.timeZoneIdentifier,
-            calendarId: request.calendarId,
-            location: request.location,
-            notes: request.notes,
-            syncKey: request.idempotencyKey,
-            operationFingerprint: request.manifest.fingerprint
-        ))
-        try assertCalendarMatchesManifest(created, request: request)
-        transaction.calendarEventId = created.localEventId
-        transaction.calendarId = created.calendarId
-        transaction.providerExternalId = created.providerExternalId
-        transaction.stage = .calendarCreated
-        transaction.partialEffects.append("created calendar event \(created.localEventId)")
+        transaction.stage = .calendarCreateIntent
+        transaction.lastError = nil
+        transaction.partialEffects.append("persisted EventKit create intent")
         transaction = try await transactions.save(transaction)
-        fieldsWritten.append(contentsOf: [
-            "title", "start", "end", "timeZone", "calendarId", "location", "notes",
-            "syncKey", "operationFingerprint"
-        ])
-        return created
+        try Task.checkCancellation()
+
+        do {
+            let created = try await calendar.create(ExternalCalendarDraft(
+                title: request.title,
+                start: request.start,
+                end: request.end,
+                timeZoneIdentifier: request.timeZoneIdentifier,
+                calendarId: request.calendarId,
+                location: request.location,
+                notes: request.notes,
+                syncKey: request.idempotencyKey,
+                operationFingerprint: request.manifest.fingerprint
+            ))
+            try assertCalendarMatchesManifest(created, request: request)
+            try setCalendarIdentity(created, on: &transaction)
+            transaction.stage = .calendarCreated
+            transaction.partialEffects.append("created calendar event \(created.localEventId)")
+            transaction = try await transactions.save(transaction)
+            fieldsWritten.append(contentsOf: [
+                "title", "start", "end", "timeZone", "calendarId", "location", "notes",
+                "syncKey", "operationFingerprint"
+            ])
+            return created
+        } catch {
+            transaction.stage = .calendarEffectUnknown
+            transaction.lastError = error.localizedDescription
+            do { transaction = try await transactions.save(transaction) }
+            catch { throw error }
+            throw CalendarRegistrySyncError.calendarEffectUnknown(error.localizedDescription)
+        }
+    }
+
+    private func setCalendarIdentity(
+        _ item: ExternalCalendarItem,
+        on transaction: inout CalendarRegistryTransaction
+    ) throws {
+        for (name, existing, candidate) in [
+            ("calendar event id", transaction.calendarEventId, Optional(item.localEventId)),
+            ("calendar id", transaction.calendarId, Optional(item.calendarId)),
+            ("provider external id", transaction.providerExternalId, item.providerExternalId)
+        ] where existing?.isEmpty == false && candidate?.isEmpty == false && existing != candidate {
+            throw CalendarRegistrySyncError.identityConflict("established \(name) differs from recovered provider identity")
+        }
+        transaction.calendarEventId = transaction.calendarEventId ?? item.localEventId
+        transaction.calendarId = transaction.calendarId ?? item.calendarId
+        transaction.providerExternalId = transaction.providerExternalId ?? item.providerExternalId
     }
 
     private func verify(
         request: RegistryFirstTimeInstanceRequest,
         recordId: String,
         calendarEventId: String,
-        expectedSyncHash: String? = nil,
+        requireSyncedEvidence: Bool = false,
         expectedSyncedAt: Date? = nil
-    ) async throws -> (record: TimeInstanceRecord, item: ExternalCalendarItem, evidence: [String]) {
+    ) async throws -> (
+        record: TimeInstanceRecord,
+        item: ExternalCalendarItem,
+        recomputedHash: String,
+        evidence: [String]
+    ) {
         guard let record = try await registry.get(id: recordId, forceRefresh: true) else {
             throw CalendarRegistrySyncError.verificationFailed("Notion EVENT missing after write")
         }
@@ -1114,29 +1134,36 @@ public actor CalendarRegistrySyncEngine {
         }
         try assertRegistryMatchesManifest(record, request: request)
         try assertCalendarMatchesManifest(item, request: request)
-        guard record.calendarEventId == item.localEventId,
+        guard record.calendarProvider == item.provider,
+              record.calendarEventId == item.localEventId,
               record.calendarId == item.calendarId,
               record.providerExternalId == item.providerExternalId else {
-            throw CalendarRegistrySyncError.verificationFailed("pair identity is not persisted consistently")
+            throw CalendarRegistrySyncError.verificationFailed("authoritative pair identity is not persisted consistently")
         }
-        if let expectedSyncHash {
+        let recomputedHash = Self.syncFingerprint(record: record, item: item)
+        if requireSyncedEvidence {
             guard record.syncState == .synced,
-                  record.syncHash == expectedSyncHash,
+                  record.syncHash == recomputedHash,
                   let lastSyncedAt = record.lastSyncedAt else {
-                throw CalendarRegistrySyncError.verificationFailed("final Notion read did not retain Synced evidence")
+                throw CalendarRegistrySyncError.verificationFailed(
+                    "final Notion read did not retain recomputed Synced evidence"
+                )
             }
             if let expectedSyncedAt,
                abs(lastSyncedAt.timeIntervalSince(expectedSyncedAt)) >= 1 {
-                throw CalendarRegistrySyncError.verificationFailed("Last Synced At does not match the verification transaction")
+                throw CalendarRegistrySyncError.verificationFailed(
+                    "Last Synced At does not match the verification transaction"
+                )
             }
         }
         return (
             record,
             item,
+            recomputedHash,
             [
                 "fresh Notion read confirmed EVENT \(record.id)",
                 "provider read confirmed calendar event \(item.localEventId)",
-                "canonical manifest, pair identity, event shape, and requested evidence match"
+                "canonical manifest and authoritative pair identity match final reads"
             ]
         )
     }
@@ -1146,7 +1173,10 @@ public actor CalendarRegistrySyncEngine {
         guard request.idempotencyKey.range(of: pattern, options: .regularExpression) != nil else {
             throw CalendarRegistrySyncError.invalidIdempotencyKey
         }
-        guard !request.title.isEmpty else { throw CalendarRegistrySyncError.identityConflict("title is empty after canonicalization") }
+        guard !request.registryEventId.isEmpty else { throw CalendarRegistrySyncError.missingRegistryEventId }
+        guard !request.title.isEmpty else {
+            throw CalendarRegistrySyncError.identityConflict("title is empty after canonicalization")
+        }
         guard request.end > request.start else { throw CalendarRegistrySyncError.invalidTimeRange }
         guard TimeZone(identifier: request.timeZoneIdentifier) != nil else {
             throw CalendarRegistrySyncError.invalidTimeZone(request.timeZoneIdentifier)
@@ -1165,6 +1195,9 @@ public actor CalendarRegistrySyncEngine {
         request: RegistryFirstTimeInstanceRequest
     ) throws {
         let fingerprint = request.manifest.fingerprint
+        guard record.id == request.registryEventId else {
+            throw CalendarRegistrySyncError.identityConflict("Notion page ID differs from the supplied EVENT")
+        }
         guard record.syncKey == request.idempotencyKey else {
             throw CalendarRegistrySyncError.identityConflict("Notion Sync Key differs")
         }
@@ -1211,11 +1244,19 @@ public actor CalendarRegistrySyncEngine {
         }
     }
 
-    private func applyIdentity(_ item: ExternalCalendarItem, to record: inout TimeInstanceRecord) {
-        record.calendarProvider = item.provider
-        record.calendarId = item.calendarId
-        record.calendarEventId = item.localEventId
-        record.providerExternalId = item.providerExternalId
+    private func applyIdentity(_ item: ExternalCalendarItem, to record: inout TimeInstanceRecord) throws {
+        for (name, existing, candidate) in [
+            ("calendar provider", record.calendarProvider, Optional(item.provider)),
+            ("calendar id", record.calendarId, Optional(item.calendarId)),
+            ("calendar event id", record.calendarEventId, Optional(item.localEventId)),
+            ("provider external id", record.providerExternalId, item.providerExternalId)
+        ] where existing?.isEmpty == false && candidate?.isEmpty == false && existing != candidate {
+            throw CalendarRegistrySyncError.identityConflict("Notion \(name) is immutable once established")
+        }
+        record.calendarProvider = record.calendarProvider ?? item.provider
+        record.calendarId = record.calendarId ?? item.calendarId
+        record.calendarEventId = record.calendarEventId ?? item.localEventId
+        record.providerExternalId = record.providerExternalId ?? item.providerExternalId
         record.calendarItemURL = item.itemURL
         record.calendarUpdatedAt = item.updatedAt
     }
@@ -1243,26 +1284,120 @@ public actor CalendarRegistrySyncEngine {
             item.provider,
             item.calendarId,
             item.localEventId,
-            item.providerExternalId ?? "",
-            item.itemURL ?? "",
-            record.calendarProvider ?? "",
-            record.calendarEventId ?? "",
-            record.providerExternalId ?? ""
+            item.providerExternalId ?? ""
         ].joined(separator: "\u{1F}")
         return CalendarRegistryDigest.sha256(canonical)
     }
 
-    private static let semanticFieldNames = [
-        "title", "date", "status", "syncKey", "operationFingerprint", "eventClass",
-        "meetingType", "primaryBlock", "blocks", "projects", "contacts",
-        "schedulingAuthority", "syncState", "registryUpdatedAt", "scheduledDuration",
-        "calendarLocation", "description"
-    ]
+    private static func recoveryAction(
+        for stage: CalendarRegistryTransactionStage,
+        persisted: Bool
+    ) -> String {
+        guard persisted else {
+            return "do not retry automatically; inspect Notion, EventKit, and the local coordinator"
+        }
+        switch stage {
+        case .calendarCreateIntent, .calendarEffectUnknown:
+            return "recovery only: inspect EventKit by Bridge identity; automatic recreation is prohibited"
+        case .conflict:
+            return "resolve the recorded identity discrepancy; automatic retry is prohibited"
+        case .abandoned:
+            return "explicit operator decision is required before any further action"
+        case .recoverableError:
+            return "retry with the same idempotency key after the process lock is released"
+        case .synced:
+            return "pair is verified; inspect coordinator release state before retrying"
+        default:
+            return "retry with the same idempotency key after the process lock is released"
+        }
+    }
+
+    private static func processLockFailureReceipt(
+        request: RegistryFirstTimeInstanceRequest,
+        error: CalendarRegistryProcessLockError
+    ) -> CalendarRegistrySyncReceipt {
+        let active: Bool
+        if case .operationActive = error { active = true } else { active = false }
+        return CalendarRegistrySyncReceipt(
+            succeeded: false,
+            infrastructureFault: !active,
+            recoveryStatePersisted: false,
+            registryFailureStatePersisted: false,
+            operationId: "",
+            idempotencyKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            fencingToken: nil,
+            ledgerRevision: nil,
+            verifiedSyncHash: nil,
+            verifiedAt: nil,
+            stageBefore: .prepared,
+            stageAfter: .prepared,
+            record: nil,
+            calendarItem: nil,
+            registryFieldsWritten: [],
+            calendarFieldsWritten: [],
+            verificationEvidence: [],
+            partialEffects: [],
+            recoveryAction: active
+                ? "another process owns this operation; retry only after that process exits"
+                : "inspect the canonical process-lock directory before retrying",
+            discrepancy: error.localizedDescription
+        )
+    }
+
+    private static func storeFailureReceipt(
+        request: RegistryFirstTimeInstanceRequest,
+        storeError: CalendarRegistryTransactionStoreError,
+        existing: CalendarRegistryTransaction?,
+        processReleaseError: Error?
+    ) -> CalendarRegistrySyncReceipt {
+        let conflict: Bool
+        let active: Bool
+        switch storeError {
+        case .idempotencyConflict: conflict = true; active = false
+        case .operationActive: conflict = false; active = true
+        default: conflict = false; active = false
+        }
+        let stage = conflict ? CalendarRegistryTransactionStage.conflict : (existing?.stage ?? .prepared)
+        return CalendarRegistrySyncReceipt(
+            succeeded: false,
+            infrastructureFault: (!conflict && !active) || processReleaseError != nil,
+            recoveryStatePersisted: existing != nil,
+            registryFailureStatePersisted: false,
+            operationId: existing?.operationId ?? "",
+            idempotencyKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            fencingToken: nil,
+            ledgerRevision: existing?.revision,
+            verifiedSyncHash: nil,
+            verifiedAt: nil,
+            stageBefore: existing?.stage ?? .prepared,
+            stageAfter: stage,
+            record: nil,
+            calendarItem: nil,
+            registryFieldsWritten: [],
+            calendarFieldsWritten: [],
+            verificationEvidence: [],
+            partialEffects: existing?.partialEffects ?? [],
+            recoveryAction: active
+                ? "another SQLite owner is recorded; inspect the process lock and coordinator"
+                : recoveryAction(for: stage, persisted: existing != nil),
+            discrepancy: [storeError.localizedDescription, processReleaseError?.localizedDescription]
+                .compactMap { $0 }.joined(separator: " | ")
+        )
+    }
 
     private static let pairingFieldNames = [
         "calendarProvider", "calendarId", "calendarEventId", "providerExternalId",
         "calendarUrl", "calendarUpdatedAt", "syncState", "lastSyncError"
     ]
+}
+
+private extension Result where Success == Void, Failure == Error {
+    var failure: Error? {
+        if case .failure(let error) = self { return error }
+        return nil
+    }
 }
 
 // MARK: - Versioned calendar metadata
@@ -1359,18 +1494,15 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
     private let store: any CalendarStoring
     private let providerName: String
     private let allowlistedCalendarIds: Set<String>
-    private let clock: @Sendable () -> Date
 
     public init(
         store: any CalendarStoring,
         providerName: String = "Apple Calendar",
-        allowlistedCalendarIds: Set<String>,
-        clock: @Sendable @escaping () -> Date = { Date() }
+        allowlistedCalendarIds: Set<String>
     ) {
         self.store = store
         self.providerName = providerName
         self.allowlistedCalendarIds = allowlistedCalendarIds
-        self.clock = clock
     }
 
     public func qualify(calendarId: String) async throws -> CalendarQualification {
@@ -1465,14 +1597,43 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
     private static func matchesTargetEvidence(_ event: CalendarEvent, query: CalendarRecoveryQuery) -> Bool {
         if event.id == query.localEventId { return true }
         if let external = query.providerExternalId, event.externalId == external { return true }
-        if event.notes?.contains(query.syncKey) == true || event.notes?.contains(query.operationFingerprint) == true {
-            return true
-        }
+        if malformedMetadataClaimsTarget(event.notes, query: query) { return true }
         guard event.calendarId == query.calendarId,
               event.title.caseInsensitiveCompare(query.title) == .orderedSame,
               let start = try? CalendarISOParsing.parse(event.start),
               let end = try? CalendarISOParsing.parse(event.end) else { return false }
         return abs(start.timeIntervalSince(query.start)) < 1 && abs(end.timeIntervalSince(query.end)) < 1
+    }
+
+    private static func malformedMetadataClaimsTarget(
+        _ notes: String?,
+        query: CalendarRecoveryQuery
+    ) -> Bool {
+        guard let notes,
+              let begin = notes.range(of: CalendarRegistryCalendarMetadata.beginMarker) else {
+            return false
+        }
+        let tail = notes[begin.upperBound...]
+        let body: Substring
+        if let end = tail.range(of: CalendarRegistryCalendarMetadata.endMarker) {
+            body = tail[..<end.lowerBound]
+        } else {
+            body = tail
+        }
+        for rawLine in body.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("Sync-Key:") {
+                let value = String(line.dropFirst("Sync-Key:".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if value == query.syncKey { return true }
+            }
+            if line.hasPrefix("Operation-Fingerprint:") {
+                let value = String(line.dropFirst("Operation-Fingerprint:".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if value == query.operationFingerprint { return true }
+            }
+        }
+        return false
     }
 
     private func map(_ event: CalendarEvent) throws -> ExternalCalendarItem {
@@ -1497,7 +1658,7 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
             notes: try CalendarRegistryCalendarMetadata.userNotes(from: event.notes),
             organizer: event.organizer,
             attendees: event.attendees,
-            updatedAt: event.lastModified.flatMap { try? CalendarISOParsing.parse($0) } ?? clock(),
+            updatedAt: event.lastModified.flatMap { try? CalendarISOParsing.parse($0) },
             isRecurring: event.isRecurring,
             isAllDay: event.allDay,
             isDetached: event.isDetached

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -1,0 +1,1123 @@
+// CalendarRegistrySyncEngine.swift — disabled-by-default registry-first pairing core
+//
+// Scope is intentionally narrow: one private, non-recurring, timed EventKit
+// event paired with one Notion EVENT. Calendar-first import, recurrence,
+// destructive rollback, attendees, RSVP writes, and public MCP registration are
+// outside this implementation.
+
+import Foundation
+import MCP
+
+public enum TimeInstanceEventClass: String, Codable, Sendable, CaseIterable {
+    case focus = "FOCUS"
+    case please = "PLEASE"
+    case meeting = "Meeting"
+    case presentation = "Presentation"
+    case appointment = "Appointment"
+    case travel = "Travel"
+    case buffer = "Buffer"
+}
+
+public enum TimeInstanceSchedulingAuthority: String, Codable, Sendable {
+    case registry = "Registry"
+    case calendar = "Calendar"
+    case externalOrganizer = "External Organizer"
+}
+
+public enum TimeInstanceSyncState: String, Codable, Sendable {
+    case pendingCreate = "Pending Create"
+    case synced = "Synced"
+    case conflict = "Conflict"
+    case detached = "Detached"
+    case error = "Error"
+}
+
+public struct TimeInstanceSemantics: Codable, Sendable, Equatable {
+    public var eventClass: TimeInstanceEventClass
+    public var meetingType: String?
+    public var primaryBlockId: String
+    public var blockIds: [String]
+    public var projectIds: [String]
+    public var contactIds: [String]
+
+    public init(
+        eventClass: TimeInstanceEventClass,
+        meetingType: String? = nil,
+        primaryBlockId: String,
+        blockIds: [String] = [],
+        projectIds: [String] = [],
+        contactIds: [String] = []
+    ) {
+        self.eventClass = eventClass
+        self.meetingType = meetingType
+        self.primaryBlockId = primaryBlockId
+        self.blockIds = blockIds.isEmpty ? [primaryBlockId] : blockIds
+        self.projectIds = projectIds
+        self.contactIds = contactIds
+    }
+}
+
+public struct ExternalCalendarItem: Sendable, Equatable {
+    public var provider: String
+    public var calendarId: String
+    public var localEventId: String
+    public var providerExternalId: String?
+    public var itemURL: String?
+    public var syncKey: String?
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var timeZoneIdentifier: String
+    public var location: String?
+    public var notes: String?
+    public var updatedAt: Date
+    public var isRecurring: Bool
+
+    public init(
+        provider: String,
+        calendarId: String,
+        localEventId: String,
+        providerExternalId: String? = nil,
+        itemURL: String? = nil,
+        syncKey: String? = nil,
+        title: String,
+        start: Date,
+        end: Date,
+        timeZoneIdentifier: String = TimeZone.current.identifier,
+        location: String? = nil,
+        notes: String? = nil,
+        updatedAt: Date,
+        isRecurring: Bool = false
+    ) {
+        self.provider = provider
+        self.calendarId = calendarId
+        self.localEventId = localEventId
+        self.providerExternalId = providerExternalId
+        self.itemURL = itemURL
+        self.syncKey = syncKey
+        self.title = title
+        self.start = start
+        self.end = end
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.location = location
+        self.notes = notes
+        self.updatedAt = updatedAt
+        self.isRecurring = isRecurring
+    }
+}
+
+public struct ExternalCalendarDraft: Sendable, Equatable {
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var timeZoneIdentifier: String
+    public var calendarId: String?
+    public var location: String?
+    public var notes: String?
+    public var syncKey: String
+
+    public init(
+        title: String,
+        start: Date,
+        end: Date,
+        timeZoneIdentifier: String,
+        calendarId: String? = nil,
+        location: String? = nil,
+        notes: String? = nil,
+        syncKey: String
+    ) {
+        self.title = title
+        self.start = start
+        self.end = end
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.calendarId = calendarId
+        self.location = location
+        self.notes = notes
+        self.syncKey = syncKey
+    }
+}
+
+public struct CalendarRecoveryQuery: Sendable, Equatable {
+    public var localEventId: String?
+    public var providerExternalId: String?
+    public var syncKey: String
+    public var calendarId: String?
+    public var title: String
+    public var start: Date
+    public var end: Date
+
+    public init(
+        localEventId: String? = nil,
+        providerExternalId: String? = nil,
+        syncKey: String,
+        calendarId: String?,
+        title: String,
+        start: Date,
+        end: Date
+    ) {
+        self.localEventId = localEventId
+        self.providerExternalId = providerExternalId
+        self.syncKey = syncKey
+        self.calendarId = calendarId
+        self.title = title
+        self.start = start
+        self.end = end
+    }
+}
+
+public struct TimeInstanceRecord: Sendable, Equatable {
+    public var id: String
+    public var title: String
+    public var scheduledStart: Date
+    public var scheduledEnd: Date
+    public var timeZoneIdentifier: String
+    public var location: String?
+    public var notes: String?
+    public var lifecycleStatus: String
+    public var syncKey: String
+    public var calendarProvider: String?
+    public var calendarId: String?
+    public var calendarEventId: String?
+    public var providerExternalId: String?
+    public var calendarItemURL: String?
+    public var semantics: TimeInstanceSemantics
+    public var schedulingAuthority: TimeInstanceSchedulingAuthority
+    public var syncState: TimeInstanceSyncState
+    public var lastSyncedAt: Date?
+    public var registryUpdatedAt: Date
+    public var calendarUpdatedAt: Date?
+    public var syncHash: String
+    public var lastSyncError: String?
+
+    public init(
+        id: String = "",
+        title: String,
+        scheduledStart: Date,
+        scheduledEnd: Date,
+        timeZoneIdentifier: String,
+        location: String? = nil,
+        notes: String? = nil,
+        lifecycleStatus: String = "Propose",
+        syncKey: String,
+        calendarProvider: String? = nil,
+        calendarId: String? = nil,
+        calendarEventId: String? = nil,
+        providerExternalId: String? = nil,
+        calendarItemURL: String? = nil,
+        semantics: TimeInstanceSemantics,
+        schedulingAuthority: TimeInstanceSchedulingAuthority,
+        syncState: TimeInstanceSyncState,
+        lastSyncedAt: Date? = nil,
+        registryUpdatedAt: Date,
+        calendarUpdatedAt: Date? = nil,
+        syncHash: String = "",
+        lastSyncError: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.scheduledStart = scheduledStart
+        self.scheduledEnd = scheduledEnd
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.location = location
+        self.notes = notes
+        self.lifecycleStatus = lifecycleStatus
+        self.syncKey = syncKey
+        self.calendarProvider = calendarProvider
+        self.calendarId = calendarId
+        self.calendarEventId = calendarEventId
+        self.providerExternalId = providerExternalId
+        self.calendarItemURL = calendarItemURL
+        self.semantics = semantics
+        self.schedulingAuthority = schedulingAuthority
+        self.syncState = syncState
+        self.lastSyncedAt = lastSyncedAt
+        self.registryUpdatedAt = registryUpdatedAt
+        self.calendarUpdatedAt = calendarUpdatedAt
+        self.syncHash = syncHash
+        self.lastSyncError = lastSyncError
+    }
+
+    public var scheduledDurationMinutes: Double {
+        scheduledEnd.timeIntervalSince(scheduledStart) / 60
+    }
+}
+
+public enum RegistryLookupSource: String, Sendable, Equatable {
+    case live
+    case staleCache
+}
+
+public struct RegistryIdentityLookup: Sendable, Equatable {
+    public var records: [TimeInstanceRecord]
+    public var source: RegistryLookupSource
+
+    public init(records: [TimeInstanceRecord], source: RegistryLookupSource) {
+        self.records = records
+        self.source = source
+    }
+}
+
+public struct PartialRegistryCreateError: Error, LocalizedError, Sendable, Equatable {
+    public var pageId: String
+    public var message: String
+
+    public init(pageId: String, message: String) {
+        self.pageId = pageId
+        self.message = message
+    }
+
+    public var errorDescription: String? {
+        "Notion created EVENT \(pageId) but the follow-up property update failed: \(message)"
+    }
+}
+
+public protocol TimeInstanceRegistryStoring: Sendable {
+    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord?
+    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
+    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
+}
+
+public protocol CalendarSyncProviding: Sendable {
+    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem
+    func item(id: String) async throws -> ExternalCalendarItem?
+    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem]
+}
+
+public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
+    public var idempotencyKey: String
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var timeZoneIdentifier: String
+    public var calendarId: String?
+    public var location: String?
+    public var notes: String?
+    public var semantics: TimeInstanceSemantics
+
+    public init(
+        idempotencyKey: String,
+        title: String,
+        start: Date,
+        end: Date,
+        timeZoneIdentifier: String = TimeZone.current.identifier,
+        calendarId: String? = nil,
+        location: String? = nil,
+        notes: String? = nil,
+        semantics: TimeInstanceSemantics
+    ) {
+        self.idempotencyKey = idempotencyKey
+        self.title = title
+        self.start = start
+        self.end = end
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.calendarId = calendarId
+        self.location = location
+        self.notes = notes
+        self.semantics = semantics
+    }
+
+    public var manifest: CalendarRegistryOperationManifest {
+        CalendarRegistryOperationManifest(
+            title: title,
+            start: start,
+            end: end,
+            timeZoneIdentifier: timeZoneIdentifier,
+            calendarId: calendarId,
+            location: location,
+            notes: notes,
+            eventClass: semantics.eventClass.rawValue,
+            primaryBlockId: semantics.primaryBlockId,
+            blockIds: semantics.blockIds,
+            projectIds: semantics.projectIds,
+            contactIds: semantics.contactIds
+        )
+    }
+}
+
+public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
+    public var succeeded: Bool
+    public var operationId: String
+    public var idempotencyKey: String
+    public var stageBefore: CalendarRegistryTransactionStage
+    public var stageAfter: CalendarRegistryTransactionStage
+    public var record: TimeInstanceRecord?
+    public var calendarItem: ExternalCalendarItem?
+    public var registryFieldsWritten: [String]
+    public var calendarFieldsWritten: [String]
+    public var verificationEvidence: [String]
+    public var partialEffects: [String]
+    public var recoveryAction: String?
+    public var discrepancy: String?
+}
+
+public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
+    case invalidTimeRange
+    case missingPrimaryBlock
+    case missingIdempotencyKey
+    case ambiguousRegistryIdentity([String])
+    case ambiguousCalendarIdentity([String])
+    case degradedRegistryLookup
+    case recurringEventUnsupported
+    case verificationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidTimeRange: return "scheduled end must be after scheduled start"
+        case .missingPrimaryBlock: return "Primary BLOCK is required"
+        case .missingIdempotencyKey: return "a stable idempotency key is required"
+        case .ambiguousRegistryIdentity(let ids): return "multiple registry EVENTS matched: \(ids.joined(separator: ", "))"
+        case .ambiguousCalendarIdentity(let ids): return "multiple calendar events matched: \(ids.joined(separator: ", "))"
+        case .degradedRegistryLookup: return "registry identity lookup was not live; creation refused"
+        case .recurringEventUnsupported: return "recurring events are outside the registry-first v1 slice"
+        case .verificationFailed(let reason): return "paired verification failed: \(reason)"
+        }
+    }
+}
+
+public enum CalendarRegistryRouteOwner: String, Sendable, Equatable {
+    case timeKeepr = "time-keepr"
+    case macKeepr = "mac-keepr"
+    case notionKeepr = "notion-keepr"
+}
+
+public enum CalendarRegistryRouteIntent: Sendable, Equatable {
+    case semanticScheduling
+    case calendarMechanics
+    case schemaChange
+}
+
+public enum CalendarRegistryRouteClassifier {
+    public static func owner(for intent: CalendarRegistryRouteIntent) -> CalendarRegistryRouteOwner {
+        switch intent {
+        case .semanticScheduling: return .timeKeepr
+        case .calendarMechanics: return .macKeepr
+        case .schemaChange: return .notionKeepr
+        }
+    }
+}
+
+public actor CalendarRegistrySyncEngine {
+    public let registry: any TimeInstanceRegistryStoring
+    public let calendar: any CalendarSyncProviding
+    public let transactions: any CalendarRegistryTransactionStoring
+    private let operationGate: CalendarRegistryOperationGate
+    private let clock: @Sendable () -> Date
+    private let makeOperationId: @Sendable () -> String
+
+    public init(
+        registry: any TimeInstanceRegistryStoring,
+        calendar: any CalendarSyncProviding,
+        transactions: any CalendarRegistryTransactionStoring,
+        operationGate: CalendarRegistryOperationGate = .shared,
+        clock: @Sendable @escaping () -> Date = { Date() },
+        makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() }
+    ) {
+        self.registry = registry
+        self.calendar = calendar
+        self.transactions = transactions
+        self.operationGate = operationGate
+        self.clock = clock
+        self.makeOperationId = makeOperationId
+    }
+
+    public func registryFirstCreate(
+        _ request: RegistryFirstTimeInstanceRequest
+    ) async throws -> CalendarRegistrySyncReceipt {
+        try validate(request)
+        await operationGate.acquire(request.idempotencyKey)
+        do {
+            let receipt = try await performRegistryFirstCreate(request)
+            await operationGate.release(request.idempotencyKey)
+            return receipt
+        } catch let conflict as CalendarRegistryTransactionStoreError {
+            let existing = try? await transactions.get(idempotencyKey: request.idempotencyKey)
+            await operationGate.release(request.idempotencyKey)
+            return CalendarRegistrySyncReceipt(
+                succeeded: false,
+                operationId: existing?.operationId ?? "",
+                idempotencyKey: request.idempotencyKey,
+                stageBefore: existing?.stage ?? .prepared,
+                stageAfter: .conflict,
+                record: nil,
+                calendarItem: nil,
+                registryFieldsWritten: [],
+                calendarFieldsWritten: [],
+                verificationEvidence: [],
+                partialEffects: existing?.partialEffects ?? [],
+                recoveryAction: "use a new idempotency key for a materially different manifest",
+                discrepancy: conflict.localizedDescription
+            )
+        } catch {
+            await operationGate.release(request.idempotencyKey)
+            throw error
+        }
+    }
+
+    private func performRegistryFirstCreate(
+        _ request: RegistryFirstTimeInstanceRequest
+    ) async throws -> CalendarRegistrySyncReceipt {
+        let now = clock()
+        var transaction = try await transactions.claim(
+            idempotencyKey: request.idempotencyKey,
+            manifestFingerprint: request.manifest.fingerprint,
+            operationId: makeOperationId(),
+            now: now
+        )
+        let stageBefore = transaction.stage
+        var record: TimeInstanceRecord?
+        var calendarItem: ExternalCalendarItem?
+        var registryFields: [String] = []
+        var calendarFields: [String] = []
+        var evidence: [String] = []
+
+        do {
+            record = try await resolveOrCreateRegistry(
+                request: request, transaction: &transaction, fieldsWritten: &registryFields
+            )
+            calendarItem = try await resolveOrCreateCalendar(
+                request: request, transaction: &transaction, fieldsWritten: &calendarFields
+            )
+
+            guard var pair = record, let calendarItem else {
+                throw CalendarRegistrySyncError.verificationFailed("pair resolution returned an empty surface")
+            }
+            apply(calendarItem, to: &pair)
+            pair.syncState = .pendingCreate
+            pair.lastSyncError = nil
+            pair.registryUpdatedAt = clock()
+            pair = try await registry.save(pair)
+            record = pair
+            registryFields.append(contentsOf: Self.pairingFieldNames)
+            transaction.registryEventId = pair.id
+            transaction.stage = .pairPersisted
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("pair identity persisted to Notion EVENT")
+            try await transactions.save(transaction)
+
+            let verified = try await verify(
+                request: request, recordId: pair.id, calendarEventId: calendarItem.localEventId
+            )
+            evidence = verified.evidence
+            var verifiedRecord = verified.record
+            verifiedRecord.syncState = .synced
+            verifiedRecord.lastSyncedAt = clock()
+            verifiedRecord.registryUpdatedAt = clock()
+            verifiedRecord.lastSyncError = nil
+            verifiedRecord.syncHash = Self.syncFingerprint(record: verifiedRecord, item: verified.item)
+            verifiedRecord = try await registry.save(verifiedRecord)
+
+            transaction.stage = .verified
+            transaction.lastVerifiedAt = clock()
+            transaction.updatedAt = clock()
+            transaction.lastError = nil
+            try await transactions.save(transaction)
+
+            guard let finalRecord = try await registry.get(id: verifiedRecord.id, forceRefresh: true),
+                  finalRecord.syncState == .synced,
+                  let finalItem = try await calendar.item(id: verified.item.localEventId)
+            else {
+                throw CalendarRegistrySyncError.verificationFailed("final fresh read did not confirm Synced state")
+            }
+
+            transaction.stage = .synced
+            transaction.lastVerifiedAt = clock()
+            transaction.updatedAt = clock()
+            try await transactions.save(transaction)
+            evidence.append("final fresh reads confirm one Synced EVENT and one calendar item")
+
+            return CalendarRegistrySyncReceipt(
+                succeeded: true,
+                operationId: transaction.operationId,
+                idempotencyKey: transaction.idempotencyKey,
+                stageBefore: stageBefore,
+                stageAfter: transaction.stage,
+                record: finalRecord,
+                calendarItem: finalItem,
+                registryFieldsWritten: Array(Set(registryFields)).sorted(),
+                calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
+                verificationEvidence: evidence,
+                partialEffects: transaction.partialEffects,
+                recoveryAction: nil,
+                discrepancy: nil
+            )
+        } catch {
+            if let partial = error as? PartialRegistryCreateError {
+                transaction.registryEventId = partial.pageId
+                transaction.partialEffects.append("Notion EVENT created: \(partial.pageId)")
+            }
+            transaction.stage = error is CalendarRegistryTransactionStoreError
+                ? .conflict : .recoverableError
+            if let syncError = error as? CalendarRegistrySyncError {
+                switch syncError {
+                case .ambiguousRegistryIdentity, .ambiguousCalendarIdentity:
+                    transaction.stage = .conflict
+                default:
+                    break
+                }
+            }
+            transaction.lastError = error.localizedDescription
+            transaction.updatedAt = clock()
+            try? await transactions.save(transaction)
+
+            if var failed = record {
+                failed.syncState = transaction.stage == .conflict ? .conflict : .error
+                failed.lastSyncError = error.localizedDescription
+                failed.registryUpdatedAt = clock()
+                record = try? await registry.save(failed)
+            }
+
+            return CalendarRegistrySyncReceipt(
+                succeeded: false,
+                operationId: transaction.operationId,
+                idempotencyKey: transaction.idempotencyKey,
+                stageBefore: stageBefore,
+                stageAfter: transaction.stage,
+                record: record,
+                calendarItem: calendarItem,
+                registryFieldsWritten: Array(Set(registryFields)).sorted(),
+                calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
+                verificationEvidence: evidence,
+                partialEffects: transaction.partialEffects,
+                recoveryAction: "retry with the same idempotency key; the journal will resume from \(transaction.stage.rawValue)",
+                discrepancy: error.localizedDescription
+            )
+        }
+    }
+
+    private func resolveOrCreateRegistry(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: inout CalendarRegistryTransaction,
+        fieldsWritten: inout [String]
+    ) async throws -> TimeInstanceRecord {
+        if let id = transaction.registryEventId,
+           let existing = try await registry.get(id: id, forceRefresh: true) {
+            return existing
+        }
+
+        let lookup = try await registry.findBySyncKey(request.idempotencyKey)
+        guard lookup.source == .live else { throw CalendarRegistrySyncError.degradedRegistryLookup }
+        if lookup.records.count > 1 {
+            throw CalendarRegistrySyncError.ambiguousRegistryIdentity(lookup.records.map(\.id))
+        }
+        if let existing = lookup.records.first {
+            transaction.registryEventId = existing.id
+            transaction.stage = .registryCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("reused existing Notion EVENT \(existing.id)")
+            try await transactions.save(transaction)
+            return existing
+        }
+
+        var created = TimeInstanceRecord(
+            title: request.title,
+            scheduledStart: request.start,
+            scheduledEnd: request.end,
+            timeZoneIdentifier: request.timeZoneIdentifier,
+            location: request.location,
+            notes: request.notes,
+            syncKey: request.idempotencyKey,
+            semantics: request.semantics,
+            schedulingAuthority: .registry,
+            syncState: .pendingCreate,
+            registryUpdatedAt: clock()
+        )
+        do {
+            created = try await registry.create(created)
+        } catch let partial as PartialRegistryCreateError {
+            transaction.registryEventId = partial.pageId
+            transaction.stage = .registryCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("Notion EVENT created before follow-up PATCH failure: \(partial.pageId)")
+            try? await transactions.save(transaction)
+            throw partial
+        }
+        transaction.registryEventId = created.id
+        transaction.stage = .registryCreated
+        transaction.updatedAt = clock()
+        transaction.partialEffects.append("created Notion EVENT \(created.id)")
+        try await transactions.save(transaction)
+        fieldsWritten.append(contentsOf: Self.semanticFieldNames)
+        return created
+    }
+
+    private func resolveOrCreateCalendar(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: inout CalendarRegistryTransaction,
+        fieldsWritten: inout [String]
+    ) async throws -> ExternalCalendarItem {
+        let query = CalendarRecoveryQuery(
+            localEventId: transaction.calendarEventId,
+            providerExternalId: transaction.providerExternalId,
+            syncKey: request.idempotencyKey,
+            calendarId: request.calendarId,
+            title: request.title,
+            start: request.start,
+            end: request.end
+        )
+        let recovered = try await calendar.recover(query)
+        if recovered.count > 1 {
+            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map(\.localEventId))
+        }
+        if let existing = recovered.first {
+            guard !existing.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
+            transaction.calendarEventId = existing.localEventId
+            transaction.calendarId = existing.calendarId
+            transaction.providerExternalId = existing.providerExternalId
+            transaction.stage = .calendarCreated
+            transaction.updatedAt = clock()
+            transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
+            try await transactions.save(transaction)
+            return existing
+        }
+
+        let created = try await calendar.create(ExternalCalendarDraft(
+            title: request.title,
+            start: request.start,
+            end: request.end,
+            timeZoneIdentifier: request.timeZoneIdentifier,
+            calendarId: request.calendarId,
+            location: request.location,
+            notes: request.notes,
+            syncKey: request.idempotencyKey
+        ))
+        guard !created.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
+        transaction.calendarEventId = created.localEventId
+        transaction.calendarId = created.calendarId
+        transaction.providerExternalId = created.providerExternalId
+        transaction.stage = .calendarCreated
+        transaction.updatedAt = clock()
+        transaction.partialEffects.append("created calendar event \(created.localEventId)")
+        try await transactions.save(transaction)
+        fieldsWritten.append(contentsOf: ["title", "start", "end", "timeZone", "calendarId", "location", "notes", "syncKey"])
+        return created
+    }
+
+    private func verify(
+        request: RegistryFirstTimeInstanceRequest,
+        recordId: String,
+        calendarEventId: String
+    ) async throws -> (record: TimeInstanceRecord, item: ExternalCalendarItem, evidence: [String]) {
+        guard let record = try await registry.get(id: recordId, forceRefresh: true) else {
+            throw CalendarRegistrySyncError.verificationFailed("Notion EVENT missing after write")
+        }
+        guard let item = try await calendar.item(id: calendarEventId) else {
+            throw CalendarRegistrySyncError.verificationFailed("calendar item missing after write")
+        }
+        guard !item.isRecurring else { throw CalendarRegistrySyncError.recurringEventUnsupported }
+        guard record.syncKey == request.idempotencyKey, item.syncKey == request.idempotencyKey else {
+            throw CalendarRegistrySyncError.verificationFailed("idempotency identity differs between surfaces")
+        }
+        guard record.title == item.title,
+              abs(record.scheduledStart.timeIntervalSince(item.start)) < 1,
+              abs(record.scheduledEnd.timeIntervalSince(item.end)) < 1
+        else {
+            throw CalendarRegistrySyncError.verificationFailed("title or scheduled range differs")
+        }
+        guard record.calendarEventId == item.localEventId,
+              record.calendarId == item.calendarId
+        else {
+            throw CalendarRegistrySyncError.verificationFailed("pair identity is not persisted in Notion")
+        }
+        return (
+            record,
+            item,
+            [
+                "fresh Notion read confirmed EVENT \(record.id)",
+                "provider read confirmed calendar event \(item.localEventId)",
+                "Sync Key, title, start, end, calendar ID, and event ID match"
+            ]
+        )
+    }
+
+    private func validate(_ request: RegistryFirstTimeInstanceRequest) throws {
+        guard !request.idempotencyKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CalendarRegistrySyncError.missingIdempotencyKey
+        }
+        guard request.end > request.start else { throw CalendarRegistrySyncError.invalidTimeRange }
+        guard !request.semantics.primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CalendarRegistrySyncError.missingPrimaryBlock
+        }
+    }
+
+    private func apply(_ item: ExternalCalendarItem, to record: inout TimeInstanceRecord) {
+        record.calendarProvider = item.provider
+        record.calendarId = item.calendarId
+        record.calendarEventId = item.localEventId
+        record.providerExternalId = item.providerExternalId
+        record.calendarItemURL = item.itemURL
+        record.scheduledStart = item.start
+        record.scheduledEnd = item.end
+        record.timeZoneIdentifier = item.timeZoneIdentifier
+        record.calendarUpdatedAt = item.updatedAt
+    }
+
+    private static func syncFingerprint(record: TimeInstanceRecord, item: ExternalCalendarItem) -> String {
+        let canonical = [
+            record.syncKey, item.calendarId, item.localEventId,
+            item.providerExternalId ?? "", item.title,
+            CalendarRegistryISO.string(item.start), CalendarRegistryISO.string(item.end),
+            item.timeZoneIdentifier, record.semantics.primaryBlockId,
+            record.semantics.eventClass.rawValue
+        ].joined(separator: "\u{1F}")
+        return CalendarRegistryDigest.sha256(canonical)
+    }
+
+    private static let semanticFieldNames = [
+        "title", "date", "status", "syncKey", "eventClass", "meetingType",
+        "primaryBlock", "blocks", "projects", "contacts", "schedulingAuthority",
+        "syncState", "registryUpdatedAt", "scheduledDuration", "calendarLocation", "description"
+    ]
+
+    private static let pairingFieldNames = [
+        "calendarProvider", "calendarId", "calendarEventId", "providerExternalId",
+        "calendarUrl", "calendarUpdatedAt", "syncState", "lastSyncError"
+    ]
+}
+
+// MARK: - EventKit adapter
+
+public actor CalendarStoringSyncProvider: CalendarSyncProviding {
+    private let store: any CalendarStoring
+    private let providerName: String
+    private let clock: @Sendable () -> Date
+    private var cache: [String: ExternalCalendarItem] = [:]
+
+    public init(
+        store: any CalendarStoring,
+        providerName: String = "Apple Calendar",
+        clock: @Sendable @escaping () -> Date = { Date() }
+    ) {
+        self.store = store
+        self.providerName = providerName
+        self.clock = clock
+    }
+
+    public func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
+        let event = try await store.create(CalendarEventDraft(
+            title: draft.title,
+            start: Self.iso(draft.start),
+            end: Self.iso(draft.end),
+            calendarId: draft.calendarId,
+            location: draft.location,
+            notes: Self.notes(draft.notes, syncKey: draft.syncKey),
+            timeZoneIdentifier: draft.timeZoneIdentifier
+        ))
+        let item = try map(event)
+        cache[item.localEventId] = item
+        return item
+    }
+
+    public func item(id: String) async throws -> ExternalCalendarItem? {
+        guard let event = try await store.event(id: id) else {
+            cache[id] = nil
+            return nil
+        }
+        let item = try map(event)
+        cache[id] = item
+        return item
+    }
+
+    public func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
+        if let id = query.localEventId, let direct = try await item(id: id) {
+            return [direct]
+        }
+        let lower = query.start.addingTimeInterval(-86_400)
+        let upper = query.end.addingTimeInterval(86_400)
+        let events = try await store.events(CalendarEventQuery(
+            start: Self.iso(lower), end: Self.iso(upper), calendarId: query.calendarId
+        ))
+        let mapped = try events.map(map)
+        let nonRecurring = mapped.filter { !$0.isRecurring }
+
+        let bySyncKey = nonRecurring.filter { $0.syncKey == query.syncKey }
+        if !bySyncKey.isEmpty { return bySyncKey }
+
+        if let external = query.providerExternalId {
+            let byExternal = nonRecurring.filter { $0.providerExternalId == external }
+            if !byExternal.isEmpty { return byExternal }
+        }
+
+        return nonRecurring.filter {
+            $0.title.caseInsensitiveCompare(query.title) == .orderedSame
+                && abs($0.start.timeIntervalSince(query.start)) < 1
+                && abs($0.end.timeIntervalSince(query.end)) < 1
+        }
+    }
+
+    private func map(_ event: CalendarEvent) throws -> ExternalCalendarItem {
+        guard let start = try? CalendarISOParsing.parse(event.start),
+              let end = try? CalendarISOParsing.parse(event.end)
+        else { throw CalendarModuleError.invalidDate("\(event.start) – \(event.end)") }
+        return ExternalCalendarItem(
+            provider: providerName,
+            calendarId: event.calendarId,
+            localEventId: event.id,
+            providerExternalId: event.externalId,
+            itemURL: event.conferenceURL,
+            syncKey: Self.syncKey(from: event.notes),
+            title: event.title,
+            start: start,
+            end: end,
+            timeZoneIdentifier: TimeZone.current.identifier,
+            location: event.location,
+            notes: event.notes,
+            updatedAt: event.lastModified.flatMap { try? CalendarISOParsing.parse($0) } ?? clock(),
+            isRecurring: event.isRecurring
+        )
+    }
+
+    private static func iso(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private static func notes(_ notes: String?, syncKey: String) -> String {
+        let marker = "Bridge Sync Key: \(syncKey)"
+        guard let notes, !notes.isEmpty else { return marker }
+        if notes.contains(marker) { return notes }
+        return notes + "\n\n" + marker
+    }
+
+    private static func syncKey(from notes: String?) -> String? {
+        guard let notes else { return nil }
+        let prefix = "Bridge Sync Key:"
+        guard let line = notes.split(whereSeparator: \.isNewline)
+            .first(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix(prefix) })
+        else { return nil }
+        return line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Notion registry adapter
+
+public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
+    public let entity: RegistryEntity
+    public let gateway: any RegistryNotionGateway
+    public let reader: RegistryReader
+    public let writer: RegistryWriter
+
+    public init(entity: RegistryEntity, gateway: any RegistryNotionGateway) {
+        self.entity = entity
+        self.gateway = gateway
+        self.reader = RegistryReader(gateway: gateway)
+        self.writer = RegistryWriter(gateway: gateway)
+    }
+
+    public func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
+        guard gateway.supportsAuthoritativeFiltering else {
+            throw CalendarRegistrySyncError.degradedRegistryLookup
+        }
+        guard let property = entity.property("syncKey") else {
+            throw RegistryWriter.RegistryWriteError.unknownFields(entity: entity.key, keys: ["syncKey"])
+        }
+        let filterObject: [String: Any] = [
+            "property": property.notionPropertyId ?? property.notionName,
+            "rich_text": ["equals": syncKey]
+        ]
+        let filter = try JSONSerialization.data(withJSONObject: filterObject)
+        var cursor: String? = nil
+        var records: [TimeInstanceRecord] = []
+        repeat {
+            let result = try await gateway.query(
+                dataSourceId: entity.dataSourceId,
+                workspace: entity.workspace,
+                filter: filter,
+                pageSize: 100,
+                startCursor: cursor
+            )
+            records.append(contentsOf: result.rows.compactMap { row in
+                let cached = CachedRow(
+                    entity: entity.key,
+                    pageId: row.id,
+                    title: RegistryReader.project(row, entity: entity).title,
+                    url: row.url,
+                    properties: RegistryReader.project(row, entity: entity).properties,
+                    lastEditedTime: row.lastEditedTime,
+                    writtenAt: Date(),
+                    ttlSeconds: entity.cacheTTLSeconds,
+                    callCount: 1
+                )
+                return Self.decode(cached)
+            })
+            cursor = result.nextCursor
+        } while cursor != nil
+        return RegistryIdentityLookup(records: records, source: .live)
+    }
+
+    public func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        let row = try await reader.get(entity: entity, pageId: id, forceRefresh: forceRefresh)
+        return Self.decode(row)
+    }
+
+    public func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        let resolved = RegistryWriter.resolve(fields(record), entity: entity)
+        if !resolved.unknown.isEmpty {
+            throw RegistryWriter.RegistryWriteError.unknownFields(entity: entity.key, keys: resolved.unknown)
+        }
+        if !resolved.unbound.isEmpty {
+            throw RegistryWriter.RegistryWriteError.notFullyBound(entity: entity.key, unbound: resolved.unbound)
+        }
+        let titleFields = resolved.fields.filter(\.isTitle)
+        let rest = resolved.fields.filter { !$0.isTitle }
+        let created = try await gateway.create(
+            dataSourceId: entity.dataSourceId,
+            workspace: entity.workspace,
+            fields: titleFields.isEmpty ? resolved.fields : titleFields
+        )
+        _ = await RegistryReader.store(created, entity: entity, into: reader.cache)
+        if !titleFields.isEmpty, !rest.isEmpty {
+            do {
+                _ = try await gateway.update(pageId: created.id, workspace: entity.workspace, fields: rest)
+            } catch {
+                throw PartialRegistryCreateError(pageId: created.id, message: error.localizedDescription)
+            }
+        }
+        guard let fresh = try await get(id: created.id, forceRefresh: true) else {
+            throw CalendarRegistrySyncError.verificationFailed("created Notion EVENT could not be read back")
+        }
+        return fresh
+    }
+
+    public func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        _ = try await writer.update(entity: entity, pageId: record.id, fields: fields(record))
+        return record
+    }
+
+    private func fields(_ record: TimeInstanceRecord) -> [String: Value] {
+        var out: [String: Value] = [
+            "title": .string(record.title),
+            "date": .object([
+                "start": .string(CalendarRegistryISO.string(record.scheduledStart)),
+                "end": .string(CalendarRegistryISO.string(record.scheduledEnd)),
+                "timeZone": .string(record.timeZoneIdentifier)
+            ]),
+            "status": .string(record.lifecycleStatus),
+            "syncKey": .string(record.syncKey),
+            "eventClass": .string(record.semantics.eventClass.rawValue),
+            "primaryBlock": .array([.string(record.semantics.primaryBlockId)]),
+            "blocks": .array(record.semantics.blockIds.map(Value.string)),
+            "projects": .array(record.semantics.projectIds.map(Value.string)),
+            "contacts": .array(record.semantics.contactIds.map(Value.string)),
+            "schedulingAuthority": .string(record.schedulingAuthority.rawValue),
+            "syncState": .string(record.syncState.rawValue),
+            "registryUpdatedAt": .string(CalendarRegistryISO.string(record.registryUpdatedAt)),
+            "syncHash": .string(record.syncHash),
+            "scheduledDuration": .double(record.scheduledDurationMinutes),
+            "description": Self.nullable(record.notes),
+            "calendarLocation": Self.nullable(record.location),
+            "calendarProvider": Self.nullable(record.calendarProvider),
+            "calendarId": Self.nullable(record.calendarId),
+            "calendarEventId": Self.nullable(record.calendarEventId),
+            "calendarUrl": Self.nullable(record.calendarItemURL),
+            "meetingType": Self.nullable(record.semantics.meetingType),
+            "lastSyncError": Self.nullable(record.lastSyncError),
+            "lastSyncedAt": Self.nullableDate(record.lastSyncedAt),
+            "calendarUpdatedAt": Self.nullableDate(record.calendarUpdatedAt)
+        ]
+        if entity.property("providerExternalId") != nil {
+            out["providerExternalId"] = Self.nullable(record.providerExternalId)
+        }
+        return out
+    }
+
+    private static func decode(_ row: CachedRow) -> TimeInstanceRecord? {
+        guard case .object(let properties) = row.properties,
+              let range = dateRange(properties["date"]),
+              let syncKey = string(properties["syncKey"]),
+              let primaryBlock = strings(properties["primaryBlock"]).first,
+              let eventClassRaw = string(properties["eventClass"]),
+              let eventClass = TimeInstanceEventClass(rawValue: eventClassRaw)
+        else { return nil }
+        let authority = TimeInstanceSchedulingAuthority(
+            rawValue: string(properties["schedulingAuthority"]) ?? ""
+        ) ?? .registry
+        let state = TimeInstanceSyncState(
+            rawValue: string(properties["syncState"]) ?? ""
+        ) ?? .error
+        return TimeInstanceRecord(
+            id: row.pageId,
+            title: row.title,
+            scheduledStart: range.start,
+            scheduledEnd: range.end,
+            timeZoneIdentifier: range.timeZone,
+            location: string(properties["calendarLocation"]),
+            notes: string(properties["description"]),
+            lifecycleStatus: string(properties["status"]) ?? "Propose",
+            syncKey: syncKey,
+            calendarProvider: string(properties["calendarProvider"]),
+            calendarId: string(properties["calendarId"]),
+            calendarEventId: string(properties["calendarEventId"]),
+            providerExternalId: string(properties["providerExternalId"]),
+            calendarItemURL: string(properties["calendarUrl"]),
+            semantics: TimeInstanceSemantics(
+                eventClass: eventClass,
+                meetingType: string(properties["meetingType"]),
+                primaryBlockId: primaryBlock,
+                blockIds: strings(properties["blocks"]),
+                projectIds: strings(properties["projects"]),
+                contactIds: strings(properties["contacts"])
+            ),
+            schedulingAuthority: authority,
+            syncState: state,
+            lastSyncedAt: date(properties["lastSyncedAt"]),
+            registryUpdatedAt: date(properties["registryUpdatedAt"])
+                ?? CalendarRegistryISO.date(row.lastEditedTime) ?? .distantPast,
+            calendarUpdatedAt: date(properties["calendarUpdatedAt"]),
+            syncHash: string(properties["syncHash"]) ?? "",
+            lastSyncError: string(properties["lastSyncError"])
+        )
+    }
+
+    private static func nullable(_ value: String?) -> Value {
+        guard let value, !value.isEmpty else { return .null }
+        return .string(value)
+    }
+
+    private static func nullableDate(_ value: Date?) -> Value {
+        guard let value else { return .null }
+        return .string(CalendarRegistryISO.string(value))
+    }
+
+    private static func string(_ value: Value?) -> String? {
+        if case .string(let string)? = value, !string.isEmpty { return string }
+        return nil
+    }
+
+    private static func strings(_ value: Value?) -> [String] {
+        guard case .array(let values)? = value else { return [] }
+        return values.compactMap(string)
+    }
+
+    private static func date(_ value: Value?) -> Date? {
+        string(value).flatMap(CalendarRegistryISO.date)
+    }
+
+    private static func dateRange(_ value: Value?) -> (start: Date, end: Date, timeZone: String)? {
+        if case .object(let object)? = value,
+           case .string(let startString)? = object["start"],
+           case .string(let endString)? = object["end"],
+           let start = CalendarRegistryISO.date(startString),
+           let end = CalendarRegistryISO.date(endString) {
+            let timeZone: String
+            if case .string(let identifier)? = object["timeZone"] { timeZone = identifier }
+            else { timeZone = TimeZone.current.identifier }
+            return (start, end, timeZone)
+        }
+        if let startString = string(value), let start = CalendarRegistryISO.date(startString) {
+            return (start, start, TimeZone.current.identifier)
+        }
+        return nil
+    }
+}
+
+public extension CalendarRegistrySyncEngine {
+    static let requiredScheduleCanonicalFields: Set<String> = [
+        "syncKey", "calendarProvider", "calendarId", "calendarEventId",
+        "providerExternalId", "calendarUrl", "eventClass", "meetingType",
+        "primaryBlock", "schedulingAuthority", "syncState", "lastSyncedAt",
+        "registryUpdatedAt", "calendarUpdatedAt", "syncHash", "lastSyncError",
+        "scheduledDuration", "calendarLocation"
+    ]
+}

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -72,6 +72,7 @@ public struct ExternalCalendarItem: Sendable, Equatable {
     public var itemURL: String?
     public var syncKey: String?
     public var operationFingerprint: String?
+    public var createInvocationId: String?
     public var title: String
     public var start: Date
     public var end: Date
@@ -93,6 +94,7 @@ public struct ExternalCalendarItem: Sendable, Equatable {
         itemURL: String? = nil,
         syncKey: String? = nil,
         operationFingerprint: String? = nil,
+        createInvocationId: String? = nil,
         title: String,
         start: Date,
         end: Date,
@@ -113,6 +115,7 @@ public struct ExternalCalendarItem: Sendable, Equatable {
         self.itemURL = itemURL
         self.syncKey = syncKey
         self.operationFingerprint = operationFingerprint
+        self.createInvocationId = createInvocationId
         self.title = title
         self.start = start
         self.end = end
@@ -138,6 +141,7 @@ public struct ExternalCalendarDraft: Sendable, Equatable {
     public var notes: String?
     public var syncKey: String
     public var operationFingerprint: String
+    public var createInvocationId: String
 
     public init(
         title: String,
@@ -148,7 +152,8 @@ public struct ExternalCalendarDraft: Sendable, Equatable {
         location: String? = nil,
         notes: String? = nil,
         syncKey: String,
-        operationFingerprint: String
+        operationFingerprint: String,
+        createInvocationId: String
     ) {
         self.title = title
         self.start = start
@@ -159,6 +164,7 @@ public struct ExternalCalendarDraft: Sendable, Equatable {
         self.notes = notes
         self.syncKey = syncKey
         self.operationFingerprint = operationFingerprint
+        self.createInvocationId = createInvocationId
     }
 }
 
@@ -167,6 +173,7 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
     public var providerExternalId: String?
     public var syncKey: String
     public var operationFingerprint: String
+    public var createInvocationId: String?
     public var calendarId: String
     public var title: String
     public var start: Date
@@ -177,6 +184,7 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
         providerExternalId: String? = nil,
         syncKey: String,
         operationFingerprint: String,
+        createInvocationId: String? = nil,
         calendarId: String,
         title: String,
         start: Date,
@@ -186,6 +194,7 @@ public struct CalendarRecoveryQuery: Sendable, Equatable {
         self.providerExternalId = providerExternalId
         self.syncKey = syncKey
         self.operationFingerprint = operationFingerprint
+        self.createInvocationId = createInvocationId
         self.calendarId = calendarId
         self.title = title
         self.start = start
@@ -237,6 +246,9 @@ public struct TimeInstanceRecord: Sendable, Equatable {
     public var calendarEventId: String?
     public var providerExternalId: String?
     public var calendarItemURL: String?
+    public var createInvocationId: String?
+    public var syncWriterToken: String?
+    public var syncRevision: Int
     public var semantics: TimeInstanceSemantics
     public var schedulingAuthority: TimeInstanceSchedulingAuthority
     public var syncState: TimeInstanceSyncState
@@ -263,6 +275,9 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         calendarEventId: String? = nil,
         providerExternalId: String? = nil,
         calendarItemURL: String? = nil,
+        createInvocationId: String? = nil,
+        syncWriterToken: String? = nil,
+        syncRevision: Int = 0,
         semantics: TimeInstanceSemantics,
         schedulingAuthority: TimeInstanceSchedulingAuthority,
         syncState: TimeInstanceSyncState,
@@ -288,6 +303,9 @@ public struct TimeInstanceRecord: Sendable, Equatable {
         self.calendarEventId = calendarEventId
         self.providerExternalId = providerExternalId
         self.calendarItemURL = calendarItemURL
+        self.createInvocationId = createInvocationId
+        self.syncWriterToken = syncWriterToken
+        self.syncRevision = syncRevision
         self.semantics = semantics
         self.schedulingAuthority = schedulingAuthority
         self.syncState = syncState
@@ -344,7 +362,7 @@ public struct RegistryIdentityLookup: Sendable, Equatable {
     }
 }
 
-public struct PartialRegistryCreateError: Error, LocalizedError, Sendable, Equatable {
+package struct PartialRegistryCreateError: Error, LocalizedError, Sendable, Equatable {
     public var pageId: String
     public var message: String
 
@@ -479,6 +497,14 @@ public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
     public var calendarIdentityCount: Int? = nil
     public var finalRegistryRevision: String? = nil
     public var attemptId: String? = nil
+    public var createInvocationId: String? = nil
+    public var syncWriterToken: String? = nil
+    public var syncRevision: Int? = nil
+    public var calendarSearchScopes: [String] = []
+    public var ledgerOutcomePersisted: Bool = false
+    public var notionOutcomePersisted: Bool = false
+    public var pairIdentityPersisted: Bool = false
+    public var coordinatorReleaseSucceeded: Bool = false
 }
 
 public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
@@ -498,6 +524,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
     case detachedEventUnsupported
     case participantConsequencesUnsupported
     case calendarEffectUnknown(String)
+    case operatorReview(String)
     case identityConflict(String)
     case verificationFailed(String)
 
@@ -519,6 +546,7 @@ public enum CalendarRegistrySyncError: Error, LocalizedError, Equatable {
         case .detachedEventUnsupported: return "detached recurring occurrences are outside the registry-first v1 slice"
         case .participantConsequencesUnsupported: return "attendee or organizer consequences are outside the registry-first v1 slice"
         case .calendarEffectUnknown(let reason): return "calendar create effect is unknown; recovery only: \(reason)"
+        case .operatorReview(let reason): return "calendar-registry operator review required: \(reason)"
         case .identityConflict(let reason): return "calendar-registry identity conflict: \(reason)"
         case .verificationFailed(let reason): return "paired verification failed: \(reason)"
         }
@@ -556,6 +584,8 @@ public actor CalendarRegistrySyncEngine {
     private let clock: @Sendable () -> Date
     private let makeOperationId: @Sendable () -> String
     private let makeLeaseToken: @Sendable () -> String
+    private let makeCreateInvocationId: @Sendable () -> String
+    private let makeSyncWriterToken: @Sendable () -> String
     private let leaseDuration: TimeInterval
 
     package init(
@@ -567,6 +597,8 @@ public actor CalendarRegistrySyncEngine {
         clock: @Sendable @escaping () -> Date = { Date() },
         makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
         makeLeaseToken: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
+        makeCreateInvocationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
+        makeSyncWriterToken: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
         leaseDuration: TimeInterval = 600
     ) {
         self.registry = registry
@@ -577,6 +609,8 @@ public actor CalendarRegistrySyncEngine {
         self.clock = clock
         self.makeOperationId = makeOperationId
         self.makeLeaseToken = makeLeaseToken
+        self.makeCreateInvocationId = makeCreateInvocationId
+        self.makeSyncWriterToken = makeSyncWriterToken
         self.leaseDuration = leaseDuration
     }
 
@@ -613,6 +647,7 @@ public actor CalendarRegistrySyncEngine {
             }
             do {
                 try processLock.release()
+                receipt.coordinatorReleaseSucceeded = true
             } catch {
                 receipt.succeeded = false
                 receipt.infrastructureFault = true
@@ -653,12 +688,11 @@ public actor CalendarRegistrySyncEngine {
         attemptId: String
     ) async throws -> CalendarRegistrySyncReceipt {
         let fingerprint = request.manifest.fingerprint
-        let operationId = attemptId
         var transaction = try await transactions.claim(
             idempotencyKey: request.idempotencyKey,
             manifestFingerprint: fingerprint,
-            operationId: operationId,
-            leaseOwner: operationId,
+            operationId: attemptId,
+            leaseOwner: attemptId,
             leaseToken: makeLeaseToken(),
             leaseDuration: leaseDuration,
             exclusiveProcessLockHeld: true
@@ -670,295 +704,389 @@ public actor CalendarRegistrySyncEngine {
         var registryFields: [String] = []
         var calendarFields: [String] = []
         var evidence: [String] = []
+        var searchScopes: [String] = []
+        var notionOutcomePersisted = false
+        var pairPersisted = [.pairIdentityPersisted, .syncEvidencePersisted, .complete].contains(transaction.stage)
+        var createAuthorizedThisAttempt = false
 
-        if transaction.stage == .conflict || transaction.stage == .abandoned {
+        if [.conflict, .operatorReview, .abandoned].contains(transaction.stage) {
             let released = try await transactions.release(transaction)
-            return CalendarRegistrySyncReceipt(
-                succeeded: false,
-                infrastructureFault: false,
-                recoveryStatePersisted: true,
-                registryFailureStatePersisted: false,
-                operationId: transaction.operationId,
-                idempotencyKey: transaction.idempotencyKey,
-                operationFingerprint: fingerprint,
-                fencingToken: fencingToken,
-                ledgerRevision: released.revision,
-                verifiedSyncHash: nil,
-                verifiedAt: nil,
-                stageBefore: stageBefore,
-                stageAfter: stageBefore,
-                record: nil,
-                calendarItem: nil,
-                registryFieldsWritten: [],
-                calendarFieldsWritten: [],
-                verificationEvidence: [],
-                partialEffects: transaction.partialEffects,
-                recoveryAction: Self.recoveryAction(for: stageBefore, persisted: true),
-                discrepancy: transaction.lastError ?? "transaction is not automatically resumable"
+            return makeReceipt(
+                succeeded: false, infrastructureFault: false, ledgerPersisted: true,
+                notionPersisted: false, pairPersisted: pairPersisted,
+                transaction: released, fencingToken: fencingToken, stageBefore: stageBefore,
+                record: nil, item: nil, registryFields: [], calendarFields: [],
+                evidence: [], searchScopes: [], recoveryAction: Self.recoveryAction(for: stageBefore, persisted: true),
+                discrepancy: transaction.lastError ?? "transaction requires explicit operator resolution"
             )
-        }
-
-        if transaction.stage == .synced,
-           let recordId = transaction.registryEventId,
-           let calendarEventId = transaction.calendarEventId {
-            do {
-                let final = try await verify(
-                    request: request,
-                    recordId: recordId,
-                    calendarEventId: calendarEventId,
-                    requireSyncedEvidence: true,
-                    expectedSyncedAt: transaction.lastVerifiedAt
-                )
-                let released = try await transactions.release(transaction)
-                return CalendarRegistrySyncReceipt(
-                    succeeded: true,
-                    infrastructureFault: false,
-                    recoveryStatePersisted: true,
-                    registryFailureStatePersisted: false,
-                    operationId: transaction.operationId,
-                    idempotencyKey: transaction.idempotencyKey,
-                    operationFingerprint: fingerprint,
-                    fencingToken: fencingToken,
-                    ledgerRevision: released.revision,
-                    verifiedSyncHash: final.recomputedHash,
-                    verifiedAt: final.record.lastSyncedAt,
-                    stageBefore: stageBefore,
-                    stageAfter: .synced,
-                    record: final.record,
-                    calendarItem: final.item,
-                    registryFieldsWritten: [],
-                    calendarFieldsWritten: [],
-                    verificationEvidence: final.evidence + ["existing Synced pair was reverified without new writes"],
-                    partialEffects: transaction.partialEffects,
-                    recoveryAction: nil,
-                    discrepancy: nil
-                )
-            } catch {
-                transaction.stage = Self.isConflict(error) ? .conflict : .recoverableError
-                transaction.lastError = error.localizedDescription
-                transaction = try await transactions.save(transaction)
-                var releaseError: Error?
-                do { transaction = try await transactions.release(transaction) }
-                catch { releaseError = error }
-                return CalendarRegistrySyncReceipt(
-                    succeeded: false,
-                    infrastructureFault: releaseError != nil,
-                    recoveryStatePersisted: true,
-                    registryFailureStatePersisted: false,
-                    operationId: transaction.operationId,
-                    idempotencyKey: transaction.idempotencyKey,
-                    operationFingerprint: fingerprint,
-                    fencingToken: fencingToken,
-                    ledgerRevision: transaction.revision,
-                    verifiedSyncHash: nil,
-                    verifiedAt: nil,
-                    stageBefore: stageBefore,
-                    stageAfter: transaction.stage,
-                    record: nil,
-                    calendarItem: nil,
-                    registryFieldsWritten: [],
-                    calendarFieldsWritten: [],
-                    verificationEvidence: [],
-                    partialEffects: transaction.partialEffects,
-                    recoveryAction: Self.recoveryAction(for: transaction.stage, persisted: true),
-                    discrepancy: [error.localizedDescription, releaseError?.localizedDescription]
-                        .compactMap { $0 }.joined(separator: " | ")
-                )
-            }
         }
 
         do {
-            try Task.checkCancellation()
-            let qualification = try await calendar.qualify(calendarId: request.calendarId)
-            guard qualification.qualifiedForPrivateSmoke else {
-                throw CalendarRegistrySyncError.calendarNotQualified(
-                    "calendar must be explicitly allowlisted, writable, local, and non-subscribed"
-                )
-            }
-            evidence.append("qualified explicit private-smoke calendar \(qualification.calendarId)")
+            while true {
+                switch transaction.stage {
+                case .claimed:
+                    record = try await resolveExistingRegistry(request: request, transaction: transaction)
+                    guard record?.createInvocationId == nil else {
+                        throw CalendarRegistrySyncError.operatorReview(
+                            "Notion contains a Create Invocation ID that is absent from the claimed ledger state"
+                        )
+                    }
+                    transaction.registryEventId = request.registryEventId
+                    transaction.stage = .registryAuthorized
+                    transaction.lastError = nil
+                    transaction.partialEffects.append("strictly authorized pre-existing Notion EVENT \(request.registryEventId)")
+                    transaction = try await transactions.save(transaction)
+                    evidence.append("Notion authority and admissibility were proven before EventKit access")
 
-            record = try await resolveExistingRegistry(
-                request: request,
-                transaction: &transaction
-            )
-            evidence.append("verified pre-existing canonical Notion EVENT \(record!.id)")
+                case .registryAuthorized:
+                    record = try await requireRegistryRecord(request: request, transaction: transaction)
+                    if let notionInvocation = record?.createInvocationId {
+                        guard notionInvocation == transaction.createInvocationId else {
+                            throw CalendarRegistrySyncError.operatorReview(
+                                "Notion and SQLite disagree about the Create Invocation ID"
+                            )
+                        }
+                        transaction.stage = .createInvocationPersisted
+                        transaction = try await transactions.save(transaction)
+                        continue
+                    }
+                    let qualification = try await calendar.qualify(calendarId: request.calendarId)
+                    guard qualification.qualifiedForPrivateSmoke else {
+                        throw CalendarRegistrySyncError.calendarNotQualified(
+                            "calendar must be explicitly allowlisted, writable, local, and non-subscribed"
+                        )
+                    }
+                    evidence.append("qualified explicit private-smoke calendar \(qualification.calendarId)")
+                    guard var authorized = record else {
+                        throw CalendarRegistrySyncError.verificationFailed("authorized registry record disappeared")
+                    }
+                    let invocationId = makeCreateInvocationId()
+                    let writerToken = makeSyncWriterToken()
+                    authorized.createInvocationId = invocationId
+                    authorized.syncRevision += 1
+                    authorized.syncWriterToken = writerToken
+                    authorized.registryUpdatedAt = clock()
+                    try await heartbeat(&transaction)
+                    authorized = try await registry.savePairing(authorized, expectedRevision: authorized.registryRevision)
+                    try assertWriterEvidence(
+                        authorized, expectedInvocationId: invocationId,
+                        expectedWriterToken: writerToken, expectedSyncRevision: authorized.syncRevision
+                    )
+                    notionOutcomePersisted = true
+                    registryFields.append(contentsOf: ["createInvocationId", "syncWriterToken", "syncRevision"])
+                    record = authorized
+                    transaction.createInvocationId = invocationId
+                    transaction.syncWriterToken = writerToken
+                    transaction.syncRevision = authorized.syncRevision
+                    transaction.stage = .createInvocationPersisted
+                    transaction.partialEffects.append("persisted Create Invocation ID \(invocationId) before EventKit create")
+                    transaction = try await transactions.save(transaction)
+                    createAuthorizedThisAttempt = true
 
-            calendarItem = try await resolveOrCreateCalendar(
-                request: request,
-                record: record!,
-                transaction: &transaction,
-                fieldsWritten: &calendarFields
-            )
+                case .createInvocationPersisted, .calendarEffectUnknown:
+                    record = try await requireRegistryRecord(request: request, transaction: transaction)
+                    guard let invocationId = transaction.createInvocationId,
+                          invocationId == record?.createInvocationId else {
+                        throw CalendarRegistrySyncError.operatorReview(
+                            "Create Invocation ID is not durably consistent across Notion and SQLite"
+                        )
+                    }
+                    let query = recoveryQuery(request: request, transaction: transaction, record: record)
+                    searchScopes.append(Self.searchScopeDescription(query))
+                    let recovered = try await calendar.recover(query)
+                    if recovered.count > 1 {
+                        throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map { $0.localEventId })
+                    }
+                    if let existing = recovered.first {
+                        try assertCalendarMatchesManifest(existing, request: request, createInvocationId: invocationId)
+                        try setCalendarIdentity(existing, on: &transaction)
+                        calendarItem = existing
+                        transaction.stage = .calendarIdentified
+                        transaction.lastError = nil
+                        transaction.partialEffects.append("identified owned calendar event \(existing.localEventId)")
+                        transaction = try await transactions.save(transaction)
+                        continue
+                    }
+                    if transaction.stage == .calendarEffectUnknown || !createAuthorizedThisAttempt {
+                        throw CalendarRegistrySyncError.operatorReview(
+                            "Create Invocation ID exists but no owned EventKit candidate is recoverable; automatic recreation is prohibited"
+                        )
+                    }
+                    try Task.checkCancellation()
+                    do {
+                        let created = try await calendar.create(ExternalCalendarDraft(
+                            title: request.title,
+                            start: request.start,
+                            end: request.end,
+                            timeZoneIdentifier: request.timeZoneIdentifier,
+                            calendarId: request.calendarId,
+                            location: request.location,
+                            notes: request.notes,
+                            syncKey: request.idempotencyKey,
+                            operationFingerprint: request.manifest.fingerprint,
+                            createInvocationId: invocationId
+                        ))
+                        try assertCalendarMatchesManifest(created, request: request, createInvocationId: invocationId)
+                        try setCalendarIdentity(created, on: &transaction)
+                        calendarItem = created
+                        transaction.stage = .calendarIdentified
+                        transaction.lastError = nil
+                        transaction.partialEffects.append("invoked EventKit create once for \(invocationId) and identified \(created.localEventId)")
+                        transaction = try await transactions.save(transaction)
+                        calendarFields.append(contentsOf: [
+                            "title", "start", "end", "timeZone", "calendarId", "location", "notes",
+                            "syncKey", "operationFingerprint", "createInvocationId"
+                        ])
+                    } catch {
+                        transaction.stage = .calendarEffectUnknown
+                        transaction.lastError = error.localizedDescription
+                        transaction = try await transactions.save(transaction)
+                        throw CalendarRegistrySyncError.calendarEffectUnknown(error.localizedDescription)
+                    }
 
-            guard var pair = record, let calendarItem else {
-                throw CalendarRegistrySyncError.verificationFailed("pair resolution returned an empty surface")
-            }
-            try assertCalendarMatchesManifest(calendarItem, request: request)
-            try applyIdentity(calendarItem, to: &pair)
-            pair.syncState = .pendingCreate
-            pair.lastSyncError = nil
-            pair.registryUpdatedAt = clock()
-            try await heartbeat(&transaction)
-            pair = try await registry.savePairing(pair, expectedRevision: record?.registryRevision)
-            record = pair
-            registryFields.append(contentsOf: Self.pairingFieldNames)
+                case .calendarIdentified:
+                    record = try await requireRegistryRecord(request: request, transaction: transaction)
+                    calendarItem = try await requireCalendarItem(request: request, transaction: transaction, record: record)
+                    guard var pair = record, let item = calendarItem else {
+                        throw CalendarRegistrySyncError.verificationFailed("identified pair surface disappeared")
+                    }
+                    try applyIdentity(item, to: &pair)
+                    pair.createInvocationId = transaction.createInvocationId
+                    pair.syncState = .pendingCreate
+                    pair.lastSyncError = nil
+                    pair.syncRevision += 1
+                    pair.syncWriterToken = makeSyncWriterToken()
+                    pair.registryUpdatedAt = clock()
+                    try await heartbeat(&transaction)
+                    pair = try await registry.savePairing(pair, expectedRevision: record?.registryRevision)
+                    try assertWriterEvidence(
+                        pair, expectedInvocationId: transaction.createInvocationId,
+                        expectedWriterToken: pair.syncWriterToken, expectedSyncRevision: pair.syncRevision
+                    )
+                    notionOutcomePersisted = true
+                    registryFields.append(contentsOf: Self.pairingFieldNames + ["createInvocationId", "syncWriterToken", "syncRevision"])
+                    record = pair
+                    transaction.registryEventId = pair.id
+                    transaction.syncWriterToken = pair.syncWriterToken
+                    transaction.syncRevision = pair.syncRevision
+                    transaction.stage = .pairIdentityPersisted
+                    transaction.partialEffects.append("persisted immutable pair identity to Notion")
+                    transaction = try await transactions.save(transaction)
+                    pairPersisted = true
 
-            transaction.registryEventId = pair.id
-            transaction.stage = .pairPersisted
-            transaction.partialEffects.append("pair identity persisted to pre-existing Notion EVENT")
-            transaction = try await transactions.save(transaction)
+                case .pairIdentityPersisted:
+                    guard let recordId = transaction.registryEventId,
+                          let eventId = transaction.calendarEventId else {
+                        throw CalendarRegistrySyncError.identityConflict("pair-persisted ledger is missing pair identifiers")
+                    }
+                    let preliminary = try await verify(
+                        request: request, recordId: recordId, calendarEventId: eventId,
+                        requireSyncedEvidence: false, expectedSyncedAt: nil,
+                        expectedCreateInvocationId: transaction.createInvocationId
+                    )
+                    evidence.append(contentsOf: preliminary.evidence)
+                    searchScopes.append(contentsOf: preliminary.searchScopes)
+                    if preliminary.record.syncState == .synced {
+                        guard preliminary.record.syncHash == preliminary.recomputedHash,
+                              preliminary.record.lastSyncedAt != nil else {
+                            throw CalendarRegistrySyncError.identityConflict(
+                                "Notion claims Synced but final synchronization evidence is incomplete"
+                            )
+                        }
+                        transaction.lastVerifiedAt = preliminary.record.lastSyncedAt
+                        transaction.syncWriterToken = preliminary.record.syncWriterToken
+                        transaction.syncRevision = preliminary.record.syncRevision
+                        transaction.stage = .syncEvidencePersisted
+                        transaction = try await transactions.save(transaction)
+                        continue
+                    }
+                    var syncedRecord = preliminary.record
+                    let verifiedAt = clock()
+                    syncedRecord.syncState = .synced
+                    syncedRecord.lastSyncedAt = verifiedAt
+                    syncedRecord.registryUpdatedAt = verifiedAt
+                    syncedRecord.lastSyncError = nil
+                    syncedRecord.syncHash = preliminary.recomputedHash
+                    syncedRecord.syncRevision += 1
+                    syncedRecord.syncWriterToken = makeSyncWriterToken()
+                    try await heartbeat(&transaction)
+                    syncedRecord = try await registry.savePairing(
+                        syncedRecord, expectedRevision: preliminary.record.registryRevision
+                    )
+                    try assertWriterEvidence(
+                        syncedRecord, expectedInvocationId: transaction.createInvocationId,
+                        expectedWriterToken: syncedRecord.syncWriterToken,
+                        expectedSyncRevision: syncedRecord.syncRevision
+                    )
+                    notionOutcomePersisted = true
+                    record = syncedRecord
+                    transaction.lastVerifiedAt = verifiedAt
+                    transaction.syncWriterToken = syncedRecord.syncWriterToken
+                    transaction.syncRevision = syncedRecord.syncRevision
+                    transaction.stage = .syncEvidencePersisted
+                    transaction.lastError = nil
+                    transaction = try await transactions.save(transaction)
 
-            let verified = try await verify(
-                request: request,
-                recordId: pair.id,
-                calendarEventId: calendarItem.localEventId
-            )
-            evidence.append(contentsOf: verified.evidence)
-            var verifiedRecord = verified.record
-            let verifiedAt = clock()
-            let expectedHash = verified.recomputedHash
-            verifiedRecord.syncState = .synced
-            verifiedRecord.lastSyncedAt = verifiedAt
-            verifiedRecord.registryUpdatedAt = verifiedAt
-            verifiedRecord.lastSyncError = nil
-            verifiedRecord.syncHash = expectedHash
-            try await heartbeat(&transaction)
-            verifiedRecord = try await registry.savePairing(verifiedRecord, expectedRevision: verified.record.registryRevision)
+                case .syncEvidencePersisted:
+                    guard let recordId = transaction.registryEventId,
+                          let eventId = transaction.calendarEventId else {
+                        throw CalendarRegistrySyncError.identityConflict("sync-evidence ledger is missing pair identifiers")
+                    }
+                    let final = try await verify(
+                        request: request, recordId: recordId, calendarEventId: eventId,
+                        requireSyncedEvidence: true, expectedSyncedAt: transaction.lastVerifiedAt,
+                        expectedCreateInvocationId: transaction.createInvocationId
+                    )
+                    record = final.record
+                    calendarItem = final.item
+                    evidence.append(contentsOf: final.evidence)
+                    searchScopes.append(contentsOf: final.searchScopes)
+                    transaction.stage = .complete
+                    transaction.lastVerifiedAt = final.record.lastSyncedAt
+                    transaction.lastError = nil
+                    transaction = try await transactions.save(transaction)
 
-            transaction.stage = .verified
-            transaction.lastVerifiedAt = verifiedAt
-            transaction.lastError = nil
-            transaction = try await transactions.save(transaction)
+                case .complete:
+                    guard let recordId = transaction.registryEventId,
+                          let eventId = transaction.calendarEventId else {
+                        throw CalendarRegistrySyncError.identityConflict("complete ledger is missing pair identifiers")
+                    }
+                    let final = try await verify(
+                        request: request, recordId: recordId, calendarEventId: eventId,
+                        requireSyncedEvidence: true, expectedSyncedAt: transaction.lastVerifiedAt,
+                        expectedCreateInvocationId: transaction.createInvocationId
+                    )
+                    let released = try await transactions.release(transaction)
+                    return makeReceipt(
+                        succeeded: true, infrastructureFault: false, ledgerPersisted: true,
+                        notionPersisted: notionOutcomePersisted, pairPersisted: true,
+                        transaction: released, fencingToken: fencingToken, stageBefore: stageBefore,
+                        record: final.record, item: final.item,
+                        registryFields: registryFields, calendarFields: calendarFields,
+                        evidence: evidence + final.evidence + ["forward-only transaction reached Complete"],
+                        searchScopes: Array(Set(searchScopes + final.searchScopes)).sorted(),
+                        recoveryAction: nil, discrepancy: nil,
+                        verifiedHash: final.recomputedHash, verifiedAt: final.record.lastSyncedAt,
+                        registryCount: 1, calendarCount: 1
+                    )
 
-            let final = try await verify(
-                request: request,
-                recordId: verifiedRecord.id,
-                calendarEventId: verified.item.localEventId,
-                requireSyncedEvidence: true,
-                expectedSyncedAt: verifiedAt
-            )
-            transaction.stage = .synced
-            transaction.lastVerifiedAt = verifiedAt
-            transaction = try await transactions.save(transaction)
-            evidence.append("final fresh reads recomputed Sync Hash and confirmed Last Synced At")
-
-            do {
-                let released = try await transactions.release(transaction)
-                return CalendarRegistrySyncReceipt(
-                    succeeded: true,
-                    infrastructureFault: false,
-                    recoveryStatePersisted: true,
-                    registryFailureStatePersisted: false,
-                    operationId: transaction.operationId,
-                    idempotencyKey: transaction.idempotencyKey,
-                    operationFingerprint: fingerprint,
-                    fencingToken: fencingToken,
-                    ledgerRevision: released.revision,
-                    verifiedSyncHash: final.recomputedHash,
-                    verifiedAt: final.record.lastSyncedAt,
-                    stageBefore: stageBefore,
-                    stageAfter: .synced,
-                    record: final.record,
-                    calendarItem: final.item,
-                    registryFieldsWritten: Array(Set(registryFields)).sorted(),
-                    calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
-                    verificationEvidence: evidence,
-                    partialEffects: transaction.partialEffects,
-                    recoveryAction: nil,
-                    discrepancy: nil
-                )
-            } catch {
-                return CalendarRegistrySyncReceipt(
-                    succeeded: false,
-                    infrastructureFault: true,
-                    recoveryStatePersisted: true,
-                    registryFailureStatePersisted: false,
-                    operationId: transaction.operationId,
-                    idempotencyKey: transaction.idempotencyKey,
-                    operationFingerprint: fingerprint,
-                    fencingToken: fencingToken,
-                    ledgerRevision: transaction.revision,
-                    verifiedSyncHash: final.recomputedHash,
-                    verifiedAt: final.record.lastSyncedAt,
-                    stageBefore: stageBefore,
-                    stageAfter: transaction.stage,
-                    record: final.record,
-                    calendarItem: final.item,
-                    registryFieldsWritten: Array(Set(registryFields)).sorted(),
-                    calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
-                    verificationEvidence: evidence,
-                    partialEffects: transaction.partialEffects,
-                    recoveryAction: "pair is verified Synced; inspect the coordinator before retrying",
-                    discrepancy: "pair synchronized but SQLite lease release failed: \(error.localizedDescription)"
-                )
+                case .conflict, .operatorReview, .abandoned:
+                    let released = try await transactions.release(transaction)
+                    return makeReceipt(
+                        succeeded: false, infrastructureFault: false, ledgerPersisted: true,
+                        notionPersisted: notionOutcomePersisted, pairPersisted: pairPersisted,
+                        transaction: released, fencingToken: fencingToken, stageBefore: stageBefore,
+                        record: record, item: calendarItem, registryFields: registryFields,
+                        calendarFields: calendarFields, evidence: evidence,
+                        searchScopes: searchScopes,
+                        recoveryAction: Self.recoveryAction(for: transaction.stage, persisted: true),
+                        discrepancy: transaction.lastError
+                    )
+                }
             }
         } catch {
             let targetStage: CalendarRegistryTransactionStage
-            if transaction.stage == .calendarCreateIntent || transaction.stage == .calendarEffectUnknown {
+            switch error {
+            case CalendarRegistrySyncError.operatorReview:
+                targetStage = .operatorReview
+            case CalendarRegistrySyncError.calendarEffectUnknown:
                 targetStage = .calendarEffectUnknown
-            } else {
-                targetStage = Self.isConflict(error) ? .conflict : .recoverableError
+            default:
+                targetStage = Self.isConflict(error) ? .conflict : transaction.stage
             }
             transaction.stage = targetStage
             transaction.lastError = error.localizedDescription
-
             var ledgerError: Error?
             do { transaction = try await transactions.save(transaction) }
             catch { ledgerError = error }
-
-            var registryError: Error?
-            var registryFailureWriteAttempted = false
-            if var failed = record, ledgerError == nil {
-                registryFailureWriteAttempted = true
-                do {
-                    transaction = try await transactions.renew(transaction, leaseDuration: leaseDuration)
-                    failed.syncState = targetStage == .conflict ? .conflict : .error
-                    failed.lastSyncError = error.localizedDescription
-                    failed.registryUpdatedAt = clock()
-                    record = try await registry.savePairing(failed, expectedRevision: failed.registryRevision)
-                } catch {
-                    registryError = error
-                }
-            }
-
             var releaseError: Error?
             if ledgerError == nil {
                 do { transaction = try await transactions.release(transaction) }
                 catch { releaseError = error }
             }
             let persisted = ledgerError == nil
-            let registryPersisted = registryFailureWriteAttempted && registryError == nil
-            let combined = [
+            let discrepancy = [
                 error.localizedDescription,
                 ledgerError.map { "recovery ledger write failed: \($0.localizedDescription)" },
-                registryError.map { "registry failure-state write failed: \($0.localizedDescription)" },
                 releaseError.map { "SQLite lease release failed: \($0.localizedDescription)" }
             ].compactMap { $0 }.joined(separator: " | ")
-
-            return CalendarRegistrySyncReceipt(
+            return makeReceipt(
                 succeeded: false,
                 infrastructureFault: !persisted || releaseError != nil,
-                recoveryStatePersisted: persisted,
-                registryFailureStatePersisted: registryPersisted,
-                operationId: transaction.operationId,
-                idempotencyKey: transaction.idempotencyKey,
-                operationFingerprint: fingerprint,
+                ledgerPersisted: persisted,
+                notionPersisted: notionOutcomePersisted,
+                pairPersisted: pairPersisted,
+                transaction: transaction,
                 fencingToken: fencingToken,
-                ledgerRevision: transaction.revision,
-                verifiedSyncHash: nil,
-                verifiedAt: nil,
                 stageBefore: stageBefore,
-                stageAfter: targetStage,
                 record: record,
-                calendarItem: calendarItem,
-                registryFieldsWritten: Array(Set(registryFields)).sorted(),
-                calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
-                verificationEvidence: evidence,
-                partialEffects: transaction.partialEffects,
+                item: calendarItem,
+                registryFields: registryFields,
+                calendarFields: calendarFields,
+                evidence: evidence,
+                searchScopes: searchScopes,
                 recoveryAction: Self.recoveryAction(for: targetStage, persisted: persisted),
-                discrepancy: combined
+                discrepancy: discrepancy
             )
         }
+    }
+
+    private func makeReceipt(
+        succeeded: Bool,
+        infrastructureFault: Bool,
+        ledgerPersisted: Bool,
+        notionPersisted: Bool,
+        pairPersisted: Bool,
+        transaction: CalendarRegistryTransaction,
+        fencingToken: String?,
+        stageBefore: CalendarRegistryTransactionStage,
+        record: TimeInstanceRecord?,
+        item: ExternalCalendarItem?,
+        registryFields: [String],
+        calendarFields: [String],
+        evidence: [String],
+        searchScopes: [String],
+        recoveryAction: String?,
+        discrepancy: String?,
+        verifiedHash: String? = nil,
+        verifiedAt: Date? = nil,
+        registryCount: Int? = nil,
+        calendarCount: Int? = nil
+    ) -> CalendarRegistrySyncReceipt {
+        var receipt = CalendarRegistrySyncReceipt(
+            succeeded: succeeded,
+            infrastructureFault: infrastructureFault,
+            recoveryStatePersisted: ledgerPersisted,
+            registryFailureStatePersisted: false,
+            operationId: transaction.operationId,
+            idempotencyKey: transaction.idempotencyKey,
+            operationFingerprint: transaction.manifestFingerprint,
+            fencingToken: fencingToken,
+            ledgerRevision: transaction.revision,
+            verifiedSyncHash: verifiedHash,
+            verifiedAt: verifiedAt,
+            stageBefore: stageBefore,
+            stageAfter: transaction.stage,
+            record: record,
+            calendarItem: item,
+            registryFieldsWritten: Array(Set(registryFields)).sorted(),
+            calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
+            verificationEvidence: evidence,
+            partialEffects: transaction.partialEffects,
+            recoveryAction: recoveryAction,
+            discrepancy: discrepancy
+        )
+        receipt.createInvocationId = transaction.createInvocationId ?? record?.createInvocationId
+        receipt.syncWriterToken = record?.syncWriterToken ?? transaction.syncWriterToken
+        receipt.syncRevision = record?.syncRevision ?? transaction.syncRevision
+        receipt.calendarSearchScopes = Array(Set(searchScopes)).sorted()
+        receipt.ledgerOutcomePersisted = ledgerPersisted
+        receipt.notionOutcomePersisted = notionPersisted
+        receipt.pairIdentityPersisted = pairPersisted
+        receipt.registryIdentityCount = registryCount
+        receipt.calendarIdentityCount = calendarCount
+        receipt.finalRegistryRevision = record?.registryRevision
+        return receipt
     }
 
     private func heartbeat(_ transaction: inout CalendarRegistryTransaction) async throws {
@@ -969,15 +1097,14 @@ public actor CalendarRegistrySyncEngine {
 
     private func resolveExistingRegistry(
         request: RegistryFirstTimeInstanceRequest,
-        transaction: inout CalendarRegistryTransaction
+        transaction: CalendarRegistryTransaction
     ) async throws -> TimeInstanceRecord {
         if let existingId = transaction.registryEventId, existingId != request.registryEventId {
             throw CalendarRegistrySyncError.identityConflict("ledger registry EVENT differs from the supplied page")
         }
-
         let direct: TimeInstanceRecord
         switch try await registry.readIdentity(id: request.registryEventId, forceRefresh: true) {
-        case .decoded(let record): direct = record
+        case .decoded(let value): direct = value
         case .partial:
             throw CalendarRegistrySyncError.identityConflict("supplied Notion EVENT is partial; automatic repair is disabled")
         case .missing:
@@ -985,36 +1112,102 @@ public actor CalendarRegistrySyncEngine {
         case .malformed(_, let reason):
             throw CalendarRegistrySyncError.identityConflict("supplied Notion EVENT is malformed: \(reason)")
         }
-
         let lookup = try await registry.findBySyncKey(request.idempotencyKey)
         guard lookup.source == .live else { throw CalendarRegistrySyncError.degradedRegistryLookup }
         guard lookup.unresolvedIdentities.isEmpty else {
-            throw CalendarRegistrySyncError.undecodableRegistryIdentity(lookup.unresolvedIdentities.map(\.pageId))
+            throw CalendarRegistrySyncError.undecodableRegistryIdentity(lookup.unresolvedIdentities.map { $0.pageId })
         }
         guard lookup.records.count == 1, let queried = lookup.records.first else {
             if lookup.records.count > 1 {
-                throw CalendarRegistrySyncError.ambiguousRegistryIdentity(lookup.records.map(\.id))
+                throw CalendarRegistrySyncError.ambiguousRegistryIdentity(lookup.records.map { $0.id })
             }
             throw CalendarRegistrySyncError.identityConflict("Sync Key query did not return the supplied pre-existing EVENT")
         }
         guard queried.id == request.registryEventId, direct.id == request.registryEventId else {
             throw CalendarRegistrySyncError.identityConflict("supplied EVENT differs from the unique Sync Key result")
         }
+        if transaction.stage == .claimed, direct.createInvocationId != nil {
+            throw CalendarRegistrySyncError.operatorReview(
+                "Notion contains a Create Invocation ID but the local ledger has no corresponding durable authorization"
+            )
+        }
+        if transaction.stage == .registryAuthorized,
+           direct.createInvocationId != nil, transaction.createInvocationId == nil {
+            throw CalendarRegistrySyncError.operatorReview(
+                "Notion persisted Create Invocation ID before SQLite could record the same authorization"
+            )
+        }
         try assertRegistryMatchesManifest(direct, request: request)
         try assertRegistryMatchesManifest(queried, request: request)
         try assertRegistryAdmissibleForPairing(direct, request: request, transaction: transaction)
         try assertRegistryAdmissibleForPairing(queried, request: request, transaction: transaction)
-
-        transaction.registryEventId = request.registryEventId
-        try adoptExistingCalendarIdentity(from: direct, into: &transaction)
-        if transaction.stage == .prepared || transaction.stage == .recoverableError {
-            transaction.stage = .registryVerified
-        }
-        if !transaction.partialEffects.contains("verified pre-existing Notion EVENT \(request.registryEventId)") {
-            transaction.partialEffects.append("verified pre-existing Notion EVENT \(request.registryEventId)")
-        }
-        transaction = try await transactions.save(transaction)
         return direct
+    }
+
+    private func requireRegistryRecord(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: CalendarRegistryTransaction
+    ) async throws -> TimeInstanceRecord {
+        try await resolveExistingRegistry(request: request, transaction: transaction)
+    }
+
+    private func assertWriterEvidence(
+        _ record: TimeInstanceRecord,
+        expectedInvocationId: String?,
+        expectedWriterToken: String?,
+        expectedSyncRevision: Int
+    ) throws {
+        guard record.createInvocationId == expectedInvocationId,
+              record.syncWriterToken == expectedWriterToken,
+              record.syncRevision == expectedSyncRevision,
+              record.registryRevision?.isEmpty == false else {
+            throw CalendarRegistrySyncError.identityConflict(
+                "Notion synchronization write did not retain the expected invocation, writer token, revision, and page revision"
+            )
+        }
+    }
+
+    private func recoveryQuery(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: CalendarRegistryTransaction,
+        record: TimeInstanceRecord?
+    ) -> CalendarRecoveryQuery {
+        CalendarRecoveryQuery(
+            localEventId: transaction.calendarEventId ?? record?.calendarEventId,
+            providerExternalId: transaction.providerExternalId ?? record?.providerExternalId,
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            createInvocationId: transaction.createInvocationId ?? record?.createInvocationId,
+            calendarId: request.calendarId,
+            title: request.title,
+            start: request.start,
+            end: request.end
+        )
+    }
+
+    private static func searchScopeDescription(_ query: CalendarRecoveryQuery) -> String {
+        let lower = query.start.addingTimeInterval(-30 * 86_400)
+        let upper = query.end.addingTimeInterval(30 * 86_400)
+        return "calendar=\(query.calendarId) window=\(CalendarRegistryISO.string(lower))...\(CalendarRegistryISO.string(upper)) channels=localId,providerId,createInvocationId,syncKey+fingerprint,exact-time"
+    }
+
+    private func requireCalendarItem(
+        request: RegistryFirstTimeInstanceRequest,
+        transaction: CalendarRegistryTransaction,
+        record: TimeInstanceRecord?
+    ) async throws -> ExternalCalendarItem {
+        let query = recoveryQuery(request: request, transaction: transaction, record: record)
+        let matches = try await calendar.recover(query)
+        if matches.count > 1 {
+            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(matches.map { $0.localEventId })
+        }
+        guard let item = matches.first else {
+            throw CalendarRegistrySyncError.operatorReview(
+                "the durable pair identity exists but no owned EventKit item is recoverable within the declared search scope"
+            )
+        }
+        try assertCalendarMatchesManifest(item, request: request, createInvocationId: transaction.createInvocationId)
+        return item
     }
 
     private func adoptExistingCalendarIdentity(
@@ -1055,12 +1248,12 @@ public actor CalendarRegistrySyncEngine {
         )
         let recovered = try await calendar.recover(query)
         if recovered.count > 1 {
-            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map(\.localEventId))
+            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(recovered.map { $0.localEventId })
         }
         if let existing = recovered.first {
             try assertCalendarMatchesManifest(existing, request: request)
             try setCalendarIdentity(existing, on: &transaction)
-            transaction.stage = .calendarCreated
+            transaction.stage = .calendarIdentified
             if !transaction.partialEffects.contains("recovered calendar event \(existing.localEventId)") {
                 transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
             }
@@ -1068,8 +1261,8 @@ public actor CalendarRegistrySyncEngine {
             return existing
         }
 
-        if transaction.stage == .calendarCreateIntent || transaction.stage == .calendarEffectUnknown {
-            if transaction.stage == .calendarCreateIntent {
+        if transaction.stage == .createInvocationPersisted || transaction.stage == .calendarEffectUnknown {
+            if transaction.stage == .createInvocationPersisted {
                 transaction.stage = .calendarEffectUnknown
                 transaction.lastError = "calendar create intent exists but recovery found no unique item"
                 transaction = try await transactions.save(transaction)
@@ -1083,13 +1276,13 @@ public actor CalendarRegistrySyncEngine {
                 "prior calendar identity exists but no unique provider item could be recovered"
             )
         }
-        guard transaction.stage == .registryVerified else {
+        guard transaction.stage == .registryAuthorized else {
             throw CalendarRegistrySyncError.identityConflict(
                 "calendar create is allowed only immediately after registry verification"
             )
         }
 
-        transaction.stage = .calendarCreateIntent
+        transaction.stage = .createInvocationPersisted
         transaction.lastError = nil
         transaction.partialEffects.append("persisted EventKit create intent")
         transaction = try await transactions.save(transaction)
@@ -1105,11 +1298,12 @@ public actor CalendarRegistrySyncEngine {
                 location: request.location,
                 notes: request.notes,
                 syncKey: request.idempotencyKey,
-                operationFingerprint: request.manifest.fingerprint
+                operationFingerprint: request.manifest.fingerprint,
+                createInvocationId: transaction.createInvocationId ?? ""
             ))
             try assertCalendarMatchesManifest(created, request: request)
             try setCalendarIdentity(created, on: &transaction)
-            transaction.stage = .calendarCreated
+            transaction.stage = .calendarIdentified
             transaction.partialEffects.append("created calendar event \(created.localEventId)")
             transaction = try await transactions.save(transaction)
             fieldsWritten.append(contentsOf: [
@@ -1147,70 +1341,64 @@ public actor CalendarRegistrySyncEngine {
         recordId: String,
         calendarEventId: String,
         requireSyncedEvidence: Bool = false,
-        expectedSyncedAt: Date? = nil
+        expectedSyncedAt: Date? = nil,
+        expectedCreateInvocationId: String? = nil
     ) async throws -> (
         record: TimeInstanceRecord,
         item: ExternalCalendarItem,
         recomputedHash: String,
-        evidence: [String]
+        evidence: [String],
+        searchScopes: [String]
     ) {
         guard let record = try await registry.get(id: recordId, forceRefresh: true) else {
-            throw CalendarRegistrySyncError.verificationFailed("Notion EVENT missing after write")
+            throw CalendarRegistrySyncError.identityConflict("Notion EVENT missing during verification")
         }
         guard let item = try await calendar.item(id: calendarEventId) else {
-            throw CalendarRegistrySyncError.verificationFailed("calendar item missing after write")
+            throw CalendarRegistrySyncError.operatorReview("calendar item missing during verification")
         }
         try assertRegistryMatchesManifest(record, request: request)
-        try assertCalendarMatchesManifest(item, request: request)
-        guard record.calendarProvider == item.provider,
+        try assertCalendarMatchesManifest(item, request: request, createInvocationId: expectedCreateInvocationId)
+        guard record.createInvocationId == expectedCreateInvocationId,
+              record.calendarProvider == item.provider,
               record.calendarEventId == item.localEventId,
               record.calendarId == item.calendarId,
               record.providerExternalId == item.providerExternalId else {
-            throw CalendarRegistrySyncError.verificationFailed("authoritative pair identity is not persisted consistently")
+            throw CalendarRegistrySyncError.identityConflict("authoritative pair identity is not persisted consistently")
         }
-
         let registryLookup = try await registry.findBySyncKey(request.idempotencyKey)
         guard registryLookup.source == .live, registryLookup.unresolvedIdentities.isEmpty else {
-            throw CalendarRegistrySyncError.verificationFailed(
-                "final registry uniqueness lookup was degraded or undecodable"
-            )
+            throw CalendarRegistrySyncError.identityConflict("final registry uniqueness lookup was degraded or undecodable")
         }
         guard registryLookup.records.count == 1, registryLookup.records.first?.id == record.id else {
-            throw CalendarRegistrySyncError.verificationFailed(
-                "final registry uniqueness proof did not resolve exactly one supplied EVENT"
-            )
+            throw CalendarRegistrySyncError.ambiguousRegistryIdentity(registryLookup.records.map { $0.id })
         }
-
-        let calendarMatches = try await calendar.recover(CalendarRecoveryQuery(
+        let query = CalendarRecoveryQuery(
             localEventId: item.localEventId,
             providerExternalId: item.providerExternalId,
             syncKey: request.idempotencyKey,
             operationFingerprint: request.manifest.fingerprint,
+            createInvocationId: expectedCreateInvocationId,
             calendarId: request.calendarId,
             title: request.title,
             start: request.start,
             end: request.end
-        ))
+        )
+        let calendarMatches = try await calendar.recover(query)
         guard calendarMatches.count == 1, calendarMatches.first?.localEventId == item.localEventId else {
-            throw CalendarRegistrySyncError.verificationFailed(
-                "final calendar uniqueness proof did not resolve exactly one paired item"
-            )
+            throw CalendarRegistrySyncError.ambiguousCalendarIdentity(calendarMatches.map { $0.localEventId })
         }
-
         let recomputedHash = Self.syncFingerprint(record: record, item: item)
         if requireSyncedEvidence {
             guard record.syncState == .synced,
                   record.syncHash == recomputedHash,
-                  let lastSyncedAt = record.lastSyncedAt else {
-                throw CalendarRegistrySyncError.verificationFailed(
-                    "final Notion read did not retain recomputed Synced evidence"
-                )
+                  let lastSyncedAt = record.lastSyncedAt,
+                  record.syncWriterToken?.isEmpty == false,
+                  record.syncRevision > 0 else {
+                throw CalendarRegistrySyncError.identityConflict("final Notion read did not retain recomputed Synced evidence")
             }
             if let expectedSyncedAt,
                abs(lastSyncedAt.timeIntervalSince(expectedSyncedAt)) >= 1 {
-                throw CalendarRegistrySyncError.verificationFailed(
-                    "Last Synced At does not match the verification transaction"
-                )
+                throw CalendarRegistrySyncError.identityConflict("Last Synced At does not match the verification transaction")
             }
         }
         return (
@@ -1220,9 +1408,10 @@ public actor CalendarRegistrySyncEngine {
             [
                 "fresh Notion read confirmed EVENT \(record.id)",
                 "provider read confirmed calendar event \(item.localEventId)",
-                "canonical manifest and authoritative pair identity match final reads",
-                "final uniqueness proof found one Notion EVENT and one EventKit item"
-            ]
+                "canonical manifest, Create Invocation ID, and pair identity match",
+                "authoritative Notion uniqueness and owned EventKit uniqueness within declared search scope passed"
+            ],
+            [Self.searchScopeDescription(query)]
         )
     }
 
@@ -1285,62 +1474,111 @@ public actor CalendarRegistrySyncEngine {
         request: RegistryFirstTimeInstanceRequest,
         transaction: CalendarRegistryTransaction
     ) throws {
-        let providerPresent = record.calendarProvider?.isEmpty == false
-        let calendarIdPresent = record.calendarId?.isEmpty == false
-        let eventIdPresent = record.calendarEventId?.isEmpty == false
-        let externalPresent = record.providerExternalId?.isEmpty == false
-        let urlPresent = record.calendarItemURL?.isEmpty == false
-        let anyPairEvidence = providerPresent || calendarIdPresent || eventIdPresent || externalPresent || urlPresent
-        let completeCoreIdentity = providerPresent && calendarIdPresent && eventIdPresent
+        let pairValues = [
+            record.calendarProvider, record.calendarId, record.calendarEventId,
+            record.providerExternalId, record.calendarItemURL
+        ]
+        let pairPresence = pairValues.map { $0?.isEmpty == false }
+        let anyPairEvidence = pairPresence.contains(true)
+        let completeCoreIdentity = pairPresence[0] && pairPresence[1] && pairPresence[2]
+        let invocationPresent = record.createInvocationId?.isEmpty == false
+        let writerEvidencePresent = record.syncWriterToken?.isEmpty == false && record.syncRevision > 0
 
-        if !anyPairEvidence {
-            let resumableFailure = transaction.stage != .prepared && record.syncState == .error
-            guard record.syncState == .pendingCreate || resumableFailure else {
-                throw CalendarRegistrySyncError.identityConflict(
-                    "clean unpaired EVENT must be Pending Create; recovery Error requires an existing transaction"
-                )
-            }
-            guard record.syncHash.isEmpty, record.lastSyncedAt == nil, record.calendarUpdatedAt == nil else {
-                throw CalendarRegistrySyncError.identityConflict(
-                    "unpaired EVENT contains stale synchronization evidence"
-                )
-            }
-            return
+        if let ledgerInvocation = transaction.createInvocationId,
+           invocationPresent, record.createInvocationId != ledgerInvocation {
+            throw CalendarRegistrySyncError.identityConflict("Notion and SQLite Create Invocation IDs differ")
+        }
+        if let ledgerEvent = transaction.calendarEventId,
+           record.calendarEventId?.isEmpty == false, record.calendarEventId != ledgerEvent {
+            throw CalendarRegistrySyncError.identityConflict("Notion and SQLite calendar event IDs differ")
         }
 
-        guard completeCoreIdentity else {
-            throw CalendarRegistrySyncError.identityConflict(
-                "Notion EVENT contains a partial calendar identity"
-            )
-        }
-        guard record.calendarId == request.calendarId else {
-            throw CalendarRegistrySyncError.identityConflict(
-                "Notion EVENT is paired to a different calendar"
-            )
-        }
-        switch record.syncState {
-        case .pendingCreate, .error:
-            guard record.syncHash.isEmpty, record.lastSyncedAt == nil else {
+        switch transaction.stage {
+        case .claimed:
+            guard !invocationPresent, !writerEvidencePresent, !anyPairEvidence,
+                  record.syncState == .pendingCreate,
+                  record.syncHash.isEmpty, record.lastSyncedAt == nil,
+                  record.calendarUpdatedAt == nil else {
                 throw CalendarRegistrySyncError.identityConflict(
-                    "non-Synced EVENT contains final synchronization evidence"
+                    "initial EVENT is not a clean Pending Create registry-authority record"
                 )
             }
-        case .synced:
-            guard !record.syncHash.isEmpty, record.lastSyncedAt != nil else {
+
+        case .registryAuthorized:
+            if invocationPresent {
+                guard writerEvidencePresent, !anyPairEvidence,
+                      record.createInvocationId == transaction.createInvocationId,
+                      record.syncState == .pendingCreate,
+                      record.syncHash.isEmpty, record.lastSyncedAt == nil else {
+                    throw CalendarRegistrySyncError.identityConflict(
+                        "registry-authorized EVENT contains inconsistent Create Invocation evidence"
+                    )
+                }
+            } else {
+                guard !writerEvidencePresent, !anyPairEvidence,
+                      record.syncState == .pendingCreate,
+                      record.syncHash.isEmpty, record.lastSyncedAt == nil,
+                      record.calendarUpdatedAt == nil else {
+                    throw CalendarRegistrySyncError.identityConflict(
+                        "registry-authorized EVENT is not a clean Pending Create record"
+                    )
+                }
+            }
+
+        case .createInvocationPersisted, .calendarEffectUnknown:
+            guard invocationPresent, writerEvidencePresent,
+                  record.createInvocationId == transaction.createInvocationId,
+                  !anyPairEvidence,
+                  record.syncState == .pendingCreate,
+                  record.syncHash.isEmpty, record.lastSyncedAt == nil else {
                 throw CalendarRegistrySyncError.identityConflict(
-                    "Synced EVENT is missing final synchronization evidence"
+                    "Create Invocation state is incomplete or contains premature pair evidence"
                 )
             }
-        case .conflict, .detached:
-            throw CalendarRegistrySyncError.identityConflict(
-                "EVENT Sync State is not admissible for automatic pairing"
-            )
+
+        case .calendarIdentified:
+            guard invocationPresent, writerEvidencePresent,
+                  record.createInvocationId == transaction.createInvocationId,
+                  record.syncState == .pendingCreate else {
+                throw CalendarRegistrySyncError.identityConflict("calendar-identified EVENT has inconsistent invocation evidence")
+            }
+            if anyPairEvidence && !completeCoreIdentity {
+                throw CalendarRegistrySyncError.identityConflict("Notion EVENT contains a partial calendar identity")
+            }
+
+        case .pairIdentityPersisted:
+            guard invocationPresent, writerEvidencePresent, completeCoreIdentity,
+                  record.calendarId == request.calendarId,
+                  record.syncState == .pendingCreate || record.syncState == .synced else {
+                throw CalendarRegistrySyncError.identityConflict("pair-persisted EVENT is incomplete or contradictory")
+            }
+            if record.syncState == .pendingCreate {
+                guard record.syncHash.isEmpty, record.lastSyncedAt == nil else {
+                    throw CalendarRegistrySyncError.identityConflict("Pending Create EVENT contains final synchronization evidence")
+                }
+            } else {
+                guard !record.syncHash.isEmpty, record.lastSyncedAt != nil else {
+                    throw CalendarRegistrySyncError.identityConflict("Synced EVENT is missing final synchronization evidence")
+                }
+            }
+
+        case .syncEvidencePersisted, .complete:
+            guard invocationPresent, writerEvidencePresent, completeCoreIdentity,
+                  record.calendarId == request.calendarId,
+                  record.syncState == .synced,
+                  !record.syncHash.isEmpty, record.lastSyncedAt != nil else {
+                throw CalendarRegistrySyncError.identityConflict("final EVENT evidence is incomplete or contradictory")
+            }
+
+        case .conflict, .operatorReview, .abandoned:
+            throw CalendarRegistrySyncError.identityConflict("terminal transaction is not admissible for automatic mutation")
         }
     }
 
     private func assertCalendarMatchesManifest(
         _ item: ExternalCalendarItem,
-        request: RegistryFirstTimeInstanceRequest
+        request: RegistryFirstTimeInstanceRequest,
+        createInvocationId: String? = nil
     ) throws {
         if item.isRecurring { throw CalendarRegistrySyncError.recurringEventUnsupported }
         if item.isAllDay { throw CalendarRegistrySyncError.allDayEventUnsupported }
@@ -1349,7 +1587,8 @@ public actor CalendarRegistrySyncEngine {
             throw CalendarRegistrySyncError.participantConsequencesUnsupported
         }
         guard item.syncKey == request.idempotencyKey,
-              item.operationFingerprint == request.manifest.fingerprint else {
+              item.operationFingerprint == request.manifest.fingerprint,
+              createInvocationId == nil || item.createInvocationId == createInvocationId else {
             throw CalendarRegistrySyncError.identityConflict("calendar metadata identity differs or is missing")
         }
         guard item.title == request.title,
@@ -1416,15 +1655,17 @@ public actor CalendarRegistrySyncEngine {
             return "do not retry automatically; inspect Notion, EventKit, and the local coordinator"
         }
         switch stage {
-        case .calendarCreateIntent, .calendarEffectUnknown:
+        case .createInvocationPersisted, .calendarEffectUnknown:
             return "recovery only: inspect EventKit by Bridge identity; automatic recreation is prohibited"
         case .conflict:
             return "resolve the recorded identity discrepancy; automatic retry is prohibited"
+        case .operatorReview:
+            return "operator review is required; automatic create, repair, and retry are prohibited"
         case .abandoned:
             return "explicit operator decision is required before any further action"
-        case .recoverableError:
+        case .claimed:
             return "retry with the same idempotency key after the process lock is released"
-        case .synced:
+        case .complete:
             return "pair is verified; inspect coordinator release state before retrying"
         default:
             return "retry with the same idempotency key after the process lock is released"
@@ -1449,8 +1690,8 @@ public actor CalendarRegistrySyncEngine {
             ledgerRevision: nil,
             verifiedSyncHash: nil,
             verifiedAt: nil,
-            stageBefore: .prepared,
-            stageAfter: .prepared,
+            stageBefore: .claimed,
+            stageAfter: .claimed,
             record: nil,
             calendarItem: nil,
             registryFieldsWritten: [],
@@ -1477,7 +1718,7 @@ public actor CalendarRegistrySyncEngine {
         case .operationActive: conflict = false; active = true
         default: conflict = false; active = false
         }
-        let stage = conflict ? CalendarRegistryTransactionStage.conflict : (existing?.stage ?? .prepared)
+        let stage = conflict ? CalendarRegistryTransactionStage.conflict : (existing?.stage ?? .claimed)
         return CalendarRegistrySyncReceipt(
             succeeded: false,
             infrastructureFault: (!conflict && !active) || processReleaseError != nil,
@@ -1490,7 +1731,7 @@ public actor CalendarRegistrySyncEngine {
             ledgerRevision: existing?.revision,
             verifiedSyncHash: nil,
             verifiedAt: nil,
-            stageBefore: existing?.stage ?? .prepared,
+            stageBefore: existing?.stage ?? .claimed,
             stageAfter: stage,
             record: nil,
             calendarItem: nil,
@@ -1522,16 +1763,18 @@ private extension Result where Success == Void, Failure == Error {
 // MARK: - Versioned calendar metadata
 
 public enum CalendarRegistryCalendarMetadata {
-    public static let beginMarker = "--- BRIDGE-CALENDAR-REGISTRY v1 ---"
+    public static let beginMarker = "--- BRIDGE-CALENDAR-REGISTRY v2 ---"
     public static let endMarker = "--- END BRIDGE-CALENDAR-REGISTRY ---"
 
     public struct Identity: Sendable, Equatable {
         public var syncKey: String
         public var operationFingerprint: String
+        public var createInvocationId: String
 
-        public init(syncKey: String, operationFingerprint: String) {
+        public init(syncKey: String, operationFingerprint: String, createInvocationId: String) {
             self.syncKey = syncKey
             self.operationFingerprint = operationFingerprint
+            self.createInvocationId = createInvocationId
         }
     }
 
@@ -1544,6 +1787,7 @@ public enum CalendarRegistryCalendarMetadata {
             beginMarker,
             "Sync-Key: \(identity.syncKey)",
             "Operation-Fingerprint: \(identity.operationFingerprint)",
+            "Create-Invocation-ID: \(identity.createInvocationId)",
             endMarker
         ].joined(separator: "\n")
         guard let notes, !notes.isEmpty else { return block }
@@ -1582,6 +1826,7 @@ public enum CalendarRegistryCalendarMetadata {
         let body = notes[begin.upperBound..<end.lowerBound]
         var syncKey: String?
         var fingerprint: String?
+        var createInvocationId: String?
         for raw in body.split(whereSeparator: \.isNewline) {
             let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             if line.hasPrefix("Sync-Key:") {
@@ -1594,16 +1839,22 @@ public enum CalendarRegistryCalendarMetadata {
                     throw CalendarRegistrySyncError.identityConflict("calendar contains duplicate fingerprint metadata")
                 }
                 fingerprint = String(line.dropFirst("Operation-Fingerprint:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("Create-Invocation-ID:") {
+                guard createInvocationId == nil else {
+                    throw CalendarRegistrySyncError.identityConflict("calendar contains duplicate Create Invocation ID metadata")
+                }
+                createInvocationId = String(line.dropFirst("Create-Invocation-ID:".count)).trimmingCharacters(in: .whitespaces)
             }
         }
         let keyPattern = #"^[A-Za-z0-9._:-]{1,128}$"#
         let hexPattern = #"^[0-9a-f]{64}$"#
-        guard let syncKey, let fingerprint,
+        guard let syncKey, let fingerprint, let createInvocationId,
               syncKey.range(of: keyPattern, options: .regularExpression) != nil,
-              fingerprint.range(of: hexPattern, options: .regularExpression) != nil else {
+              fingerprint.range(of: hexPattern, options: .regularExpression) != nil,
+              createInvocationId.range(of: keyPattern, options: .regularExpression) != nil else {
             throw CalendarRegistrySyncError.identityConflict("calendar Bridge metadata is incomplete or invalid")
         }
-        return Identity(syncKey: syncKey, operationFingerprint: fingerprint)
+        return Identity(syncKey: syncKey, operationFingerprint: fingerprint, createInvocationId: createInvocationId)
     }
 }
 
@@ -1650,7 +1901,8 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
             to: draft.notes,
             identity: .init(
                 syncKey: draft.syncKey,
-                operationFingerprint: draft.operationFingerprint
+                operationFingerprint: draft.operationFingerprint,
+                createInvocationId: draft.createInvocationId
             )
         )
         let event = try await store.create(CalendarEventDraft(
@@ -1699,12 +1951,13 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
         for item in mapped {
             let identityMatch = item.syncKey == query.syncKey
                 && item.operationFingerprint == query.operationFingerprint
+            let invocationMatch = query.createInvocationId.map { item.createInvocationId == $0 } ?? false
             let externalMatch = query.providerExternalId.map { item.providerExternalId == $0 } ?? false
             let fallbackMatch = item.calendarId == query.calendarId
                 && item.title.caseInsensitiveCompare(query.title) == .orderedSame
                 && abs(item.start.timeIntervalSince(query.start)) < 1
                 && abs(item.end.timeIntervalSince(query.end)) < 1
-            if identityMatch || externalMatch || fallbackMatch {
+            if identityMatch || invocationMatch || externalMatch || fallbackMatch {
                 candidates[item.localEventId] = item
             }
         }
@@ -1749,6 +2002,11 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 if value == query.operationFingerprint { return true }
             }
+            if line.hasPrefix("Create-Invocation-ID:"), let expected = query.createInvocationId {
+                let value = String(line.dropFirst("Create-Invocation-ID:".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if value == expected { return true }
+            }
         }
         return false
     }
@@ -1767,6 +2025,7 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
             itemURL: event.conferenceURL,
             syncKey: metadata?.syncKey,
             operationFingerprint: metadata?.operationFingerprint,
+            createInvocationId: metadata?.createInvocationId,
             title: event.title,
             start: start,
             end: end,
@@ -1887,7 +2146,7 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         }
     }
 
-    public func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+    package func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
         let all = try resolvedFields(record)
         let identityNames = Set(["title", "syncKey", "operationFingerprint", "syncState"].compactMap {
             entity.property($0)?.notionName
@@ -1923,7 +2182,7 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         return fresh
     }
 
-    public func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+    package func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
         var repair = record
         repair.id = id
         _ = try await writer.update(entity: entity, pageId: id, fields: fields(repair))
@@ -1956,6 +2215,11 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         guard let fresh = try await get(id: record.id, forceRefresh: true) else {
             throw CalendarRegistrySyncError.verificationFailed("updated Notion EVENT could not be read back")
         }
+        guard fresh.createInvocationId == record.createInvocationId,
+              fresh.syncWriterToken == record.syncWriterToken,
+              fresh.syncRevision == record.syncRevision else {
+            throw CalendarRegistrySyncError.identityConflict("Notion pairing PATCH lost writer fencing evidence")
+        }
         return fresh
     }
 
@@ -1977,6 +2241,9 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             "calendarEventId": Self.nullable(record.calendarEventId),
             "providerExternalId": Self.nullable(record.providerExternalId),
             "calendarUrl": Self.nullable(record.calendarItemURL),
+            "createInvocationId": Self.nullable(record.createInvocationId),
+            "syncWriterToken": Self.nullable(record.syncWriterToken),
+            "syncRevision": .double(Double(record.syncRevision)),
             "syncState": .string(record.syncState.rawValue),
             "registryUpdatedAt": .string(CalendarRegistryISO.string(record.registryUpdatedAt)),
             "syncHash": .string(record.syncHash),
@@ -2014,6 +2281,9 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             "calendarEventId": Self.nullable(record.calendarEventId),
             "providerExternalId": Self.nullable(record.providerExternalId),
             "calendarUrl": Self.nullable(record.calendarItemURL),
+            "createInvocationId": Self.nullable(record.createInvocationId),
+            "syncWriterToken": Self.nullable(record.syncWriterToken),
+            "syncRevision": .double(Double(record.syncRevision)),
             "meetingType": Self.nullable(record.semantics.meetingType),
             "lastSyncError": Self.nullable(record.lastSyncError),
             "lastSyncedAt": Self.nullableDate(record.lastSyncedAt),
@@ -2038,18 +2308,19 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
 
     private static func decode(_ row: CachedRow) -> TimeInstanceRecord? {
         guard case .object(let properties) = row.properties,
+              let registryRevisionDate = CalendarRegistryISO.date(row.lastEditedTime),
               let range = dateRange(properties["date"]),
+              TimeZone(identifier: range.timeZone) != nil,
               let syncKey = string(properties["syncKey"]),
               let fingerprint = string(properties["operationFingerprint"]),
               let primaryBlock = strings(properties["primaryBlock"]).first,
               let eventClassRaw = string(properties["eventClass"]),
-              let eventClass = TimeInstanceEventClass(rawValue: eventClassRaw) else { return nil }
-        let authority = TimeInstanceSchedulingAuthority(
-            rawValue: string(properties["schedulingAuthority"]) ?? ""
-        ) ?? .registry
-        let state = TimeInstanceSyncState(
-            rawValue: string(properties["syncState"]) ?? ""
-        ) ?? .error
+              let eventClass = TimeInstanceEventClass(rawValue: eventClassRaw),
+              let authorityRaw = string(properties["schedulingAuthority"]),
+              let authority = TimeInstanceSchedulingAuthority(rawValue: authorityRaw),
+              let stateRaw = string(properties["syncState"]),
+              let state = TimeInstanceSyncState(rawValue: stateRaw),
+              let syncRevision = integer(properties["syncRevision"]), syncRevision >= 0 else { return nil }
         return TimeInstanceRecord(
             id: row.pageId,
             title: row.title,
@@ -2066,6 +2337,9 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             calendarEventId: string(properties["calendarEventId"]),
             providerExternalId: string(properties["providerExternalId"]),
             calendarItemURL: string(properties["calendarUrl"]),
+            createInvocationId: string(properties["createInvocationId"]),
+            syncWriterToken: string(properties["syncWriterToken"]),
+            syncRevision: syncRevision,
             semantics: TimeInstanceSemantics(
                 eventClass: eventClass,
                 meetingType: string(properties["meetingType"]),
@@ -2078,7 +2352,7 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
             syncState: state,
             lastSyncedAt: date(properties["lastSyncedAt"]),
             registryUpdatedAt: date(properties["registryUpdatedAt"])
-                ?? CalendarRegistryISO.date(row.lastEditedTime) ?? .distantPast,
+                ?? registryRevisionDate,
             calendarUpdatedAt: date(properties["calendarUpdatedAt"]),
             syncHash: string(properties["syncHash"]) ?? "",
             lastSyncError: string(properties["lastSyncError"]),
@@ -2098,6 +2372,13 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
 
     private static func string(_ value: Value?) -> String? {
         if case .string(let string)? = value, !string.isEmpty { return string }
+        return nil
+    }
+
+    private static func integer(_ value: Value?) -> Int? {
+        if case .double(let number)? = value, number.isFinite, number >= 0, number.rounded() == number {
+            return Int(number)
+        }
         return nil
     }
 
@@ -2127,6 +2408,7 @@ public extension CalendarRegistrySyncEngine {
         "calendarEventId", "providerExternalId", "calendarUrl", "eventClass",
         "meetingType", "primaryBlock", "schedulingAuthority", "syncState",
         "lastSyncedAt", "registryUpdatedAt", "calendarUpdatedAt", "syncHash",
-        "lastSyncError", "scheduledDuration", "calendarLocation"
+        "lastSyncError", "scheduledDuration", "calendarLocation",
+        "createInvocationId", "syncWriterToken", "syncRevision"
     ]
 }

--- a/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
+++ b/TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift
@@ -47,11 +47,20 @@ public struct TimeInstanceSemantics: Codable, Sendable, Equatable {
         contactIds: [String] = []
     ) {
         self.eventClass = eventClass
-        self.meetingType = meetingType
-        self.primaryBlockId = primaryBlockId
-        self.blockIds = blockIds.isEmpty ? [primaryBlockId] : blockIds
-        self.projectIds = projectIds
-        self.contactIds = contactIds
+        self.meetingType = Self.optional(meetingType)
+        self.primaryBlockId = primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.blockIds = Array(Set((blockIds + [self.primaryBlockId])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })).sorted()
+        self.projectIds = Array(Set(projectIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })).sorted()
+        self.contactIds = Array(Set(contactIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })).sorted()
+    }
+
+    private static func optional(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
     }
 }
 
@@ -299,12 +308,21 @@ public enum RegistryLookupSource: String, Sendable, Equatable {
 
 public struct RegistryUnresolvedIdentity: Sendable, Equatable {
     public var pageId: String
+    public var syncKey: String?
     public var operationFingerprint: String?
 
-    public init(pageId: String, operationFingerprint: String?) {
+    public init(pageId: String, syncKey: String? = nil, operationFingerprint: String?) {
         self.pageId = pageId
+        self.syncKey = syncKey
         self.operationFingerprint = operationFingerprint
     }
+}
+
+public enum RegistryRecordIdentityRead: Sendable, Equatable {
+    case decoded(TimeInstanceRecord)
+    case partial(pageId: String, syncKey: String?, operationFingerprint: String?)
+    case missing
+    case malformed(pageId: String, reason: String)
 }
 
 public struct RegistryIdentityLookup: Sendable, Equatable {
@@ -339,6 +357,7 @@ public struct PartialRegistryCreateError: Error, LocalizedError, Sendable, Equat
 
 public protocol TimeInstanceRegistryStoring: Sendable {
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup
+    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead
     func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord?
     func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord
     func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord
@@ -385,6 +404,28 @@ public struct RegistryFirstTimeInstanceRequest: Sendable, Equatable {
         self.semantics = semantics
     }
 
+    public var canonicalized: RegistryFirstTimeInstanceRequest {
+        let manifest = self.manifest
+        return RegistryFirstTimeInstanceRequest(
+            idempotencyKey: idempotencyKey,
+            title: manifest.title,
+            start: manifest.start,
+            end: manifest.end,
+            timeZoneIdentifier: manifest.timeZoneIdentifier,
+            calendarId: manifest.calendarId,
+            location: manifest.location,
+            notes: manifest.notes,
+            semantics: TimeInstanceSemantics(
+                eventClass: semantics.eventClass,
+                meetingType: manifest.meetingType,
+                primaryBlockId: manifest.primaryBlockId,
+                blockIds: manifest.blockIds,
+                projectIds: manifest.projectIds,
+                contactIds: manifest.contactIds
+            )
+        )
+    }
+
     public var manifest: CalendarRegistryOperationManifest {
         CalendarRegistryOperationManifest(
             title: title,
@@ -412,6 +453,10 @@ public struct CalendarRegistrySyncReceipt: Sendable, Equatable {
     public var operationId: String
     public var idempotencyKey: String
     public var operationFingerprint: String
+    public var fencingToken: String?
+    public var ledgerRevision: Int?
+    public var verifiedSyncHash: String?
+    public var verifiedAt: Date?
     public var stageBefore: CalendarRegistryTransactionStage
     public var stageAfter: CalendarRegistryTransactionStage
     public var record: TimeInstanceRecord?
@@ -493,6 +538,8 @@ public actor CalendarRegistrySyncEngine {
     private let operationGate: CalendarRegistryOperationGate
     private let clock: @Sendable () -> Date
     private let makeOperationId: @Sendable () -> String
+    private let makeLeaseToken: @Sendable () -> String
+    private let leaseDuration: TimeInterval
 
     public init(
         registry: any TimeInstanceRegistryStoring,
@@ -500,7 +547,9 @@ public actor CalendarRegistrySyncEngine {
         transactions: any CalendarRegistryTransactionStoring,
         operationGate: CalendarRegistryOperationGate = .shared,
         clock: @Sendable @escaping () -> Date = { Date() },
-        makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() }
+        makeOperationId: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
+        makeLeaseToken: @Sendable @escaping () -> String = { UUID().uuidString.lowercased() },
+        leaseDuration: TimeInterval = 600
     ) {
         self.registry = registry
         self.calendar = calendar
@@ -508,42 +557,56 @@ public actor CalendarRegistrySyncEngine {
         self.operationGate = operationGate
         self.clock = clock
         self.makeOperationId = makeOperationId
+        self.makeLeaseToken = makeLeaseToken
+        self.leaseDuration = leaseDuration
     }
 
     public func registryFirstCreate(
-        _ request: RegistryFirstTimeInstanceRequest
+        _ rawRequest: RegistryFirstTimeInstanceRequest
     ) async throws -> CalendarRegistrySyncReceipt {
+        let request = rawRequest.canonicalized
         try validate(request)
-        await operationGate.acquire(request.idempotencyKey)
+        try await operationGate.acquire(request.idempotencyKey)
         do {
             let receipt = try await performRegistryFirstCreate(request)
             await operationGate.release(request.idempotencyKey)
             return receipt
-        } catch let conflict as CalendarRegistryTransactionStoreError {
+        } catch let storeError as CalendarRegistryTransactionStoreError {
             let existing = try? await transactions.get(idempotencyKey: request.idempotencyKey)
-            let isConflict: Bool
-            if case .idempotencyConflict = conflict { isConflict = true } else { isConflict = false }
             await operationGate.release(request.idempotencyKey)
+            let isConflict: Bool
+            let active: Bool
+            switch storeError {
+            case .idempotencyConflict: isConflict = true; active = false
+            case .operationActive: isConflict = false; active = true
+            default: isConflict = false; active = false
+            }
             return CalendarRegistrySyncReceipt(
                 succeeded: false,
-                infrastructureFault: !isConflict,
+                infrastructureFault: !isConflict && !active,
                 recoveryStatePersisted: existing != nil,
                 registryFailureStatePersisted: false,
                 operationId: existing?.operationId ?? "",
                 idempotencyKey: request.idempotencyKey,
                 operationFingerprint: request.manifest.fingerprint,
+                fencingToken: nil,
+                ledgerRevision: existing?.revision,
+                verifiedSyncHash: nil,
+                verifiedAt: nil,
                 stageBefore: existing?.stage ?? .prepared,
-                stageAfter: isConflict ? .conflict : .recoverableError,
+                stageAfter: isConflict ? .conflict : (existing?.stage ?? .prepared),
                 record: nil,
                 calendarItem: nil,
                 registryFieldsWritten: [],
                 calendarFieldsWritten: [],
                 verificationEvidence: [],
                 partialEffects: existing?.partialEffects ?? [],
-                recoveryAction: isConflict
-                    ? "use a new idempotency key for a materially different manifest"
-                    : "inspect the SQLite recovery ledger before retrying",
-                discrepancy: conflict.localizedDescription
+                recoveryAction: active
+                    ? "another fenced worker owns this operation; retry after its lease ends"
+                    : (isConflict
+                        ? "use a new idempotency key for a materially different manifest"
+                        : "inspect the SQLite recovery ledger before retrying"),
+                discrepancy: storeError.localizedDescription
             )
         } catch {
             await operationGate.release(request.idempotencyKey)
@@ -555,20 +618,131 @@ public actor CalendarRegistrySyncEngine {
         _ request: RegistryFirstTimeInstanceRequest
     ) async throws -> CalendarRegistrySyncReceipt {
         let fingerprint = request.manifest.fingerprint
+        let operationId = makeOperationId()
+        let requestedFence = makeLeaseToken()
         var transaction = try await transactions.claim(
             idempotencyKey: request.idempotencyKey,
             manifestFingerprint: fingerprint,
-            operationId: makeOperationId(),
-            now: clock()
+            operationId: operationId,
+            leaseOwner: operationId,
+            leaseToken: requestedFence,
+            leaseDuration: leaseDuration
         )
         let stageBefore = transaction.stage
+        let fencingToken = transaction.leaseToken
         var record: TimeInstanceRecord?
         var calendarItem: ExternalCalendarItem?
         var registryFields: [String] = []
         var calendarFields: [String] = []
         var evidence: [String] = []
 
+        if transaction.stage == .conflict || transaction.stage == .abandoned {
+            let released = try await transactions.release(transaction)
+            return CalendarRegistrySyncReceipt(
+                succeeded: false,
+                infrastructureFault: false,
+                recoveryStatePersisted: true,
+                registryFailureStatePersisted: false,
+                operationId: transaction.operationId,
+                idempotencyKey: transaction.idempotencyKey,
+                operationFingerprint: fingerprint,
+                fencingToken: fencingToken,
+                ledgerRevision: released.revision,
+                verifiedSyncHash: nil,
+                verifiedAt: nil,
+                stageBefore: stageBefore,
+                stageAfter: stageBefore,
+                record: nil,
+                calendarItem: nil,
+                registryFieldsWritten: [],
+                calendarFieldsWritten: [],
+                verificationEvidence: [],
+                partialEffects: transaction.partialEffects,
+                recoveryAction: "resolve the recorded conflict before automatic retry",
+                discrepancy: transaction.lastError ?? "transaction is not automatically resumable"
+            )
+        }
+
+        if transaction.stage == .synced,
+           let recordId = transaction.registryEventId,
+           let calendarEventId = transaction.calendarEventId {
+            do {
+                let final = try await verify(
+                    request: request,
+                    recordId: recordId,
+                    calendarEventId: calendarEventId
+                )
+                guard final.record.syncState == .synced,
+                      !final.record.syncHash.isEmpty,
+                      let lastSyncedAt = final.record.lastSyncedAt else {
+                    throw CalendarRegistrySyncError.verificationFailed("existing Synced pair lacks durable evidence")
+                }
+                let expectedHash = Self.syncFingerprint(record: final.record, item: final.item)
+                guard final.record.syncHash == expectedHash else {
+                    throw CalendarRegistrySyncError.verificationFailed("existing Synced pair hash differs")
+                }
+                let released = try await transactions.release(transaction)
+                return CalendarRegistrySyncReceipt(
+                    succeeded: true,
+                    infrastructureFault: false,
+                    recoveryStatePersisted: true,
+                    registryFailureStatePersisted: true,
+                    operationId: transaction.operationId,
+                    idempotencyKey: transaction.idempotencyKey,
+                    operationFingerprint: fingerprint,
+                    fencingToken: fencingToken,
+                    ledgerRevision: released.revision,
+                    verifiedSyncHash: expectedHash,
+                    verifiedAt: lastSyncedAt,
+                    stageBefore: stageBefore,
+                    stageAfter: .synced,
+                    record: final.record,
+                    calendarItem: final.item,
+                    registryFieldsWritten: [],
+                    calendarFieldsWritten: [],
+                    verificationEvidence: final.evidence + ["existing Synced pair was reverified without new writes"],
+                    partialEffects: transaction.partialEffects,
+                    recoveryAction: nil,
+                    discrepancy: nil
+                )
+            } catch {
+                transaction.stage = Self.isConflict(error) ? .conflict : .recoverableError
+                transaction.lastError = error.localizedDescription
+                transaction = try await transactions.save(transaction)
+                var releaseError: Error?
+                do { transaction = try await transactions.release(transaction) }
+                catch { releaseError = error }
+                return CalendarRegistrySyncReceipt(
+                    succeeded: false,
+                    infrastructureFault: releaseError != nil,
+                    recoveryStatePersisted: true,
+                    registryFailureStatePersisted: false,
+                    operationId: transaction.operationId,
+                    idempotencyKey: transaction.idempotencyKey,
+                    operationFingerprint: fingerprint,
+                    fencingToken: fencingToken,
+                    ledgerRevision: transaction.revision,
+                    verifiedSyncHash: nil,
+                    verifiedAt: nil,
+                    stageBefore: stageBefore,
+                    stageAfter: transaction.stage,
+                    record: nil,
+                    calendarItem: nil,
+                    registryFieldsWritten: [],
+                    calendarFieldsWritten: [],
+                    verificationEvidence: [],
+                    partialEffects: transaction.partialEffects,
+                    recoveryAction: releaseError == nil
+                        ? "inspect the previously Synced pair before retrying"
+                        : "do not retry until the prior lease expires or the ledger is inspected",
+                    discrepancy: [error.localizedDescription, releaseError.map { "lease release failed: \($0.localizedDescription)" }]
+                        .compactMap { $0 }.joined(separator: " | ")
+                )
+            }
+        }
+
         do {
+            try Task.checkCancellation()
             let qualification = try await calendar.qualify(calendarId: request.calendarId)
             guard qualification.qualifiedForPrivateSmoke else {
                 throw CalendarRegistrySyncError.calendarNotQualified(
@@ -595,68 +769,98 @@ public actor CalendarRegistrySyncEngine {
             pair.syncState = .pendingCreate
             pair.lastSyncError = nil
             pair.registryUpdatedAt = clock()
+            try await fence(&transaction)
             pair = try await registry.save(pair)
             record = pair
             registryFields.append(contentsOf: Self.pairingFieldNames)
 
             transaction.registryEventId = pair.id
             transaction.stage = .pairPersisted
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("pair identity persisted to Notion EVENT")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
 
             let verified = try await verify(
                 request: request, recordId: pair.id, calendarEventId: calendarItem.localEventId
             )
             evidence.append(contentsOf: verified.evidence)
             var verifiedRecord = verified.record
+            let verifiedAt = clock()
+            let expectedHash = Self.syncFingerprint(record: verifiedRecord, item: verified.item)
             verifiedRecord.syncState = .synced
-            verifiedRecord.lastSyncedAt = clock()
-            verifiedRecord.registryUpdatedAt = clock()
+            verifiedRecord.lastSyncedAt = verifiedAt
+            verifiedRecord.registryUpdatedAt = verifiedAt
             verifiedRecord.lastSyncError = nil
-            verifiedRecord.syncHash = Self.syncFingerprint(record: verifiedRecord, item: verified.item)
+            verifiedRecord.syncHash = expectedHash
+            try await fence(&transaction)
             verifiedRecord = try await registry.save(verifiedRecord)
 
             transaction.stage = .verified
-            transaction.lastVerifiedAt = clock()
-            transaction.updatedAt = clock()
+            transaction.lastVerifiedAt = verifiedAt
             transaction.lastError = nil
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
 
             let final = try await verify(
                 request: request,
                 recordId: verifiedRecord.id,
-                calendarEventId: verified.item.localEventId
+                calendarEventId: verified.item.localEventId,
+                expectedSyncHash: expectedHash,
+                expectedSyncedAt: verifiedAt
             )
-            guard final.record.syncState == .synced else {
-                throw CalendarRegistrySyncError.verificationFailed("final Notion read did not retain Synced state")
-            }
-
             transaction.stage = .synced
-            transaction.lastVerifiedAt = clock()
-            transaction.updatedAt = clock()
-            try await transactions.save(transaction)
-            evidence.append("final fresh reads repeated the complete manifest and pair comparison")
+            transaction.lastVerifiedAt = verifiedAt
+            transaction = try await transactions.save(transaction)
+            evidence.append("final fresh reads confirmed the complete manifest, pair identity, Sync Hash, and Last Synced At")
 
-            return CalendarRegistrySyncReceipt(
-                succeeded: true,
-                infrastructureFault: false,
-                recoveryStatePersisted: true,
-                registryFailureStatePersisted: true,
-                operationId: transaction.operationId,
-                idempotencyKey: transaction.idempotencyKey,
-                operationFingerprint: fingerprint,
-                stageBefore: stageBefore,
-                stageAfter: transaction.stage,
-                record: final.record,
-                calendarItem: final.item,
-                registryFieldsWritten: Array(Set(registryFields)).sorted(),
-                calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
-                verificationEvidence: evidence,
-                partialEffects: transaction.partialEffects,
-                recoveryAction: nil,
-                discrepancy: nil
-            )
+            do {
+                let released = try await transactions.release(transaction)
+                return CalendarRegistrySyncReceipt(
+                    succeeded: true,
+                    infrastructureFault: false,
+                    recoveryStatePersisted: true,
+                    registryFailureStatePersisted: true,
+                    operationId: transaction.operationId,
+                    idempotencyKey: transaction.idempotencyKey,
+                    operationFingerprint: fingerprint,
+                    fencingToken: fencingToken,
+                    ledgerRevision: released.revision,
+                    verifiedSyncHash: expectedHash,
+                    verifiedAt: verifiedAt,
+                    stageBefore: stageBefore,
+                    stageAfter: transaction.stage,
+                    record: final.record,
+                    calendarItem: final.item,
+                    registryFieldsWritten: Array(Set(registryFields)).sorted(),
+                    calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
+                    verificationEvidence: evidence,
+                    partialEffects: transaction.partialEffects,
+                    recoveryAction: nil,
+                    discrepancy: nil
+                )
+            } catch {
+                return CalendarRegistrySyncReceipt(
+                    succeeded: false,
+                    infrastructureFault: true,
+                    recoveryStatePersisted: true,
+                    registryFailureStatePersisted: true,
+                    operationId: transaction.operationId,
+                    idempotencyKey: transaction.idempotencyKey,
+                    operationFingerprint: fingerprint,
+                    fencingToken: fencingToken,
+                    ledgerRevision: transaction.revision,
+                    verifiedSyncHash: expectedHash,
+                    verifiedAt: verifiedAt,
+                    stageBefore: stageBefore,
+                    stageAfter: transaction.stage,
+                    record: final.record,
+                    calendarItem: final.item,
+                    registryFieldsWritten: Array(Set(registryFields)).sorted(),
+                    calendarFieldsWritten: Array(Set(calendarFields)).sorted(),
+                    verificationEvidence: evidence,
+                    partialEffects: transaction.partialEffects,
+                    recoveryAction: "pair is verified Synced; wait for lease expiry or inspect the ledger before retrying",
+                    discrepancy: "pair synchronized but lease release failed: \(error.localizedDescription)"
+                )
+            }
         } catch {
             if let partial = error as? PartialRegistryCreateError {
                 transaction.registryEventId = partial.pageId
@@ -664,37 +868,52 @@ public actor CalendarRegistrySyncEngine {
             }
             transaction.stage = Self.isConflict(error) ? .conflict : .recoverableError
             transaction.lastError = error.localizedDescription
-            transaction.updatedAt = clock()
 
             var ledgerError: Error?
-            do { try await transactions.save(transaction) }
+            do { transaction = try await transactions.save(transaction) }
             catch { ledgerError = error }
 
             var registryError: Error?
-            if var failed = record {
-                failed.syncState = transaction.stage == .conflict ? .conflict : .error
-                failed.lastSyncError = error.localizedDescription
-                failed.registryUpdatedAt = clock()
-                do { record = try await registry.save(failed) }
-                catch { registryError = error }
+            var registryFailureWriteAttempted = false
+            if var failed = record, ledgerError == nil {
+                registryFailureWriteAttempted = true
+                do {
+                    transaction = try await transactions.renew(transaction, leaseDuration: leaseDuration)
+                    failed.syncState = transaction.stage == .conflict ? .conflict : .error
+                    failed.lastSyncError = error.localizedDescription
+                    failed.registryUpdatedAt = clock()
+                    record = try await registry.save(failed)
+                } catch {
+                    registryError = error
+                }
             }
 
+            var releaseError: Error?
+            if ledgerError == nil {
+                do { transaction = try await transactions.release(transaction) }
+                catch { releaseError = error }
+            }
             let persisted = ledgerError == nil
-            let registryPersisted = record == nil ? false : registryError == nil
+            let registryPersisted = registryFailureWriteAttempted && registryError == nil
             let combined = [
                 error.localizedDescription,
                 ledgerError.map { "recovery ledger write failed: \($0.localizedDescription)" },
-                registryError.map { "registry failure-state write failed: \($0.localizedDescription)" }
+                registryError.map { "registry failure-state write failed: \($0.localizedDescription)" },
+                releaseError.map { "lease release failed: \($0.localizedDescription)" }
             ].compactMap { $0 }.joined(separator: " | ")
 
             return CalendarRegistrySyncReceipt(
                 succeeded: false,
-                infrastructureFault: !persisted,
+                infrastructureFault: !persisted || releaseError != nil,
                 recoveryStatePersisted: persisted,
                 registryFailureStatePersisted: registryPersisted,
                 operationId: transaction.operationId,
                 idempotencyKey: transaction.idempotencyKey,
                 operationFingerprint: fingerprint,
+                fencingToken: fencingToken,
+                ledgerRevision: transaction.revision,
+                verifiedSyncHash: nil,
+                verifiedAt: nil,
                 stageBefore: stageBefore,
                 stageAfter: transaction.stage,
                 record: record,
@@ -704,11 +923,17 @@ public actor CalendarRegistrySyncEngine {
                 verificationEvidence: evidence,
                 partialEffects: transaction.partialEffects,
                 recoveryAction: persisted
-                    ? "retry with the same idempotency key; resume from \(transaction.stage.rawValue)"
+                    ? "retry with the same idempotency key after the lease is released; resume from \(transaction.stage.rawValue)"
                     : "do not retry automatically; inspect Notion by Sync Key and Calendar by Bridge metadata before reconstructing the ledger",
                 discrepancy: combined
             )
         }
+    }
+
+    private func fence(_ transaction: inout CalendarRegistryTransaction) async throws {
+        try Task.checkCancellation()
+        transaction = try await transactions.renew(transaction, leaseDuration: leaseDuration)
+        try Task.checkCancellation()
     }
 
     private func desiredRecord(_ request: RegistryFirstTimeInstanceRequest) -> TimeInstanceRecord {
@@ -735,14 +960,25 @@ public actor CalendarRegistrySyncEngine {
     ) async throws -> TimeInstanceRecord {
         let desired = desiredRecord(request)
         if let id = transaction.registryEventId {
-            if let existing = try await registry.get(id: id, forceRefresh: true) {
+            switch try await registry.readIdentity(id: id, forceRefresh: true) {
+            case .decoded(let existing):
                 try assertRegistryMatchesManifest(existing, request: request)
                 return existing
+            case .partial(_, let syncKey, let operationFingerprint):
+                guard syncKey == request.idempotencyKey,
+                      operationFingerprint == request.manifest.fingerprint else {
+                    throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page identity differs or is missing")
+                }
+                try await fence(&transaction)
+                let repaired = try await registry.repair(id: id, from: desired)
+                try assertRegistryMatchesManifest(repaired, request: request)
+                fieldsWritten.append(contentsOf: Self.semanticFieldNames)
+                return repaired
+            case .missing:
+                throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page is missing; replacement creation refused")
+            case .malformed(_, let reason):
+                throw CalendarRegistrySyncError.identityConflict("ledger-known Notion page is malformed: \(reason)")
             }
-            let repaired = try await registry.repair(id: id, from: desired)
-            try assertRegistryMatchesManifest(repaired, request: request)
-            fieldsWritten.append(contentsOf: Self.semanticFieldNames)
-            return repaired
         }
 
         let lookup = try await registry.findBySyncKey(request.idempotencyKey)
@@ -754,17 +990,16 @@ public actor CalendarRegistrySyncEngine {
             )
         }
         if let unresolved = lookup.unresolvedIdentities.first {
-            guard unresolved.operationFingerprint == request.manifest.fingerprint else {
-                throw CalendarRegistrySyncError.identityConflict(
-                    "partial Notion EVENT fingerprint differs or is missing"
-                )
+            guard unresolved.syncKey == request.idempotencyKey,
+                  unresolved.operationFingerprint == request.manifest.fingerprint else {
+                throw CalendarRegistrySyncError.identityConflict("partial Notion EVENT identity differs or is missing")
             }
+            try await fence(&transaction)
             let repaired = try await registry.repair(id: unresolved.pageId, from: desired)
             transaction.registryEventId = repaired.id
             transaction.stage = .registryCreated
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("repaired partial Notion EVENT \(repaired.id)")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
             fieldsWritten.append(contentsOf: Self.semanticFieldNames)
             return repaired
         }
@@ -775,27 +1010,25 @@ public actor CalendarRegistrySyncEngine {
             transaction.calendarId = existing.calendarId
             transaction.providerExternalId = existing.providerExternalId
             transaction.stage = .registryCreated
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("reused existing Notion EVENT \(existing.id)")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
             return existing
         }
 
         do {
+            try await fence(&transaction)
             let created = try await registry.create(desired)
             transaction.registryEventId = created.id
             transaction.stage = .registryCreated
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("created Notion EVENT \(created.id)")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
             fieldsWritten.append(contentsOf: Self.semanticFieldNames)
             return created
         } catch let partial as PartialRegistryCreateError {
             transaction.registryEventId = partial.pageId
             transaction.stage = .registryCreated
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("Notion identity envelope created before semantic PATCH failure: \(partial.pageId)")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
             throw partial
         }
     }
@@ -830,9 +1063,8 @@ public actor CalendarRegistrySyncEngine {
             transaction.calendarId = existing.calendarId
             transaction.providerExternalId = existing.providerExternalId
             transaction.stage = .calendarCreated
-            transaction.updatedAt = clock()
             transaction.partialEffects.append("recovered calendar event \(existing.localEventId)")
-            try await transactions.save(transaction)
+            transaction = try await transactions.save(transaction)
             return existing
         }
         if priorEvidence {
@@ -841,6 +1073,7 @@ public actor CalendarRegistrySyncEngine {
             )
         }
 
+        try await fence(&transaction)
         let created = try await calendar.create(ExternalCalendarDraft(
             title: request.title,
             start: request.start,
@@ -857,9 +1090,8 @@ public actor CalendarRegistrySyncEngine {
         transaction.calendarId = created.calendarId
         transaction.providerExternalId = created.providerExternalId
         transaction.stage = .calendarCreated
-        transaction.updatedAt = clock()
         transaction.partialEffects.append("created calendar event \(created.localEventId)")
-        try await transactions.save(transaction)
+        transaction = try await transactions.save(transaction)
         fieldsWritten.append(contentsOf: [
             "title", "start", "end", "timeZone", "calendarId", "location", "notes",
             "syncKey", "operationFingerprint"
@@ -870,7 +1102,9 @@ public actor CalendarRegistrySyncEngine {
     private func verify(
         request: RegistryFirstTimeInstanceRequest,
         recordId: String,
-        calendarEventId: String
+        calendarEventId: String,
+        expectedSyncHash: String? = nil,
+        expectedSyncedAt: Date? = nil
     ) async throws -> (record: TimeInstanceRecord, item: ExternalCalendarItem, evidence: [String]) {
         guard let record = try await registry.get(id: recordId, forceRefresh: true) else {
             throw CalendarRegistrySyncError.verificationFailed("Notion EVENT missing after write")
@@ -885,13 +1119,24 @@ public actor CalendarRegistrySyncEngine {
               record.providerExternalId == item.providerExternalId else {
             throw CalendarRegistrySyncError.verificationFailed("pair identity is not persisted consistently")
         }
+        if let expectedSyncHash {
+            guard record.syncState == .synced,
+                  record.syncHash == expectedSyncHash,
+                  let lastSyncedAt = record.lastSyncedAt else {
+                throw CalendarRegistrySyncError.verificationFailed("final Notion read did not retain Synced evidence")
+            }
+            if let expectedSyncedAt,
+               abs(lastSyncedAt.timeIntervalSince(expectedSyncedAt)) >= 1 {
+                throw CalendarRegistrySyncError.verificationFailed("Last Synced At does not match the verification transaction")
+            }
+        }
         return (
             record,
             item,
             [
                 "fresh Notion read confirmed EVENT \(record.id)",
                 "provider read confirmed calendar event \(item.localEventId)",
-                "Sync Key, operation fingerprint, title, start, end, timezone, calendar ID, event ID, and event shape match the immutable manifest"
+                "canonical manifest, pair identity, event shape, and requested evidence match"
             ]
         )
     }
@@ -901,16 +1146,13 @@ public actor CalendarRegistrySyncEngine {
         guard request.idempotencyKey.range(of: pattern, options: .regularExpression) != nil else {
             throw CalendarRegistrySyncError.invalidIdempotencyKey
         }
+        guard !request.title.isEmpty else { throw CalendarRegistrySyncError.identityConflict("title is empty after canonicalization") }
         guard request.end > request.start else { throw CalendarRegistrySyncError.invalidTimeRange }
         guard TimeZone(identifier: request.timeZoneIdentifier) != nil else {
             throw CalendarRegistrySyncError.invalidTimeZone(request.timeZoneIdentifier)
         }
-        guard !request.calendarId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw CalendarRegistrySyncError.missingCalendarId
-        }
-        guard !request.semantics.primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw CalendarRegistrySyncError.missingPrimaryBlock
-        }
+        guard !request.calendarId.isEmpty else { throw CalendarRegistrySyncError.missingCalendarId }
+        guard !request.semantics.primaryBlockId.isEmpty else { throw CalendarRegistrySyncError.missingPrimaryBlock }
         if let notes = request.notes,
            notes.contains(CalendarRegistryCalendarMetadata.beginMarker) ||
            notes.contains(CalendarRegistryCalendarMetadata.endMarker) {
@@ -937,10 +1179,10 @@ public actor CalendarRegistrySyncEngine {
               record.location == request.location,
               record.notes == request.notes,
               record.semantics == request.semantics else {
-            throw CalendarRegistrySyncError.identityConflict("Notion semantic state differs from the immutable manifest")
+            throw CalendarRegistrySyncError.identityConflict("Notion semantic state differs from the canonical manifest")
         }
         if let calendarId = record.calendarId, calendarId != request.calendarId {
-            throw CalendarRegistrySyncError.identityConflict("Notion calendar ID differs from the immutable manifest")
+            throw CalendarRegistrySyncError.identityConflict("Notion calendar ID differs from the canonical manifest")
         }
     }
 
@@ -965,7 +1207,7 @@ public actor CalendarRegistrySyncEngine {
               item.calendarId == request.calendarId,
               item.location == request.location,
               item.notes == request.notes else {
-            throw CalendarRegistrySyncError.identityConflict("calendar state differs from the immutable manifest")
+            throw CalendarRegistrySyncError.identityConflict("calendar state differs from the canonical manifest")
         }
     }
 
@@ -982,7 +1224,9 @@ public actor CalendarRegistrySyncEngine {
         if let sync = error as? CalendarRegistrySyncError {
             switch sync {
             case .ambiguousRegistryIdentity, .undecodableRegistryIdentity,
-                 .ambiguousCalendarIdentity, .identityConflict:
+                 .ambiguousCalendarIdentity, .identityConflict,
+                 .recurringEventUnsupported, .allDayEventUnsupported,
+                 .detachedEventUnsupported, .participantConsequencesUnsupported:
                 return true
             default:
                 return false
@@ -994,11 +1238,16 @@ public actor CalendarRegistrySyncEngine {
 
     private static func syncFingerprint(record: TimeInstanceRecord, item: ExternalCalendarItem) -> String {
         let canonical = [
-            record.syncKey, record.operationFingerprint, item.calendarId, item.localEventId,
-            item.providerExternalId ?? "", item.title,
-            CalendarRegistryISO.string(item.start), CalendarRegistryISO.string(item.end),
-            item.timeZoneIdentifier, record.semantics.primaryBlockId,
-            record.semantics.eventClass.rawValue
+            record.operationFingerprint,
+            record.syncKey,
+            item.provider,
+            item.calendarId,
+            item.localEventId,
+            item.providerExternalId ?? "",
+            item.itemURL ?? "",
+            record.calendarProvider ?? "",
+            record.calendarEventId ?? "",
+            record.providerExternalId ?? ""
         ].joined(separator: "\u{1F}")
         return CalendarRegistryDigest.sha256(canonical)
     }
@@ -1093,8 +1342,12 @@ public enum CalendarRegistryCalendarMetadata {
                 fingerprint = String(line.dropFirst("Operation-Fingerprint:".count)).trimmingCharacters(in: .whitespaces)
             }
         }
-        guard let syncKey, let fingerprint, !syncKey.isEmpty, fingerprint.count == 64 else {
-            throw CalendarRegistrySyncError.identityConflict("calendar Bridge metadata is incomplete")
+        let keyPattern = #"^[A-Za-z0-9._:-]{1,128}$"#
+        let hexPattern = #"^[0-9a-f]{64}$"#
+        guard let syncKey, let fingerprint,
+              syncKey.range(of: keyPattern, options: .regularExpression) != nil,
+              fingerprint.range(of: hexPattern, options: .regularExpression) != nil else {
+            throw CalendarRegistrySyncError.identityConflict("calendar Bridge metadata is incomplete or invalid")
         }
         return Identity(syncKey: syncKey, operationFingerprint: fingerprint)
     }
@@ -1176,25 +1429,50 @@ public actor CalendarStoringSyncProvider: CalendarSyncProviding {
         let events = try await store.events(CalendarEventQuery(
             start: Self.iso(lower), end: Self.iso(upper), calendarId: nil
         ))
-        let mapped = try events.map(map)
-        let eligible = mapped.filter { !$0.isRecurring && !$0.isAllDay && !$0.isDetached }
+        var mapped: [ExternalCalendarItem] = []
+        for event in events {
+            do {
+                mapped.append(try map(event))
+            } catch {
+                if Self.matchesTargetEvidence(event, query: query) {
+                    throw CalendarRegistrySyncError.identityConflict(
+                        "target-related calendar metadata is malformed for event \(event.id)"
+                    )
+                }
+                continue
+            }
+        }
 
-        let byIdentity = eligible.filter {
+        let byIdentity = mapped.filter {
             $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
         }
         if !byIdentity.isEmpty { return byIdentity }
 
         if let external = query.providerExternalId {
-            let byExternal = eligible.filter { $0.providerExternalId == external }
+            let byExternal = mapped.filter { $0.providerExternalId == external }
             if !byExternal.isEmpty { return byExternal }
         }
 
+        let eligible = mapped.filter { !$0.isRecurring && !$0.isAllDay && !$0.isDetached }
         return eligible.filter {
             $0.calendarId == query.calendarId
                 && $0.title.caseInsensitiveCompare(query.title) == .orderedSame
                 && abs($0.start.timeIntervalSince(query.start)) < 1
                 && abs($0.end.timeIntervalSince(query.end)) < 1
         }
+    }
+
+    private static func matchesTargetEvidence(_ event: CalendarEvent, query: CalendarRecoveryQuery) -> Bool {
+        if event.id == query.localEventId { return true }
+        if let external = query.providerExternalId, event.externalId == external { return true }
+        if event.notes?.contains(query.syncKey) == true || event.notes?.contains(query.operationFingerprint) == true {
+            return true
+        }
+        guard event.calendarId == query.calendarId,
+              event.title.caseInsensitiveCompare(query.title) == .orderedSame,
+              let start = try? CalendarISOParsing.parse(event.start),
+              let end = try? CalendarISOParsing.parse(event.end) else { return false }
+        return abs(start.timeIntervalSince(query.start)) < 1 && abs(end.timeIntervalSince(query.end)) < 1
     }
 
     private func map(_ event: CalendarEvent) throws -> ExternalCalendarItem {
@@ -1282,8 +1560,15 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
                     } else {
                         fingerprint = nil
                     }
+                    let rawSyncKey: String?
+                    if case .object(let properties) = cached.properties {
+                        rawSyncKey = Self.string(properties["syncKey"])
+                    } else {
+                        rawSyncKey = nil
+                    }
                     unresolved.append(RegistryUnresolvedIdentity(
                         pageId: row.id,
+                        syncKey: rawSyncKey,
                         operationFingerprint: fingerprint
                     ))
                 }
@@ -1297,9 +1582,31 @@ public struct NotionTimeInstanceRegistryStore: TimeInstanceRegistryStoring {
         )
     }
 
+    public func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
+        let row: CachedRow
+        do {
+            row = try await reader.get(entity: entity, pageId: id, forceRefresh: forceRefresh)
+        } catch let error as RegistryReader.RegistryReadError {
+            if case .deleted = error { return .missing }
+            throw error
+        }
+        if let decoded = Self.decode(row) { return .decoded(decoded) }
+        guard case .object(let properties) = row.properties else {
+            return .malformed(pageId: row.pageId, reason: "projected properties are not an object")
+        }
+        let syncKey = Self.string(properties["syncKey"])
+        let fingerprint = Self.string(properties["operationFingerprint"])
+        if syncKey != nil || fingerprint != nil {
+            return .partial(pageId: row.pageId, syncKey: syncKey, operationFingerprint: fingerprint)
+        }
+        return .malformed(pageId: row.pageId, reason: "Sync Key and Operation Fingerprint are absent")
+    }
+
     public func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
-        let row = try await reader.get(entity: entity, pageId: id, forceRefresh: forceRefresh)
-        return Self.decode(row)
+        switch try await readIdentity(id: id, forceRefresh: forceRefresh) {
+        case .decoded(let record): return record
+        case .partial, .missing, .malformed: return nil
+        }
     }
 
     public func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -1,7 +1,12 @@
-// CalendarRegistryTransactionStore.swift — durable registry-first operation journal
+// CalendarRegistryTransactionStore.swift — transactional registry-first recovery ledger
 
 import CryptoKit
 import Foundation
+import SQLite3
+
+private let calendarRegistrySQLiteTransient = unsafeBitCast(
+    OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self
+)
 
 public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIterable {
     case prepared
@@ -20,19 +25,36 @@ public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
     public var start: Date
     public var end: Date
     public var timeZoneIdentifier: String
-    public var calendarId: String?
+    public var calendarId: String
     public var location: String?
     public var notes: String?
     public var eventClass: String
+    public var meetingType: String?
     public var primaryBlockId: String
     public var blockIds: [String]
     public var projectIds: [String]
     public var contactIds: [String]
 
+    public var canonicalized: CalendarRegistryOperationManifest {
+        var copy = self
+        copy.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.calendarId = calendarId.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.timeZoneIdentifier = timeZoneIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.location = location?.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.notes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.meetingType = meetingType?.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.primaryBlockId = primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.blockIds = Array(Set(blockIds)).sorted()
+        copy.projectIds = Array(Set(projectIds)).sorted()
+        copy.contactIds = Array(Set(contactIds)).sorted()
+        return copy
+    }
+
     public var fingerprint: String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(self) else { return "" }
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(canonicalized) else { return "" }
         return CalendarRegistryDigest.sha256(data)
     }
 }
@@ -85,14 +107,20 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
 
 public enum CalendarRegistryTransactionStoreError: Error, LocalizedError, Equatable {
     case idempotencyConflict(String)
-    case corruptJournal(String)
+    case corruptLedger(String)
+    case storageFailure(String)
+    case missingTransaction(String)
 
     public var errorDescription: String? {
         switch self {
         case .idempotencyConflict(let key):
             return "idempotency key already belongs to a different manifest: \(key)"
-        case .corruptJournal(let reason):
-            return "calendar-registry transaction journal is corrupt: \(reason)"
+        case .corruptLedger(let reason):
+            return "calendar-registry transaction ledger is corrupt: \(reason)"
+        case .storageFailure(let reason):
+            return "calendar-registry transaction ledger failed: \(reason)"
+        case .missingTransaction(let key):
+            return "calendar-registry transaction is missing: \(key)"
         }
     }
 }
@@ -108,25 +136,344 @@ public protocol CalendarRegistryTransactionStoring: Sendable {
     func save(_ transaction: CalendarRegistryTransaction) async throws
 }
 
-public actor JSONCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
+/// SQLite-backed recovery ledger. SQLite's unique key and `BEGIN IMMEDIATE`
+/// transaction are the correctness boundary across actors and processes. The
+/// process-local operation gate is only a latency optimization.
+public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
+    public static let schemaVersion = 1
+
     private let url: URL
-    private var transactions: [String: CalendarRegistryTransaction]
+    nonisolated(unsafe) private var db: OpaquePointer?
 
     public init(url: URL) throws {
         self.url = url
-        if FileManager.default.fileExists(atPath: url.path) {
-            do {
-                let data = try Data(contentsOf: url)
-                self.transactions = try JSONDecoder().decode(
-                    [String: CalendarRegistryTransaction].self, from: data
-                )
-            } catch {
-                throw CalendarRegistryTransactionStoreError.corruptJournal(error.localizedDescription)
-            }
-        } else {
-            self.transactions = [:]
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+        let rc = sqlite3_open_v2(url.path, &handle, flags, nil)
+        guard rc == SQLITE_OK, let handle else {
+            let message = handle.map { String(cString: sqlite3_errmsg($0)) } ?? "sqlite3_open_v2 rc=\(rc)"
+            if let handle { sqlite3_close_v2(handle) }
+            throw CalendarRegistryTransactionStoreError.storageFailure(message)
+        }
+        self.db = handle
+        sqlite3_busy_timeout(handle, 5_000)
+        do {
+            try Self.bootstrap(handle)
+        } catch {
+            sqlite3_close_v2(handle)
+            self.db = nil
+            throw error
         }
     }
+
+    deinit {
+        if let db { sqlite3_close_v2(db) }
+    }
+
+    private static func bootstrap(_ db: OpaquePointer) throws {
+        func exec(_ sql: String) throws {
+            var error: UnsafeMutablePointer<Int8>?
+            let rc = sqlite3_exec(db, sql, nil, nil, &error)
+            guard rc == SQLITE_OK else {
+                let message = error.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
+                if let error { sqlite3_free(error) }
+                throw CalendarRegistryTransactionStoreError.storageFailure(message)
+            }
+        }
+        try exec("PRAGMA journal_mode=WAL;")
+        try exec("PRAGMA synchronous=FULL;")
+        try exec("PRAGMA foreign_keys=ON;")
+        try exec("CREATE TABLE IF NOT EXISTS calendar_registry_schema (version INTEGER NOT NULL);")
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "SELECT version FROM calendar_registry_schema LIMIT 1;", -1, &stmt, nil) == SQLITE_OK else {
+            throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+        }
+        defer { sqlite3_finalize(stmt) }
+        let rc = sqlite3_step(stmt)
+        if rc == SQLITE_DONE {
+            try exec("INSERT INTO calendar_registry_schema(version) VALUES (\(Self.schemaVersion));")
+        } else if rc == SQLITE_ROW {
+            let version = Int(sqlite3_column_int64(stmt, 0))
+            guard version == Self.schemaVersion else {
+                throw CalendarRegistryTransactionStoreError.corruptLedger(
+                    "unsupported schema version \(version); expected \(Self.schemaVersion)"
+                )
+            }
+        } else {
+            throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+        }
+        try exec("""
+        CREATE TABLE IF NOT EXISTS calendar_registry_transactions (
+            idempotency_key TEXT PRIMARY KEY NOT NULL,
+            operation_id TEXT NOT NULL,
+            manifest_fingerprint TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            registry_event_id TEXT,
+            calendar_event_id TEXT,
+            calendar_id TEXT,
+            provider_external_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_verified_at TEXT,
+            last_error TEXT,
+            partial_effects_json TEXT NOT NULL
+        );
+        """)
+    }
+
+    public func claim(
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        operationId: String,
+        now: Date
+    ) throws -> CalendarRegistryTransaction {
+        try beginImmediate()
+        do {
+            if let existing = try select(idempotencyKey: idempotencyKey) {
+                guard existing.manifestFingerprint == manifestFingerprint else {
+                    try rollback()
+                    throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
+                }
+                try commit()
+                return existing
+            }
+            let transaction = CalendarRegistryTransaction(
+                operationId: operationId,
+                idempotencyKey: idempotencyKey,
+                manifestFingerprint: manifestFingerprint,
+                createdAt: now,
+                updatedAt: now
+            )
+            try insert(transaction)
+            try commit()
+            return transaction
+        } catch {
+            try? rollback()
+            throw error
+        }
+    }
+
+    public func get(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
+        try select(idempotencyKey: idempotencyKey)
+    }
+
+    public func save(_ transaction: CalendarRegistryTransaction) throws {
+        try beginImmediate()
+        do {
+            guard let existing = try select(idempotencyKey: transaction.idempotencyKey) else {
+                throw CalendarRegistryTransactionStoreError.missingTransaction(transaction.idempotencyKey)
+            }
+            guard existing.manifestFingerprint == transaction.manifestFingerprint else {
+                throw CalendarRegistryTransactionStoreError.idempotencyConflict(transaction.idempotencyKey)
+            }
+            try update(transaction)
+            try commit()
+        } catch {
+            try? rollback()
+            throw error
+        }
+    }
+
+    private func migrate() throws {
+        try execute("CREATE TABLE IF NOT EXISTS calendar_registry_schema (version INTEGER NOT NULL);")
+        let version = try scalarInt("SELECT version FROM calendar_registry_schema LIMIT 1;")
+        if version == nil {
+            try execute("INSERT INTO calendar_registry_schema(version) VALUES (\(Self.schemaVersion));")
+        } else if version != Self.schemaVersion {
+            throw CalendarRegistryTransactionStoreError.corruptLedger(
+                "unsupported schema version \(version ?? -1); expected \(Self.schemaVersion)"
+            )
+        }
+        try execute("""
+        CREATE TABLE IF NOT EXISTS calendar_registry_transactions (
+            idempotency_key TEXT PRIMARY KEY NOT NULL,
+            operation_id TEXT NOT NULL,
+            manifest_fingerprint TEXT NOT NULL,
+            stage TEXT NOT NULL,
+            registry_event_id TEXT,
+            calendar_event_id TEXT,
+            calendar_id TEXT,
+            provider_external_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_verified_at TEXT,
+            last_error TEXT,
+            partial_effects_json TEXT NOT NULL
+        );
+        """)
+    }
+
+    private func insert(_ transaction: CalendarRegistryTransaction) throws {
+        let sql = """
+        INSERT INTO calendar_registry_transactions (
+            idempotency_key, operation_id, manifest_fingerprint, stage,
+            registry_event_id, calendar_event_id, calendar_id, provider_external_id,
+            created_at, updated_at, last_verified_at, last_error, partial_effects_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """
+        try withStatement(sql) { stmt in try bind(transaction, to: stmt); try stepDone(stmt) }
+    }
+
+    private func update(_ transaction: CalendarRegistryTransaction) throws {
+        let sql = """
+        UPDATE calendar_registry_transactions SET
+            operation_id=?, manifest_fingerprint=?, stage=?, registry_event_id=?,
+            calendar_event_id=?, calendar_id=?, provider_external_id=?, created_at=?,
+            updated_at=?, last_verified_at=?, last_error=?, partial_effects_json=?
+        WHERE idempotency_key=?;
+        """
+        try withStatement(sql) { stmt in
+            try bindText(stmt, 1, transaction.operationId)
+            try bindText(stmt, 2, transaction.manifestFingerprint)
+            try bindText(stmt, 3, transaction.stage.rawValue)
+            try bindOptionalText(stmt, 4, transaction.registryEventId)
+            try bindOptionalText(stmt, 5, transaction.calendarEventId)
+            try bindOptionalText(stmt, 6, transaction.calendarId)
+            try bindOptionalText(stmt, 7, transaction.providerExternalId)
+            try bindText(stmt, 8, CalendarRegistryISO.string(transaction.createdAt))
+            try bindText(stmt, 9, CalendarRegistryISO.string(transaction.updatedAt))
+            try bindOptionalText(stmt, 10, transaction.lastVerifiedAt.map(CalendarRegistryISO.string))
+            try bindOptionalText(stmt, 11, transaction.lastError)
+            try bindText(stmt, 12, try partialEffectsJSON(transaction.partialEffects))
+            try bindText(stmt, 13, transaction.idempotencyKey)
+            try stepDone(stmt)
+        }
+    }
+
+    private func bind(_ transaction: CalendarRegistryTransaction, to stmt: OpaquePointer?) throws {
+        try bindText(stmt, 1, transaction.idempotencyKey)
+        try bindText(stmt, 2, transaction.operationId)
+        try bindText(stmt, 3, transaction.manifestFingerprint)
+        try bindText(stmt, 4, transaction.stage.rawValue)
+        try bindOptionalText(stmt, 5, transaction.registryEventId)
+        try bindOptionalText(stmt, 6, transaction.calendarEventId)
+        try bindOptionalText(stmt, 7, transaction.calendarId)
+        try bindOptionalText(stmt, 8, transaction.providerExternalId)
+        try bindText(stmt, 9, CalendarRegistryISO.string(transaction.createdAt))
+        try bindText(stmt, 10, CalendarRegistryISO.string(transaction.updatedAt))
+        try bindOptionalText(stmt, 11, transaction.lastVerifiedAt.map(CalendarRegistryISO.string))
+        try bindOptionalText(stmt, 12, transaction.lastError)
+        try bindText(stmt, 13, try partialEffectsJSON(transaction.partialEffects))
+    }
+
+    private func select(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
+        let sql = """
+        SELECT operation_id, idempotency_key, manifest_fingerprint, stage,
+               registry_event_id, calendar_event_id, calendar_id, provider_external_id,
+               created_at, updated_at, last_verified_at, last_error, partial_effects_json
+        FROM calendar_registry_transactions WHERE idempotency_key=? LIMIT 1;
+        """
+        return try withStatement(sql) { stmt in
+            try bindText(stmt, 1, idempotencyKey)
+            let rc = sqlite3_step(stmt)
+            if rc == SQLITE_DONE { return nil }
+            guard rc == SQLITE_ROW else { throw sqliteError("select", rc: rc) }
+            guard
+                let stage = CalendarRegistryTransactionStage(rawValue: text(stmt, 3) ?? ""),
+                let createdAt = text(stmt, 8).flatMap(CalendarRegistryISO.date),
+                let updatedAt = text(stmt, 9).flatMap(CalendarRegistryISO.date)
+            else {
+                throw CalendarRegistryTransactionStoreError.corruptLedger(
+                    "invalid transaction row for \(idempotencyKey)"
+                )
+            }
+            let effectsData = Data((text(stmt, 12) ?? "[]").utf8)
+            let effects = (try? JSONDecoder().decode([String].self, from: effectsData)) ?? []
+            return CalendarRegistryTransaction(
+                operationId: text(stmt, 0) ?? "",
+                idempotencyKey: text(stmt, 1) ?? idempotencyKey,
+                manifestFingerprint: text(stmt, 2) ?? "",
+                stage: stage,
+                registryEventId: text(stmt, 4),
+                calendarEventId: text(stmt, 5),
+                calendarId: text(stmt, 6),
+                providerExternalId: text(stmt, 7),
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                lastVerifiedAt: text(stmt, 10).flatMap(CalendarRegistryISO.date),
+                lastError: text(stmt, 11),
+                partialEffects: effects
+            )
+        }
+    }
+
+    private func partialEffectsJSON(_ effects: [String]) throws -> String {
+        String(decoding: try JSONEncoder().encode(effects), as: UTF8.self)
+    }
+
+    private func beginImmediate() throws { try execute("BEGIN IMMEDIATE;") }
+    private func commit() throws { try execute("COMMIT;") }
+    private func rollback() throws { try execute("ROLLBACK;") }
+
+    private func execute(_ sql: String) throws {
+        guard let db else { throw CalendarRegistryTransactionStoreError.storageFailure("database is closed") }
+        var error: UnsafeMutablePointer<Int8>?
+        let rc = sqlite3_exec(db, sql, nil, nil, &error)
+        guard rc == SQLITE_OK else {
+            let message = error.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
+            if let error { sqlite3_free(error) }
+            throw CalendarRegistryTransactionStoreError.storageFailure(message)
+        }
+    }
+
+    private func scalarInt(_ sql: String) throws -> Int? {
+        try withStatement(sql) { stmt in
+            let rc = sqlite3_step(stmt)
+            if rc == SQLITE_DONE { return nil }
+            guard rc == SQLITE_ROW else { throw sqliteError("scalar", rc: rc) }
+            return Int(sqlite3_column_int64(stmt, 0))
+        }
+    }
+
+    private func withStatement<T>(_ sql: String, _ body: (OpaquePointer?) throws -> T) throws -> T {
+        guard let db else { throw CalendarRegistryTransactionStoreError.storageFailure("database is closed") }
+        var stmt: OpaquePointer?
+        let rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nil)
+        guard rc == SQLITE_OK else { throw sqliteError("prepare", rc: rc) }
+        defer { sqlite3_finalize(stmt) }
+        return try body(stmt)
+    }
+
+    private func bindText(_ stmt: OpaquePointer?, _ index: Int32, _ value: String) throws {
+        let rc = sqlite3_bind_text(stmt, index, value, -1, calendarRegistrySQLiteTransient)
+        guard rc == SQLITE_OK else { throw sqliteError("bind text", rc: rc) }
+    }
+
+    private func bindOptionalText(_ stmt: OpaquePointer?, _ index: Int32, _ value: String?) throws {
+        if let value { try bindText(stmt, index, value) }
+        else {
+            let rc = sqlite3_bind_null(stmt, index)
+            guard rc == SQLITE_OK else { throw sqliteError("bind null", rc: rc) }
+        }
+    }
+
+    private func stepDone(_ stmt: OpaquePointer?) throws {
+        let rc = sqlite3_step(stmt)
+        guard rc == SQLITE_DONE else { throw sqliteError("step", rc: rc) }
+    }
+
+    private func text(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL,
+              let raw = sqlite3_column_text(stmt, index) else { return nil }
+        return String(cString: raw)
+    }
+
+    private func sqliteError(_ operation: String, rc: Int32) -> CalendarRegistryTransactionStoreError {
+        let message = db.map { String(cString: sqlite3_errmsg($0)) } ?? "sqlite rc=\(rc)"
+        return .storageFailure("\(operation): \(message)")
+    }
+}
+
+public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
+    private var transactions: [String: CalendarRegistryTransaction] = [:]
+    private var failNextSaveMessage: String?
+
+    public init() {}
+
+    public func setFailNextSave(_ message: String?) { failNextSaveMessage = message }
 
     public func claim(
         idempotencyKey: String,
@@ -148,7 +495,6 @@ public actor JSONCalendarRegistryTransactionStore: CalendarRegistryTransactionSt
             updatedAt: now
         )
         transactions[idempotencyKey] = transaction
-        try persist()
         return transaction
     }
 
@@ -157,57 +503,13 @@ public actor JSONCalendarRegistryTransactionStore: CalendarRegistryTransactionSt
     }
 
     public func save(_ transaction: CalendarRegistryTransaction) throws {
-        transactions[transaction.idempotencyKey] = transaction
-        try persist()
-    }
-
-    private func persist() throws {
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(transactions)
-        try data.write(to: url, options: .atomic)
-    }
-}
-
-public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
-    private var transactions: [String: CalendarRegistryTransaction] = [:]
-
-    public init() {}
-
-    public func claim(
-        idempotencyKey: String,
-        manifestFingerprint: String,
-        operationId: String,
-        now: Date
-    ) throws -> CalendarRegistryTransaction {
-        if let existing = transactions[idempotencyKey] {
-            guard existing.manifestFingerprint == manifestFingerprint else {
-                throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
-            }
-            return existing
+        if let message = failNextSaveMessage {
+            failNextSaveMessage = nil
+            throw CalendarRegistryTransactionStoreError.storageFailure(message)
         }
-        let transaction = CalendarRegistryTransaction(
-            operationId: operationId,
-            idempotencyKey: idempotencyKey,
-            manifestFingerprint: manifestFingerprint,
-            createdAt: now,
-            updatedAt: now
-        )
-        transactions[idempotencyKey] = transaction
-        return transaction
-    }
-
-    public func get(idempotencyKey: String) -> CalendarRegistryTransaction? {
-        transactions[idempotencyKey]
-    }
-
-    public func save(_ transaction: CalendarRegistryTransaction) {
         transactions[transaction.idempotencyKey] = transaction
     }
 }
-
 
 public enum CalendarRegistryDigest {
     public static func sha256(_ data: Data) -> String {
@@ -234,7 +536,6 @@ public enum CalendarRegistryISO {
         return formatter.date(from: value)
     }
 }
-
 
 public actor CalendarRegistryOperationGate {
     public static let shared = CalendarRegistryOperationGate()

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -10,7 +10,9 @@ private let calendarRegistrySQLiteTransient = unsafeBitCast(
 
 public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIterable {
     case prepared
-    case registryCreated
+    case registryVerified
+    case calendarCreateIntent
+    case calendarEffectUnknown
     case calendarCreated
     case pairPersisted
     case verified
@@ -22,24 +24,31 @@ public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIte
     fileprivate var progressRank: Int? {
         switch self {
         case .prepared: return 0
-        case .registryCreated: return 1
-        case .calendarCreated: return 2
-        case .pairPersisted: return 3
-        case .verified: return 4
-        case .synced: return 5
-        case .recoverableError, .conflict, .abandoned: return nil
+        case .registryVerified: return 1
+        case .calendarCreateIntent: return 2
+        case .calendarCreated: return 3
+        case .pairPersisted: return 4
+        case .verified: return 5
+        case .synced: return 6
+        case .calendarEffectUnknown, .recoverableError, .conflict, .abandoned: return nil
         }
     }
 
     fileprivate func permitsTransition(to next: Self) -> Bool {
         if self == next { return true }
-        if next == .recoverableError || next == .conflict || next == .abandoned { return true }
+        if next == .conflict || next == .abandoned { return true }
         switch self {
         case .conflict, .abandoned:
             return false
+        case .calendarCreateIntent:
+            return next == .calendarEffectUnknown || next == .calendarCreated
+                || next == .recoverableError || next == .conflict || next == .abandoned
+        case .calendarEffectUnknown:
+            return next == .calendarCreated || next == .conflict || next == .abandoned
         case .recoverableError:
-            return next.progressRank != nil
+            return next == .registryVerified || next == .conflict || next == .abandoned
         default:
+            if next == .recoverableError { return true }
             guard let current = progressRank, let target = next.progressRank else { return false }
             return target >= current
         }
@@ -205,7 +214,8 @@ public protocol CalendarRegistryTransactionStoring: Sendable {
         operationId: String,
         leaseOwner: String,
         leaseToken: String,
-        leaseDuration: TimeInterval
+        leaseDuration: TimeInterval,
+        exclusiveProcessLockHeld: Bool
     ) async throws -> CalendarRegistryTransaction
     func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) async throws -> CalendarRegistryTransaction
     func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction?
@@ -213,11 +223,12 @@ public protocol CalendarRegistryTransactionStoring: Sendable {
     func release(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction
 }
 
-/// SQLite-backed single-machine transaction coordinator. The unique key,
-/// lease/fencing token, monotonic revision, and compare-and-swap saves are the
-/// correctness boundary across actors and processes sharing this local file.
+/// SQLite-backed single-machine recovery ledger. The unique key, lease metadata,
+/// monotonic revision, and compare-and-swap saves preserve transaction evidence.
+/// Cross-process external-effect exclusion is provided by the separate OS advisory
+/// lock; callers may override a stale SQLite lease only while holding that lock.
 public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
-    public static let schemaVersion = 2
+    public static let schemaVersion = 3
 
     private let url: URL
     nonisolated(unsafe) private var db: OpaquePointer?
@@ -300,9 +311,9 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             }
             if schemaRows == 1 {
                 let existingVersion = try scalarInt("SELECT version FROM calendar_registry_schema LIMIT 1;") ?? -1
-                guard existingVersion == 1 || existingVersion == Self.schemaVersion else {
+                guard (1...Self.schemaVersion).contains(existingVersion) else {
                     throw CalendarRegistryTransactionStoreError.corruptLedger(
-                        "unsupported schema version \(existingVersion); expected 1 or \(Self.schemaVersion)"
+                        "unsupported schema version \(existingVersion); expected 1...\(Self.schemaVersion)"
                     )
                 }
             }
@@ -340,6 +351,7 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 try exec("ALTER TABLE calendar_registry_transactions ADD COLUMN \(name) \(definition);")
             }
             try exec("UPDATE calendar_registry_transactions SET revision=1 WHERE revision IS NULL OR revision < 1;")
+            try exec("UPDATE calendar_registry_transactions SET stage='registryVerified' WHERE stage='registryCreated';")
 
             try exec("DROP TABLE IF EXISTS calendar_registry_schema_new;")
             try exec("CREATE TABLE calendar_registry_schema_new (id INTEGER PRIMARY KEY CHECK(id=1), version INTEGER NOT NULL);")
@@ -359,7 +371,8 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         operationId: String,
         leaseOwner: String,
         leaseToken: String,
-        leaseDuration: TimeInterval
+        leaseDuration: TimeInterval,
+        exclusiveProcessLockHeld: Bool
     ) throws -> CalendarRegistryTransaction {
         try validateIdentity(idempotencyKey, manifestFingerprint, operationId, leaseOwner, leaseToken)
         guard leaseDuration > 0 else { throw CalendarRegistryTransactionStoreError.storageFailure("lease duration must be positive") }
@@ -370,7 +383,8 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 guard existing.manifestFingerprint == manifestFingerprint else {
                     throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
                 }
-                if let expiry = existing.leaseExpiresAt?.timeIntervalSince1970,
+                if !exclusiveProcessLockHeld,
+                   let expiry = existing.leaseExpiresAt?.timeIntervalSince1970,
                    existing.leaseToken?.isEmpty == false,
                    expiry > now {
                     throw CalendarRegistryTransactionStoreError.operationActive(
@@ -429,8 +443,7 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             let sql = """
             UPDATE calendar_registry_transactions SET
                 lease_expires_at=?, heartbeat_at=?, updated_at=?, revision=revision+1
-            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?
-              AND lease_expires_at > CAST(strftime('%s','now') AS REAL);
+            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?;
             """
             try withStatement(sql) { stmt in
                 try bindDouble(stmt, 1, now + leaseDuration)
@@ -469,8 +482,7 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 calendar_event_id=?, calendar_id=?, provider_external_id=?, created_at=?,
                 updated_at=?, last_verified_at=?, last_error=?, partial_effects_json=?,
                 heartbeat_at=?, revision=revision+1
-            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?
-              AND lease_expires_at > CAST(strftime('%s','now') AS REAL);
+            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?;
             """
             try withStatement(sql) { stmt in
                 try bindText(stmt, 1, transaction.operationId)
@@ -555,20 +567,17 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             ("calendar event id", existing.calendarEventId, incoming.calendarEventId),
             ("calendar id", existing.calendarId, incoming.calendarId),
             ("provider external id", existing.providerExternalId, incoming.providerExternalId)
-        ] where old?.isEmpty == false && new?.isEmpty != false {
-            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) cannot be cleared")
+        ] where old?.isEmpty == false && new != old {
+            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) is immutable once established")
         }
     }
 
-    private func ownershipError(for transaction: CalendarRegistryTransaction, requireUnexpired: Bool = true) throws -> CalendarRegistryTransactionStoreError {
+    private func ownershipError(for transaction: CalendarRegistryTransaction, requireUnexpired _: Bool = true) throws -> CalendarRegistryTransactionStoreError {
         guard let current = try select(idempotencyKey: transaction.idempotencyKey) else {
             return .missingTransaction(transaction.idempotencyKey)
         }
         if current.revision != transaction.revision { return .staleRevision(transaction.idempotencyKey) }
         if current.leaseToken != transaction.leaseToken || current.leaseOwner != transaction.leaseOwner {
-            return .leaseLost(transaction.idempotencyKey)
-        }
-        if requireUnexpired, let expiry = current.leaseExpiresAt, expiry.timeIntervalSince1970 <= (try currentEpoch()) {
             return .leaseLost(transaction.idempotencyKey)
         }
         return .storageFailure("compare-and-swap update changed no rows")
@@ -757,12 +766,14 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
         operationId: String,
         leaseOwner: String,
         leaseToken: String,
-        leaseDuration: TimeInterval
+        leaseDuration: TimeInterval,
+        exclusiveProcessLockHeld: Bool
     ) throws -> CalendarRegistryTransaction {
         let now = Date()
         if var existing = transactions[idempotencyKey] {
             guard existing.manifestFingerprint == manifestFingerprint else { throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey) }
-            if let expiry = existing.leaseExpiresAt, existing.leaseToken != nil, expiry > now {
+            if !exclusiveProcessLockHeld,
+               let expiry = existing.leaseExpiresAt, existing.leaseToken != nil, expiry > now {
                 throw CalendarRegistryTransactionStoreError.operationActive(idempotencyKey, expiry)
             }
             existing.operationId = operationId
@@ -817,8 +828,8 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
             ("calendar event id", current.calendarEventId, transaction.calendarEventId),
             ("calendar id", current.calendarId, transaction.calendarId),
             ("provider external id", current.providerExternalId, transaction.providerExternalId)
-        ] where old?.isEmpty == false && new?.isEmpty != false {
-            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) cannot be cleared")
+        ] where old?.isEmpty == false && new != old {
+            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) is immutable once established")
         }
         var saved = transaction
         saved.revision += 1
@@ -840,12 +851,11 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
         return current
     }
 
-    private func owned(_ transaction: CalendarRegistryTransaction, requireUnexpired: Bool = true) throws -> CalendarRegistryTransaction {
+    private func owned(_ transaction: CalendarRegistryTransaction, requireUnexpired _: Bool = true) throws -> CalendarRegistryTransaction {
         guard let current = transactions[transaction.idempotencyKey] else { throw CalendarRegistryTransactionStoreError.missingTransaction(transaction.idempotencyKey) }
         guard current.revision == transaction.revision else { throw CalendarRegistryTransactionStoreError.staleRevision(transaction.idempotencyKey) }
         guard current.leaseToken == transaction.leaseToken, current.leaseOwner == transaction.leaseOwner,
               transaction.leaseToken?.isEmpty == false else { throw CalendarRegistryTransactionStoreError.leaseLost(transaction.idempotencyKey) }
-        if requireUnexpired, let expiry = current.leaseExpiresAt, expiry <= Date() { throw CalendarRegistryTransactionStoreError.leaseLost(transaction.idempotencyKey) }
         return current
     }
 }

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -65,6 +65,8 @@ public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
     public var notes: String?
     public var eventClass: String
     public var meetingType: String?
+    public var schedulingAuthority: String
+    public var expectedInitialSyncState: String
     public var primaryBlockId: String
     public var blockIds: [String]
     public var projectIds: [String]
@@ -86,6 +88,8 @@ public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
         copy.notes = Self.normalizedOptional(notes)
         copy.eventClass = eventClass.trimmingCharacters(in: .whitespacesAndNewlines)
         copy.meetingType = Self.normalizedOptional(meetingType)
+        copy.schedulingAuthority = schedulingAuthority.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.expectedInitialSyncState = expectedInitialSyncState.trimmingCharacters(in: .whitespacesAndNewlines)
         copy.primaryBlockId = primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines)
         copy.blockIds = Array(Set(blockIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty } + [copy.primaryBlockId].filter { !$0.isEmpty })).sorted()
@@ -111,6 +115,8 @@ public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
             optional(value.notes),
             field(value.eventClass),
             optional(value.meetingType),
+            field(value.schedulingAuthority),
+            field(value.expectedInitialSyncState),
             field(value.primaryBlockId),
             list(value.blockIds),
             list(value.projectIds),
@@ -393,19 +399,18 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 }
                 let sql = """
                 UPDATE calendar_registry_transactions SET
-                    operation_id=?, lease_owner=?, lease_token=?, lease_expires_at=?, heartbeat_at=?,
+                    lease_owner=?, lease_token=?, lease_expires_at=?, heartbeat_at=?,
                     updated_at=?, revision=revision+1
                 WHERE idempotency_key=? AND revision=?;
                 """
                 try withStatement(sql) { stmt in
-                    try bindText(stmt, 1, operationId)
-                    try bindText(stmt, 2, leaseOwner)
-                    try bindText(stmt, 3, leaseToken)
-                    try bindDouble(stmt, 4, now + leaseDuration)
-                    try bindDouble(stmt, 5, now)
-                    try bindText(stmt, 6, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
-                    try bindText(stmt, 7, idempotencyKey)
-                    try bindInt(stmt, 8, existing.revision)
+                    try bindText(stmt, 1, leaseOwner)
+                    try bindText(stmt, 2, leaseToken)
+                    try bindDouble(stmt, 3, now + leaseDuration)
+                    try bindDouble(stmt, 4, now)
+                    try bindText(stmt, 5, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
+                    try bindText(stmt, 6, idempotencyKey)
+                    try bindInt(stmt, 7, existing.revision)
                     try stepDone(stmt)
                 }
                 guard sqlite3_changes(db) == 1 else { throw CalendarRegistryTransactionStoreError.staleRevision(idempotencyKey) }
@@ -776,7 +781,6 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
                let expiry = existing.leaseExpiresAt, existing.leaseToken != nil, expiry > now {
                 throw CalendarRegistryTransactionStoreError.operationActive(idempotencyKey, expiry)
             }
-            existing.operationId = operationId
             existing.leaseOwner = leaseOwner
             existing.leaseToken = leaseToken
             existing.leaseExpiresAt = now.addingTimeInterval(leaseDuration)

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -9,46 +9,43 @@ private let calendarRegistrySQLiteTransient = unsafeBitCast(
 )
 
 public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIterable {
-    case prepared
-    case registryVerified
-    case calendarCreateIntent
+    case claimed
+    case registryAuthorized
+    case createInvocationPersisted
     case calendarEffectUnknown
-    case calendarCreated
-    case pairPersisted
-    case verified
-    case synced
-    case recoverableError
+    case calendarIdentified
+    case pairIdentityPersisted
+    case syncEvidencePersisted
+    case complete
     case conflict
+    case operatorReview
     case abandoned
 
     fileprivate var progressRank: Int? {
         switch self {
-        case .prepared: return 0
-        case .registryVerified: return 1
-        case .calendarCreateIntent: return 2
-        case .calendarCreated: return 3
-        case .pairPersisted: return 4
-        case .verified: return 5
-        case .synced: return 6
-        case .calendarEffectUnknown, .recoverableError, .conflict, .abandoned: return nil
+        case .claimed: return 0
+        case .registryAuthorized: return 1
+        case .createInvocationPersisted: return 2
+        case .calendarIdentified: return 3
+        case .pairIdentityPersisted: return 4
+        case .syncEvidencePersisted: return 5
+        case .complete: return 6
+        case .calendarEffectUnknown, .conflict, .operatorReview, .abandoned: return nil
         }
     }
 
     fileprivate func permitsTransition(to next: Self) -> Bool {
         if self == next { return true }
-        if next == .conflict || next == .abandoned { return true }
+        if next == .conflict || next == .operatorReview || next == .abandoned { return true }
         switch self {
-        case .conflict, .abandoned:
+        case .conflict, .operatorReview, .abandoned:
             return false
-        case .calendarCreateIntent:
-            return next == .calendarEffectUnknown || next == .calendarCreated
-                || next == .recoverableError || next == .conflict || next == .abandoned
+        case .createInvocationPersisted:
+            return next == .calendarEffectUnknown || next == .calendarIdentified
+                || next == .conflict || next == .operatorReview || next == .abandoned
         case .calendarEffectUnknown:
-            return next == .calendarCreated || next == .conflict || next == .abandoned
-        case .recoverableError:
-            return next == .registryVerified || next == .conflict || next == .abandoned
+            return next == .calendarIdentified || next == .conflict || next == .operatorReview || next == .abandoned
         default:
-            if next == .recoverableError { return true }
             guard let current = progressRank, let target = next.progressRank else { return false }
             return target >= current
         }
@@ -135,6 +132,9 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
     public var calendarEventId: String?
     public var calendarId: String?
     public var providerExternalId: String?
+    public var createInvocationId: String?
+    public var syncWriterToken: String?
+    public var syncRevision: Int
     public var createdAt: Date
     public var updatedAt: Date
     public var lastVerifiedAt: Date?
@@ -150,11 +150,14 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
         operationId: String,
         idempotencyKey: String,
         manifestFingerprint: String,
-        stage: CalendarRegistryTransactionStage = .prepared,
+        stage: CalendarRegistryTransactionStage = .claimed,
         registryEventId: String? = nil,
         calendarEventId: String? = nil,
         calendarId: String? = nil,
         providerExternalId: String? = nil,
+        createInvocationId: String? = nil,
+        syncWriterToken: String? = nil,
+        syncRevision: Int = 0,
         createdAt: Date,
         updatedAt: Date,
         lastVerifiedAt: Date? = nil,
@@ -174,6 +177,9 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
         self.calendarEventId = calendarEventId
         self.calendarId = calendarId
         self.providerExternalId = providerExternalId
+        self.createInvocationId = createInvocationId
+        self.syncWriterToken = syncWriterToken
+        self.syncRevision = syncRevision
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.lastVerifiedAt = lastVerifiedAt
@@ -234,18 +240,31 @@ public protocol CalendarRegistryTransactionStoring: Sendable {
 /// Cross-process external-effect exclusion is provided by the separate OS advisory
 /// lock; callers may override a stale SQLite lease only while holding that lock.
 public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
-    public static let schemaVersion = 3
+    public static let schemaVersion = 4
 
     private let url: URL
+    private let ledgerIdentity: CalendarRegistryFilesystemIdentity
     nonisolated(unsafe) private var db: OpaquePointer?
 
-    public init(url: URL) throws {
-        self.url = url
-        let parent = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+    public init(url requestedURL: URL) throws {
+        let parent: URL
+        let resolvedURL: URL
+        let initialIdentity: CalendarRegistryFilesystemIdentity
+        do {
+            let prepared = try CalendarRegistryCoordinatorTrust.prepareDirectory(
+                requestedURL.deletingLastPathComponent()
+            )
+            parent = prepared.url
+            resolvedURL = parent.appendingPathComponent(requestedURL.lastPathComponent, isDirectory: false)
+            initialIdentity = try CalendarRegistryCoordinatorTrust.prepareRegularFile(resolvedURL)
+        } catch {
+            throw CalendarRegistryTransactionStoreError.storageFailure(error.localizedDescription)
+        }
+        self.url = resolvedURL
+        self.ledgerIdentity = initialIdentity
         var handle: OpaquePointer?
         let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
-        let rc = sqlite3_open_v2(url.path, &handle, flags, nil)
+        let rc = sqlite3_open_v2(resolvedURL.path, &handle, flags, nil)
         guard rc == SQLITE_OK, let handle else {
             let message = handle.map { String(cString: sqlite3_errmsg($0)) } ?? "sqlite3_open_v2 rc=\(rc)"
             if let handle { sqlite3_close_v2(handle) }
@@ -253,8 +272,11 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         }
         self.db = handle
         sqlite3_busy_timeout(handle, 10_000)
-        do { try Self.bootstrap(handle) }
-        catch {
+        do {
+            try Self.bootstrap(handle)
+            try validateStorageFiles()
+            try CalendarRegistryCoordinatorTrust.syncDirectory(parent)
+        } catch {
             sqlite3_close_v2(handle)
             self.db = nil
             throw error
@@ -342,7 +364,10 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 lease_owner TEXT,
                 lease_token TEXT,
                 lease_expires_at REAL,
-                heartbeat_at REAL
+                heartbeat_at REAL,
+                create_invocation_id TEXT,
+                sync_writer_token TEXT,
+                sync_revision INTEGER NOT NULL DEFAULT 0
             );
             """)
             let existingColumns = try columns("calendar_registry_transactions")
@@ -351,13 +376,23 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 ("lease_owner", "TEXT"),
                 ("lease_token", "TEXT"),
                 ("lease_expires_at", "REAL"),
-                ("heartbeat_at", "REAL")
+                ("heartbeat_at", "REAL"),
+                ("create_invocation_id", "TEXT"),
+                ("sync_writer_token", "TEXT"),
+                ("sync_revision", "INTEGER NOT NULL DEFAULT 0")
             ]
             for (name, definition) in additions where !existingColumns.contains(name) {
                 try exec("ALTER TABLE calendar_registry_transactions ADD COLUMN \(name) \(definition);")
             }
             try exec("UPDATE calendar_registry_transactions SET revision=1 WHERE revision IS NULL OR revision < 1;")
-            try exec("UPDATE calendar_registry_transactions SET stage='registryVerified' WHERE stage='registryCreated';")
+            try exec("UPDATE calendar_registry_transactions SET sync_revision=0 WHERE sync_revision IS NULL OR sync_revision < 0;")
+            try exec("UPDATE calendar_registry_transactions SET stage='claimed' WHERE stage IN ('prepared','recoverableError');")
+            try exec("UPDATE calendar_registry_transactions SET stage='registryAuthorized' WHERE stage IN ('registryCreated','registryVerified');")
+            try exec("UPDATE calendar_registry_transactions SET stage='createInvocationPersisted' WHERE stage='calendarCreateIntent';")
+            try exec("UPDATE calendar_registry_transactions SET stage='calendarIdentified' WHERE stage='calendarCreated';")
+            try exec("UPDATE calendar_registry_transactions SET stage='pairIdentityPersisted' WHERE stage='pairPersisted';")
+            try exec("UPDATE calendar_registry_transactions SET stage='syncEvidencePersisted' WHERE stage='verified';")
+            try exec("UPDATE calendar_registry_transactions SET stage='complete' WHERE stage='synced';")
 
             try exec("DROP TABLE IF EXISTS calendar_registry_schema_new;")
             try exec("CREATE TABLE calendar_registry_schema_new (id INTEGER PRIMARY KEY CHECK(id=1), version INTEGER NOT NULL);")
@@ -470,7 +505,8 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
     }
 
     public func get(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
-        try select(idempotencyKey: idempotencyKey)
+        try validateStorageFiles()
+        return try select(idempotencyKey: idempotencyKey)
     }
 
     public func save(_ transaction: CalendarRegistryTransaction) throws -> CalendarRegistryTransaction {
@@ -486,7 +522,7 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 operation_id=?, manifest_fingerprint=?, stage=?, registry_event_id=?,
                 calendar_event_id=?, calendar_id=?, provider_external_id=?, created_at=?,
                 updated_at=?, last_verified_at=?, last_error=?, partial_effects_json=?,
-                heartbeat_at=?, revision=revision+1
+                heartbeat_at=?, create_invocation_id=?, sync_writer_token=?, sync_revision=?, revision=revision+1
             WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?;
             """
             try withStatement(sql) { stmt in
@@ -503,10 +539,13 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 try bindOptionalText(stmt, 11, transaction.lastError)
                 try bindText(stmt, 12, try partialEffectsJSON(transaction.partialEffects))
                 try bindDouble(stmt, 13, now)
-                try bindText(stmt, 14, transaction.idempotencyKey)
-                try bindInt(stmt, 15, transaction.revision)
-                try bindText(stmt, 16, transaction.leaseToken ?? "")
-                try bindText(stmt, 17, transaction.leaseOwner ?? "")
+                try bindOptionalText(stmt, 14, transaction.createInvocationId)
+                try bindOptionalText(stmt, 15, transaction.syncWriterToken)
+                try bindInt(stmt, 16, transaction.syncRevision)
+                try bindText(stmt, 17, transaction.idempotencyKey)
+                try bindInt(stmt, 18, transaction.revision)
+                try bindText(stmt, 19, transaction.leaseToken ?? "")
+                try bindText(stmt, 20, transaction.leaseOwner ?? "")
                 try stepDone(stmt)
             }
             guard sqlite3_changes(db) == 1 else { throw try ownershipError(for: transaction) }
@@ -571,9 +610,13 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             ("registry event id", existing.registryEventId, incoming.registryEventId),
             ("calendar event id", existing.calendarEventId, incoming.calendarEventId),
             ("calendar id", existing.calendarId, incoming.calendarId),
-            ("provider external id", existing.providerExternalId, incoming.providerExternalId)
+            ("provider external id", existing.providerExternalId, incoming.providerExternalId),
+            ("create invocation id", existing.createInvocationId, incoming.createInvocationId)
         ] where old?.isEmpty == false && new != old {
             throw CalendarRegistryTransactionStoreError.identityRegression("\(name) is immutable once established")
+        }
+        guard incoming.syncRevision >= existing.syncRevision else {
+            throw CalendarRegistryTransactionStoreError.identityRegression("sync revision cannot decrease")
         }
     }
 
@@ -594,8 +637,9 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             idempotency_key, operation_id, manifest_fingerprint, stage,
             registry_event_id, calendar_event_id, calendar_id, provider_external_id,
             created_at, updated_at, last_verified_at, last_error, partial_effects_json,
-            revision, lease_owner, lease_token, lease_expires_at, heartbeat_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            revision, lease_owner, lease_token, lease_expires_at, heartbeat_at,
+            create_invocation_id, sync_writer_token, sync_revision
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """
         try withStatement(sql) { stmt in try bind(transaction, to: stmt); try stepDone(stmt) }
     }
@@ -619,6 +663,9 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         try bindOptionalText(stmt, 16, transaction.leaseToken)
         try bindOptionalDouble(stmt, 17, transaction.leaseExpiresAt?.timeIntervalSince1970)
         try bindOptionalDouble(stmt, 18, transaction.heartbeatAt?.timeIntervalSince1970)
+        try bindOptionalText(stmt, 19, transaction.createInvocationId)
+        try bindOptionalText(stmt, 20, transaction.syncWriterToken)
+        try bindInt(stmt, 21, transaction.syncRevision)
     }
 
     private func requiredSelect(_ key: String) throws -> CalendarRegistryTransaction {
@@ -631,7 +678,8 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         SELECT operation_id, idempotency_key, manifest_fingerprint, stage,
                registry_event_id, calendar_event_id, calendar_id, provider_external_id,
                created_at, updated_at, last_verified_at, last_error, partial_effects_json,
-               revision, lease_owner, lease_token, lease_expires_at, heartbeat_at
+               revision, lease_owner, lease_token, lease_expires_at, heartbeat_at,
+               create_invocation_id, sync_writer_token, sync_revision
         FROM calendar_registry_transactions WHERE idempotency_key=? LIMIT 1;
         """
         return try withStatement(sql) { stmt in
@@ -654,6 +702,8 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             guard revision >= 1 else { throw CalendarRegistryTransactionStoreError.corruptLedger("invalid revision for \(idempotencyKey)") }
             let leaseExpiry = optionalDouble(stmt, 16).map(Date.init(timeIntervalSince1970:))
             let heartbeat = optionalDouble(stmt, 17).map(Date.init(timeIntervalSince1970:))
+            let syncRevision = Int(sqlite3_column_int64(stmt, 20))
+            guard syncRevision >= 0 else { throw CalendarRegistryTransactionStoreError.corruptLedger("invalid sync revision for \(idempotencyKey)") }
             return CalendarRegistryTransaction(
                 operationId: operationId,
                 idempotencyKey: storedKey,
@@ -663,6 +713,9 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 calendarEventId: text(stmt, 5),
                 calendarId: text(stmt, 6),
                 providerExternalId: text(stmt, 7),
+                createInvocationId: text(stmt, 18),
+                syncWriterToken: text(stmt, 19),
+                syncRevision: syncRevision,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
                 lastVerifiedAt: text(stmt, 10).flatMap(CalendarRegistryISO.date),
@@ -688,8 +741,38 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         }
     }
 
-    private func beginImmediate() throws { try execute("BEGIN IMMEDIATE;") }
-    private func commit() throws { try execute("COMMIT;") }
+
+    nonisolated private func validateStorageFiles() throws {
+        do {
+            guard let main = try CalendarRegistryCoordinatorTrust.validateRegularFileIfPresent(url) else {
+                throw CalendarRegistryCoordinatorTrustError.unsafe("SQLite ledger disappeared: \(url.path)")
+            }
+            try CalendarRegistryCoordinatorTrust.requireStable(
+                ledgerIdentity, actual: main, label: "SQLite ledger"
+            )
+            _ = try CalendarRegistryCoordinatorTrust.validateRegularFileIfPresent(
+                URL(fileURLWithPath: url.path + "-wal")
+            )
+            _ = try CalendarRegistryCoordinatorTrust.validateRegularFileIfPresent(
+                URL(fileURLWithPath: url.path + "-shm")
+            )
+        } catch {
+            throw CalendarRegistryTransactionStoreError.storageFailure(error.localizedDescription)
+        }
+    }
+    private func beginImmediate() throws {
+        try validateStorageFiles()
+        try execute("BEGIN IMMEDIATE;")
+    }
+    private func commit() throws {
+        try execute("COMMIT;")
+        try validateStorageFiles()
+        do {
+            try CalendarRegistryCoordinatorTrust.syncDirectory(url.deletingLastPathComponent())
+        } catch {
+            throw CalendarRegistryTransactionStoreError.storageFailure(error.localizedDescription)
+        }
+    }
     private func rollback() throws { try execute("ROLLBACK;") }
 
     private func execute(_ sql: String) throws {
@@ -831,9 +914,13 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
             ("registry event id", current.registryEventId, transaction.registryEventId),
             ("calendar event id", current.calendarEventId, transaction.calendarEventId),
             ("calendar id", current.calendarId, transaction.calendarId),
-            ("provider external id", current.providerExternalId, transaction.providerExternalId)
+            ("provider external id", current.providerExternalId, transaction.providerExternalId),
+            ("create invocation id", current.createInvocationId, transaction.createInvocationId)
         ] where old?.isEmpty == false && new != old {
             throw CalendarRegistryTransactionStoreError.identityRegression("\(name) is immutable once established")
+        }
+        guard transaction.syncRevision >= current.syncRevision else {
+            throw CalendarRegistryTransactionStoreError.identityRegression("sync revision cannot decrease")
         }
         var saved = transaction
         saved.revision += 1

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -1,4 +1,4 @@
-// CalendarRegistryTransactionStore.swift — transactional registry-first recovery ledger
+// CalendarRegistryTransactionStore.swift — fenced registry-first transaction ledger
 
 import CryptoKit
 import Foundation
@@ -18,6 +18,32 @@ public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIte
     case recoverableError
     case conflict
     case abandoned
+
+    fileprivate var progressRank: Int? {
+        switch self {
+        case .prepared: return 0
+        case .registryCreated: return 1
+        case .calendarCreated: return 2
+        case .pairPersisted: return 3
+        case .verified: return 4
+        case .synced: return 5
+        case .recoverableError, .conflict, .abandoned: return nil
+        }
+    }
+
+    fileprivate func permitsTransition(to next: Self) -> Bool {
+        if self == next { return true }
+        if next == .recoverableError || next == .conflict || next == .abandoned { return true }
+        switch self {
+        case .conflict, .abandoned:
+            return false
+        case .recoverableError:
+            return next.progressRank != nil
+        default:
+            guard let current = progressRank, let target = next.progressRank else { return false }
+            return target >= current
+        }
+    }
 }
 
 public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
@@ -35,27 +61,53 @@ public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
     public var projectIds: [String]
     public var contactIds: [String]
 
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
     public var canonicalized: CalendarRegistryOperationManifest {
         var copy = self
         copy.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
         copy.calendarId = calendarId.trimmingCharacters(in: .whitespacesAndNewlines)
         copy.timeZoneIdentifier = timeZoneIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
-        copy.location = location?.trimmingCharacters(in: .whitespacesAndNewlines)
-        copy.notes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
-        copy.meetingType = meetingType?.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.location = Self.normalizedOptional(location)
+        copy.notes = Self.normalizedOptional(notes)
+        copy.eventClass = eventClass.trimmingCharacters(in: .whitespacesAndNewlines)
+        copy.meetingType = Self.normalizedOptional(meetingType)
         copy.primaryBlockId = primaryBlockId.trimmingCharacters(in: .whitespacesAndNewlines)
-        copy.blockIds = Array(Set(blockIds)).sorted()
-        copy.projectIds = Array(Set(projectIds)).sorted()
-        copy.contactIds = Array(Set(contactIds)).sorted()
+        copy.blockIds = Array(Set(blockIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } + [copy.primaryBlockId].filter { !$0.isEmpty })).sorted()
+        copy.projectIds = Array(Set(projectIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })).sorted()
+        copy.contactIds = Array(Set(contactIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty })).sorted()
         return copy
     }
 
     public var fingerprint: String {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(canonicalized) else { return "" }
-        return CalendarRegistryDigest.sha256(data)
+        let value = canonicalized
+        func field(_ raw: String) -> String { "\(raw.utf8.count):\(raw)" }
+        func optional(_ raw: String?) -> String { raw.map { "1:" + field($0) } ?? "0:" }
+        func list(_ values: [String]) -> String { values.map(field).joined(separator: "|") }
+        let canonical = [
+            field(value.title),
+            field(CalendarRegistryISO.string(value.start)),
+            field(CalendarRegistryISO.string(value.end)),
+            field(value.timeZoneIdentifier),
+            field(value.calendarId),
+            optional(value.location),
+            optional(value.notes),
+            field(value.eventClass),
+            optional(value.meetingType),
+            field(value.primaryBlockId),
+            list(value.blockIds),
+            list(value.projectIds),
+            list(value.contactIds)
+        ].joined(separator: "\u{1F}")
+        return CalendarRegistryDigest.sha256(canonical)
     }
 }
 
@@ -73,6 +125,11 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
     public var lastVerifiedAt: Date?
     public var lastError: String?
     public var partialEffects: [String]
+    public var revision: Int
+    public var leaseOwner: String?
+    public var leaseToken: String?
+    public var leaseExpiresAt: Date?
+    public var heartbeatAt: Date?
 
     public init(
         operationId: String,
@@ -87,7 +144,12 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
         updatedAt: Date,
         lastVerifiedAt: Date? = nil,
         lastError: String? = nil,
-        partialEffects: [String] = []
+        partialEffects: [String] = [],
+        revision: Int = 0,
+        leaseOwner: String? = nil,
+        leaseToken: String? = nil,
+        leaseExpiresAt: Date? = nil,
+        heartbeatAt: Date? = nil
     ) {
         self.operationId = operationId
         self.idempotencyKey = idempotencyKey
@@ -102,25 +164,36 @@ public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
         self.lastVerifiedAt = lastVerifiedAt
         self.lastError = lastError
         self.partialEffects = partialEffects
+        self.revision = revision
+        self.leaseOwner = leaseOwner
+        self.leaseToken = leaseToken
+        self.leaseExpiresAt = leaseExpiresAt
+        self.heartbeatAt = heartbeatAt
     }
 }
 
 public enum CalendarRegistryTransactionStoreError: Error, LocalizedError, Equatable {
     case idempotencyConflict(String)
+    case operationActive(String, Date)
+    case staleRevision(String)
+    case leaseLost(String)
+    case stageRegression(String)
+    case identityRegression(String)
     case corruptLedger(String)
     case storageFailure(String)
     case missingTransaction(String)
 
     public var errorDescription: String? {
         switch self {
-        case .idempotencyConflict(let key):
-            return "idempotency key already belongs to a different manifest: \(key)"
-        case .corruptLedger(let reason):
-            return "calendar-registry transaction ledger is corrupt: \(reason)"
-        case .storageFailure(let reason):
-            return "calendar-registry transaction ledger failed: \(reason)"
-        case .missingTransaction(let key):
-            return "calendar-registry transaction is missing: \(key)"
+        case .idempotencyConflict(let key): return "idempotency key already belongs to a different manifest: \(key)"
+        case .operationActive(let key, let until): return "calendar-registry operation is already active for \(key) until \(CalendarRegistryISO.string(until))"
+        case .staleRevision(let key): return "calendar-registry transaction revision is stale: \(key)"
+        case .leaseLost(let key): return "calendar-registry transaction lease is absent, expired, or fenced: \(key)"
+        case .stageRegression(let reason): return "calendar-registry stage regression refused: \(reason)"
+        case .identityRegression(let reason): return "calendar-registry identity regression refused: \(reason)"
+        case .corruptLedger(let reason): return "calendar-registry transaction ledger is corrupt: \(reason)"
+        case .storageFailure(let reason): return "calendar-registry transaction ledger failed: \(reason)"
+        case .missingTransaction(let key): return "calendar-registry transaction is missing: \(key)"
         }
     }
 }
@@ -130,17 +203,21 @@ public protocol CalendarRegistryTransactionStoring: Sendable {
         idempotencyKey: String,
         manifestFingerprint: String,
         operationId: String,
-        now: Date
+        leaseOwner: String,
+        leaseToken: String,
+        leaseDuration: TimeInterval
     ) async throws -> CalendarRegistryTransaction
+    func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) async throws -> CalendarRegistryTransaction
     func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction?
-    func save(_ transaction: CalendarRegistryTransaction) async throws
+    func save(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction
+    func release(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction
 }
 
-/// SQLite-backed recovery ledger. SQLite's unique key and `BEGIN IMMEDIATE`
-/// transaction are the correctness boundary across actors and processes. The
-/// process-local operation gate is only a latency optimization.
+/// SQLite-backed single-machine transaction coordinator. The unique key,
+/// lease/fencing token, monotonic revision, and compare-and-swap saves are the
+/// correctness boundary across actors and processes sharing this local file.
 public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
-    public static let schemaVersion = 1
+    public static let schemaVersion = 2
 
     private let url: URL
     nonisolated(unsafe) private var db: OpaquePointer?
@@ -149,7 +226,6 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         self.url = url
         let parent = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-
         var handle: OpaquePointer?
         let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
         let rc = sqlite3_open_v2(url.path, &handle, flags, nil)
@@ -159,10 +235,9 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             throw CalendarRegistryTransactionStoreError.storageFailure(message)
         }
         self.db = handle
-        sqlite3_busy_timeout(handle, 5_000)
-        do {
-            try Self.bootstrap(handle)
-        } catch {
+        sqlite3_busy_timeout(handle, 10_000)
+        do { try Self.bootstrap(handle) }
+        catch {
             sqlite3_close_v2(handle)
             self.db = nil
             throw error
@@ -170,7 +245,10 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
     }
 
     deinit {
-        if let db { sqlite3_close_v2(db) }
+        if let db {
+            let rc = sqlite3_close_v2(db)
+            assert(rc == SQLITE_OK, "SQLite close failed with rc=\(rc)")
+        }
     }
 
     private static func bootstrap(_ db: OpaquePointer) throws {
@@ -183,69 +261,156 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 throw CalendarRegistryTransactionStoreError.storageFailure(message)
             }
         }
+        func columns(_ table: String) throws -> Set<String> {
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "PRAGMA table_info(\(table));", -1, &statement, nil) == SQLITE_OK else {
+                throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+            }
+            defer { sqlite3_finalize(statement) }
+            var result: Set<String> = []
+            while sqlite3_step(statement) == SQLITE_ROW, let raw = sqlite3_column_text(statement, 1) {
+                result.insert(String(cString: raw))
+            }
+            return result
+        }
+
+        func scalarInt(_ sql: String) throws -> Int? {
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+            }
+            defer { sqlite3_finalize(statement) }
+            let rc = sqlite3_step(statement)
+            if rc == SQLITE_DONE { return nil }
+            guard rc == SQLITE_ROW else {
+                throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+            }
+            return Int(sqlite3_column_int64(statement, 0))
+        }
+
         try exec("PRAGMA journal_mode=WAL;")
         try exec("PRAGMA synchronous=FULL;")
         try exec("PRAGMA foreign_keys=ON;")
-        try exec("CREATE TABLE IF NOT EXISTS calendar_registry_schema (version INTEGER NOT NULL);")
-        var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(db, "SELECT version FROM calendar_registry_schema LIMIT 1;", -1, &stmt, nil) == SQLITE_OK else {
-            throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
-        }
-        defer { sqlite3_finalize(stmt) }
-        let rc = sqlite3_step(stmt)
-        if rc == SQLITE_DONE {
-            try exec("INSERT INTO calendar_registry_schema(version) VALUES (\(Self.schemaVersion));")
-        } else if rc == SQLITE_ROW {
-            let version = Int(sqlite3_column_int64(stmt, 0))
-            guard version == Self.schemaVersion else {
-                throw CalendarRegistryTransactionStoreError.corruptLedger(
-                    "unsupported schema version \(version); expected \(Self.schemaVersion)"
-                )
+        try exec("BEGIN IMMEDIATE;")
+        do {
+            try exec("CREATE TABLE IF NOT EXISTS calendar_registry_schema (version INTEGER NOT NULL);")
+            let schemaRows = try scalarInt("SELECT COUNT(*) FROM calendar_registry_schema;") ?? 0
+            guard schemaRows <= 1 else {
+                throw CalendarRegistryTransactionStoreError.corruptLedger("schema metadata contains multiple rows")
             }
-        } else {
-            throw CalendarRegistryTransactionStoreError.storageFailure(String(cString: sqlite3_errmsg(db)))
+            if schemaRows == 1 {
+                let existingVersion = try scalarInt("SELECT version FROM calendar_registry_schema LIMIT 1;") ?? -1
+                guard existingVersion == 1 || existingVersion == Self.schemaVersion else {
+                    throw CalendarRegistryTransactionStoreError.corruptLedger(
+                        "unsupported schema version \(existingVersion); expected 1 or \(Self.schemaVersion)"
+                    )
+                }
+            }
+            try exec("""
+            CREATE TABLE IF NOT EXISTS calendar_registry_transactions (
+                idempotency_key TEXT PRIMARY KEY NOT NULL,
+                operation_id TEXT NOT NULL,
+                manifest_fingerprint TEXT NOT NULL,
+                stage TEXT NOT NULL,
+                registry_event_id TEXT,
+                calendar_event_id TEXT,
+                calendar_id TEXT,
+                provider_external_id TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_verified_at TEXT,
+                last_error TEXT,
+                partial_effects_json TEXT NOT NULL,
+                revision INTEGER NOT NULL DEFAULT 1,
+                lease_owner TEXT,
+                lease_token TEXT,
+                lease_expires_at REAL,
+                heartbeat_at REAL
+            );
+            """)
+            let existingColumns = try columns("calendar_registry_transactions")
+            let additions: [(String, String)] = [
+                ("revision", "INTEGER NOT NULL DEFAULT 1"),
+                ("lease_owner", "TEXT"),
+                ("lease_token", "TEXT"),
+                ("lease_expires_at", "REAL"),
+                ("heartbeat_at", "REAL")
+            ]
+            for (name, definition) in additions where !existingColumns.contains(name) {
+                try exec("ALTER TABLE calendar_registry_transactions ADD COLUMN \(name) \(definition);")
+            }
+            try exec("UPDATE calendar_registry_transactions SET revision=1 WHERE revision IS NULL OR revision < 1;")
+
+            try exec("DROP TABLE IF EXISTS calendar_registry_schema_new;")
+            try exec("CREATE TABLE calendar_registry_schema_new (id INTEGER PRIMARY KEY CHECK(id=1), version INTEGER NOT NULL);")
+            try exec("INSERT INTO calendar_registry_schema_new(id, version) VALUES (1, \(Self.schemaVersion));")
+            try exec("DROP TABLE IF EXISTS calendar_registry_schema;")
+            try exec("ALTER TABLE calendar_registry_schema_new RENAME TO calendar_registry_schema;")
+            try exec("COMMIT;")
+        } catch {
+            try? exec("ROLLBACK;")
+            throw error
         }
-        try exec("""
-        CREATE TABLE IF NOT EXISTS calendar_registry_transactions (
-            idempotency_key TEXT PRIMARY KEY NOT NULL,
-            operation_id TEXT NOT NULL,
-            manifest_fingerprint TEXT NOT NULL,
-            stage TEXT NOT NULL,
-            registry_event_id TEXT,
-            calendar_event_id TEXT,
-            calendar_id TEXT,
-            provider_external_id TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL,
-            last_verified_at TEXT,
-            last_error TEXT,
-            partial_effects_json TEXT NOT NULL
-        );
-        """)
     }
 
     public func claim(
         idempotencyKey: String,
         manifestFingerprint: String,
         operationId: String,
-        now: Date
+        leaseOwner: String,
+        leaseToken: String,
+        leaseDuration: TimeInterval
     ) throws -> CalendarRegistryTransaction {
+        try validateIdentity(idempotencyKey, manifestFingerprint, operationId, leaseOwner, leaseToken)
+        guard leaseDuration > 0 else { throw CalendarRegistryTransactionStoreError.storageFailure("lease duration must be positive") }
         try beginImmediate()
         do {
+            let now = try currentEpoch()
             if let existing = try select(idempotencyKey: idempotencyKey) {
                 guard existing.manifestFingerprint == manifestFingerprint else {
-                    try rollback()
                     throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
                 }
+                if let expiry = existing.leaseExpiresAt?.timeIntervalSince1970,
+                   existing.leaseToken?.isEmpty == false,
+                   expiry > now {
+                    throw CalendarRegistryTransactionStoreError.operationActive(
+                        idempotencyKey, Date(timeIntervalSince1970: expiry)
+                    )
+                }
+                let sql = """
+                UPDATE calendar_registry_transactions SET
+                    operation_id=?, lease_owner=?, lease_token=?, lease_expires_at=?, heartbeat_at=?,
+                    updated_at=?, revision=revision+1
+                WHERE idempotency_key=? AND revision=?;
+                """
+                try withStatement(sql) { stmt in
+                    try bindText(stmt, 1, operationId)
+                    try bindText(stmt, 2, leaseOwner)
+                    try bindText(stmt, 3, leaseToken)
+                    try bindDouble(stmt, 4, now + leaseDuration)
+                    try bindDouble(stmt, 5, now)
+                    try bindText(stmt, 6, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
+                    try bindText(stmt, 7, idempotencyKey)
+                    try bindInt(stmt, 8, existing.revision)
+                    try stepDone(stmt)
+                }
+                guard sqlite3_changes(db) == 1 else { throw CalendarRegistryTransactionStoreError.staleRevision(idempotencyKey) }
                 try commit()
-                return existing
+                return try requiredSelect(idempotencyKey)
             }
+
+            let nowDate = Date(timeIntervalSince1970: now)
             let transaction = CalendarRegistryTransaction(
                 operationId: operationId,
                 idempotencyKey: idempotencyKey,
                 manifestFingerprint: manifestFingerprint,
-                createdAt: now,
-                updatedAt: now
+                createdAt: nowDate,
+                updatedAt: nowDate,
+                revision: 1,
+                leaseOwner: leaseOwner,
+                leaseToken: leaseToken,
+                leaseExpiresAt: Date(timeIntervalSince1970: now + leaseDuration),
+                heartbeatAt: nowDate
             )
             try insert(transaction)
             try commit()
@@ -256,54 +421,157 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         }
     }
 
-    public func get(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
-        try select(idempotencyKey: idempotencyKey)
-    }
-
-    public func save(_ transaction: CalendarRegistryTransaction) throws {
+    public func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) throws -> CalendarRegistryTransaction {
+        guard leaseDuration > 0 else { throw CalendarRegistryTransactionStoreError.storageFailure("lease duration must be positive") }
         try beginImmediate()
         do {
-            guard let existing = try select(idempotencyKey: transaction.idempotencyKey) else {
-                throw CalendarRegistryTransactionStoreError.missingTransaction(transaction.idempotencyKey)
+            let now = try currentEpoch()
+            let sql = """
+            UPDATE calendar_registry_transactions SET
+                lease_expires_at=?, heartbeat_at=?, updated_at=?, revision=revision+1
+            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?
+              AND lease_expires_at > CAST(strftime('%s','now') AS REAL);
+            """
+            try withStatement(sql) { stmt in
+                try bindDouble(stmt, 1, now + leaseDuration)
+                try bindDouble(stmt, 2, now)
+                try bindText(stmt, 3, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
+                try bindText(stmt, 4, transaction.idempotencyKey)
+                try bindInt(stmt, 5, transaction.revision)
+                try bindText(stmt, 6, transaction.leaseToken ?? "")
+                try bindText(stmt, 7, transaction.leaseOwner ?? "")
+                try stepDone(stmt)
             }
-            guard existing.manifestFingerprint == transaction.manifestFingerprint else {
-                throw CalendarRegistryTransactionStoreError.idempotencyConflict(transaction.idempotencyKey)
-            }
-            try update(transaction)
+            guard sqlite3_changes(db) == 1 else { throw try ownershipError(for: transaction) }
             try commit()
+            return try requiredSelect(transaction.idempotencyKey)
         } catch {
             try? rollback()
             throw error
         }
     }
 
-    private func migrate() throws {
-        try execute("CREATE TABLE IF NOT EXISTS calendar_registry_schema (version INTEGER NOT NULL);")
-        let version = try scalarInt("SELECT version FROM calendar_registry_schema LIMIT 1;")
-        if version == nil {
-            try execute("INSERT INTO calendar_registry_schema(version) VALUES (\(Self.schemaVersion));")
-        } else if version != Self.schemaVersion {
-            throw CalendarRegistryTransactionStoreError.corruptLedger(
-                "unsupported schema version \(version ?? -1); expected \(Self.schemaVersion)"
-            )
+    public func get(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
+        try select(idempotencyKey: idempotencyKey)
+    }
+
+    public func save(_ transaction: CalendarRegistryTransaction) throws -> CalendarRegistryTransaction {
+        try beginImmediate()
+        do {
+            guard let existing = try select(idempotencyKey: transaction.idempotencyKey) else {
+                throw CalendarRegistryTransactionStoreError.missingTransaction(transaction.idempotencyKey)
+            }
+            try validateMutation(from: existing, to: transaction)
+            let now = try currentEpoch()
+            let sql = """
+            UPDATE calendar_registry_transactions SET
+                operation_id=?, manifest_fingerprint=?, stage=?, registry_event_id=?,
+                calendar_event_id=?, calendar_id=?, provider_external_id=?, created_at=?,
+                updated_at=?, last_verified_at=?, last_error=?, partial_effects_json=?,
+                heartbeat_at=?, revision=revision+1
+            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?
+              AND lease_expires_at > CAST(strftime('%s','now') AS REAL);
+            """
+            try withStatement(sql) { stmt in
+                try bindText(stmt, 1, transaction.operationId)
+                try bindText(stmt, 2, transaction.manifestFingerprint)
+                try bindText(stmt, 3, transaction.stage.rawValue)
+                try bindOptionalText(stmt, 4, transaction.registryEventId)
+                try bindOptionalText(stmt, 5, transaction.calendarEventId)
+                try bindOptionalText(stmt, 6, transaction.calendarId)
+                try bindOptionalText(stmt, 7, transaction.providerExternalId)
+                try bindText(stmt, 8, CalendarRegistryISO.string(transaction.createdAt))
+                try bindText(stmt, 9, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
+                try bindOptionalText(stmt, 10, transaction.lastVerifiedAt.map(CalendarRegistryISO.string))
+                try bindOptionalText(stmt, 11, transaction.lastError)
+                try bindText(stmt, 12, try partialEffectsJSON(transaction.partialEffects))
+                try bindDouble(stmt, 13, now)
+                try bindText(stmt, 14, transaction.idempotencyKey)
+                try bindInt(stmt, 15, transaction.revision)
+                try bindText(stmt, 16, transaction.leaseToken ?? "")
+                try bindText(stmt, 17, transaction.leaseOwner ?? "")
+                try stepDone(stmt)
+            }
+            guard sqlite3_changes(db) == 1 else { throw try ownershipError(for: transaction) }
+            try commit()
+            return try requiredSelect(transaction.idempotencyKey)
+        } catch {
+            try? rollback()
+            throw error
         }
-        try execute("""
-        CREATE TABLE IF NOT EXISTS calendar_registry_transactions (
-            idempotency_key TEXT PRIMARY KEY NOT NULL,
-            operation_id TEXT NOT NULL,
-            manifest_fingerprint TEXT NOT NULL,
-            stage TEXT NOT NULL,
-            registry_event_id TEXT,
-            calendar_event_id TEXT,
-            calendar_id TEXT,
-            provider_external_id TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL,
-            last_verified_at TEXT,
-            last_error TEXT,
-            partial_effects_json TEXT NOT NULL
-        );
-        """)
+    }
+
+    public func release(_ transaction: CalendarRegistryTransaction) throws -> CalendarRegistryTransaction {
+        try beginImmediate()
+        do {
+            let now = try currentEpoch()
+            let sql = """
+            UPDATE calendar_registry_transactions SET
+                lease_owner=NULL, lease_token=NULL, lease_expires_at=NULL,
+                heartbeat_at=?, updated_at=?, revision=revision+1
+            WHERE idempotency_key=? AND revision=? AND lease_token=? AND lease_owner=?;
+            """
+            try withStatement(sql) { stmt in
+                try bindDouble(stmt, 1, now)
+                try bindText(stmt, 2, CalendarRegistryISO.string(Date(timeIntervalSince1970: now)))
+                try bindText(stmt, 3, transaction.idempotencyKey)
+                try bindInt(stmt, 4, transaction.revision)
+                try bindText(stmt, 5, transaction.leaseToken ?? "")
+                try bindText(stmt, 6, transaction.leaseOwner ?? "")
+                try stepDone(stmt)
+            }
+            guard sqlite3_changes(db) == 1 else { throw try ownershipError(for: transaction, requireUnexpired: false) }
+            try commit()
+            return try requiredSelect(transaction.idempotencyKey)
+        } catch {
+            try? rollback()
+            throw error
+        }
+    }
+
+    private func validateIdentity(_ key: String, _ fingerprint: String, _ operation: String, _ owner: String, _ token: String) throws {
+        let values = [("idempotency key", key), ("manifest fingerprint", fingerprint), ("operation id", operation), ("lease owner", owner), ("lease token", token)]
+        if let invalid = values.first(where: { $0.1.isEmpty }) {
+            throw CalendarRegistryTransactionStoreError.corruptLedger("\(invalid.0) must not be empty")
+        }
+    }
+
+    private func validateMutation(from existing: CalendarRegistryTransaction, to incoming: CalendarRegistryTransaction) throws {
+        guard existing.manifestFingerprint == incoming.manifestFingerprint else {
+            throw CalendarRegistryTransactionStoreError.idempotencyConflict(incoming.idempotencyKey)
+        }
+        guard existing.revision == incoming.revision else {
+            throw CalendarRegistryTransactionStoreError.staleRevision(incoming.idempotencyKey)
+        }
+        guard existing.leaseToken == incoming.leaseToken, existing.leaseOwner == incoming.leaseOwner,
+              incoming.leaseToken?.isEmpty == false, incoming.leaseOwner?.isEmpty == false else {
+            throw CalendarRegistryTransactionStoreError.leaseLost(incoming.idempotencyKey)
+        }
+        guard existing.stage.permitsTransition(to: incoming.stage) else {
+            throw CalendarRegistryTransactionStoreError.stageRegression("\(existing.stage.rawValue) → \(incoming.stage.rawValue)")
+        }
+        for (name, old, new) in [
+            ("registry event id", existing.registryEventId, incoming.registryEventId),
+            ("calendar event id", existing.calendarEventId, incoming.calendarEventId),
+            ("calendar id", existing.calendarId, incoming.calendarId),
+            ("provider external id", existing.providerExternalId, incoming.providerExternalId)
+        ] where old?.isEmpty == false && new?.isEmpty != false {
+            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) cannot be cleared")
+        }
+    }
+
+    private func ownershipError(for transaction: CalendarRegistryTransaction, requireUnexpired: Bool = true) throws -> CalendarRegistryTransactionStoreError {
+        guard let current = try select(idempotencyKey: transaction.idempotencyKey) else {
+            return .missingTransaction(transaction.idempotencyKey)
+        }
+        if current.revision != transaction.revision { return .staleRevision(transaction.idempotencyKey) }
+        if current.leaseToken != transaction.leaseToken || current.leaseOwner != transaction.leaseOwner {
+            return .leaseLost(transaction.idempotencyKey)
+        }
+        if requireUnexpired, let expiry = current.leaseExpiresAt, expiry.timeIntervalSince1970 <= (try currentEpoch()) {
+            return .leaseLost(transaction.idempotencyKey)
+        }
+        return .storageFailure("compare-and-swap update changed no rows")
     }
 
     private func insert(_ transaction: CalendarRegistryTransaction) throws {
@@ -311,36 +579,11 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         INSERT INTO calendar_registry_transactions (
             idempotency_key, operation_id, manifest_fingerprint, stage,
             registry_event_id, calendar_event_id, calendar_id, provider_external_id,
-            created_at, updated_at, last_verified_at, last_error, partial_effects_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            created_at, updated_at, last_verified_at, last_error, partial_effects_json,
+            revision, lease_owner, lease_token, lease_expires_at, heartbeat_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """
         try withStatement(sql) { stmt in try bind(transaction, to: stmt); try stepDone(stmt) }
-    }
-
-    private func update(_ transaction: CalendarRegistryTransaction) throws {
-        let sql = """
-        UPDATE calendar_registry_transactions SET
-            operation_id=?, manifest_fingerprint=?, stage=?, registry_event_id=?,
-            calendar_event_id=?, calendar_id=?, provider_external_id=?, created_at=?,
-            updated_at=?, last_verified_at=?, last_error=?, partial_effects_json=?
-        WHERE idempotency_key=?;
-        """
-        try withStatement(sql) { stmt in
-            try bindText(stmt, 1, transaction.operationId)
-            try bindText(stmt, 2, transaction.manifestFingerprint)
-            try bindText(stmt, 3, transaction.stage.rawValue)
-            try bindOptionalText(stmt, 4, transaction.registryEventId)
-            try bindOptionalText(stmt, 5, transaction.calendarEventId)
-            try bindOptionalText(stmt, 6, transaction.calendarId)
-            try bindOptionalText(stmt, 7, transaction.providerExternalId)
-            try bindText(stmt, 8, CalendarRegistryISO.string(transaction.createdAt))
-            try bindText(stmt, 9, CalendarRegistryISO.string(transaction.updatedAt))
-            try bindOptionalText(stmt, 10, transaction.lastVerifiedAt.map(CalendarRegistryISO.string))
-            try bindOptionalText(stmt, 11, transaction.lastError)
-            try bindText(stmt, 12, try partialEffectsJSON(transaction.partialEffects))
-            try bindText(stmt, 13, transaction.idempotencyKey)
-            try stepDone(stmt)
-        }
     }
 
     private func bind(_ transaction: CalendarRegistryTransaction, to stmt: OpaquePointer?) throws {
@@ -357,13 +600,24 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
         try bindOptionalText(stmt, 11, transaction.lastVerifiedAt.map(CalendarRegistryISO.string))
         try bindOptionalText(stmt, 12, transaction.lastError)
         try bindText(stmt, 13, try partialEffectsJSON(transaction.partialEffects))
+        try bindInt(stmt, 14, transaction.revision)
+        try bindOptionalText(stmt, 15, transaction.leaseOwner)
+        try bindOptionalText(stmt, 16, transaction.leaseToken)
+        try bindOptionalDouble(stmt, 17, transaction.leaseExpiresAt?.timeIntervalSince1970)
+        try bindOptionalDouble(stmt, 18, transaction.heartbeatAt?.timeIntervalSince1970)
+    }
+
+    private func requiredSelect(_ key: String) throws -> CalendarRegistryTransaction {
+        guard let selected = try select(idempotencyKey: key) else { throw CalendarRegistryTransactionStoreError.missingTransaction(key) }
+        return selected
     }
 
     private func select(idempotencyKey: String) throws -> CalendarRegistryTransaction? {
         let sql = """
         SELECT operation_id, idempotency_key, manifest_fingerprint, stage,
                registry_event_id, calendar_event_id, calendar_id, provider_external_id,
-               created_at, updated_at, last_verified_at, last_error, partial_effects_json
+               created_at, updated_at, last_verified_at, last_error, partial_effects_json,
+               revision, lease_owner, lease_token, lease_expires_at, heartbeat_at
         FROM calendar_registry_transactions WHERE idempotency_key=? LIMIT 1;
         """
         return try withStatement(sql) { stmt in
@@ -371,21 +625,25 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             let rc = sqlite3_step(stmt)
             if rc == SQLITE_DONE { return nil }
             guard rc == SQLITE_ROW else { throw sqliteError("select", rc: rc) }
-            guard
-                let stage = CalendarRegistryTransactionStage(rawValue: text(stmt, 3) ?? ""),
-                let createdAt = text(stmt, 8).flatMap(CalendarRegistryISO.date),
-                let updatedAt = text(stmt, 9).flatMap(CalendarRegistryISO.date)
-            else {
-                throw CalendarRegistryTransactionStoreError.corruptLedger(
-                    "invalid transaction row for \(idempotencyKey)"
-                )
+            guard let operationId = text(stmt, 0), !operationId.isEmpty,
+                  let storedKey = text(stmt, 1), !storedKey.isEmpty,
+                  let fingerprint = text(stmt, 2), !fingerprint.isEmpty,
+                  let stage = CalendarRegistryTransactionStage(rawValue: text(stmt, 3) ?? ""),
+                  let createdAt = text(stmt, 8).flatMap(CalendarRegistryISO.date),
+                  let updatedAt = text(stmt, 9).flatMap(CalendarRegistryISO.date),
+                  let effectsRaw = text(stmt, 12),
+                  let effects = try? JSONDecoder().decode([String].self, from: Data(effectsRaw.utf8)),
+                  sqlite3_column_type(stmt, 13) != SQLITE_NULL else {
+                throw CalendarRegistryTransactionStoreError.corruptLedger("invalid transaction row for \(idempotencyKey)")
             }
-            let effectsData = Data((text(stmt, 12) ?? "[]").utf8)
-            let effects = (try? JSONDecoder().decode([String].self, from: effectsData)) ?? []
+            let revision = Int(sqlite3_column_int64(stmt, 13))
+            guard revision >= 1 else { throw CalendarRegistryTransactionStoreError.corruptLedger("invalid revision for \(idempotencyKey)") }
+            let leaseExpiry = optionalDouble(stmt, 16).map(Date.init(timeIntervalSince1970:))
+            let heartbeat = optionalDouble(stmt, 17).map(Date.init(timeIntervalSince1970:))
             return CalendarRegistryTransaction(
-                operationId: text(stmt, 0) ?? "",
-                idempotencyKey: text(stmt, 1) ?? idempotencyKey,
-                manifestFingerprint: text(stmt, 2) ?? "",
+                operationId: operationId,
+                idempotencyKey: storedKey,
+                manifestFingerprint: fingerprint,
                 stage: stage,
                 registryEventId: text(stmt, 4),
                 calendarEventId: text(stmt, 5),
@@ -395,13 +653,25 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
                 updatedAt: updatedAt,
                 lastVerifiedAt: text(stmt, 10).flatMap(CalendarRegistryISO.date),
                 lastError: text(stmt, 11),
-                partialEffects: effects
+                partialEffects: effects,
+                revision: revision,
+                leaseOwner: text(stmt, 14),
+                leaseToken: text(stmt, 15),
+                leaseExpiresAt: leaseExpiry,
+                heartbeatAt: heartbeat
             )
         }
     }
 
     private func partialEffectsJSON(_ effects: [String]) throws -> String {
         String(decoding: try JSONEncoder().encode(effects), as: UTF8.self)
+    }
+
+    private func currentEpoch() throws -> TimeInterval {
+        try withStatement("SELECT CAST(strftime('%s','now') AS REAL);") { stmt in
+            guard sqlite3_step(stmt) == SQLITE_ROW else { throw sqliteError("clock", rc: sqlite3_errcode(db)) }
+            return sqlite3_column_double(stmt, 0)
+        }
     }
 
     private func beginImmediate() throws { try execute("BEGIN IMMEDIATE;") }
@@ -416,15 +686,6 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
             let message = error.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
             if let error { sqlite3_free(error) }
             throw CalendarRegistryTransactionStoreError.storageFailure(message)
-        }
-    }
-
-    private func scalarInt(_ sql: String) throws -> Int? {
-        try withStatement(sql) { stmt in
-            let rc = sqlite3_step(stmt)
-            if rc == SQLITE_DONE { return nil }
-            guard rc == SQLITE_ROW else { throw sqliteError("scalar", rc: rc) }
-            return Int(sqlite3_column_int64(stmt, 0))
         }
     }
 
@@ -444,10 +705,22 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
 
     private func bindOptionalText(_ stmt: OpaquePointer?, _ index: Int32, _ value: String?) throws {
         if let value { try bindText(stmt, index, value) }
-        else {
-            let rc = sqlite3_bind_null(stmt, index)
-            guard rc == SQLITE_OK else { throw sqliteError("bind null", rc: rc) }
-        }
+        else { guard sqlite3_bind_null(stmt, index) == SQLITE_OK else { throw sqliteError("bind null", rc: sqlite3_errcode(db)) } }
+    }
+
+    private func bindInt(_ stmt: OpaquePointer?, _ index: Int32, _ value: Int) throws {
+        let rc = sqlite3_bind_int64(stmt, index, sqlite3_int64(value))
+        guard rc == SQLITE_OK else { throw sqliteError("bind int", rc: rc) }
+    }
+
+    private func bindDouble(_ stmt: OpaquePointer?, _ index: Int32, _ value: Double) throws {
+        let rc = sqlite3_bind_double(stmt, index, value)
+        guard rc == SQLITE_OK else { throw sqliteError("bind double", rc: rc) }
+    }
+
+    private func bindOptionalDouble(_ stmt: OpaquePointer?, _ index: Int32, _ value: Double?) throws {
+        if let value { try bindDouble(stmt, index, value) }
+        else { guard sqlite3_bind_null(stmt, index) == SQLITE_OK else { throw sqliteError("bind null", rc: sqlite3_errcode(db)) } }
     }
 
     private func stepDone(_ stmt: OpaquePointer?) throws {
@@ -456,9 +729,13 @@ public actor SQLiteCalendarRegistryTransactionStore: CalendarRegistryTransaction
     }
 
     private func text(_ stmt: OpaquePointer?, _ index: Int32) -> String? {
-        guard sqlite3_column_type(stmt, index) != SQLITE_NULL,
-              let raw = sqlite3_column_text(stmt, index) else { return nil }
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL, let raw = sqlite3_column_text(stmt, index) else { return nil }
         return String(cString: raw)
+    }
+
+    private func optionalDouble(_ stmt: OpaquePointer?, _ index: Int32) -> Double? {
+        guard sqlite3_column_type(stmt, index) != SQLITE_NULL else { return nil }
+        return sqlite3_column_double(stmt, index)
     }
 
     private func sqliteError(_ operation: String, rc: Int32) -> CalendarRegistryTransactionStoreError {
@@ -472,19 +749,30 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
     private var failNextSaveMessage: String?
 
     public init() {}
-
     public func setFailNextSave(_ message: String?) { failNextSaveMessage = message }
 
     public func claim(
         idempotencyKey: String,
         manifestFingerprint: String,
         operationId: String,
-        now: Date
+        leaseOwner: String,
+        leaseToken: String,
+        leaseDuration: TimeInterval
     ) throws -> CalendarRegistryTransaction {
-        if let existing = transactions[idempotencyKey] {
-            guard existing.manifestFingerprint == manifestFingerprint else {
-                throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
+        let now = Date()
+        if var existing = transactions[idempotencyKey] {
+            guard existing.manifestFingerprint == manifestFingerprint else { throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey) }
+            if let expiry = existing.leaseExpiresAt, existing.leaseToken != nil, expiry > now {
+                throw CalendarRegistryTransactionStoreError.operationActive(idempotencyKey, expiry)
             }
+            existing.operationId = operationId
+            existing.leaseOwner = leaseOwner
+            existing.leaseToken = leaseToken
+            existing.leaseExpiresAt = now.addingTimeInterval(leaseDuration)
+            existing.heartbeatAt = now
+            existing.updatedAt = now
+            existing.revision += 1
+            transactions[idempotencyKey] = existing
             return existing
         }
         let transaction = CalendarRegistryTransaction(
@@ -492,33 +780,79 @@ public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransacti
             idempotencyKey: idempotencyKey,
             manifestFingerprint: manifestFingerprint,
             createdAt: now,
-            updatedAt: now
+            updatedAt: now,
+            revision: 1,
+            leaseOwner: leaseOwner,
+            leaseToken: leaseToken,
+            leaseExpiresAt: now.addingTimeInterval(leaseDuration),
+            heartbeatAt: now
         )
         transactions[idempotencyKey] = transaction
         return transaction
     }
 
-    public func get(idempotencyKey: String) -> CalendarRegistryTransaction? {
-        transactions[idempotencyKey]
+    public func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) throws -> CalendarRegistryTransaction {
+        var current = try owned(transaction)
+        current.leaseExpiresAt = Date().addingTimeInterval(leaseDuration)
+        current.heartbeatAt = Date()
+        current.updatedAt = Date()
+        current.revision += 1
+        transactions[current.idempotencyKey] = current
+        return current
     }
 
-    public func save(_ transaction: CalendarRegistryTransaction) throws {
+    public func get(idempotencyKey: String) -> CalendarRegistryTransaction? { transactions[idempotencyKey] }
+
+    public func save(_ transaction: CalendarRegistryTransaction) throws -> CalendarRegistryTransaction {
         if let message = failNextSaveMessage {
             failNextSaveMessage = nil
             throw CalendarRegistryTransactionStoreError.storageFailure(message)
         }
-        transactions[transaction.idempotencyKey] = transaction
+        let current = try owned(transaction)
+        guard current.stage.permitsTransition(to: transaction.stage) else {
+            throw CalendarRegistryTransactionStoreError.stageRegression("\(current.stage.rawValue) → \(transaction.stage.rawValue)")
+        }
+        for (name, old, new) in [
+            ("registry event id", current.registryEventId, transaction.registryEventId),
+            ("calendar event id", current.calendarEventId, transaction.calendarEventId),
+            ("calendar id", current.calendarId, transaction.calendarId),
+            ("provider external id", current.providerExternalId, transaction.providerExternalId)
+        ] where old?.isEmpty == false && new?.isEmpty != false {
+            throw CalendarRegistryTransactionStoreError.identityRegression("\(name) cannot be cleared")
+        }
+        var saved = transaction
+        saved.revision += 1
+        saved.updatedAt = Date()
+        saved.heartbeatAt = Date()
+        transactions[saved.idempotencyKey] = saved
+        return saved
+    }
+
+    public func release(_ transaction: CalendarRegistryTransaction) throws -> CalendarRegistryTransaction {
+        var current = try owned(transaction, requireUnexpired: false)
+        current.leaseOwner = nil
+        current.leaseToken = nil
+        current.leaseExpiresAt = nil
+        current.heartbeatAt = Date()
+        current.updatedAt = Date()
+        current.revision += 1
+        transactions[current.idempotencyKey] = current
+        return current
+    }
+
+    private func owned(_ transaction: CalendarRegistryTransaction, requireUnexpired: Bool = true) throws -> CalendarRegistryTransaction {
+        guard let current = transactions[transaction.idempotencyKey] else { throw CalendarRegistryTransactionStoreError.missingTransaction(transaction.idempotencyKey) }
+        guard current.revision == transaction.revision else { throw CalendarRegistryTransactionStoreError.staleRevision(transaction.idempotencyKey) }
+        guard current.leaseToken == transaction.leaseToken, current.leaseOwner == transaction.leaseOwner,
+              transaction.leaseToken?.isEmpty == false else { throw CalendarRegistryTransactionStoreError.leaseLost(transaction.idempotencyKey) }
+        if requireUnexpired, let expiry = current.leaseExpiresAt, expiry <= Date() { throw CalendarRegistryTransactionStoreError.leaseLost(transaction.idempotencyKey) }
+        return current
     }
 }
 
 public enum CalendarRegistryDigest {
-    public static func sha256(_ data: Data) -> String {
-        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-    }
-
-    public static func sha256(_ value: String) -> String {
-        sha256(Data(value.utf8))
-    }
+    public static func sha256(_ data: Data) -> String { SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined() }
+    public static func sha256(_ value: String) -> String { sha256(Data(value.utf8)) }
 }
 
 public enum CalendarRegistryISO {
@@ -527,7 +861,6 @@ public enum CalendarRegistryISO {
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter.string(from: date)
     }
-
     public static func date(_ value: String) -> Date? {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -540,29 +873,69 @@ public enum CalendarRegistryISO {
 public actor CalendarRegistryOperationGate {
     public static let shared = CalendarRegistryOperationGate()
 
+    private final class WaiterState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cancelled = false
+        func cancel() { lock.lock(); cancelled = true; lock.unlock() }
+        func isCancelled() -> Bool { lock.lock(); defer { lock.unlock() }; return cancelled }
+    }
+
+    private struct Waiter {
+        let id: UUID
+        let state: WaiterState
+        let continuation: CheckedContinuation<Void, Error>
+    }
     private var locked: Set<String> = []
-    private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var waiters: [String: [Waiter]] = [:]
+    private var cancelled: Set<UUID> = []
 
     public init() {}
 
-    public func acquire(_ key: String) async {
+    public func acquire(_ key: String) async throws {
+        try Task.checkCancellation()
         if !locked.contains(key) {
             locked.insert(key)
             return
         }
-        await withCheckedContinuation { continuation in
-            waiters[key, default: []].append(continuation)
+        let id = UUID()
+        let state = WaiterState()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if state.isCancelled() || cancelled.remove(id) != nil || Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waiters[key, default: []].append(Waiter(id: id, state: state, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            state.cancel()
+            Task { await self.cancel(key: key, id: id) }
+        }
+    }
+
+    private func cancel(key: String, id: UUID) {
+        if let index = waiters[key]?.firstIndex(where: { $0.id == id }) {
+            let waiter = waiters[key]!.remove(at: index)
+            if waiters[key]?.isEmpty == true { waiters[key] = nil }
+            waiter.continuation.resume(throwing: CancellationError())
+        } else {
+            cancelled.insert(id)
         }
     }
 
     public func release(_ key: String) {
-        guard var queued = waiters[key], !queued.isEmpty else {
-            locked.remove(key)
-            waiters[key] = nil
+        while var queued = waiters[key], !queued.isEmpty {
+            let next = queued.removeFirst()
+            waiters[key] = queued.isEmpty ? nil : queued
+            let cancellationMarker = cancelled.remove(next.id) != nil
+            if next.state.isCancelled() || cancellationMarker {
+                next.continuation.resume(throwing: CancellationError())
+                continue
+            }
+            next.continuation.resume()
             return
         }
-        let next = queued.removeFirst()
-        waiters[key] = queued.isEmpty ? nil : queued
-        next.resume()
+        locked.remove(key)
+        waiters[key] = nil
     }
 }

--- a/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
+++ b/TheBridge/Modules/Time/CalendarRegistryTransactionStore.swift
@@ -1,0 +1,267 @@
+// CalendarRegistryTransactionStore.swift — durable registry-first operation journal
+
+import CryptoKit
+import Foundation
+
+public enum CalendarRegistryTransactionStage: String, Codable, Sendable, CaseIterable {
+    case prepared
+    case registryCreated
+    case calendarCreated
+    case pairPersisted
+    case verified
+    case synced
+    case recoverableError
+    case conflict
+    case abandoned
+}
+
+public struct CalendarRegistryOperationManifest: Codable, Sendable, Equatable {
+    public var title: String
+    public var start: Date
+    public var end: Date
+    public var timeZoneIdentifier: String
+    public var calendarId: String?
+    public var location: String?
+    public var notes: String?
+    public var eventClass: String
+    public var primaryBlockId: String
+    public var blockIds: [String]
+    public var projectIds: [String]
+    public var contactIds: [String]
+
+    public var fingerprint: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(self) else { return "" }
+        return CalendarRegistryDigest.sha256(data)
+    }
+}
+
+public struct CalendarRegistryTransaction: Codable, Sendable, Equatable {
+    public var operationId: String
+    public var idempotencyKey: String
+    public var manifestFingerprint: String
+    public var stage: CalendarRegistryTransactionStage
+    public var registryEventId: String?
+    public var calendarEventId: String?
+    public var calendarId: String?
+    public var providerExternalId: String?
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var lastVerifiedAt: Date?
+    public var lastError: String?
+    public var partialEffects: [String]
+
+    public init(
+        operationId: String,
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        stage: CalendarRegistryTransactionStage = .prepared,
+        registryEventId: String? = nil,
+        calendarEventId: String? = nil,
+        calendarId: String? = nil,
+        providerExternalId: String? = nil,
+        createdAt: Date,
+        updatedAt: Date,
+        lastVerifiedAt: Date? = nil,
+        lastError: String? = nil,
+        partialEffects: [String] = []
+    ) {
+        self.operationId = operationId
+        self.idempotencyKey = idempotencyKey
+        self.manifestFingerprint = manifestFingerprint
+        self.stage = stage
+        self.registryEventId = registryEventId
+        self.calendarEventId = calendarEventId
+        self.calendarId = calendarId
+        self.providerExternalId = providerExternalId
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.lastVerifiedAt = lastVerifiedAt
+        self.lastError = lastError
+        self.partialEffects = partialEffects
+    }
+}
+
+public enum CalendarRegistryTransactionStoreError: Error, LocalizedError, Equatable {
+    case idempotencyConflict(String)
+    case corruptJournal(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .idempotencyConflict(let key):
+            return "idempotency key already belongs to a different manifest: \(key)"
+        case .corruptJournal(let reason):
+            return "calendar-registry transaction journal is corrupt: \(reason)"
+        }
+    }
+}
+
+public protocol CalendarRegistryTransactionStoring: Sendable {
+    func claim(
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        operationId: String,
+        now: Date
+    ) async throws -> CalendarRegistryTransaction
+    func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction?
+    func save(_ transaction: CalendarRegistryTransaction) async throws
+}
+
+public actor JSONCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
+    private let url: URL
+    private var transactions: [String: CalendarRegistryTransaction]
+
+    public init(url: URL) throws {
+        self.url = url
+        if FileManager.default.fileExists(atPath: url.path) {
+            do {
+                let data = try Data(contentsOf: url)
+                self.transactions = try JSONDecoder().decode(
+                    [String: CalendarRegistryTransaction].self, from: data
+                )
+            } catch {
+                throw CalendarRegistryTransactionStoreError.corruptJournal(error.localizedDescription)
+            }
+        } else {
+            self.transactions = [:]
+        }
+    }
+
+    public func claim(
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        operationId: String,
+        now: Date
+    ) throws -> CalendarRegistryTransaction {
+        if let existing = transactions[idempotencyKey] {
+            guard existing.manifestFingerprint == manifestFingerprint else {
+                throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
+            }
+            return existing
+        }
+        let transaction = CalendarRegistryTransaction(
+            operationId: operationId,
+            idempotencyKey: idempotencyKey,
+            manifestFingerprint: manifestFingerprint,
+            createdAt: now,
+            updatedAt: now
+        )
+        transactions[idempotencyKey] = transaction
+        try persist()
+        return transaction
+    }
+
+    public func get(idempotencyKey: String) -> CalendarRegistryTransaction? {
+        transactions[idempotencyKey]
+    }
+
+    public func save(_ transaction: CalendarRegistryTransaction) throws {
+        transactions[transaction.idempotencyKey] = transaction
+        try persist()
+    }
+
+    private func persist() throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(transactions)
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+public actor InMemoryCalendarRegistryTransactionStore: CalendarRegistryTransactionStoring {
+    private var transactions: [String: CalendarRegistryTransaction] = [:]
+
+    public init() {}
+
+    public func claim(
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        operationId: String,
+        now: Date
+    ) throws -> CalendarRegistryTransaction {
+        if let existing = transactions[idempotencyKey] {
+            guard existing.manifestFingerprint == manifestFingerprint else {
+                throw CalendarRegistryTransactionStoreError.idempotencyConflict(idempotencyKey)
+            }
+            return existing
+        }
+        let transaction = CalendarRegistryTransaction(
+            operationId: operationId,
+            idempotencyKey: idempotencyKey,
+            manifestFingerprint: manifestFingerprint,
+            createdAt: now,
+            updatedAt: now
+        )
+        transactions[idempotencyKey] = transaction
+        return transaction
+    }
+
+    public func get(idempotencyKey: String) -> CalendarRegistryTransaction? {
+        transactions[idempotencyKey]
+    }
+
+    public func save(_ transaction: CalendarRegistryTransaction) {
+        transactions[transaction.idempotencyKey] = transaction
+    }
+}
+
+
+public enum CalendarRegistryDigest {
+    public static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func sha256(_ value: String) -> String {
+        sha256(Data(value.utf8))
+    }
+}
+
+public enum CalendarRegistryISO {
+    public static func string(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    public static func date(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+}
+
+
+public actor CalendarRegistryOperationGate {
+    public static let shared = CalendarRegistryOperationGate()
+
+    private var locked: Set<String> = []
+    private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    public init() {}
+
+    public func acquire(_ key: String) async {
+        if !locked.contains(key) {
+            locked.insert(key)
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters[key, default: []].append(continuation)
+        }
+    }
+
+    public func release(_ key: String) {
+        guard var queued = waiters[key], !queued.isEmpty else {
+            locked.remove(key)
+            waiters[key] = nil
+            return
+        }
+        let next = queued.removeFirst()
+        waiters[key] = queued.isEmpty ? nil : queued
+        next.resume()
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoListQuery.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoListQuery.swift
@@ -1,0 +1,149 @@
+// VoiceMemoListQuery.swift — filtered/paginated list for voice_memo_list
+// TheBridge · Modules · VoiceMemo
+//
+// Voice Memo Reliability packet (Ship The Bridge v4): unbounded
+// `voice_memo_list` returned 200+ memos forcing client-side date filtering.
+// This pure helper applies date range, processed-state, transcript presence,
+// text contains, sort, limit, and opaque cursor — no disk I/O of its own.
+
+import Foundation
+
+public struct VoiceMemoListQuery: Sendable, Equatable {
+    public var includeProcessed: Bool
+    /// Max rows to return (clamped 1...500). Nil → default 50.
+    public var limit: Int?
+    /// Opaque cursor from a prior response (`nextCursor`).
+    public var cursor: String?
+    public var dateFrom: Date?
+    public var dateTo: Date?
+    public var hasTranscript: Bool?
+    public var transcriptContains: String?
+    /// Default newest-first (`false`).
+    public var sortAscending: Bool
+
+    public static let defaultLimit = 50
+    public static let maxLimit = 500
+
+    public init(
+        includeProcessed: Bool = false,
+        limit: Int? = nil,
+        cursor: String? = nil,
+        dateFrom: Date? = nil,
+        dateTo: Date? = nil,
+        hasTranscript: Bool? = nil,
+        transcriptContains: String? = nil,
+        sortAscending: Bool = false
+    ) {
+        self.includeProcessed = includeProcessed
+        self.limit = limit
+        self.cursor = cursor
+        self.dateFrom = dateFrom
+        self.dateTo = dateTo
+        self.hasTranscript = hasTranscript
+        self.transcriptContains = transcriptContains
+        self.sortAscending = sortAscending
+    }
+
+    public var effectiveLimit: Int {
+        let raw = limit ?? Self.defaultLimit
+        return min(max(raw, 1), Self.maxLimit)
+    }
+}
+
+public struct VoiceMemoListPage: Sendable, Equatable {
+    public let memos: [VoiceMemoRecording]
+    public let totalMatched: Int
+    public let nextCursor: String?
+    public let hasMore: Bool
+
+    public init(memos: [VoiceMemoRecording], totalMatched: Int, nextCursor: String?, hasMore: Bool) {
+        self.memos = memos
+        self.totalMatched = totalMatched
+        self.nextCursor = nextCursor
+        self.hasMore = hasMore
+    }
+}
+
+public enum VoiceMemoListFilter {
+
+    /// Apply query filters + pagination over a pre-discovered recording set.
+    /// `isProcessed` is injected so tests can stub the processed store.
+    public static func page(
+        recordings: [VoiceMemoRecording],
+        query: VoiceMemoListQuery,
+        isProcessed: (String) -> Bool = { VoiceMemoProcessedStore.isProcessed(id: $0) }
+    ) -> VoiceMemoListPage {
+        var filtered = recordings.filter { rec in
+            if !query.includeProcessed, isProcessed(rec.id) { return false }
+            if let from = query.dateFrom, rec.recordedAt < from { return false }
+            if let to = query.dateTo, rec.recordedAt > to { return false }
+            if let wantTranscript = query.hasTranscript, rec.hasTranscript != wantTranscript { return false }
+            if let needle = query.transcriptContains?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !needle.isEmpty {
+                let hay = ((rec.transcript ?? "") + " " + rec.title)
+                    .lowercased()
+                if !hay.contains(needle.lowercased()) { return false }
+            }
+            return true
+        }
+
+        filtered.sort {
+            if query.sortAscending {
+                if $0.recordedAt != $1.recordedAt { return $0.recordedAt < $1.recordedAt }
+                return $0.id < $1.id
+            } else {
+                if $0.recordedAt != $1.recordedAt { return $0.recordedAt > $1.recordedAt }
+                return $0.id > $1.id
+            }
+        }
+
+        let total = filtered.count
+        let start: Int
+        if let cursor = query.cursor, let decoded = decodeCursor(cursor) {
+            if let idx = filtered.firstIndex(where: {
+                $0.id == decoded.id && abs($0.recordedAt.timeIntervalSince(decoded.recordedAt)) < 1.0
+            }) {
+                start = idx + 1
+            } else {
+                // Cursor not found: treat as start of list (idempotent resume).
+                start = 0
+            }
+        } else {
+            start = 0
+        }
+
+        let limit = query.effectiveLimit
+        guard start < filtered.count else {
+            return VoiceMemoListPage(memos: [], totalMatched: total, nextCursor: nil, hasMore: false)
+        }
+        let end = min(start + limit, filtered.count)
+        let slice = Array(filtered[start..<end])
+        let hasMore = end < filtered.count
+        let next: String? = hasMore ? encodeCursor(slice.last!) : nil
+        return VoiceMemoListPage(memos: slice, totalMatched: total, nextCursor: next, hasMore: hasMore)
+    }
+
+    // Cursor: base64url("ISO8601|id")
+    public static func encodeCursor(_ rec: VoiceMemoRecording) -> String {
+        let iso = ISO8601DateFormatter().string(from: rec.recordedAt)
+        let raw = "\(iso)|\(rec.id)"
+        return Data(raw.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    public static func decodeCursor(_ cursor: String) -> (recordedAt: Date, id: String)? {
+        var b64 = cursor
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64.append("=") }
+        guard let data = Data(base64Encoded: b64),
+              let raw = String(data: data, encoding: .utf8) else { return nil }
+        let parts = raw.split(separator: "|", maxSplits: 1).map(String.init)
+        guard parts.count == 2,
+              let date = ISO8601DateFormatter().date(from: parts[0]) else { return nil }
+        return (date, parts[1])
+    }
+}
+

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
@@ -31,7 +31,7 @@ public enum VoiceMemoModule {
             name: "voice_memo_list",
             module: moduleName,
             tier: .open,
-            description: "List Voice Memos recordings discovered on disk. Marks which are already processed by the morning curator job. Read-only.",
+            description: "List Voice Memos recordings discovered on disk with optional date/transcript/processed filters, limit/cursor pagination, and curator/backlog health. Read-only.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -39,22 +39,84 @@ public enum VoiceMemoModule {
                         "type": .string("boolean"),
                         "description": .string("Include memos already processed (default false)."),
                     ]),
+                    "limit": .object([
+                        "type": .string("integer"),
+                        "description": .string("Max memos to return (default 50, max 500)."),
+                    ]),
+                    "cursor": .object([
+                        "type": .string("string"),
+                        "description": .string("Opaque pagination cursor from a prior nextCursor."),
+                    ]),
+                    "dateFrom": .object([
+                        "type": .string("string"),
+                        "description": .string("ISO-8601 lower bound on recordedAt (inclusive)."),
+                    ]),
+                    "dateTo": .object([
+                        "type": .string("string"),
+                        "description": .string("ISO-8601 upper bound on recordedAt (inclusive)."),
+                    ]),
+                    "hasTranscript": .object([
+                        "type": .string("boolean"),
+                        "description": .string("When set, only memos with/without a transcript body."),
+                    ]),
+                    "transcriptContains": .object([
+                        "type": .string("string"),
+                        "description": .string("Case-insensitive substring match against title + known transcript text."),
+                    ]),
+                    "sort": .object([
+                        "type": .string("string"),
+                        "description": .string("recordedAt_desc (default) or recordedAt_asc."),
+                    ]),
+                    "includeHealth": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Include curator job status + backlog counts (default true)."),
+                    ]),
                 ]),
             ]),
             metadata: ToolMetadata(
                 title: "Voice Memo List",
-                whenToUse: ["inspect unprocessed Voice Memos before running the curator", "debug discovery paths and transcript sidecars"],
+                whenToUse: [
+                    "inspect unprocessed Voice Memos before running the curator",
+                    "date-scoped triage without downloading the full backlog",
+                    "debug discovery paths and transcript sidecars",
+                ],
                 whenNotToUse: ["routing writes — use voice_memo_process"],
-                relatedTools: ["voice_memo_process"]
+                relatedTools: ["voice_memo_process", "voice_memo_settings_get"]
             ),
             handler: { args in
-                var includeProcessed = false
-                if case .object(let obj) = args, case .bool(let b)? = obj["includeProcessed"] { includeProcessed = b }
+                let obj: [String: Value]
+                if case .object(let o) = args { obj = o } else { obj = [:] }
+
+                var query = VoiceMemoListQuery()
+                if case .bool(let b)? = obj["includeProcessed"] { query.includeProcessed = b }
+                if case .int(let n)? = obj["limit"] { query.limit = n }
+                if case .double(let d)? = obj["limit"] { query.limit = Int(d) }
+                if case .string(let c)? = obj["cursor"] { query.cursor = c }
+                if case .bool(let b)? = obj["hasTranscript"] { query.hasTranscript = b }
+                if case .string(let s)? = obj["transcriptContains"] { query.transcriptContains = s }
+                if case .string(let sort)? = obj["sort"] {
+                    query.sortAscending = sort.lowercased().contains("asc")
+                }
+                let iso = ISO8601DateFormatter()
+                iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                let isoBasic = ISO8601DateFormatter()
+                if case .string(let from)? = obj["dateFrom"] {
+                    query.dateFrom = iso.date(from: from) ?? isoBasic.date(from: from)
+                }
+                if case .string(let to)? = obj["dateTo"] {
+                    query.dateTo = iso.date(from: to) ?? isoBasic.date(from: to)
+                }
+                var includeHealth = true
+                if case .bool(let b)? = obj["includeHealth"] { includeHealth = b }
+
                 let all = VoiceMemoDiscovery.listRecordings(roots: VoiceMemoDiscovery.defaultRecordingRoots())
-                let rows = all.filter { includeProcessed || !VoiceMemoProcessedStore.isProcessed(id: $0.id) }
-                return .object([
-                    "count": .int(rows.count),
-                    "memos": .array(rows.map { memo in
+                let page = VoiceMemoListFilter.page(recordings: all, query: query)
+
+                var result: [String: Value] = [
+                    "count": .int(page.memos.count),
+                    "totalMatched": .int(page.totalMatched),
+                    "hasMore": .bool(page.hasMore),
+                    "memos": .array(page.memos.map { memo in
                         .object([
                             "id": .string(memo.id),
                             "title": .string(memo.title),
@@ -65,7 +127,33 @@ public enum VoiceMemoModule {
                             "processed": .bool(VoiceMemoProcessedStore.isProcessed(id: memo.id)),
                         ])
                     }),
-                ])
+                ]
+                if let next = page.nextCursor { result["nextCursor"] = .string(next) }
+
+                if includeHealth {
+                    let unprocessed = all.filter { !VoiceMemoProcessedStore.isProcessed(id: $0.id) }.count
+                    let pendingReview = VoiceMemoReviewStore.pendingEntries().count
+                    var curatorStatus = "missing"
+                    var curatorActive = false
+                    do {
+                        try await JobStore.shared.open()
+                        if let job = try await JobStore.shared.fetch(id: VoiceMemoCuratorJob.jobId) {
+                            curatorStatus = job.status.rawValue
+                            curatorActive = job.status == .active
+                        }
+                    } catch {
+                        curatorStatus = "unavailable"
+                    }
+                    result["health"] = .object([
+                        "curatorJobId": .string(VoiceMemoCuratorJob.jobId),
+                        "curatorStatus": .string(curatorStatus),
+                        "curatorActive": .bool(curatorActive),
+                        "unprocessedCount": .int(unprocessed),
+                        "pendingReviewCount": .int(pendingReview),
+                        "backlogHealthy": .bool(unprocessed < 50 && curatorActive),
+                    ])
+                }
+                return .object(result)
             }
         )
     }

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -1422,14 +1422,19 @@ public enum VoiceMemoProcessor {
                 ),
                 provenance: "stage-timeout"
             ))
-            return .object([
-                "ok": .bool(false),
-                "needsManual": .bool(true),
-                "memoId": .string(recording.id),
-                "intentKind": .string(kind.rawValue),
-                "detail": .string(timeoutError.localizedDescription),
-                "markedProcessed": .bool(false),
-            ])
+            var receipt = commitReceipt(
+                ok: false,
+                memoId: recording.id,
+                intentKind: kind.rawValue,
+                intentState: "review_required",
+                detail: timeoutError.localizedDescription,
+                markedProcessed: false
+            )
+            if case .object(var obj) = receipt {
+                obj["needsManual"] = .bool(true)
+                receipt = .object(obj)
+            }
+            return receipt
         }
         var intent = plan.intents.first { $0.kind == kind } ?? VoiceMemoIntent(kind: kind, confidence: 1.0)
         if let entityKey = stringArg(obj, "entityKey") { intent.entityKey = entityKey }
@@ -1492,24 +1497,34 @@ public enum VoiceMemoProcessor {
                 entityHint: intent.entityHint,
                 provenance: "stage-timeout"
             ))
-            return .object([
-                "ok": .bool(false),
-                "needsManual": .bool(true),
-                "memoId": .string(recording.id),
-                "intentKind": .string(kind.rawValue),
-                "detail": .string(timeoutError.localizedDescription),
-                "markedProcessed": .bool(false),
-            ])
+            var receipt = commitReceipt(
+                ok: false,
+                memoId: recording.id,
+                intentKind: kind.rawValue,
+                intentState: "review_required",
+                detail: timeoutError.localizedDescription,
+                markedProcessed: false
+            )
+            if case .object(var obj) = receipt {
+                obj["needsManual"] = .bool(true)
+                receipt = .object(obj)
+            }
+            return receipt
         } catch let error as VoiceMemoError {
             if case .registryAmbiguous = error {
-                return .object([
-                    "ok": .bool(false),
-                    "needsManual": .bool(true),
-                    "memoId": .string(recording.id),
-                    "intentKind": .string(kind.rawValue),
-                    "detail": .string(error.localizedDescription),
-                    "markedProcessed": .bool(false),
-                ])
+                var receipt = commitReceipt(
+                    ok: false,
+                    memoId: recording.id,
+                    intentKind: kind.rawValue,
+                    intentState: "review_required",
+                    detail: error.localizedDescription,
+                    markedProcessed: false
+                )
+                if case .object(var obj) = receipt {
+                    obj["needsManual"] = .bool(true)
+                    receipt = .object(obj)
+                }
+                return receipt
             }
             if case .contentQualityRejected = error {
                 // GH #81 — the commit-time counterpart of processOne's queueReview: an
@@ -1531,14 +1546,19 @@ public enum VoiceMemoProcessor {
                     entityHint: intent.entityHint,
                     provenance: "content-quality-gate"
                 ))
-                return .object([
-                    "ok": .bool(false),
-                    "needsManual": .bool(true),
-                    "memoId": .string(recording.id),
-                    "intentKind": .string(kind.rawValue),
-                    "detail": .string(error.localizedDescription),
-                    "markedProcessed": .bool(false),
-                ])
+                var receipt = commitReceipt(
+                    ok: false,
+                    memoId: recording.id,
+                    intentKind: kind.rawValue,
+                    intentState: "review_required",
+                    detail: error.localizedDescription,
+                    markedProcessed: false
+                )
+                if case .object(var obj) = receipt {
+                    obj["needsManual"] = .bool(true)
+                    receipt = .object(obj)
+                }
+                return receipt
             }
             throw error
         }
@@ -1559,13 +1579,87 @@ public enum VoiceMemoProcessor {
         }
         let markedProcessed = try VoiceMemoProcessedGate.markProcessedIfClear(memoId: recording.id)
         recordCommitted(recording: recording, intentId: committedIntentId, kind: kind, detail: detail)
-        return .object([
-            "ok": .bool(true),
-            "memoId": .string(recording.id),
-            "intentKind": .string(kind.rawValue),
+        return commitReceipt(
+            ok: true,
+            memoId: recording.id,
+            intentKind: kind.rawValue,
+            intentState: "committed",
+            detail: detail,
+            markedProcessed: markedProcessed,
+            write: parseWriteDestination(detail: detail, kind: kind, intent: intent)
+        )
+    }
+
+    /// Structured commit receipt (Voice Memo Reliability packet SC #7 / proposed receipt).
+    /// Additive fields — existing clients still read ok/memoId/intentKind/detail/markedProcessed.
+    static func commitReceipt(
+        ok: Bool,
+        memoId: String,
+        intentKind: String,
+        intentState: String,
+        detail: String,
+        markedProcessed: Bool,
+        write: [String: Value]? = nil
+    ) -> Value {
+        let remaining = VoiceMemoReviewStore.pendingEntries()
+            .filter { $0.memoId == memoId }
+            .map { $0.intentKind }
+        let completed = VoiceMemoReviewStore.load().entries
+            .filter { $0.memoId == memoId && ($0.status == .resolved || $0.status == .dismissed) }
+            .map { $0.intentKind }
+        // Include the intent we just committed even if the review entry was just resolved.
+        var completedSet = Set(completed)
+        if ok { completedSet.insert(intentKind) }
+
+        let memoState: String
+        if markedProcessed {
+            memoState = "committed"
+        } else if !remaining.isEmpty {
+            memoState = "partially_committed"
+        } else if !ok {
+            memoState = intentState == "review_required" ? "review_required" : "failed"
+        } else {
+            memoState = "partially_committed"
+        }
+
+        var obj: [String: Value] = [
+            "ok": .bool(ok),
+            "memoId": .string(memoId),
+            "intentKind": .string(intentKind),
+            "intentState": .string(intentState),
+            "memoState": .string(memoState),
             "detail": .string(detail),
             "markedProcessed": .bool(markedProcessed),
-        ])
+            "completedIntents": .array(completedSet.sorted().map { .string($0) }),
+            "remainingIntents": .array(remaining.sorted().map { .string($0) }),
+        ]
+        if let write { obj["write"] = .object(write) }
+        return .object(obj)
+    }
+
+    /// Best-effort parse of lane execute() detail strings into a write receipt block.
+    static func parseWriteDestination(
+        detail: String,
+        kind: VoiceMemoIntentKind,
+        intent: VoiceMemoIntent
+    ) -> [String: Value]? {
+        // Common detail shapes: "memory_keep pageId=…", "registry_update contact rowId=…",
+        // "reminder id=…", "memory_remember scope=… (N chars)".
+        var write: [String: Value] = [
+            "tool": .string(kind.rawValue),
+        ]
+        if let entity = intent.entityKey { write["entity"] = .string(entity) }
+        if let title = intent.entityHint ?? intent.title { write["title"] = .string(title) }
+        // Capture first UUID-looking token as recordId when present.
+        let uuidPattern = #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32}"#
+        if let regex = try? NSRegularExpression(pattern: uuidPattern),
+           let match = regex.firstMatch(in: detail, range: NSRange(detail.startIndex..., in: detail)),
+           let range = Range(match.range, in: detail) {
+            write["recordId"] = .string(String(detail[range]))
+        }
+        if detail.contains("append") { write["mode"] = .string("append") }
+        write["detail"] = .string(detail)
+        return write
     }
 
     static func memoValue(_ recording: VoiceMemoRecording, transcript: String) -> Value {

--- a/TheBridge/Notion/NotionClient.swift
+++ b/TheBridge/Notion/NotionClient.swift
@@ -721,16 +721,12 @@ public actor NotionClient {
         return data
     }
 
-    /// A9b: Create a comment on a page.
-    /// POST /v1/comments
-    public func createComment(pageId: String, text: String) async throws -> Data {
+    /// A9b: Create a comment on a page, or reply to an existing discussion.
+    /// POST /v1/comments — exactly one of `pageId` (parent.page_id) or `discussionId`.
+    /// When `discussionId` is set, the body is a thread reply (no parent).
+    public func createComment(pageId: String? = nil, discussionId: String? = nil, text: String) async throws -> Data {
         try Self.validateSingleRichTextRun(text, context: "notion_comment_create")
-        // v1.9.0 B3: accept raw UUID, dashed UUID, Notion URL, or compressed placeholder
-        let cleanId = Self.normalizePageId(pageId)
-        let body: [String: Any] = [
-            "parent": ["page_id": cleanId],
-            "rich_text": [["type": "text", "text": ["content": text]]]
-        ]
+        let body = try Self.buildCreateCommentRequestBody(pageId: pageId, discussionId: discussionId, text: text)
         let bodyData = try JSONSerialization.data(withJSONObject: body)
         let (data, response) = try await request(method: "POST", path: "/comments", body: bodyData)
         guard (200...299).contains(response.statusCode) else {
@@ -738,6 +734,35 @@ public actor NotionClient {
             throw NotionClientError.httpError(response.statusCode, msg)
         }
         return data
+    }
+
+    /// Builds the JSON body for create-comment. Public for unit tests.
+    /// Exactly one of `pageId` or `discussionId` must be non-empty (API contract).
+    nonisolated public static func buildCreateCommentRequestBody(
+        pageId: String?,
+        discussionId: String?,
+        text: String
+    ) throws -> [String: Any] {
+        let hasPage = !(pageId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        let hasDiscussion = !(discussionId?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        guard hasPage != hasDiscussion else {
+            throw NotionClientError.decodingError(
+                "createComment requires exactly one of pageId or discussionId (got page=\(hasPage) discussion=\(hasDiscussion))"
+            )
+        }
+        let richText: [[String: Any]] = [["type": "text", "text": ["content": text]]]
+        if hasDiscussion, let discussionId {
+            let clean = discussionId.replacingOccurrences(of: "-", with: "")
+            return [
+                "discussion_id": clean,
+                "rich_text": richText
+            ]
+        }
+        let cleanId = Self.normalizePageId(pageId!)
+        return [
+            "parent": ["page_id": cleanId],
+            "rich_text": richText
+        ]
     }
 
     /// A10a: List all users in the workspace.
@@ -971,16 +996,47 @@ public actor NotionClient {
 
     /// E5 (v1.9.1): Create a new discussion thread on a page.
     /// POST /v1/comments with parent.page_id (no discussion_id → starts a new thread).
-    /// Accepts raw UUID, dashed UUID, Notion URL, or compressed placeholder (via normalizePageId).
+    /// Not a reply primitive — for replies use `createComment(discussionId:text:)`.
     public func createDiscussion(pageId: String, text: String) async throws -> Data {
-        try Self.validateSingleRichTextRun(text, context: "notion_discussion_create")
-        let cleanId = Self.normalizePageId(pageId)
-        let body: [String: Any] = [
-            "parent": ["page_id": cleanId],
-            "rich_text": [["type": "text", "text": ["content": text]]]
-        ]
-        let bodyData = try JSONSerialization.data(withJSONObject: body)
-        let (data, response) = try await request(method: "POST", path: "/comments", body: bodyData)
+        try await createComment(pageId: pageId, discussionId: nil, text: text)
+    }
+
+    // MARK: - Views API (2025-09-03+ / 2026-03-11)
+
+    /// List views for a database and/or data source.
+    /// GET /v1/views?database_id=… and/or data_source_id=…
+    /// At least one of `databaseId` / `dataSourceId` is required.
+    public func listViews(databaseId: String? = nil, dataSourceId: String? = nil, startCursor: String? = nil, pageSize: Int = 100) async throws -> Data {
+        var parts: [String] = []
+        if let databaseId, !databaseId.isEmpty {
+            parts.append("database_id=\(databaseId.replacingOccurrences(of: "-", with: ""))")
+        }
+        if let dataSourceId, !dataSourceId.isEmpty {
+            parts.append("data_source_id=\(dataSourceId.replacingOccurrences(of: "-", with: ""))")
+        }
+        guard !parts.isEmpty else {
+            throw NotionClientError.decodingError("listViews requires databaseId and/or dataSourceId")
+        }
+        let size = min(max(pageSize, 1), 100)
+        parts.append("page_size=\(size)")
+        if let startCursor, !startCursor.isEmpty {
+            let encoded = startCursor.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? startCursor
+            parts.append("start_cursor=\(encoded)")
+        }
+        let path = "/views?" + parts.joined(separator: "&")
+        let (data, response) = try await request(method: "GET", path: path)
+        guard (200...299).contains(response.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? ""
+            throw NotionClientError.httpError(response.statusCode, msg)
+        }
+        return data
+    }
+
+    /// Retrieve a view by ID (full filter/sorts/configuration).
+    /// GET /v1/views/{view_id}
+    public func getView(viewId: String) async throws -> Data {
+        let cleanId = viewId.replacingOccurrences(of: "-", with: "")
+        let (data, response) = try await request(method: "GET", path: "/views/\(cleanId)")
         guard (200...299).contains(response.statusCode) else {
             let msg = String(data: data, encoding: .utf8) ?? ""
             throw NotionClientError.httpError(response.statusCode, msg)

--- a/TheBridge/Notion/NotionModels.swift
+++ b/TheBridge/Notion/NotionModels.swift
@@ -28,6 +28,9 @@ public enum NotionClientError: Error, LocalizedError, Sendable {
         case .maxRetriesExceeded:
             return "Max retries exceeded"
         case .httpError(let code, let body):
+            if code == 401 {
+                return "HTTP 401: Notion authorization failed. Reauthorize or replace the token in The Bridge Settings > Connections, then run notion_token_introspect before retrying the write. Response: \(String(body.prefix(300)))"
+            }
             return "HTTP \(code): \(String(body.prefix(500)))"
         case .decodingError(let msg):
             return "Decoding error: \(msg)"

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -40,6 +40,7 @@ public enum BridgeModuleRegistry {
         await FileModule.register(on: router)
         await registerSession(router)
         await MessagesModule.register(on: router)
+        await CallHistoryModule.register(on: router)      // Bridge v4 Wave 1: calls_recent read-only CallHistoryDB projection
         await MailModule.register(on: router)
         await NotesModule.register(on: router)
         await SystemModule.register(on: router)

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -129,6 +129,7 @@ public enum ToolAnnotationCatalog {
         // (alias kept; old + new are both live for one cycle).
         "clipboard_read": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "clipboard_write": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "calls_recent": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "code_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "connections_capabilities": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),
         "connections_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: false),

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -319,6 +319,8 @@ public enum ToolAnnotationCatalog {
         "notion_search": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "notion_token_introspect": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "notion_users_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "notion_views_list": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
+        "notion_view_get": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: true, requiresConfirmation: false, openWorld: true),
         "pasteboard_history": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         // fb-permissions: pure read of local TCC grant state — no prompt, no
         // mutation, no network. Same stable input → same output (idempotent).

--- a/TheBridgeTests/CalendarModuleTests.swift
+++ b/TheBridgeTests/CalendarModuleTests.swift
@@ -34,6 +34,10 @@ final class MockCalendarStore: CalendarStoring, @unchecked Sendable {
         ]
     }
 
+    func seed(_ event: CalendarEvent) {
+        items[event.id] = event
+    }
+
     func authorizationStatus() -> CalendarAuthStatus { authStatus }
 
     func ensureAccess() async throws {
@@ -51,6 +55,11 @@ final class MockCalendarStore: CalendarStoring, @unchecked Sendable {
 
     private func calTitle(_ id: String) -> String {
         cals.first(where: { $0.id == id })?.title ?? ""
+    }
+
+    func event(id: String) async throws -> CalendarEvent? {
+        try await ensureAccess()
+        return items[id]
     }
 
     func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
@@ -87,7 +96,8 @@ final class MockCalendarStore: CalendarStoring, @unchecked Sendable {
             calendarId: calId,
             calendarTitle: calTitle(calId),
             location: draft.location,
-            notes: draft.notes
+            notes: draft.notes,
+            timeZoneIdentifier: draft.timeZoneIdentifier
         )
         items[id] = event
         return event
@@ -102,6 +112,7 @@ final class MockCalendarStore: CalendarStoring, @unchecked Sendable {
         if let a = draft.allDay { event.allDay = a }
         if let loc = draft.location { event.location = loc }
         if let n = draft.notes { event.notes = n }
+        if let tz = draft.timeZoneIdentifier { event.timeZoneIdentifier = tz }
         if let c = draft.calendarId {
             guard cals.contains(where: { $0.id == c }) else {
                 throw CalendarModuleError.calendarNotFound(c)
@@ -313,6 +324,45 @@ func runCalendarModuleTests() async {
             ]))
             throw TestError.assertion("expected invalidArguments for missing end")
         } catch is ToolRouterError { /* expected */ }
+    }
+
+    await test("calendar full event output exposes provider identity and participant context") {
+        let store = MockCalendarStore()
+        store.seed(CalendarEvent(
+            id: "evt-meta",
+            title: "Partner meeting",
+            start: "2026-06-05T09:00:00Z",
+            end: "2026-06-05T10:00:00Z",
+            allDay: false,
+            calendarId: "cal-work",
+            calendarTitle: "Work",
+            location: "Conference Room",
+            notes: "Agenda",
+            externalId: "google-ical-uid@example.com",
+            organizer: "mailto:owner@example.com",
+            attendees: ["mailto:one@example.com", "mailto:two@example.com"],
+            conferenceURL: "https://meet.example.com/abc",
+            lastModified: "2026-06-04T18:00:00Z",
+            isRecurring: true,
+            isDetached: false
+        ))
+        let router = await makeCalendarRouter(store)
+        let result = try await callCalendarHandler(router, "calendar_events", .object([
+            "start": .string("2026-06-05T00:00:00Z"),
+            "end": .string("2026-06-06T00:00:00Z")
+        ]))
+        guard case .array(let events)? = calField(result, "events"), let value = events.first else {
+            throw TestError.assertion("full event output missing")
+        }
+        try expect(calField(value, "providerExternalId") == .string("google-ical-uid@example.com"))
+        try expect(calField(value, "organizer") == .string("mailto:owner@example.com"))
+        try expect(calField(value, "attendees") == .array([
+            .string("mailto:one@example.com"), .string("mailto:two@example.com")
+        ]))
+        try expect(calField(value, "itemURL") == .string("https://meet.example.com/abc"))
+        try expect(calField(value, "lastModified") == .string("2026-06-04T18:00:00Z"))
+        try expect(calField(value, "isRecurring") == .bool(true))
+        try expect(calField(value, "isDetached") == .bool(false))
     }
 
     // MARK: naive ISO parsing (CalendarISOParsing)

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -1,25 +1,48 @@
-// CalendarRegistrySyncEngineTests.swift — reduced registry-first durability matrix
+// CalendarRegistrySyncEngineTests.swift — registry-first recovery contract
 
 import Foundation
 import MCP
 import TheBridgeLib
 
+private enum SyncTestError: Error, LocalizedError {
+    case forcedCalendarCreate
+    case forcedRegistrySave
+    case forcedVerificationMiss
+    case forcedLedgerSave
+
+    var errorDescription: String? {
+        switch self {
+        case .forcedCalendarCreate: return "forced calendar create failure"
+        case .forcedRegistrySave: return "forced registry save failure"
+        case .forcedVerificationMiss: return "forced verification miss"
+        case .forcedLedgerSave: return "forced ledger save failure"
+        }
+    }
+}
+
 private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     private var records: [String: TimeInstanceRecord] = [:]
+    private var partialByKey: [String: (id: String, fingerprint: String)] = [:]
     private var sequence = 0
-    private var failNextSave = false
+    private var failNextCreatePatch = false
+    private var failAllSaves = false
     private var lookupSource: RegistryLookupSource = .live
     private(set) var createCount = 0
 
-    func setFailNextSave(_ value: Bool) { failNextSave = value }
+    func setFailNextCreatePatch(_ value: Bool) { failNextCreatePatch = value }
+    func setFailAllSaves(_ value: Bool) { failAllSaves = value }
     func setLookupSource(_ source: RegistryLookupSource) { lookupSource = source }
-    func count() -> Int { records.count }
+    func count() -> Int { records.count + partialByKey.count }
     func createdCount() -> Int { createCount }
     func allRecords() -> [TimeInstanceRecord] { Array(records.values) }
+    func record(for key: String) -> TimeInstanceRecord? { records.values.first { $0.syncKey == key } }
 
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
         RegistryIdentityLookup(
             records: records.values.filter { $0.syncKey == syncKey },
+            unresolvedIdentities: partialByKey[syncKey].map {
+                [RegistryUnresolvedIdentity(pageId: $0.id, operationFingerprint: $0.fingerprint)]
+            } ?? [],
             source: lookupSource
         )
     }
@@ -32,49 +55,67 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
         sequence += 1
         createCount += 1
+        let id = "notion-event-\(sequence)"
+        if failNextCreatePatch {
+            failNextCreatePatch = false
+            partialByKey[record.syncKey] = (id, record.operationFingerprint)
+            throw PartialRegistryCreateError(pageId: id, message: "forced semantic PATCH failure")
+        }
         var created = record
-        created.id = "notion-event-\(sequence)"
-        records[created.id] = created
+        created.id = id
+        records[id] = created
         return created
     }
 
+    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        var repaired = record
+        repaired.id = id
+        partialByKey[record.syncKey] = nil
+        records[id] = repaired
+        return repaired
+    }
+
     func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        if failNextSave {
-            failNextSave = false
-            throw SyncTestError.forcedRegistrySave
-        }
+        if failAllSaves { throw SyncTestError.forcedRegistrySave }
         records[record.id] = record
         return record
     }
-}
 
-private enum SyncTestError: Error, LocalizedError {
-    case forcedCalendarCreate
-    case forcedRegistrySave
-    case forcedVerificationMiss
-
-    var errorDescription: String? {
-        switch self {
-        case .forcedCalendarCreate: return "forced calendar create failure"
-        case .forcedRegistrySave: return "forced registry save failure"
-        case .forcedVerificationMiss: return "forced verification miss"
-        }
+    func mutateCalendarRange(key: String, start: Date, end: Date) {
+        guard let id = records.first(where: { $0.value.syncKey == key })?.key else { return }
+        records[id]?.scheduledStart = start
+        records[id]?.scheduledEnd = end
     }
 }
 
 private actor SyncTestCalendar: CalendarSyncProviding {
     private var items: [String: ExternalCalendarItem] = [:]
     private var sequence = 0
+    private var qualified = true
     private var failNextCreate = false
-    private var missNextItem = false
-    private var ambiguousRecovery = false
+    private var nextShape: (recurring: Bool, allDay: Bool, detached: Bool) = (false, false, false)
     private(set) var createCount = 0
 
+    func setQualified(_ value: Bool) { qualified = value }
     func setFailNextCreate(_ value: Bool) { failNextCreate = value }
-    func setMissNextItem(_ value: Bool) { missNextItem = value }
-    func setAmbiguousRecovery(_ value: Bool) { ambiguousRecovery = value }
+    func setNextShape(recurring: Bool = false, allDay: Bool = false, detached: Bool = false) {
+        nextShape = (recurring, allDay, detached)
+    }
     func createdCount() -> Int { createCount }
     func count() -> Int { items.count }
+    func allItems() -> [ExternalCalendarItem] { Array(items.values) }
+
+    func qualify(calendarId: String) async throws -> CalendarQualification {
+        CalendarQualification(
+            calendarId: calendarId,
+            title: "Private Smoke",
+            allowsModify: qualified,
+            explicitlyAllowlisted: qualified,
+            calendarType: qualified ? "local" : "caldav",
+            sourceType: qualified ? "local" : "caldav",
+            qualifiedForPrivateSmoke: qualified
+        )
+    }
 
     func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
         if failNextCreate {
@@ -84,68 +125,106 @@ private actor SyncTestCalendar: CalendarSyncProviding {
         sequence += 1
         createCount += 1
         let id = "calendar-event-\(sequence)"
+        let shape = nextShape
+        nextShape = (false, false, false)
         let item = ExternalCalendarItem(
             provider: "Fixture Calendar",
-            calendarId: draft.calendarId ?? "cal-private",
+            calendarId: draft.calendarId,
             localEventId: id,
             providerExternalId: "provider-\(sequence)",
             syncKey: draft.syncKey,
+            operationFingerprint: draft.operationFingerprint,
             title: draft.title,
             start: draft.start,
             end: draft.end,
             timeZoneIdentifier: draft.timeZoneIdentifier,
             location: draft.location,
             notes: draft.notes,
-            updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            isRecurring: shape.recurring,
+            isAllDay: shape.allDay,
+            isDetached: shape.detached
         )
         items[id] = item
         return item
     }
 
-    func item(id: String) async throws -> ExternalCalendarItem? {
-        if missNextItem {
-            missNextItem = false
-            return nil
-        }
-        return items[id]
-    }
+    func item(id: String) async throws -> ExternalCalendarItem? { items[id] }
 
     func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
-        if ambiguousRecovery {
-            let base = ExternalCalendarItem(
-                provider: "Fixture Calendar", calendarId: query.calendarId ?? "cal-private",
-                localEventId: "ambiguous-a", syncKey: query.syncKey,
-                title: query.title, start: query.start, end: query.end,
-                updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
-            )
-            var other = base
-            other.localEventId = "ambiguous-b"
-            return [base, other]
-        }
         if let id = query.localEventId, let direct = items[id] { return [direct] }
-        let byKey = items.values.filter { $0.syncKey == query.syncKey }
-        if !byKey.isEmpty { return Array(byKey) }
+        let byIdentity = items.values.filter {
+            $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
+        }
+        if !byIdentity.isEmpty { return Array(byIdentity) }
         if let external = query.providerExternalId {
             let byExternal = items.values.filter { $0.providerExternalId == external }
             if !byExternal.isEmpty { return Array(byExternal) }
         }
         return items.values.filter {
-            $0.title == query.title && $0.start == query.start && $0.end == query.end
+            $0.calendarId == query.calendarId && $0.title == query.title
+                && $0.start == query.start && $0.end == query.end
         }
+    }
+
+    func mutateStart(id: String, start: Date, end: Date) {
+        items[id]?.start = start
+        items[id]?.end = end
+    }
+
+    func duplicateIdentity(from id: String) {
+        guard var copy = items[id] else { return }
+        copy.localEventId = id + "-duplicate"
+        items[copy.localEventId] = copy
+    }
+}
+
+private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring {
+    private var transaction: CalendarRegistryTransaction?
+
+    func claim(
+        idempotencyKey: String,
+        manifestFingerprint: String,
+        operationId: String,
+        now: Date
+    ) async throws -> CalendarRegistryTransaction {
+        if let transaction { return transaction }
+        let created = CalendarRegistryTransaction(
+            operationId: operationId,
+            idempotencyKey: idempotencyKey,
+            manifestFingerprint: manifestFingerprint,
+            createdAt: now,
+            updatedAt: now
+        )
+        transaction = created
+        return created
+    }
+
+    func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction? {
+        guard transaction?.idempotencyKey == idempotencyKey else { return nil }
+        return transaction
+    }
+
+    func save(_ transaction: CalendarRegistryTransaction) async throws {
+        throw SyncTestError.forcedLedgerSave
     }
 }
 
 private func syncRequest(
     key: String = "operation-lift-2027-01-15",
-    title: String = "LIFT"
+    title: String = "LIFT",
+    start: Date = Date(timeIntervalSince1970: 1_800_010_000),
+    end: Date = Date(timeIntervalSince1970: 1_800_013_600),
+    timeZone: String = "America/Chicago",
+    calendarId: String = "cal-private"
 ) -> RegistryFirstTimeInstanceRequest {
     RegistryFirstTimeInstanceRequest(
         idempotencyKey: key,
         title: title,
-        start: Date(timeIntervalSince1970: 1_800_010_000),
-        end: Date(timeIntervalSince1970: 1_800_013_600),
-        timeZoneIdentifier: "America/Chicago",
-        calendarId: "cal-private",
+        start: start,
+        end: end,
+        timeZoneIdentifier: timeZone,
+        calendarId: calendarId,
         location: "Private Gym",
         notes: "Disposable fixture",
         semantics: TimeInstanceSemantics(
@@ -168,18 +247,16 @@ private func makeSyncEngine(
         transactions: transactions,
         operationGate: operationGate,
         clock: { Date(timeIntervalSince1970: 1_800_000_000) },
-        makeOperationId: { "operation-id-fixture" }
+        makeOperationId: { UUID().uuidString.lowercased() }
     )
 }
 
-private func withTempTransactionJournal(
-    _ body: (URL) async throws -> Void
-) async throws {
+private func withTempDirectory(_ body: (URL) async throws -> Void) async throws {
     let directory = URL(fileURLWithPath: NSTemporaryDirectory())
         .appendingPathComponent("bridge-calendar-sync-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: directory) }
-    try await body(directory.appendingPathComponent("transactions.json"))
+    try await body(directory)
 }
 
 // MARK: - Notion adapter fixture
@@ -189,12 +266,13 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     var pages: [String: NotionRow] = [:]
     var failUpdate = false
     var filteredQueryCalls = 0
-    var lastFilter: Data?
     private var sequence = 0
+    private(set) var lastCreatedFields: [BoundField] = []
     private(set) var lastUpdatedFields: [BoundField] = []
 
     func setFailUpdate(_ value: Bool) { failUpdate = value }
-    func updatedFields() -> [BoundField] { lastUpdatedFields }
+    func pageCount() -> Int { pages.count }
+    func createdFields() -> [BoundField] { lastCreatedFields }
 
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema {
         _ = dataSourceId; _ = workspace
@@ -209,7 +287,6 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
         _ = dataSourceId; _ = workspace; _ = pageSize; _ = startCursor
         filteredQueryCalls += 1
-        lastFilter = filter
         let object = (try? JSONSerialization.jsonObject(with: filter) as? [String: Any]) ?? [:]
         let rich = object["rich_text"] as? [String: Any]
         let wanted = rich?["equals"] as? String
@@ -233,6 +310,7 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
         _ = dataSourceId; _ = workspace
         sequence += 1
         let id = String(format: "%032d", sequence)
+        lastCreatedFields = fields
         let row = Self.row(id: id, existing: nil, fields: fields)
         pages[id] = row
         return row
@@ -262,8 +340,10 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
             )
         }
         return NotionRow(
-            id: id, url: "https://notion.fixture/\(id)",
-            lastEditedTime: "2027-01-15T08:00:00.000Z", cells: cells
+            id: id,
+            url: "https://notion.fixture/\(id)",
+            lastEditedTime: "2027-01-15T08:00:00.000Z",
+            cells: cells
         )
     }
 }
@@ -274,6 +354,7 @@ private func scheduleEntityForSyncTests() -> RegistryEntity {
         ("date", "EVENT DATE", "date", .date),
         ("status", "Status", "status", .status),
         ("syncKey", "Sync Key", "rich_text", .generic),
+        ("operationFingerprint", "Operation Fingerprint", "rich_text", .generic),
         ("eventClass", "Event Class", "select", .generic),
         ("meetingType", "Meeting Type", "select", .generic),
         ("primaryBlock", "Primary BLOCK", "relation", .relation),
@@ -297,267 +378,420 @@ private func scheduleEntityForSyncTests() -> RegistryEntity {
         ("calendarUpdatedAt", "Calendar Updated At", "date", .date)
     ]
     return RegistryEntity(
-        key: "schedule", displayName: "EVENTS", dataSourceId: "events-ds",
+        key: "schedule",
+        displayName: "EVENTS",
+        dataSourceId: "events-ds",
         properties: definitions.enumerated().map { index, item in
             RegistryProperty(
-                key: item.0, notionName: item.1,
-                notionPropertyId: "property-\(index)", type: item.2, role: item.3
+                key: item.0,
+                notionName: item.1,
+                notionPropertyId: "property-\(index)",
+                type: item.2,
+                role: item.3
             )
         },
         cacheTTLSeconds: 0
     )
 }
 
+private func testRecord(key: String = "adapter-key") -> TimeInstanceRecord {
+    let request = syncRequest(key: key)
+    return TimeInstanceRecord(
+        title: request.title,
+        scheduledStart: request.start,
+        scheduledEnd: request.end,
+        timeZoneIdentifier: request.timeZoneIdentifier,
+        location: request.location,
+        notes: request.notes,
+        syncKey: request.idempotencyKey,
+        operationFingerprint: request.manifest.fingerprint,
+        semantics: request.semantics,
+        schedulingAuthority: .registry,
+        syncState: .pendingCreate,
+        registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+    )
+}
+
 func runCalendarRegistrySyncEngineTests() async {
-    print("\n🗓 Calendar–Registry Sync — reduced durability slice")
+    print("\n🗓 Calendar–Registry Sync — recovery hardening")
 
-    await test("CR1 atomic transaction journal survives store reconstruction") {
-        try await withTempTransactionJournal { url in
-            let first = try JSONCalendarRegistryTransactionStore(url: url)
-            var transaction = try await first.claim(
-                idempotencyKey: "same-key", manifestFingerprint: "manifest",
-                operationId: "op-1", now: Date(timeIntervalSince1970: 100)
+    await test("CR1 SQLite ledger survives independent handles") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("ledger.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let created = try await first.claim(
+                idempotencyKey: "same-key",
+                manifestFingerprint: "fingerprint-a",
+                operationId: "op-1",
+                now: Date(timeIntervalSince1970: 100)
             )
-            transaction.stage = .calendarCreated
-            transaction.calendarEventId = "calendar-1"
-            try await first.save(transaction)
+            var updated = created
+            updated.stage = .calendarCreated
+            updated.calendarEventId = "event-1"
+            try await first.save(updated)
 
-            let second = try JSONCalendarRegistryTransactionStore(url: url)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
             let loaded = try await second.get(idempotencyKey: "same-key")
             try expect(loaded?.stage == .calendarCreated)
-            try expect(loaded?.calendarEventId == "calendar-1")
+            try expect(loaded?.calendarEventId == "event-1")
         }
     }
 
-    await test("CR2 ten sequential retries create exactly one pair") {
+    await test("CR2 SQLite unique key rejects a different manifest across handles") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("ledger.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            _ = try await first.claim(
+                idempotencyKey: "same-key",
+                manifestFingerprint: "fingerprint-a",
+                operationId: "op-a",
+                now: Date()
+            )
+            do {
+                _ = try await second.claim(
+                    idempotencyKey: "same-key",
+                    manifestFingerprint: "fingerprint-b",
+                    operationId: "op-b",
+                    now: Date()
+                )
+                throw TestError.assertion("expected idempotency conflict")
+            } catch CalendarRegistryTransactionStoreError.idempotencyConflict("same-key") {
+                // expected
+            }
+        }
+    }
+
+    await test("CR3 concurrent different-key SQLite writes preserve all rows") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("ledger.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            async let a = first.claim(
+                idempotencyKey: "key-a", manifestFingerprint: "fp-a",
+                operationId: "op-a", now: Date()
+            )
+            async let b = second.claim(
+                idempotencyKey: "key-b", manifestFingerprint: "fp-b",
+                operationId: "op-b", now: Date()
+            )
+            _ = try await [a, b]
+            try expect(try await first.get(idempotencyKey: "key-a") != nil)
+            try expect(try await second.get(idempotencyKey: "key-b") != nil)
+        }
+    }
+
+    await test("CR4 ten retries create one pair") {
         let registry = SyncTestRegistry()
         let calendar = SyncTestCalendar()
         let engine = makeSyncEngine(registry: registry, calendar: calendar)
         for _ in 0..<10 {
             let receipt = try await engine.registryFirstCreate(syncRequest())
             try expect(receipt.succeeded)
-            try expect(receipt.stageAfter == .synced)
         }
         try expect(await registry.createdCount() == 1)
         try expect(await calendar.createdCount() == 1)
     }
 
-    await test("CR3 concurrent same-key calls across engines create one pair") {
+    await test("CR5 partial Notion create repairs one page on retry") {
         let registry = SyncTestRegistry()
+        await registry.setFailNextCreatePatch(true)
         let calendar = SyncTestCalendar()
         let transactions = InMemoryCalendarRegistryTransactionStore()
-        let gate = CalendarRegistryOperationGate()
-        let first = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions, operationGate: gate)
-        let second = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions, operationGate: gate)
-        async let a = first.registryFirstCreate(syncRequest())
-        async let b = second.registryFirstCreate(syncRequest())
-        let receipts = try await [a, b]
-        try expect(receipts.allSatisfy(\.succeeded))
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR4 reusing an idempotency key for a different manifest conflicts") {
-        let engine = makeSyncEngine()
-        _ = try await engine.registryFirstCreate(syncRequest())
-        let receipt = try await engine.registryFirstCreate(syncRequest(title: "Different"))
-        try expect(!receipt.succeeded)
-        try expect(receipt.stageAfter == .conflict)
-        try expect(receipt.discrepancy?.contains("different manifest") == true)
-    }
-
-    await test("CR5 calendar create failure resumes without a second EVENT") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        await calendar.setFailNextCreate(true)
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions)
         let first = try await engine.registryFirstCreate(syncRequest())
         try expect(!first.succeeded)
         let second = try await engine.registryFirstCreate(syncRequest())
         try expect(second.succeeded)
+        try expect(await registry.count() == 1)
         try expect(await registry.createdCount() == 1)
         try expect(await calendar.createdCount() == 1)
     }
 
-    await test("CR6 failure after calendar creation recovers the calendar item") {
+    await test("CR6 ledger loss reconstructs the same manifest from external fingerprints") {
         let registry = SyncTestRegistry()
         let calendar = SyncTestCalendar()
-        await registry.setFailNextSave(true)
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let first = try await engine.registryFirstCreate(syncRequest())
-        try expect(!first.succeeded)
-        try expect(first.partialEffects.contains(where: { $0.contains("calendar") }))
-        let second = try await engine.registryFirstCreate(syncRequest())
-        try expect(second.succeeded)
+        let first = makeSyncEngine(registry: registry, calendar: calendar)
+        try expect(try await first.registryFirstCreate(syncRequest()).succeeded)
+        let restarted = makeSyncEngine(
+            registry: registry,
+            calendar: calendar,
+            transactions: InMemoryCalendarRegistryTransactionStore()
+        )
+        let receipt = try await restarted.registryFirstCreate(syncRequest())
+        try expect(receipt.succeeded)
         try expect(await registry.createdCount() == 1)
         try expect(await calendar.createdCount() == 1)
     }
 
-    await test("CR7 failed verification never reports Synced") {
+    await test("CR7 ledger loss plus different manifest conflicts") {
         let registry = SyncTestRegistry()
         let calendar = SyncTestCalendar()
-        await calendar.setMissNextItem(true)
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let receipt = try await engine.registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(receipt.stageAfter == .recoverableError)
-        let records = await registry.allRecords()
-        try expect(records.allSatisfy { $0.syncState != .synced })
-    }
-
-    await test("CR8 fresh EventKit provider recovers an event after provider restart") {
-        let store = MockCalendarStore()
-        let firstProvider = CalendarStoringSyncProvider(store: store)
-        var request = syncRequest()
-        request.calendarId = "cal-home"
-        let created = try await firstProvider.create(ExternalCalendarDraft(
-            title: request.title, start: request.start, end: request.end,
-            timeZoneIdentifier: request.timeZoneIdentifier,
-            calendarId: request.calendarId, location: request.location,
-            notes: request.notes, syncKey: request.idempotencyKey
-        ))
-        let restartedProvider = CalendarStoringSyncProvider(store: store)
-        let recovered = try await restartedProvider.recover(CalendarRecoveryQuery(
-            localEventId: created.localEventId,
-            providerExternalId: created.providerExternalId,
-            syncKey: request.idempotencyKey,
-            calendarId: request.calendarId,
-            title: request.title, start: request.start, end: request.end
-        ))
-        try expect(recovered.count == 1)
-        try expect(recovered.first?.syncKey == request.idempotencyKey)
-    }
-
-    await test("CR9 ambiguous provider recovery stops in Conflict") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        await calendar.setAmbiguousRecovery(true)
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let receipt = try await engine.registryFirstCreate(syncRequest())
+        try expect(try await makeSyncEngine(registry: registry, calendar: calendar)
+            .registryFirstCreate(syncRequest()).succeeded)
+        let restarted = makeSyncEngine(
+            registry: registry,
+            calendar: calendar,
+            transactions: InMemoryCalendarRegistryTransactionStore()
+        )
+        let receipt = try await restarted.registryFirstCreate(syncRequest(title: "Different"))
         try expect(!receipt.succeeded)
         try expect(receipt.stageAfter == .conflict)
-        try expect(await calendar.createdCount() == 0)
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 1)
     }
 
-    await test("CR10 degraded registry identity lookup refuses creation") {
+    await test("CR8 calendar drift conflicts without overwriting registry schedule") {
         let registry = SyncTestRegistry()
-        await registry.setLookupSource(.staleCache)
         let calendar = SyncTestCalendar()
         let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let receipt = try await engine.registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(receipt.discrepancy?.contains("not live") == true)
-        try expect(await registry.createdCount() == 0)
-        try expect(await calendar.createdCount() == 0)
-    }
-
-    await test("CR11 date ranges preserve start, end, and timezone") {
-        let property: [String: Any] = [
-            "date": [
-                "start": "2027-01-15T08:00:00-06:00",
-                "end": "2027-01-15T09:00:00-06:00",
-                "time_zone": "America/Chicago"
-            ]
-        ]
-        let decoded = RegistryPropertyCodec.decode(type: "date", property: property)
-        guard case .object(let range) = decoded else {
-            throw TestError.assertion("date range did not decode as an object")
+        let first = try await engine.registryFirstCreate(syncRequest())
+        guard let id = first.calendarItem?.localEventId else {
+            throw TestError.assertion("calendar item missing")
         }
-        try expect(range["start"] == .string("2027-01-15T08:00:00-06:00"))
-        try expect(range["end"] == .string("2027-01-15T09:00:00-06:00"))
-        try expect(range["timeZone"] == .string("America/Chicago"))
+        let driftedStart = syncRequest().start.addingTimeInterval(7_200)
+        let driftedEnd = syncRequest().end.addingTimeInterval(7_200)
+        await calendar.mutateStart(id: id, start: driftedStart, end: driftedEnd)
+        let receipt = try await engine.registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.stageAfter == .conflict)
+        let record = await registry.record(for: syncRequest().idempotencyKey)
+        try expect(record?.scheduledStart == syncRequest().start)
+        try expect(record?.scheduledEnd == syncRequest().end)
     }
 
-    await test("CR12 Notion adapter uses filtered identity lookup beyond list caps") {
-        let gateway = SyncRegistryGateway()
-        let entity = scheduleEntityForSyncTests()
-        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
-        let record = TimeInstanceRecord(
-            title: "LIFT", scheduledStart: syncRequest().start,
-            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
-            syncKey: "target-key", semantics: syncRequest().semantics,
-            schedulingAuthority: .registry, syncState: .pendingCreate,
-            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
-        )
-        let created = try await store.create(record)
-        let found = try await store.findBySyncKey("target-key")
-        try expect(found.source == .live)
-        try expect(found.records.map(\.id) == [created.id])
-        try expect(await gateway.filteredQueryCalls == 1)
+    await test("CR9 non-local timezone survives full transaction") {
+        let request = syncRequest(timeZone: "Pacific/Honolulu")
+        let receipt = try await makeSyncEngine().registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(receipt.record?.timeZoneIdentifier == "Pacific/Honolulu")
+        try expect(receipt.calendarItem?.timeZoneIdentifier == "Pacific/Honolulu")
     }
 
-    await test("CR13 Notion adapter emits explicit clears for nullable fields") {
-        let gateway = SyncRegistryGateway()
-        let entity = scheduleEntityForSyncTests()
-        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
-        var record = TimeInstanceRecord(
-            id: "existing", title: "LIFT", scheduledStart: syncRequest().start,
-            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
-            syncKey: "clear-key", semantics: syncRequest().semantics,
-            schedulingAuthority: .registry, syncState: .error,
-            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000),
-            lastSyncError: "old error"
+    await test("CR10 invalid timezone and injected keys are rejected before writes") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        do {
+            _ = try await engine.registryFirstCreate(syncRequest(timeZone: "Mars/Olympus"))
+            throw TestError.assertion("invalid timezone should fail")
+        } catch CalendarRegistrySyncError.invalidTimeZone("Mars/Olympus") {}
+        do {
+            _ = try await engine.registryFirstCreate(syncRequest(key: "bad\nkey"))
+            throw TestError.assertion("invalid key should fail")
+        } catch CalendarRegistrySyncError.invalidIdempotencyKey {}
+        try expect(await registry.count() == 0)
+        try expect(await calendar.count() == 0)
+    }
+
+    await test("CR11 recurring, all-day, and detached items fail closed") {
+        for shape in [(true, false, false), (false, true, false), (false, false, true)] {
+            let registry = SyncTestRegistry()
+            let calendar = SyncTestCalendar()
+            await calendar.setNextShape(recurring: shape.0, allDay: shape.1, detached: shape.2)
+            let receipt = try await makeSyncEngine(registry: registry, calendar: calendar)
+                .registryFirstCreate(syncRequest(key: "shape-\(shape.0)-\(shape.1)-\(shape.2)"))
+            try expect(!receipt.succeeded)
+            try expect(receipt.stageAfter == .recoverableError)
+        }
+    }
+
+    await test("CR12 unqualified calendar refuses all writes") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        await calendar.setQualified(false)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar)
+            .registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(await registry.count() == 0)
+        try expect(await calendar.count() == 0)
+    }
+
+    await test("CR13 unpersisted ledger failure is an infrastructure fault") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(
+            registry: registry,
+            calendar: calendar,
+            transactions: AlwaysFailingTransactionStore()
+        ).registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.infrastructureFault)
+        try expect(!receipt.recoveryStatePersisted)
+        try expect(receipt.recoveryAction?.contains("do not retry automatically") == true)
+    }
+
+    await test("CR14 registry failure-state write is reported separately") {
+        let registry = SyncTestRegistry()
+        await registry.setFailAllSaves(true)
+        let receipt = try await makeSyncEngine(registry: registry)
+            .registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.recoveryStatePersisted)
+        try expect(!receipt.registryFailureStatePersisted)
+        try expect(receipt.discrepancy?.contains("registry failure-state write failed") == true)
+    }
+
+    await test("CR15 versioned metadata rejects duplicates and round-trips identity") {
+        let identity = CalendarRegistryCalendarMetadata.Identity(
+            syncKey: "safe-key",
+            operationFingerprint: String(repeating: "a", count: 64)
         )
-        _ = try await gateway.create(dataSourceId: "events-ds", workspace: nil, fields: [
-            BoundField(propertyId: "property-0", notionName: "EVENT TITLE", type: "title", value: .string("LIFT"), isTitle: true)
+        let notes = try CalendarRegistryCalendarMetadata.append(to: "hello", identity: identity)
+        try expect(try CalendarRegistryCalendarMetadata.parse(notes) == identity)
+        do {
+            _ = try CalendarRegistryCalendarMetadata.parse(notes + "\n" + notes)
+            throw TestError.assertion("duplicate metadata should conflict")
+        } catch CalendarRegistrySyncError.identityConflict {}
+    }
+
+    await test("CR16 live registry gateway advertises authoritative filtering") {
+        try expect(LiveRegistryGateway().supportsAuthoritativeFiltering)
+    }
+
+    await test("CR17 strict query decoder rejects malformed or broken pagination") {
+        do {
+            _ = try RegistryQueryResponseDecoder.decode(Data("{}".utf8))
+            throw TestError.assertion("missing results should fail")
+        } catch RegistryGatewayError.invalidResponse {}
+        do {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "results": [], "has_more": true, "next_cursor": NSNull()
+            ])
+            _ = try RegistryQueryResponseDecoder.decode(data)
+            throw TestError.assertion("missing cursor should fail")
+        } catch RegistryGatewayError.invalidResponse {}
+        let valid = try JSONSerialization.data(withJSONObject: [
+            "results": [], "has_more": false, "next_cursor": NSNull()
         ])
-        record.notes = nil
-        record.location = nil
-        record.lastSyncError = nil
-        _ = try await store.save(record)
-        let fields = await gateway.updatedFields()
-        let values = Dictionary(uniqueKeysWithValues: fields.map { ($0.notionName, $0.value) })
-        try expect(values["Description"] == .null)
-        try expect(values["Calendar Location"] == .null)
-        try expect(values["Last Sync Error"] == .null)
+        let decoded = try RegistryQueryResponseDecoder.decode(valid)
+        try expect(decoded.rows.isEmpty && decoded.nextCursor == nil)
     }
 
-    await test("CR14 partial Notion create exposes the created page identity") {
+    await test("CR18 Notion identity envelope contains four critical fields") {
+        let gateway = SyncRegistryGateway()
+        let store = NotionTimeInstanceRegistryStore(
+            entity: scheduleEntityForSyncTests(), gateway: gateway
+        )
+        _ = try await store.create(testRecord())
+        let names = Set(await gateway.createdFields().map(\.notionName))
+        try expect(names == Set(["EVENT TITLE", "Sync Key", "Operation Fingerprint", "Sync State"]))
+    }
+
+    await test("CR19 real Notion adapter partial create can be found and repaired") {
         let gateway = SyncRegistryGateway()
         await gateway.setFailUpdate(true)
         let store = NotionTimeInstanceRegistryStore(
             entity: scheduleEntityForSyncTests(), gateway: gateway
         )
-        let record = TimeInstanceRecord(
-            title: "LIFT", scheduledStart: syncRequest().start,
-            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
-            syncKey: "partial-key", semantics: syncRequest().semantics,
-            schedulingAuthority: .registry, syncState: .pendingCreate,
-            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
-        )
+        let record = testRecord(key: "partial-key")
         do {
             _ = try await store.create(record)
-            throw TestError.assertion("expected partial create failure")
-        } catch let error as PartialRegistryCreateError {
-            try expect(!error.pageId.isEmpty)
+            throw TestError.assertion("expected partial create")
+        } catch let partial as PartialRegistryCreateError {
+            let lookup = try await store.findBySyncKey("partial-key")
+            try expect(lookup.records.isEmpty)
+            try expect(lookup.unresolvedIdentities.map(\.pageId) == [partial.pageId])
+            try expect(lookup.unresolvedIdentities.first?.operationFingerprint == record.operationFingerprint)
+            let repaired = try await store.repair(id: partial.pageId, from: record)
+            try expect(repaired.syncKey == "partial-key")
+            try expect(await gateway.pageCount() == 1)
         }
     }
 
-    await test("CR15 internal composition is disabled by default and validates bindings") {
+    await test("CR20 migration artifact decodes against registry roles") {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = root.appendingPathComponent("docs/migrations/calendar-registry-v1/registry-entity-patch.json")
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        try expect(object?["schemaVersion"] as? Int == 2)
+        let additions = object?["additiveProperties"] as? [[String: Any]] ?? []
+        try expect(Set(additions.compactMap { $0["key"] as? String }) == Set(["providerExternalId", "operationFingerprint"]))
+        for addition in additions {
+            guard let role = addition["role"] as? String,
+                  RegistryPropertyRole(rawValue: role) != nil else {
+                throw TestError.assertion("migration role does not decode")
+            }
+        }
+    }
+
+    await test("CR21 composition remains disabled and requires an allowlist") {
         let entity = scheduleEntityForSyncTests()
         let gateway = SyncRegistryGateway()
         do {
             _ = try CalendarRegistrySyncComposition.build(
-                entity: entity, registryGateway: gateway,
-                calendarStore: MockCalendarStore(), environment: [:]
+                entity: entity,
+                registryGateway: gateway,
+                calendarStore: PersistentCalendarStore(),
+                environment: [:]
             )
             throw TestError.assertion("composition should be disabled")
-        } catch CalendarRegistrySyncCompositionError.disabled {
-            // expected
-        }
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("calendar-composition-\(UUID().uuidString)")
-        _ = try CalendarRegistrySyncComposition.build(
-            entity: entity, registryGateway: gateway,
-            calendarStore: MockCalendarStore(),
-            environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"],
-            journalURL: directory.appendingPathComponent("journal.json")
-        )
+        } catch CalendarRegistrySyncCompositionError.disabled {}
+        do {
+            _ = try CalendarRegistrySyncComposition.build(
+                entity: entity,
+                registryGateway: gateway,
+                calendarStore: PersistentCalendarStore(),
+                environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"]
+            )
+            throw TestError.assertion("allowlist should be required")
+        } catch CalendarRegistrySyncCompositionError.missingAllowedCalendars {}
     }
 
-    await test("CR16 route ownership remains explicit") {
+    await test("CR22 route ownership remains explicit") {
         try expect(CalendarRegistryRouteClassifier.owner(for: .semanticScheduling) == .timeKeepr)
         try expect(CalendarRegistryRouteClassifier.owner(for: .calendarMechanics) == .macKeepr)
         try expect(CalendarRegistryRouteClassifier.owner(for: .schemaChange) == .notionKeepr)
     }
+}
+
+private actor PersistentCalendarStore: CalendarStoring {
+    private var eventsById: [String: CalendarEvent] = [:]
+
+    nonisolated func authorizationStatus() -> CalendarAuthStatus { .authorized }
+    func ensureAccess() async throws {}
+    func calendars() async throws -> [CalendarInfo] {
+        [CalendarInfo(
+            id: "cal-private",
+            title: "Private Smoke",
+            isDefault: false,
+            allowsModify: true,
+            calendarType: "local",
+            sourceIdentifier: "source-local",
+            sourceTitle: "On My Mac",
+            sourceType: "local"
+        )]
+    }
+    func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
+        eventsById.values.filter { query.calendarId == nil || $0.calendarId == query.calendarId }
+    }
+    func event(id: String) async throws -> CalendarEvent? { eventsById[id] }
+    func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        let id = "event-\(eventsById.count + 1)"
+        let event = CalendarEvent(
+            id: id,
+            title: draft.title ?? "",
+            start: draft.start ?? "",
+            end: draft.end ?? "",
+            allDay: draft.allDay ?? false,
+            calendarId: draft.calendarId ?? "",
+            calendarTitle: "Private Smoke",
+            location: draft.location,
+            notes: draft.notes,
+            timeZoneIdentifier: draft.timeZoneIdentifier,
+            externalId: "external-\(id)",
+            lastModified: "2027-01-15T08:00:00Z"
+        )
+        eventsById[id] = event
+        return event
+    }
+    func update(id: String, _ draft: CalendarEventDraft) async throws -> CalendarEvent {
+        guard var event = eventsById[id] else { throw CalendarModuleError.notFound(id) }
+        if let title = draft.title { event.title = title }
+        if let start = draft.start { event.start = start }
+        if let end = draft.end { event.end = end }
+        if let zone = draft.timeZoneIdentifier { event.timeZoneIdentifier = zone }
+        eventsById[id] = event
+        return event
+    }
+    func delete(id: String) async throws { eventsById[id] = nil }
 }

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -1,4 +1,4 @@
-// CalendarRegistrySyncEngineTests.swift — registry-first recovery contract
+// CalendarRegistrySyncEngineTests.swift — fail-closed registry-first smoke contract
 
 import Foundation
 import MCP
@@ -8,47 +8,48 @@ import TheBridgeLib
 private enum SyncTestError: Error, LocalizedError {
     case forcedCalendarCreate
     case forcedRegistrySave
-    case forcedVerificationMiss
     case forcedLedgerSave
+    case forcedVerificationMiss
 
     var errorDescription: String? {
         switch self {
         case .forcedCalendarCreate: return "forced calendar create failure"
         case .forcedRegistrySave: return "forced registry save failure"
-        case .forcedVerificationMiss: return "forced verification miss"
         case .forcedLedgerSave: return "forced ledger save failure"
+        case .forcedVerificationMiss: return "forced verification miss"
         }
     }
 }
 
 private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     private var records: [String: TimeInstanceRecord] = [:]
-    private var partialByKey: [String: (id: String, fingerprint: String)] = [:]
     private var identityOverrides: [String: RegistryRecordIdentityRead] = [:]
-    private var sequence = 0
-    private var failNextCreatePatch = false
-    private var failAllSaves = false
+    private var lookupExtras: [TimeInstanceRecord] = []
+    private var lookupUnresolved: [RegistryUnresolvedIdentity] = []
     private var lookupSource: RegistryLookupSource = .live
+    private var failAllSaves = false
     private var dropFinalSyncHash = false
-    private(set) var createCount = 0
+    private var mutateProviderOnFinalRead = false
+    private var mutateSyncedAtOnFinalRead = false
+    private var syncedReadCount = 0
+    private(set) var saveCount = 0
 
-    func setFailNextCreatePatch(_ value: Bool) { failNextCreatePatch = value }
-    func setFailAllSaves(_ value: Bool) { failAllSaves = value }
-    func setLookupSource(_ source: RegistryLookupSource) { lookupSource = source }
-    func setDropFinalSyncHash(_ value: Bool) { dropFinalSyncHash = value }
     func put(_ record: TimeInstanceRecord) { records[record.id] = record }
     func setIdentityOverride(id: String, value: RegistryRecordIdentityRead?) { identityOverrides[id] = value }
-    func count() -> Int { records.count + partialByKey.count }
-    func createdCount() -> Int { createCount }
-    func allRecords() -> [TimeInstanceRecord] { Array(records.values) }
-    func record(for key: String) -> TimeInstanceRecord? { records.values.first { $0.syncKey == key } }
+    func setLookupExtras(_ values: [TimeInstanceRecord]) { lookupExtras = values }
+    func setLookupUnresolved(_ values: [RegistryUnresolvedIdentity]) { lookupUnresolved = values }
+    func setLookupSource(_ value: RegistryLookupSource) { lookupSource = value }
+    func setFailAllSaves(_ value: Bool) { failAllSaves = value }
+    func setDropFinalSyncHash(_ value: Bool) { dropFinalSyncHash = value }
+    func setMutateProviderOnFinalRead(_ value: Bool) { mutateProviderOnFinalRead = value }
+    func setMutateSyncedAtOnFinalRead(_ value: Bool) { mutateSyncedAtOnFinalRead = value }
+    func record(id: String) -> TimeInstanceRecord? { records[id] }
+    func savedCount() -> Int { saveCount }
 
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
         RegistryIdentityLookup(
-            records: records.values.filter { $0.syncKey == syncKey },
-            unresolvedIdentities: partialByKey[syncKey].map {
-                [RegistryUnresolvedIdentity(pageId: $0.id, syncKey: syncKey, operationFingerprint: $0.fingerprint)]
-            } ?? [],
+            records: records.values.filter { $0.syncKey == syncKey } + lookupExtras.filter { $0.syncKey == syncKey },
+            unresolvedIdentities: lookupUnresolved.filter { $0.syncKey == syncKey },
             source: lookupSource
         )
     }
@@ -57,39 +58,22 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         _ = forceRefresh
         if let override = identityOverrides[id] { return override }
         if let record = records[id] { return .decoded(record) }
-        if let partial = partialByKey.first(where: { $0.value.id == id }) {
-            return .partial(pageId: id, syncKey: partial.key, operationFingerprint: partial.value.fingerprint)
-        }
         return .missing
     }
 
     func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
-        if case .decoded(let record) = try await readIdentity(id: id, forceRefresh: forceRefresh) { return record }
-        return nil
-    }
-
-    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        sequence += 1
-        createCount += 1
-        let id = "notion-event-\(sequence)"
-        if failNextCreatePatch {
-            failNextCreatePatch = false
-            partialByKey[record.syncKey] = (id, record.operationFingerprint)
-            throw PartialRegistryCreateError(pageId: id, message: "forced semantic PATCH failure")
+        _ = forceRefresh
+        guard var record = records[id] else { return nil }
+        if record.syncState == .synced {
+            syncedReadCount += 1
+            if mutateProviderOnFinalRead && syncedReadCount >= 1 {
+                record.calendarProvider = "Mutated Provider"
+            }
+            if mutateSyncedAtOnFinalRead && syncedReadCount >= 1 {
+                record.lastSyncedAt = record.lastSyncedAt?.addingTimeInterval(120)
+            }
         }
-        var created = record
-        created.id = id
-        records[id] = created
-        return created
-    }
-
-    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        var repaired = record
-        repaired.id = id
-        partialByKey[record.syncKey] = nil
-        identityOverrides[id] = nil
-        records[id] = repaired
-        return repaired
+        return record
     }
 
     func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
@@ -97,32 +81,43 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         var saved = record
         if dropFinalSyncHash && saved.syncState == .synced { saved.syncHash = "" }
         records[saved.id] = saved
+        saveCount += 1
         return saved
-    }
-
-    func mutateCalendarRange(key: String, start: Date, end: Date) {
-        guard let id = records.first(where: { $0.value.syncKey == key })?.key else { return }
-        records[id]?.scheduledStart = start
-        records[id]?.scheduledEnd = end
     }
 }
 
 private actor SyncTestCalendar: CalendarSyncProviding {
+    enum CreateMode { case normal, throwWithoutPersist, persistThenThrow, persistThenSuspend }
+
     private var items: [String: ExternalCalendarItem] = [:]
     private var sequence = 0
     private var qualified = true
-    private var failNextCreate = false
-    private var nextShape: (recurring: Bool, allDay: Bool, detached: Bool) = (false, false, false)
-    private(set) var createCount = 0
+    private var createMode: CreateMode = .normal
+    private var nextShape: (recurring: Bool, allDay: Bool, detached: Bool, organizer: String?, attendees: [String]) =
+        (false, false, false, nil, [])
+    private var mutateProviderOnFinalRead = false
+    private var mutateURLOnFinalRead = false
+    private var itemReadCount = 0
+    private(set) var createAttempts = 0
+    private(set) var persistedCreates = 0
+    let createEntered = AsyncTestLatch()
 
     func setQualified(_ value: Bool) { qualified = value }
-    func setFailNextCreate(_ value: Bool) { failNextCreate = value }
-    func setNextShape(recurring: Bool = false, allDay: Bool = false, detached: Bool = false) {
-        nextShape = (recurring, allDay, detached)
-    }
-    func createdCount() -> Int { createCount }
+    func setCreateMode(_ value: CreateMode) { createMode = value }
+    func setNextShape(
+        recurring: Bool = false,
+        allDay: Bool = false,
+        detached: Bool = false,
+        organizer: String? = nil,
+        attendees: [String] = []
+    ) { nextShape = (recurring, allDay, detached, organizer, attendees) }
+    func setMutateProviderOnFinalRead(_ value: Bool) { mutateProviderOnFinalRead = value }
+    func setMutateURLOnFinalRead(_ value: Bool) { mutateURLOnFinalRead = value }
+    func seed(_ item: ExternalCalendarItem) { items[item.localEventId] = item }
+    func removeAll() { items.removeAll() }
+    func attempts() -> Int { createAttempts }
+    func persistedCount() -> Int { persistedCreates }
     func count() -> Int { items.count }
-    func allItems() -> [ExternalCalendarItem] { Array(items.values) }
 
     func qualify(calendarId: String) async throws -> CalendarQualification {
         CalendarQualification(
@@ -137,20 +132,19 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     }
 
     func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
-        if failNextCreate {
-            failNextCreate = false
-            throw SyncTestError.forcedCalendarCreate
-        }
+        createAttempts += 1
+        await createEntered.open()
+        if createMode == .throwWithoutPersist { throw SyncTestError.forcedCalendarCreate }
         sequence += 1
-        createCount += 1
         let id = "calendar-event-\(sequence)"
         let shape = nextShape
-        nextShape = (false, false, false)
+        nextShape = (false, false, false, nil, [])
         let item = ExternalCalendarItem(
             provider: "Fixture Calendar",
             calendarId: draft.calendarId,
             localEventId: id,
             providerExternalId: "provider-\(sequence)",
+            itemURL: "calshow:\(id)",
             syncKey: draft.syncKey,
             operationFingerprint: draft.operationFingerprint,
             title: draft.title,
@@ -159,55 +153,55 @@ private actor SyncTestCalendar: CalendarSyncProviding {
             timeZoneIdentifier: draft.timeZoneIdentifier,
             location: draft.location,
             notes: draft.notes,
+            organizer: shape.organizer,
+            attendees: shape.attendees,
             updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
             isRecurring: shape.recurring,
             isAllDay: shape.allDay,
             isDetached: shape.detached
         )
         items[id] = item
+        persistedCreates += 1
+        if createMode == .persistThenThrow { throw SyncTestError.forcedCalendarCreate }
+        if createMode == .persistThenSuspend {
+            try await Task.sleep(nanoseconds: 10_000_000_000)
+        }
         return item
     }
 
-    func item(id: String) async throws -> ExternalCalendarItem? { items[id] }
+    func item(id: String) async throws -> ExternalCalendarItem? {
+        guard var item = items[id] else { return nil }
+        itemReadCount += 1
+        if mutateProviderOnFinalRead && itemReadCount >= 2 { item.provider = "Mutated Provider" }
+        if mutateURLOnFinalRead && itemReadCount >= 2 { item.itemURL = "calshow:mutated" }
+        return item
+    }
 
     func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
         if let id = query.localEventId, let direct = items[id] { return [direct] }
-        let byIdentity = items.values.filter {
+        let identity = items.values.filter {
             $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
         }
-        if !byIdentity.isEmpty { return Array(byIdentity) }
+        if !identity.isEmpty { return Array(identity) }
         if let external = query.providerExternalId {
-            let byExternal = items.values.filter { $0.providerExternalId == external }
-            if !byExternal.isEmpty { return Array(byExternal) }
+            let externalMatches = items.values.filter { $0.providerExternalId == external }
+            if !externalMatches.isEmpty { return Array(externalMatches) }
         }
         return items.values.filter {
             $0.calendarId == query.calendarId && $0.title == query.title
-                && $0.start == query.start && $0.end == query.end
+                && abs($0.start.timeIntervalSince(query.start)) < 1
+                && abs($0.end.timeIntervalSince(query.end)) < 1
         }
     }
-
-    func mutateStart(id: String, start: Date, end: Date) {
-        items[id]?.start = start
-        items[id]?.end = end
-    }
-
-    func duplicateIdentity(from id: String) {
-        guard var copy = items[id] else { return }
-        copy.localEventId = id + "-duplicate"
-        items[copy.localEventId] = copy
-    }
 }
-
 
 private actor AsyncTestLatch {
     private var opened = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
-
     func wait() async {
         if opened { return }
         await withCheckedContinuation { waiters.append($0) }
     }
-
     func open() {
         guard !opened else { return }
         opened = true
@@ -215,93 +209,6 @@ private actor AsyncTestLatch {
         waiters.removeAll()
         pending.forEach { $0.resume() }
     }
-}
-
-private actor PausingRegistry: TimeInstanceRegistryStoring {
-    let base: SyncTestRegistry
-    let entered: AsyncTestLatch
-    let release: AsyncTestLatch
-    private var hasPaused = false
-
-    init(base: SyncTestRegistry, entered: AsyncTestLatch, release: AsyncTestLatch) {
-        self.base = base
-        self.entered = entered
-        self.release = release
-    }
-
-    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
-        if !hasPaused {
-            hasPaused = true
-            await entered.open()
-            await release.wait()
-        }
-        return try await base.findBySyncKey(syncKey)
-    }
-    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
-        try await base.readIdentity(id: id, forceRefresh: forceRefresh)
-    }
-    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
-        try await base.get(id: id, forceRefresh: forceRefresh)
-    }
-    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.create(record) }
-    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.repair(id: id, from: record) }
-    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.save(record) }
-}
-
-
-private actor PausingCalendarBeforeCreate: CalendarSyncProviding {
-    private let base = SyncTestCalendar()
-    let entered = AsyncTestLatch()
-    let release = AsyncTestLatch()
-    private var paused = false
-
-    func qualify(calendarId: String) async throws -> CalendarQualification { try await base.qualify(calendarId: calendarId) }
-    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem { try await base.create(draft) }
-    func item(id: String) async throws -> ExternalCalendarItem? { try await base.item(id: id) }
-    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
-        if !paused {
-            paused = true
-            await entered.open()
-            await release.wait()
-        }
-        return try await base.recover(query)
-    }
-    func createdCount() async -> Int { await base.createdCount() }
-}
-
-private actor PostEffectCancellingCalendar: CalendarSyncProviding {
-    private let base = SyncTestCalendar()
-    let created = AsyncTestLatch()
-
-    func qualify(calendarId: String) async throws -> CalendarQualification { try await base.qualify(calendarId: calendarId) }
-    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
-        let item = try await base.create(draft)
-        await created.open()
-        try await Task.sleep(nanoseconds: 10_000_000_000)
-        return item
-    }
-    func item(id: String) async throws -> ExternalCalendarItem? { try await base.item(id: id) }
-    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] { try await base.recover(query) }
-    func count() async -> Int { await base.count() }
-}
-
-private func seedTransaction(
-    _ store: any CalendarRegistryTransactionStoring,
-    request: RegistryFirstTimeInstanceRequest,
-    registryEventId: String
-) async throws {
-    var tx = try await store.claim(
-        idempotencyKey: request.idempotencyKey,
-        manifestFingerprint: request.manifest.fingerprint,
-        operationId: "seed-operation",
-        leaseOwner: "seed-owner",
-        leaseToken: "seed-token",
-        leaseDuration: 600
-    )
-    tx.registryEventId = registryEventId
-    tx.stage = .registryCreated
-    tx = try await store.save(tx)
-    _ = try await store.release(tx)
 }
 
 private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring {
@@ -313,8 +220,10 @@ private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring 
         operationId: String,
         leaseOwner: String,
         leaseToken: String,
-        leaseDuration: TimeInterval
+        leaseDuration: TimeInterval,
+        exclusiveProcessLockHeld: Bool
     ) async throws -> CalendarRegistryTransaction {
+        _ = exclusiveProcessLockHeld
         if let transaction { return transaction }
         let now = Date()
         let created = CalendarRegistryTransaction(
@@ -332,28 +241,26 @@ private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring 
         transaction = created
         return created
     }
-
     func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) async throws -> CalendarRegistryTransaction {
-        _ = leaseDuration
+        _ = transaction; _ = leaseDuration
         throw SyncTestError.forcedLedgerSave
     }
-
     func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction? {
-        guard transaction?.idempotencyKey == idempotencyKey else { return nil }
-        return transaction
+        transaction?.idempotencyKey == idempotencyKey ? transaction : nil
     }
-
     func save(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction {
+        _ = transaction
         throw SyncTestError.forcedLedgerSave
     }
-
     func release(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction {
+        _ = transaction
         throw SyncTestError.forcedLedgerSave
     }
 }
 
 private func syncRequest(
     key: String = "operation-lift-2027-01-15",
+    registryEventId: String? = nil,
     title: String = "LIFT",
     start: Date = Date(timeIntervalSince1970: 1_800_010_000),
     end: Date = Date(timeIntervalSince1970: 1_800_013_600),
@@ -362,6 +269,7 @@ private func syncRequest(
 ) -> RegistryFirstTimeInstanceRequest {
     RegistryFirstTimeInstanceRequest(
         idempotencyKey: key,
+        registryEventId: registryEventId ?? "notion-\(key)",
         title: title,
         start: start,
         end: end,
@@ -377,22 +285,85 @@ private func syncRequest(
     )
 }
 
+private func canonicalRecord(_ request: RegistryFirstTimeInstanceRequest) -> TimeInstanceRecord {
+    TimeInstanceRecord(
+        id: request.registryEventId,
+        title: request.title,
+        scheduledStart: request.start,
+        scheduledEnd: request.end,
+        timeZoneIdentifier: request.timeZoneIdentifier,
+        location: request.location,
+        notes: request.notes,
+        syncKey: request.idempotencyKey,
+        operationFingerprint: request.manifest.fingerprint,
+        semantics: request.semantics,
+        schedulingAuthority: .registry,
+        syncState: .pendingCreate,
+        registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+    )
+}
+
+private func calendarItem(
+    _ request: RegistryFirstTimeInstanceRequest,
+    id: String = "calendar-existing",
+    provider: String = "Fixture Calendar",
+    external: String? = "provider-existing",
+    url: String? = "calshow:existing",
+    recurring: Bool = false,
+    allDay: Bool = false,
+    detached: Bool = false,
+    organizer: String? = nil,
+    attendees: [String] = [],
+    updatedAt: Date? = Date(timeIntervalSince1970: 1_800_000_000)
+) -> ExternalCalendarItem {
+    ExternalCalendarItem(
+        provider: provider,
+        calendarId: request.calendarId,
+        localEventId: id,
+        providerExternalId: external,
+        itemURL: url,
+        syncKey: request.idempotencyKey,
+        operationFingerprint: request.manifest.fingerprint,
+        title: request.title,
+        start: request.start,
+        end: request.end,
+        timeZoneIdentifier: request.timeZoneIdentifier,
+        location: request.location,
+        notes: request.notes,
+        organizer: organizer,
+        attendees: attendees,
+        updatedAt: updatedAt,
+        isRecurring: recurring,
+        isAllDay: allDay,
+        isDetached: detached
+    )
+}
+
 private func makeSyncEngine(
-    registry: any TimeInstanceRegistryStoring = SyncTestRegistry(),
+    registry: any TimeInstanceRegistryStoring,
     calendar: any CalendarSyncProviding = SyncTestCalendar(),
     transactions: any CalendarRegistryTransactionStoring = InMemoryCalendarRegistryTransactionStore(),
-    operationGate: CalendarRegistryOperationGate = CalendarRegistryOperationGate()
+    processLocks: any CalendarRegistryProcessLocking = InMemoryCalendarRegistryProcessLockCoordinator(),
+    operationGate: CalendarRegistryOperationGate = CalendarRegistryOperationGate(),
+    leaseDuration: TimeInterval = 600
 ) -> CalendarRegistrySyncEngine {
     CalendarRegistrySyncEngine(
         registry: registry,
         calendar: calendar,
         transactions: transactions,
+        processLocks: processLocks,
         operationGate: operationGate,
         clock: { Date(timeIntervalSince1970: 1_800_000_000) },
         makeOperationId: { UUID().uuidString.lowercased() },
         makeLeaseToken: { UUID().uuidString.lowercased() },
-        leaseDuration: 600
+        leaseDuration: leaseDuration
     )
+}
+
+private func seededRegistry(_ request: RegistryFirstTimeInstanceRequest) async -> SyncTestRegistry {
+    let registry = SyncTestRegistry()
+    await registry.put(canonicalRecord(request))
+    return registry
 }
 
 private func withTempDirectory(_ body: (URL) async throws -> Void) async throws {
@@ -403,47 +374,54 @@ private func withTempDirectory(_ body: (URL) async throws -> Void) async throws 
     try await body(directory)
 }
 
-// MARK: - Notion adapter fixture
+private func claim(
+    _ store: any CalendarRegistryTransactionStoring,
+    key: String,
+    fingerprint: String = "fingerprint",
+    operation: String = "operation",
+    token: String = "token",
+    exclusive: Bool = false,
+    duration: TimeInterval = 600
+) async throws -> CalendarRegistryTransaction {
+    try await store.claim(
+        idempotencyKey: key,
+        manifestFingerprint: fingerprint,
+        operationId: operation,
+        leaseOwner: operation,
+        leaseToken: token,
+        leaseDuration: duration,
+        exclusiveProcessLockHeld: exclusive
+    )
+}
+
+// MARK: - Registry gateway fixture
 
 private actor SyncRegistryGateway: RegistryNotionGateway {
     nonisolated var supportsAuthoritativeFiltering: Bool { true }
-    var pages: [String: NotionRow] = [:]
-    var failUpdate = false
-    var failCreateResponseAfterPersist = false
-    var filteredQueryCalls = 0
-    private var sequence = 0
-    private(set) var lastCreatedFields: [BoundField] = []
-    private(set) var lastUpdatedFields: [BoundField] = []
+    private var pages: [String: NotionRow] = [:]
+    private(set) var createCalls = 0
+    private(set) var updateCalls = 0
 
-    func setFailUpdate(_ value: Bool) { failUpdate = value }
-    func setFailCreateResponseAfterPersist(_ value: Bool) { failCreateResponseAfterPersist = value }
-    func pageCount() -> Int { pages.count }
-    func createdFields() -> [BoundField] { lastCreatedFields }
+    func seed(_ row: NotionRow) { pages[row.id] = row }
+    func createCount() -> Int { createCalls }
+    func updateCount() -> Int { updateCalls }
 
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema {
         _ = dataSourceId; _ = workspace
         return DataSourceSchema(columnsByName: [:])
     }
-
     func query(dataSourceId: String, workspace: String?, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
         _ = dataSourceId; _ = workspace; _ = pageSize; _ = startCursor
         return (Array(pages.values), nil)
     }
-
     func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
         _ = dataSourceId; _ = workspace; _ = pageSize; _ = startCursor
-        filteredQueryCalls += 1
-        let object = (try? JSONSerialization.jsonObject(with: filter) as? [String: Any]) ?? [:]
-        let rich = object["rich_text"] as? [String: Any]
-        let wanted = rich?["equals"] as? String
-        let rows = pages.values.filter { row in
-            row.cells.values.contains { cell in
-                cell.type == "rich_text" && cell.value == .string(wanted ?? "")
-            }
-        }
-        return (Array(rows), nil)
+        let object = try JSONSerialization.jsonObject(with: filter) as? [String: Any]
+        let wanted = (object?["rich_text"] as? [String: Any])?["equals"] as? String
+        return (pages.values.filter { row in
+            row.cells.values.contains { $0.type == "rich_text" && $0.value == .string(wanted ?? "") }
+        }, nil)
     }
-
     func page(pageId: String, workspace: String?) async throws -> NotionRow {
         _ = workspace
         guard let row = pages[pageId] ?? pages[CachedRow.normalize(pageId)] else {
@@ -451,43 +429,26 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
         }
         return row
     }
-
     func create(dataSourceId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
-        _ = dataSourceId; _ = workspace
-        sequence += 1
-        let id = String(format: "%032d", sequence)
-        lastCreatedFields = fields
-        let row = Self.row(id: id, existing: nil, fields: fields)
-        pages[id] = row
-        if failCreateResponseAfterPersist {
-            failCreateResponseAfterPersist = false
-            throw RegistryGatewayError.invalidResponse("simulated malformed create response after remote success")
-        }
-        return row
+        _ = dataSourceId; _ = workspace; _ = fields
+        createCalls += 1
+        throw SyncTestError.forcedRegistrySave
     }
-
     func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
         _ = workspace
-        if failUpdate {
-            failUpdate = false
-            throw SyncTestError.forcedRegistrySave
-        }
-        lastUpdatedFields = fields
+        updateCalls += 1
         let row = Self.row(id: pageId, existing: pages[pageId], fields: fields)
         pages[pageId] = row
         return row
     }
-
     func archive(pageId: String, workspace: String?) async throws { pages[pageId] = nil }
     func markdown(pageId: String, workspace: String?) async throws -> String { "" }
     func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {}
 
-    private static func row(id: String, existing: NotionRow?, fields: [BoundField]) -> NotionRow {
+    static func row(id: String, existing: NotionRow?, fields: [BoundField]) -> NotionRow {
         var cells = existing?.cells ?? [:]
         for field in fields {
-            cells[field.notionName] = NotionCell(
-                id: field.propertyId, type: field.type, value: field.value
-            )
+            cells[field.notionName] = NotionCell(id: field.propertyId, type: field.type, value: field.value)
         }
         return NotionRow(
             id: id,
@@ -544,738 +505,54 @@ private func scheduleEntityForSyncTests() -> RegistryEntity {
     )
 }
 
-private func testRecord(key: String = "adapter-key") -> TimeInstanceRecord {
-    let request = syncRequest(key: key)
-    return TimeInstanceRecord(
-        title: request.title,
-        scheduledStart: request.start,
-        scheduledEnd: request.end,
-        timeZoneIdentifier: request.timeZoneIdentifier,
-        location: request.location,
-        notes: request.notes,
-        syncKey: request.idempotencyKey,
-        operationFingerprint: request.manifest.fingerprint,
-        semantics: request.semantics,
-        schedulingAuthority: .registry,
-        syncState: .pendingCreate,
-        registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
-    )
+private func notionRow(for record: TimeInstanceRecord, entity: RegistryEntity) throws -> NotionRow {
+    let gateway = SyncRegistryGateway()
+    _ = gateway
+    let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: SyncRegistryGateway())
+    let mirror = Mirror(reflecting: store)
+    _ = mirror
+    let fields: [String: Value] = [
+        "title": .string(record.title),
+        "date": .object([
+            "start": .string(CalendarRegistryISO.string(record.scheduledStart)),
+            "end": .string(CalendarRegistryISO.string(record.scheduledEnd)),
+            "timeZone": .string(record.timeZoneIdentifier)
+        ]),
+        "status": .string(record.lifecycleStatus),
+        "syncKey": .string(record.syncKey),
+        "operationFingerprint": .string(record.operationFingerprint),
+        "eventClass": .string(record.semantics.eventClass.rawValue),
+        "meetingType": record.semantics.meetingType.map(Value.string) ?? .null,
+        "primaryBlock": .array([.string(record.semantics.primaryBlockId)]),
+        "blocks": .array(record.semantics.blockIds.map(Value.string)),
+        "projects": .array(record.semantics.projectIds.map(Value.string)),
+        "contacts": .array(record.semantics.contactIds.map(Value.string)),
+        "schedulingAuthority": .string(record.schedulingAuthority.rawValue),
+        "syncState": .string(record.syncState.rawValue),
+        "registryUpdatedAt": .string(CalendarRegistryISO.string(record.registryUpdatedAt)),
+        "syncHash": .string(record.syncHash),
+        "scheduledDuration": .double(record.scheduledDurationMinutes),
+        "description": record.notes.map(Value.string) ?? .null,
+        "calendarLocation": record.location.map(Value.string) ?? .null,
+        "calendarProvider": record.calendarProvider.map(Value.string) ?? .null,
+        "calendarId": record.calendarId.map(Value.string) ?? .null,
+        "calendarEventId": record.calendarEventId.map(Value.string) ?? .null,
+        "providerExternalId": record.providerExternalId.map(Value.string) ?? .null,
+        "calendarUrl": record.calendarItemURL.map(Value.string) ?? .null,
+        "lastSyncError": record.lastSyncError.map(Value.string) ?? .null,
+        "lastSyncedAt": record.lastSyncedAt.map { .string(CalendarRegistryISO.string($0)) } ?? .null,
+        "calendarUpdatedAt": record.calendarUpdatedAt.map { .string(CalendarRegistryISO.string($0)) } ?? .null
+    ]
+    let bound = RegistryWriter.resolve(fields, entity: entity).fields
+    return SyncRegistryGateway.row(id: record.id, existing: nil, fields: bound)
 }
 
-func runCalendarRegistrySyncEngineTests() async {
-    print("\n🗓 Calendar–Registry Sync — recovery hardening")
-
-    await test("CR1 SQLite ledger survives independent handles") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("ledger.sqlite3")
-            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let created = try await first.claim(
-                idempotencyKey: "same-key",
-                manifestFingerprint: "fingerprint-a",
-                operationId: "op-1",
-                leaseOwner: "worker-1", leaseToken: "token-1", leaseDuration: 600
-            )
-            var updated = created
-            updated.stage = .calendarCreated
-            updated.calendarEventId = "event-1"
-            _ = try await first.save(updated)
-
-            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let loaded = try await second.get(idempotencyKey: "same-key")
-            try expect(loaded?.stage == .calendarCreated)
-            try expect(loaded?.calendarEventId == "event-1")
-        }
-    }
-
-    await test("CR2 SQLite unique key rejects a different manifest across handles") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("ledger.sqlite3")
-            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
-            _ = try await first.claim(
-                idempotencyKey: "same-key",
-                manifestFingerprint: "fingerprint-a",
-                operationId: "op-a",
-                leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 600
-            )
-            do {
-                _ = try await second.claim(
-                    idempotencyKey: "same-key",
-                    manifestFingerprint: "fingerprint-b",
-                    operationId: "op-b",
-                    leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
-                )
-                throw TestError.assertion("expected idempotency conflict")
-            } catch CalendarRegistryTransactionStoreError.idempotencyConflict("same-key") {
-                // expected
-            }
-        }
-    }
-
-    await test("CR3 concurrent different-key SQLite writes preserve all rows") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("ledger.sqlite3")
-            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
-            async let a = first.claim(
-                idempotencyKey: "key-a", manifestFingerprint: "fp-a",
-                operationId: "op-a", leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 600
-            )
-            async let b = second.claim(
-                idempotencyKey: "key-b", manifestFingerprint: "fp-b",
-                operationId: "op-b", leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
-            )
-            _ = try await [a, b]
-            try expect(try await first.get(idempotencyKey: "key-a") != nil)
-            try expect(try await second.get(idempotencyKey: "key-b") != nil)
-        }
-    }
-
-    await test("CR4 ten retries create one pair") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        for _ in 0..<10 {
-            let receipt = try await engine.registryFirstCreate(syncRequest())
-            try expect(receipt.succeeded)
-        }
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR5 partial Notion create repairs one page on retry") {
-        let registry = SyncTestRegistry()
-        await registry.setFailNextCreatePatch(true)
-        let calendar = SyncTestCalendar()
-        let transactions = InMemoryCalendarRegistryTransactionStore()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions)
-        let first = try await engine.registryFirstCreate(syncRequest())
-        try expect(!first.succeeded)
-        let second = try await engine.registryFirstCreate(syncRequest())
-        try expect(second.succeeded)
-        try expect(await registry.count() == 1)
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR6 ledger loss reconstructs the same manifest from external fingerprints") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        let first = makeSyncEngine(registry: registry, calendar: calendar)
-        try expect(try await first.registryFirstCreate(syncRequest()).succeeded)
-        let restarted = makeSyncEngine(
-            registry: registry,
-            calendar: calendar,
-            transactions: InMemoryCalendarRegistryTransactionStore()
-        )
-        let receipt = try await restarted.registryFirstCreate(syncRequest())
-        try expect(receipt.succeeded)
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR7 ledger loss plus different manifest conflicts") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        try expect(try await makeSyncEngine(registry: registry, calendar: calendar)
-            .registryFirstCreate(syncRequest()).succeeded)
-        let restarted = makeSyncEngine(
-            registry: registry,
-            calendar: calendar,
-            transactions: InMemoryCalendarRegistryTransactionStore()
-        )
-        let receipt = try await restarted.registryFirstCreate(syncRequest(title: "Different"))
-        try expect(!receipt.succeeded)
-        try expect(receipt.stageAfter == .conflict)
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR8 calendar drift conflicts without overwriting registry schedule") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let first = try await engine.registryFirstCreate(syncRequest())
-        guard let id = first.calendarItem?.localEventId else {
-            throw TestError.assertion("calendar item missing")
-        }
-        let driftedStart = syncRequest().start.addingTimeInterval(7_200)
-        let driftedEnd = syncRequest().end.addingTimeInterval(7_200)
-        await calendar.mutateStart(id: id, start: driftedStart, end: driftedEnd)
-        let receipt = try await engine.registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(receipt.stageAfter == .conflict)
-        let record = await registry.record(for: syncRequest().idempotencyKey)
-        try expect(record?.scheduledStart == syncRequest().start)
-        try expect(record?.scheduledEnd == syncRequest().end)
-    }
-
-    await test("CR9 non-local timezone survives full transaction") {
-        let request = syncRequest(timeZone: "Pacific/Honolulu")
-        let receipt = try await makeSyncEngine().registryFirstCreate(request)
-        try expect(receipt.succeeded)
-        try expect(receipt.record?.timeZoneIdentifier == "Pacific/Honolulu")
-        try expect(receipt.calendarItem?.timeZoneIdentifier == "Pacific/Honolulu")
-    }
-
-    await test("CR10 invalid timezone and injected keys are rejected before writes") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        do {
-            _ = try await engine.registryFirstCreate(syncRequest(timeZone: "Mars/Olympus"))
-            throw TestError.assertion("invalid timezone should fail")
-        } catch CalendarRegistrySyncError.invalidTimeZone("Mars/Olympus") {}
-        do {
-            _ = try await engine.registryFirstCreate(syncRequest(key: "bad\nkey"))
-            throw TestError.assertion("invalid key should fail")
-        } catch CalendarRegistrySyncError.invalidIdempotencyKey {}
-        try expect(await registry.count() == 0)
-        try expect(await calendar.count() == 0)
-    }
-
-    await test("CR11 recurring, all-day, and detached items fail closed") {
-        for shape in [(true, false, false), (false, true, false), (false, false, true)] {
-            let registry = SyncTestRegistry()
-            let calendar = SyncTestCalendar()
-            await calendar.setNextShape(recurring: shape.0, allDay: shape.1, detached: shape.2)
-            let receipt = try await makeSyncEngine(registry: registry, calendar: calendar)
-                .registryFirstCreate(syncRequest(key: "shape-\(shape.0)-\(shape.1)-\(shape.2)"))
-            try expect(!receipt.succeeded)
-            try expect(receipt.stageAfter == .conflict)
-        }
-    }
-
-    await test("CR12 unqualified calendar refuses all writes") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        await calendar.setQualified(false)
-        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar)
-            .registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(await registry.count() == 0)
-        try expect(await calendar.count() == 0)
-    }
-
-    await test("CR13 unpersisted ledger failure is an infrastructure fault") {
-        let registry = SyncTestRegistry()
-        let calendar = SyncTestCalendar()
-        let receipt = try await makeSyncEngine(
-            registry: registry,
-            calendar: calendar,
-            transactions: AlwaysFailingTransactionStore()
-        ).registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(receipt.infrastructureFault)
-        try expect(!receipt.recoveryStatePersisted)
-        try expect(receipt.recoveryAction?.contains("do not retry automatically") == true)
-    }
-
-    await test("CR14 registry failure-state write is reported separately") {
-        let registry = SyncTestRegistry()
-        await registry.setFailAllSaves(true)
-        let receipt = try await makeSyncEngine(registry: registry)
-            .registryFirstCreate(syncRequest())
-        try expect(!receipt.succeeded)
-        try expect(receipt.recoveryStatePersisted)
-        try expect(!receipt.registryFailureStatePersisted)
-        try expect(receipt.discrepancy?.contains("registry failure-state write failed") == true)
-    }
-
-    await test("CR15 versioned metadata rejects duplicates and round-trips identity") {
-        let identity = CalendarRegistryCalendarMetadata.Identity(
-            syncKey: "safe-key",
-            operationFingerprint: String(repeating: "a", count: 64)
-        )
-        let notes = try CalendarRegistryCalendarMetadata.append(to: "hello", identity: identity)
-        try expect(try CalendarRegistryCalendarMetadata.parse(notes) == identity)
-        do {
-            _ = try CalendarRegistryCalendarMetadata.parse(notes + "\n" + notes)
-            throw TestError.assertion("duplicate metadata should conflict")
-        } catch CalendarRegistrySyncError.identityConflict {}
-    }
-
-    await test("CR16 live registry gateway advertises authoritative filtering") {
-        try expect(LiveRegistryGateway().supportsAuthoritativeFiltering)
-    }
-
-    await test("CR17 strict query decoder rejects malformed or broken pagination") {
-        do {
-            _ = try RegistryQueryResponseDecoder.decode(Data("{}".utf8))
-            throw TestError.assertion("missing results should fail")
-        } catch RegistryGatewayError.invalidResponse {}
-        do {
-            let data = try JSONSerialization.data(withJSONObject: [
-                "results": [], "has_more": true, "next_cursor": NSNull()
-            ])
-            _ = try RegistryQueryResponseDecoder.decode(data)
-            throw TestError.assertion("missing cursor should fail")
-        } catch RegistryGatewayError.invalidResponse {}
-        let valid = try JSONSerialization.data(withJSONObject: [
-            "results": [], "has_more": false, "next_cursor": NSNull()
-        ])
-        let decoded = try RegistryQueryResponseDecoder.decode(valid)
-        try expect(decoded.rows.isEmpty && decoded.nextCursor == nil)
-    }
-
-    await test("CR18 Notion identity envelope contains four critical fields") {
-        let gateway = SyncRegistryGateway()
-        let store = NotionTimeInstanceRegistryStore(
-            entity: scheduleEntityForSyncTests(), gateway: gateway
-        )
-        _ = try await store.create(testRecord())
-        let names = Set(await gateway.createdFields().map(\.notionName))
-        try expect(names == Set(["EVENT TITLE", "Sync Key", "Operation Fingerprint", "Sync State"]))
-    }
-
-    await test("CR19 real Notion adapter partial create can be found and repaired") {
-        let gateway = SyncRegistryGateway()
-        await gateway.setFailUpdate(true)
-        let store = NotionTimeInstanceRegistryStore(
-            entity: scheduleEntityForSyncTests(), gateway: gateway
-        )
-        let record = testRecord(key: "partial-key")
-        do {
-            _ = try await store.create(record)
-            throw TestError.assertion("expected partial create")
-        } catch let partial as PartialRegistryCreateError {
-            let lookup = try await store.findBySyncKey("partial-key")
-            try expect(lookup.records.isEmpty)
-            try expect(lookup.unresolvedIdentities.map(\.pageId) == [partial.pageId])
-            try expect(lookup.unresolvedIdentities.first?.operationFingerprint == record.operationFingerprint)
-            let repaired = try await store.repair(id: partial.pageId, from: record)
-            try expect(repaired.syncKey == "partial-key")
-            try expect(await gateway.pageCount() == 1)
-        }
-    }
-
-    await test("CR20 migration artifact decodes against registry roles") {
-        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        let url = root.appendingPathComponent("docs/migrations/calendar-registry-v1/registry-entity-patch.json")
-        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
-        try expect(object?["schemaVersion"] as? Int == 2)
-        let additions = object?["additiveProperties"] as? [[String: Any]] ?? []
-        try expect(Set(additions.compactMap { $0["key"] as? String }) == Set(["providerExternalId", "operationFingerprint"]))
-        for addition in additions {
-            guard let role = addition["role"] as? String,
-                  RegistryPropertyRole(rawValue: role) != nil else {
-                throw TestError.assertion("migration role does not decode")
-            }
-        }
-    }
-
-    await test("CR21 composition remains disabled and requires an allowlist") {
-        let entity = scheduleEntityForSyncTests()
-        let gateway = SyncRegistryGateway()
-        do {
-            _ = try CalendarRegistrySyncComposition.build(
-                entity: entity,
-                registryGateway: gateway,
-                calendarStore: PersistentCalendarStore(),
-                environment: [:]
-            )
-            throw TestError.assertion("composition should be disabled")
-        } catch CalendarRegistrySyncCompositionError.disabled {}
-        do {
-            _ = try CalendarRegistrySyncComposition.build(
-                entity: entity,
-                registryGateway: gateway,
-                calendarStore: PersistentCalendarStore(),
-                environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"]
-            )
-            throw TestError.assertion("allowlist should be required")
-        } catch CalendarRegistrySyncCompositionError.missingAllowedCalendars {}
-    }
-
-
-    await test("CR22 same-key independent engines permit one external writer") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("race.sqlite3")
-            let firstStore = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let secondStore = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let baseRegistry = SyncTestRegistry()
-            let entered = AsyncTestLatch()
-            let release = AsyncTestLatch()
-            let registry = PausingRegistry(base: baseRegistry, entered: entered, release: release)
-            let calendar = SyncTestCalendar()
-            let firstEngine = makeSyncEngine(registry: registry, calendar: calendar, transactions: firstStore)
-            let secondEngine = makeSyncEngine(registry: registry, calendar: calendar, transactions: secondStore)
-
-            let first = Task { try await firstEngine.registryFirstCreate(syncRequest(key: "race-key")) }
-            await entered.wait()
-            let second = Task { try await secondEngine.registryFirstCreate(syncRequest(key: "race-key")) }
-            try await Task.sleep(nanoseconds: 50_000_000)
-            await release.open()
-            let receipts = try await [first.value, second.value]
-            try expect(receipts.filter(\.succeeded).count == 1)
-            try expect(receipts.contains { $0.discrepancy?.contains("already active") == true })
-            try expect(await baseRegistry.createdCount() == 1)
-            try expect(await calendar.createdCount() == 1)
-        }
-    }
-
-    await test("CR23 stale revisions, fencing tokens, stage regression, and identity clearing are refused") {
-        try await withTempDirectory { directory in
-            let store = try SQLiteCalendarRegistryTransactionStore(url: directory.appendingPathComponent("cas.sqlite3"))
-            let claimed = try await store.claim(
-                idempotencyKey: "cas-key", manifestFingerprint: "fingerprint",
-                operationId: "op", leaseOwner: "worker", leaseToken: "fence-a", leaseDuration: 600
-            )
-            var progressed = claimed
-            progressed.stage = .calendarCreated
-            progressed.calendarEventId = "event-1"
-            let saved = try await store.save(progressed)
-
-            var stale = claimed
-            stale.stage = .registryCreated
-            do { _ = try await store.save(stale); throw TestError.assertion("stale revision should fail") }
-            catch CalendarRegistryTransactionStoreError.staleRevision("cas-key") {}
-
-            var wrongFence = saved
-            wrongFence.leaseToken = "fence-b"
-            do { _ = try await store.save(wrongFence); throw TestError.assertion("wrong fence should fail") }
-            catch CalendarRegistryTransactionStoreError.leaseLost("cas-key") {}
-
-            var regressed = saved
-            regressed.stage = .registryCreated
-            do { _ = try await store.save(regressed); throw TestError.assertion("stage regression should fail") }
-            catch CalendarRegistryTransactionStoreError.stageRegression {}
-
-            var cleared = saved
-            cleared.stage = .pairPersisted
-            cleared.calendarEventId = nil
-            do { _ = try await store.save(cleared); throw TestError.assertion("identity clearing should fail") }
-            catch CalendarRegistryTransactionStoreError.identityRegression {}
-        }
-    }
-
-    await test("CR24 expired lease can be fenced and resumed once") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("expiry.sqlite3")
-            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
-            let original = try await first.claim(
-                idempotencyKey: "expiry-key", manifestFingerprint: "fingerprint",
-                operationId: "op-a", leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 0.1
-            )
-            try await Task.sleep(nanoseconds: 1_100_000_000)
-            let resumed = try await second.claim(
-                idempotencyKey: "expiry-key", manifestFingerprint: "fingerprint",
-                operationId: "op-b", leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
-            )
-            try expect(resumed.leaseToken == "token-b")
-            try expect(resumed.revision > original.revision)
-            do { _ = try await first.save(original); throw TestError.assertion("expired worker should be fenced") }
-            catch CalendarRegistryTransactionStoreError.staleRevision("expiry-key") {}
-        }
-    }
-
-    await test("CR25 canonical manifest normalizes relations, primary block, and empty optionals") {
-        let requestA = RegistryFirstTimeInstanceRequest(
-            idempotencyKey: "canonical-key", title: "  LIFT  ",
-            start: syncRequest().start, end: syncRequest().end,
-            timeZoneIdentifier: " America/Chicago ", calendarId: " cal-private ",
-            location: "   ", notes: " note ",
-            semantics: TimeInstanceSemantics(
-                eventClass: .focus, meetingType: " ", primaryBlockId: " block-primary ",
-                blockIds: ["block-b", "block-primary", "block-b"],
-                projectIds: ["project-b", "project-a", "project-b"],
-                contactIds: ["contact-b", "contact-a"]
-            )
-        ).canonicalized
-        let requestB = RegistryFirstTimeInstanceRequest(
-            idempotencyKey: "canonical-key", title: "LIFT",
-            start: syncRequest().start, end: syncRequest().end,
-            timeZoneIdentifier: "America/Chicago", calendarId: "cal-private",
-            location: nil, notes: "note",
-            semantics: TimeInstanceSemantics(
-                eventClass: .focus, primaryBlockId: "block-primary",
-                blockIds: ["block-primary", "block-b"],
-                projectIds: ["project-a", "project-b"],
-                contactIds: ["contact-a", "contact-b"]
-            )
-        ).canonicalized
-        try expect(requestA == requestB)
-        try expect(requestA.manifest.fingerprint == requestB.manifest.fingerprint)
-        try expect(requestA.semantics.blockIds == ["block-b", "block-primary"])
-        try expect(requestA.location == nil && requestA.semantics.meetingType == nil)
-    }
-
-    await test("CR26 final success verifies Sync Hash and Last Synced At") {
-        let receipt = try await makeSyncEngine().registryFirstCreate(syncRequest(key: "evidence-key"))
-        try expect(receipt.succeeded)
-        try expect(receipt.verifiedSyncHash?.count == 64)
-        try expect(receipt.record?.syncHash == receipt.verifiedSyncHash)
-        try expect(receipt.record?.lastSyncedAt == receipt.verifiedAt)
-        try expect(receipt.fencingToken?.isEmpty == false)
-        try expect((receipt.ledgerRevision ?? 0) > 1)
-    }
-
-    await test("CR27 a dropped final Sync Hash prevents success") {
-        let registry = SyncTestRegistry()
-        await registry.setDropFinalSyncHash(true)
-        let receipt = try await makeSyncEngine(registry: registry)
-            .registryFirstCreate(syncRequest(key: "dropped-hash"))
-        try expect(!receipt.succeeded)
-        try expect(receipt.discrepancy?.contains("Synced evidence") == true)
-    }
-
-    await test("CR28 ledger-known matching partial page repairs; mismatched, malformed, and missing pages do not") {
-        for mode in ["matching", "mismatch", "malformed", "missing"] {
-            let request = syncRequest(key: "known-\(mode)")
-            let registry = SyncTestRegistry()
-            let calendar = SyncTestCalendar()
-            let store = InMemoryCalendarRegistryTransactionStore()
-            let id = "known-page-\(mode)"
-            switch mode {
-            case "matching":
-                await registry.setIdentityOverride(id: id, value: .partial(
-                    pageId: id, syncKey: request.idempotencyKey,
-                    operationFingerprint: request.manifest.fingerprint
-                ))
-            case "mismatch":
-                await registry.setIdentityOverride(id: id, value: .partial(
-                    pageId: id, syncKey: request.idempotencyKey,
-                    operationFingerprint: String(repeating: "b", count: 64)
-                ))
-            case "malformed":
-                await registry.setIdentityOverride(id: id, value: .malformed(pageId: id, reason: "broken relation"))
-            default:
-                await registry.setIdentityOverride(id: id, value: .missing)
-            }
-            try await seedTransaction(store, request: request, registryEventId: id)
-            let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
-                .registryFirstCreate(request)
-            if mode == "matching" {
-                try expect(receipt.succeeded)
-                try expect(await registry.createdCount() == 0)
-                try expect(await calendar.createdCount() == 1)
-            } else {
-                try expect(!receipt.succeeded)
-                try expect(receipt.stageAfter == .conflict)
-                try expect(await registry.createdCount() == 0)
-                try expect(await calendar.createdCount() == 0)
-            }
-        }
-    }
-
-    await test("CR29 remotely successful Notion create with invalid response recovers without duplication") {
-        let gateway = SyncRegistryGateway()
-        await gateway.setFailCreateResponseAfterPersist(true)
-        let registry = NotionTimeInstanceRegistryStore(entity: scheduleEntityForSyncTests(), gateway: gateway)
-        let calendar = SyncTestCalendar()
-        let transactions = InMemoryCalendarRegistryTransactionStore()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions)
-        let request = syncRequest(key: "uncertain-create")
-        let first = try await engine.registryFirstCreate(request)
-        try expect(!first.succeeded)
-        let second = try await engine.registryFirstCreate(request)
-        try expect(second.succeeded)
-        try expect(await gateway.pageCount() == 1)
-        try expect(await calendar.createdCount() == 1)
-    }
-
-    await test("CR30 strict row decoders reject malformed synchronization responses") {
-        for data in [Data("{}".utf8), Data("{\"id\":\"page\"}".utf8)] {
-            do {
-                _ = try RegistryRowResponseDecoder.decode(data, context: "test")
-                throw TestError.assertion("malformed row should fail")
-            } catch RegistryGatewayError.invalidResponse {}
-        }
-        let malformedResult = try JSONSerialization.data(withJSONObject: [
-            "results": [["id": "page-without-properties"]], "has_more": false
-        ])
-        do {
-            _ = try RegistryQueryResponseDecoder.decode(malformedResult)
-            throw TestError.assertion("malformed query row should fail")
-        } catch RegistryGatewayError.invalidResponse {}
-    }
-
-    await test("CR31 identity-bearing unsupported calendar shapes conflict instead of duplicating") {
-        for shape in ["recurring", "all-day", "detached", "participant"] {
-            let request = syncRequest(key: "shape-existing-\(shape)")
-            let store = PersistentCalendarStore()
-            let identity = CalendarRegistryCalendarMetadata.Identity(
-                syncKey: request.idempotencyKey,
-                operationFingerprint: request.manifest.fingerprint
-            )
-            let notes = try CalendarRegistryCalendarMetadata.append(to: request.notes, identity: identity)
-            await store.seed(CalendarEvent(
-                id: "existing-\(shape)", title: request.title,
-                start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
-                allDay: shape == "all-day", calendarId: request.calendarId,
-                calendarTitle: "Private Smoke", location: request.location, notes: notes,
-                timeZoneIdentifier: request.timeZoneIdentifier, externalId: "external-\(shape)",
-                organizer: shape == "participant" ? "owner@example.com" : nil,
-                attendees: shape == "participant" ? ["person@example.com"] : [],
-                lastModified: CalendarRegistryISO.string(Date()),
-                isRecurring: shape == "recurring", isDetached: shape == "detached"
-            ))
-            let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
-            let receipt = try await makeSyncEngine(registry: SyncTestRegistry(), calendar: provider)
-                .registryFirstCreate(request)
-            try expect(!receipt.succeeded)
-            try expect(receipt.stageAfter == .conflict)
-            try expect(await store.count() == 1)
-        }
-    }
-
-    await test("CR32 unrelated malformed calendar metadata does not poison target recovery") {
-        let request = syncRequest(key: "target-metadata")
-        let store = PersistentCalendarStore()
-        await store.seed(CalendarEvent(
-            id: "unrelated", title: "Other", start: CalendarRegistryISO.string(request.start),
-            end: CalendarRegistryISO.string(request.end), allDay: false,
-            calendarId: request.calendarId, calendarTitle: "Private Smoke", location: nil,
-            notes: CalendarRegistryCalendarMetadata.beginMarker + "\ninvalid",
-            timeZoneIdentifier: request.timeZoneIdentifier
-        ))
-        let identity = CalendarRegistryCalendarMetadata.Identity(
-            syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint
-        )
-        await store.seed(CalendarEvent(
-            id: "target", title: request.title, start: CalendarRegistryISO.string(request.start),
-            end: CalendarRegistryISO.string(request.end), allDay: false,
-            calendarId: request.calendarId, calendarTitle: "Private Smoke", location: request.location,
-            notes: try CalendarRegistryCalendarMetadata.append(to: request.notes, identity: identity),
-            timeZoneIdentifier: request.timeZoneIdentifier, externalId: "target-external"
-        ))
-        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
-        let recovered = try await provider.recover(CalendarRecoveryQuery(
-            syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint,
-            calendarId: request.calendarId, title: request.title, start: request.start, end: request.end
-        ))
-        try expect(recovered.map(\.localEventId) == ["target"])
-    }
-
-    await test("CR33 invalid partial-effect JSON is ledger corruption") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("corrupt.sqlite3")
-            let store = try SQLiteCalendarRegistryTransactionStore(url: url)
-            _ = try await store.claim(
-                idempotencyKey: "corrupt-key", manifestFingerprint: "fingerprint",
-                operationId: "op", leaseOwner: "worker", leaseToken: "token", leaseDuration: 600
-            )
-            var db: OpaquePointer?
-            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK)
-            defer { if let db { sqlite3_close_v2(db) } }
-            try expect(sqlite3_exec(db, "UPDATE calendar_registry_transactions SET partial_effects_json='not-json' WHERE idempotency_key='corrupt-key';", nil, nil, nil) == SQLITE_OK)
-            do {
-                _ = try await store.get(idempotencyKey: "corrupt-key")
-                throw TestError.assertion("corrupt effects should fail")
-            } catch CalendarRegistryTransactionStoreError.corruptLedger {}
-        }
-    }
-
-    await test("CR34 cancelled gate waiter never acquires later") {
-        let gate = CalendarRegistryOperationGate()
-        try await gate.acquire("cancel-key")
-        let waiter = Task { try await gate.acquire("cancel-key") }
-        try await Task.sleep(nanoseconds: 20_000_000)
-        waiter.cancel()
-        await gate.release("cancel-key")
-        do { try await waiter.value; throw TestError.assertion("cancelled waiter should fail") }
-        catch is CancellationError {}
-        try await gate.acquire("cancel-key")
-        await gate.release("cancel-key")
-    }
-
-    await test("CR35 cancellation before Notion create produces no external write") {
-        let base = SyncTestRegistry()
-        let entered = AsyncTestLatch()
-        let release = AsyncTestLatch()
-        let registry = PausingRegistry(base: base, entered: entered, release: release)
-        let calendar = SyncTestCalendar()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-before-create")) }
-        await entered.wait()
-        task.cancel()
-        await release.open()
-        let receipt = try await task.value
-        try expect(!receipt.succeeded)
-        try expect(await base.createdCount() == 0)
-        try expect(await calendar.createdCount() == 0)
-    }
-
-    await test("CR36 cancellation after calendar side effect persists recovery evidence") {
-        let registry = SyncTestRegistry()
-        let calendar = PostEffectCancellingCalendar()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-after-calendar")) }
-        await calendar.created.wait()
-        task.cancel()
-        let receipt = try await task.value
-        try expect(!receipt.succeeded)
-        try expect(receipt.recoveryStatePersisted)
-        try expect(await calendar.count() == 1)
-    }
-
-
-    await test("CR37 cancellation before EventKit create produces no calendar write") {
-        let registry = SyncTestRegistry()
-        let calendar = PausingCalendarBeforeCreate()
-        let engine = makeSyncEngine(registry: registry, calendar: calendar)
-        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-before-calendar")) }
-        await calendar.entered.wait()
-        task.cancel()
-        await calendar.release.open()
-        let receipt = try await task.value
-        try expect(!receipt.succeeded)
-        try expect(receipt.recoveryStatePersisted)
-        try expect(await registry.createdCount() == 1)
-        try expect(await calendar.createdCount() == 0)
-    }
-
-    await test("CR38 target-related malformed calendar metadata conflicts") {
-        let request = syncRequest(key: "target-malformed")
-        let store = PersistentCalendarStore()
-        await store.seed(CalendarEvent(
-            id: "target-malformed-event", title: request.title,
-            start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
-            allDay: false, calendarId: request.calendarId, calendarTitle: "Private Smoke",
-            location: request.location,
-            notes: CalendarRegistryCalendarMetadata.beginMarker + "\nSync-Key: \(request.idempotencyKey)",
-            timeZoneIdentifier: request.timeZoneIdentifier
-        ))
-        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
-        do {
-            _ = try await provider.recover(CalendarRecoveryQuery(
-                syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint,
-                calendarId: request.calendarId, title: request.title, start: request.start, end: request.end
-            ))
-            throw TestError.assertion("target-related malformed metadata should conflict")
-        } catch CalendarRegistrySyncError.identityConflict {}
-    }
-
-    await test("CR39 unknown future ledger schema is refused without downgrade") {
-        try await withTempDirectory { directory in
-            let url = directory.appendingPathComponent("future.sqlite3")
-            var db: OpaquePointer?
-            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
-            try expect(sqlite3_exec(db, "CREATE TABLE calendar_registry_schema (id INTEGER PRIMARY KEY, version INTEGER NOT NULL); INSERT INTO calendar_registry_schema(id,version) VALUES(1,99);", nil, nil, nil) == SQLITE_OK)
-            if let db { sqlite3_close_v2(db) }
-            do {
-                _ = try SQLiteCalendarRegistryTransactionStore(url: url)
-                throw TestError.assertion("future schema should be refused")
-            } catch CalendarRegistryTransactionStoreError.corruptLedger(let reason) {
-                try expect(reason.contains("unsupported schema version 99"))
-            }
-        }
-    }
-
-    await test("CR40 route ownership remains explicit") {
-        try expect(CalendarRegistryRouteClassifier.owner(for: .semanticScheduling) == .timeKeepr)
-        try expect(CalendarRegistryRouteClassifier.owner(for: .calendarMechanics) == .macKeepr)
-        try expect(CalendarRegistryRouteClassifier.owner(for: .schemaChange) == .notionKeepr)
-    }
-}
+// MARK: - Calendar store fixture
 
 private actor PersistentCalendarStore: CalendarStoring {
     private var eventsById: [String: CalendarEvent] = [:]
-
     func seed(_ event: CalendarEvent) { eventsById[event.id] = event }
     func count() -> Int { eventsById.count }
-
     nonisolated func authorizationStatus() -> CalendarAuthStatus { .authorized }
     func ensureAccess() async throws {}
     func calendars() async throws -> [CalendarInfo] {
@@ -1308,7 +585,7 @@ private actor PersistentCalendarStore: CalendarStoring {
             notes: draft.notes,
             timeZoneIdentifier: draft.timeZoneIdentifier,
             externalId: "external-\(id)",
-            lastModified: "2027-01-15T08:00:00Z"
+            lastModified: nil
         )
         eventsById[id] = event
         return event
@@ -1323,4 +600,851 @@ private actor PersistentCalendarStore: CalendarStoring {
         return event
     }
     func delete(id: String) async throws { eventsById[id] = nil }
+}
+
+// MARK: - Tests
+
+func runCalendarRegistrySyncEngineTests() async {
+    await test("CR1 SQLite ledger survives independent handles") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("ledger.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let tx = try await claim(first, key: "same-key", exclusive: true)
+            _ = try await first.release(tx)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            try expect(try await second.get(idempotencyKey: "same-key") != nil)
+        }
+    }
+
+    await test("CR2 SQLite key rejects a different manifest") {
+        try await withTempDirectory { directory in
+            let store = try SQLiteCalendarRegistryTransactionStore(url: directory.appendingPathComponent("ledger.sqlite3"))
+            let tx = try await claim(store, key: "same-key", fingerprint: "a", exclusive: true)
+            _ = try await store.release(tx)
+            do {
+                _ = try await claim(store, key: "same-key", fingerprint: "b", exclusive: true)
+                throw TestError.assertion("different manifest should conflict")
+            } catch CalendarRegistryTransactionStoreError.idempotencyConflict("same-key") {}
+        }
+    }
+
+    await test("CR3 SQLite preserves concurrent different-key rows") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("ledger.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            async let a = claim(first, key: "a", operation: "a", token: "a", exclusive: true)
+            async let b = claim(second, key: "b", operation: "b", token: "b", exclusive: true)
+            _ = try await (a, b)
+            try expect(try await first.get(idempotencyKey: "a") != nil)
+            try expect(try await second.get(idempotencyKey: "b") != nil)
+        }
+    }
+
+    await test("CR4 process lock path is deterministic and key-safe") {
+        try await withTempDirectory { directory in
+            let locks = try FileCalendarRegistryProcessLockCoordinator(rootURL: directory)
+            let a = locks.lockURL(idempotencyKey: "a/b")
+            let b = locks.lockURL(idempotencyKey: "a:b")
+            try expect(a != b)
+            try expect(a.lastPathComponent.count == 69)
+            try expect(!a.lastPathComponent.contains("/"))
+        }
+    }
+
+    await test("CR5 in-memory process lock refuses a second owner") {
+        let locks = InMemoryCalendarRegistryProcessLockCoordinator()
+        let first = try locks.acquire(idempotencyKey: "key")
+        do {
+            _ = try locks.acquire(idempotencyKey: "key")
+            throw TestError.assertion("second owner should fail")
+        } catch CalendarRegistryProcessLockError.operationActive("key") {}
+        try first.release()
+        let second = try locks.acquire(idempotencyKey: "key")
+        try second.release()
+    }
+
+    await test("CR6 file process lock refuses a second owner") {
+        try await withTempDirectory { directory in
+            let locks = try FileCalendarRegistryProcessLockCoordinator(rootURL: directory)
+            let first = try locks.acquire(idempotencyKey: "key")
+            do {
+                _ = try locks.acquire(idempotencyKey: "key")
+                throw TestError.assertion("second file owner should fail")
+            } catch CalendarRegistryProcessLockError.operationActive("key") {}
+            try first.release()
+        }
+    }
+
+    await test("CR7 missing supplied EVENT fails before calendar write") {
+        let request = syncRequest(key: "missing")
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR8 partial supplied EVENT fails without repair") {
+        let request = syncRequest(key: "partial")
+        let registry = SyncTestRegistry()
+        await registry.setIdentityOverride(id: request.registryEventId, value: .partial(
+            pageId: request.registryEventId,
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint
+        ))
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR9 malformed supplied EVENT fails without repair") {
+        let request = syncRequest(key: "malformed")
+        let registry = SyncTestRegistry()
+        await registry.setIdentityOverride(id: request.registryEventId, value: .malformed(
+            pageId: request.registryEventId, reason: "broken relation"
+        ))
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+    }
+
+    await test("CR10 duplicate Sync Key query fails before calendar write") {
+        let request = syncRequest(key: "duplicate")
+        let registry = await seededRegistry(request)
+        var duplicate = canonicalRecord(request)
+        duplicate.id = "other-page"
+        await registry.setLookupExtras([duplicate])
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR11 supplied page must equal the unique Sync Key result") {
+        let request = syncRequest(key: "wrong-page")
+        let registry = SyncTestRegistry()
+        var other = canonicalRecord(request)
+        other.id = "different-page"
+        await registry.put(other)
+        await registry.setIdentityOverride(id: request.registryEventId, value: .decoded(canonicalRecord(request)))
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+    }
+
+    await test("CR12 degraded registry lookup refuses calendar creation") {
+        let request = syncRequest(key: "stale")
+        let registry = await seededRegistry(request)
+        await registry.setLookupSource(.staleCache)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR13 canonical pre-existing EVENT pairs successfully") {
+        let request = syncRequest(key: "happy")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(await calendar.persistedCount() == 1)
+        try expect(receipt.record?.id == request.registryEventId)
+    }
+
+    await test("CR14 smoke path performs no Notion create") {
+        let request = syncRequest(key: "no-notion-create", registryEventId: "00000000000000000000000000000014")
+        let entity = scheduleEntityForSyncTests()
+        let gateway = SyncRegistryGateway()
+        await gateway.seed(try notionRow(for: canonicalRecord(request), entity: entity))
+        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+        let receipt = try await makeSyncEngine(registry: store).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(await gateway.createCount() == 0)
+        try expect(await gateway.updateCount() >= 2)
+    }
+
+    await test("CR15 ten retries create one calendar item") {
+        let request = syncRequest(key: "retries")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        for _ in 0..<10 {
+            let receipt = try await engine.registryFirstCreate(request)
+            try expect(receipt.succeeded)
+        }
+        try expect(await calendar.persistedCount() == 1)
+    }
+
+    await test("CR16 calendar create intent is persisted before provider failure") {
+        let request = syncRequest(key: "intent")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.throwWithoutPersist)
+        let store = InMemoryCalendarRegistryTransactionStore()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+            .registryFirstCreate(request)
+        let tx = try await store.get(idempotencyKey: request.idempotencyKey)
+        try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
+        try expect(tx?.partialEffects.contains("persisted EventKit create intent") == true)
+    }
+
+    await test("CR17 provider persist-then-error records unknown effect") {
+        let request = syncRequest(key: "persist-error")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.persistThenThrow)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
+        try expect(await calendar.persistedCount() == 1)
+        try expect(receipt.recoveryAction?.contains("recovery only") == true)
+    }
+
+    await test("CR18 unknown effect retry recovers the existing calendar item") {
+        let request = syncRequest(key: "recover-unknown")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.persistThenThrow)
+        let store = InMemoryCalendarRegistryTransactionStore()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+        let first = try await engine.registryFirstCreate(request)
+        try expect(first.stageAfter == .calendarEffectUnknown)
+        await calendar.setCreateMode(.normal)
+        let second = try await engine.registryFirstCreate(request)
+        try expect(second.succeeded)
+        try expect(await calendar.attempts() == 1)
+        try expect(await calendar.persistedCount() == 1)
+    }
+
+    await test("CR19 unknown effect with zero candidates never recreates") {
+        let request = syncRequest(key: "unknown-zero")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.throwWithoutPersist)
+        let store = InMemoryCalendarRegistryTransactionStore()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+        let first = try await engine.registryFirstCreate(request)
+        try expect(first.stageAfter == .calendarEffectUnknown)
+        await calendar.setCreateMode(.normal)
+        let second = try await engine.registryFirstCreate(request)
+        try expect(!second.succeeded && second.stageAfter == .calendarEffectUnknown)
+        try expect(await calendar.attempts() == 1)
+    }
+
+    await test("CR20 restart after create intent is recovery-only") {
+        let request = syncRequest(key: "intent-restart")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(
+            store,
+            key: request.idempotencyKey,
+            fingerprint: request.manifest.fingerprint,
+            exclusive: true
+        )
+        tx.registryEventId = request.registryEventId
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.stage = .calendarCreateIntent
+        tx = try await store.save(tx)
+        _ = try await store.release(tx)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+            .registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR21 multiple recovered calendar identities conflict") {
+        let request = syncRequest(key: "ambiguous-calendar")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.seed(calendarItem(request, id: "one"))
+        await calendar.seed(calendarItem(request, id: "two"))
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR22 identity-bearing unsupported shapes conflict") {
+        for shape in ["recurring", "all-day", "detached", "participant"] {
+            let request = syncRequest(key: "shape-\(shape)")
+            let registry = await seededRegistry(request)
+            let calendar = SyncTestCalendar()
+            await calendar.seed(calendarItem(
+                request,
+                recurring: shape == "recurring",
+                allDay: shape == "all-day",
+                detached: shape == "detached",
+                organizer: shape == "participant" ? "owner@example.com" : nil,
+                attendees: shape == "participant" ? ["person@example.com"] : []
+            ))
+            let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+            try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+            try expect(await calendar.attempts() == 0)
+        }
+    }
+
+    await test("CR23 established registry EVENT id cannot be substituted") {
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: "immutable-registry", exclusive: true)
+        tx.registryEventId = "page-a"
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.registryEventId = "page-b"
+        do { _ = try await store.save(tx); throw TestError.assertion("substitution should fail") }
+        catch CalendarRegistryTransactionStoreError.identityRegression {}
+    }
+
+    await test("CR24 established calendar event id cannot be substituted") {
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: "immutable-event", exclusive: true)
+        tx.registryEventId = "page"
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.stage = .calendarCreated
+        tx.calendarEventId = "event-a"
+        tx.calendarId = "cal"
+        tx = try await store.save(tx)
+        tx.calendarEventId = "event-b"
+        do { _ = try await store.save(tx); throw TestError.assertion("substitution should fail") }
+        catch CalendarRegistryTransactionStoreError.identityRegression {}
+    }
+
+    await test("CR25 established calendar id cannot be substituted") {
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: "immutable-cal", exclusive: true)
+        tx.registryEventId = "page"
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.stage = .calendarCreated
+        tx.calendarEventId = "event"
+        tx.calendarId = "cal-a"
+        tx = try await store.save(tx)
+        tx.calendarId = "cal-b"
+        do { _ = try await store.save(tx); throw TestError.assertion("substitution should fail") }
+        catch CalendarRegistryTransactionStoreError.identityRegression {}
+    }
+
+    await test("CR26 established provider external id cannot be substituted") {
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: "immutable-provider", exclusive: true)
+        tx.registryEventId = "page"
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.stage = .calendarCreated
+        tx.calendarEventId = "event"
+        tx.calendarId = "cal"
+        tx.providerExternalId = "external-a"
+        tx = try await store.save(tx)
+        tx.providerExternalId = "external-b"
+        do { _ = try await store.save(tx); throw TestError.assertion("substitution should fail") }
+        catch CalendarRegistryTransactionStoreError.identityRegression {}
+    }
+
+    await test("CR27 established identifiers cannot be cleared") {
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: "immutable-clear", exclusive: true)
+        tx.registryEventId = "page"
+        tx.stage = .registryVerified
+        tx = try await store.save(tx)
+        tx.registryEventId = nil
+        do { _ = try await store.save(tx); throw TestError.assertion("clearing should fail") }
+        catch CalendarRegistryTransactionStoreError.identityRegression {}
+    }
+
+    await test("CR28 final success recomputes Sync Hash") {
+        let request = syncRequest(key: "final-hash")
+        let registry = await seededRegistry(request)
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(receipt.verifiedSyncHash?.count == 64)
+        try expect(receipt.record?.syncHash == receipt.verifiedSyncHash)
+    }
+
+    await test("CR29 dropped final Sync Hash prevents success") {
+        let request = syncRequest(key: "drop-hash")
+        let registry = await seededRegistry(request)
+        await registry.setDropFinalSyncHash(true)
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+        try expect(receipt.discrepancy?.contains("recomputed Synced evidence") == true)
+    }
+
+    await test("CR30 final provider mutation prevents success") {
+        let request = syncRequest(key: "mutate-provider")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setMutateProviderOnFinalRead(true)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+    }
+
+    await test("CR31 observational Calendar URL mutation does not change pair identity") {
+        let request = syncRequest(key: "mutate-url")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setMutateURLOnFinalRead(true)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+    }
+
+    await test("CR32 final Last Synced At mutation prevents success") {
+        let request = syncRequest(key: "mutate-synced-at")
+        let registry = await seededRegistry(request)
+        await registry.setMutateSyncedAtOnFinalRead(true)
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+    }
+
+    await test("CR33 conflict receipt prohibits automatic retry") {
+        let request = syncRequest(key: "conflict-action")
+        let registry = await seededRegistry(request)
+        var duplicate = canonicalRecord(request)
+        duplicate.id = "duplicate"
+        await registry.setLookupExtras([duplicate])
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(receipt.stageAfter == .conflict)
+        try expect(receipt.recoveryAction?.contains("automatic retry is prohibited") == true)
+    }
+
+    await test("CR34 unknown-effect receipt is recovery-only") {
+        let request = syncRequest(key: "unknown-action")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.throwWithoutPersist)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(receipt.stageAfter == .calendarEffectUnknown)
+        try expect(receipt.recoveryAction?.contains("automatic recreation is prohibited") == true)
+    }
+
+    await test("CR35 cancellation before EventKit create produces no calendar item") {
+        let request = syncRequest(key: "cancel-before-calendar")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        let locks = InMemoryCalendarRegistryProcessLockCoordinator()
+        let gate = CalendarRegistryOperationGate()
+        try await gate.acquire(request.idempotencyKey)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, processLocks: locks, operationGate: gate)
+        let task = Task { try await engine.registryFirstCreate(request) }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        task.cancel()
+        await gate.release(request.idempotencyKey)
+        do { _ = try await task.value } catch is CancellationError {}
+        try expect(await calendar.persistedCount() == 0)
+    }
+
+    await test("CR36 cancellation after calendar side effect records unknown state") {
+        let request = syncRequest(key: "cancel-after-effect")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.persistThenSuspend)
+        let task = Task { try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request) }
+        await calendar.createEntered.wait()
+        task.cancel()
+        let receipt = try await task.value
+        try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
+        try expect(await calendar.persistedCount() == 1)
+    }
+
+    await test("CR37 exact malformed metadata target conflicts") {
+        let request = syncRequest(key: "malformed-target")
+        let store = PersistentCalendarStore()
+        await store.seed(CalendarEvent(
+            id: "target", title: request.title,
+            start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
+            allDay: false, calendarId: request.calendarId, calendarTitle: "Private Smoke",
+            location: request.location,
+            notes: CalendarRegistryCalendarMetadata.beginMarker + "\nSync-Key: \(request.idempotencyKey)",
+            timeZoneIdentifier: request.timeZoneIdentifier
+        ))
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        do {
+            _ = try await provider.recover(CalendarRecoveryQuery(
+                syncKey: request.idempotencyKey,
+                operationFingerprint: request.manifest.fingerprint,
+                calendarId: request.calendarId,
+                title: request.title,
+                start: request.start,
+                end: request.end
+            ))
+            throw TestError.assertion("target metadata should conflict")
+        } catch CalendarRegistrySyncError.identityConflict {}
+    }
+
+    await test("CR38 arbitrary user-note substring does not poison recovery") {
+        let request = syncRequest(key: "substring-key")
+        let store = PersistentCalendarStore()
+        await store.seed(CalendarEvent(
+            id: "unrelated", title: "Other",
+            start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
+            allDay: false, calendarId: request.calendarId, calendarTitle: "Private Smoke",
+            location: nil,
+            notes: "Discuss \(request.idempotencyKey)\n" + CalendarRegistryCalendarMetadata.beginMarker + "\ninvalid",
+            timeZoneIdentifier: request.timeZoneIdentifier
+        ))
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        let recovered = try await provider.recover(CalendarRecoveryQuery(
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            calendarId: request.calendarId,
+            title: request.title,
+            start: request.start,
+            end: request.end
+        ))
+        try expect(recovered.isEmpty)
+    }
+
+    await test("CR39 absent provider modification time remains nil") {
+        let request = syncRequest(key: "provider-time")
+        let store = PersistentCalendarStore()
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        let created = try await provider.create(ExternalCalendarDraft(
+            title: request.title,
+            start: request.start,
+            end: request.end,
+            timeZoneIdentifier: request.timeZoneIdentifier,
+            calendarId: request.calendarId,
+            location: request.location,
+            notes: request.notes,
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint
+        ))
+        try expect(created.updatedAt == nil)
+    }
+
+    await test("CR40 composition remains disabled by default") {
+        do {
+            _ = try CalendarRegistrySyncComposition.build(
+                entity: scheduleEntityForSyncTests(),
+                registryGateway: SyncRegistryGateway(),
+                calendarStore: PersistentCalendarStore(),
+                environment: [:]
+            )
+            throw TestError.assertion("composition should be disabled")
+        } catch CalendarRegistrySyncCompositionError.disabled {}
+    }
+
+    await test("CR41 composition builds only with local canonical coordinator") {
+        try await withTempDirectory { directory in
+            let engine = try CalendarRegistrySyncComposition.build(
+                entity: scheduleEntityForSyncTests(),
+                registryGateway: SyncRegistryGateway(),
+                calendarStore: PersistentCalendarStore(),
+                environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"],
+                allowedCalendarIds: ["cal-private"],
+                ledgerURL: directory.appendingPathComponent("ledger.sqlite3")
+            )
+            _ = engine
+            let lockRoot = directory.appendingPathComponent("calendar-registry-locks")
+            try expect(FileManager.default.fileExists(atPath: lockRoot.path))
+        }
+    }
+
+    await test("CR42 migration artifact decodes against registry roles") {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("docs/migrations/calendar-registry-v1/registry-entity-patch.json")
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        let properties = object?["additiveProperties"] as? [[String: Any]] ?? []
+        try expect(object?["schemaVersion"] as? Int == 2)
+        try expect(properties.count == 2)
+        for property in properties {
+            let role = property["role"] as? String
+            try expect(role == RegistryPropertyRole.generic.rawValue)
+        }
+    }
+
+    await test("CR43 strict query decoder rejects malformed rows") {
+        let malformed = try JSONSerialization.data(withJSONObject: [
+            "results": [["id": "page-without-properties"]], "has_more": false
+        ])
+        do {
+            _ = try RegistryQueryResponseDecoder.decode(malformed)
+            throw TestError.assertion("malformed query row should fail")
+        } catch RegistryGatewayError.invalidResponse {}
+    }
+
+    await test("CR44 schema v2 registry-created rows migrate to registry-verified") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("migration.sqlite3")
+            var db: OpaquePointer?
+            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+            defer { if let db { sqlite3_close_v2(db) } }
+            let sql = """
+            CREATE TABLE calendar_registry_schema (id INTEGER PRIMARY KEY CHECK(id=1), version INTEGER NOT NULL);
+            INSERT INTO calendar_registry_schema(id,version) VALUES(1,2);
+            CREATE TABLE calendar_registry_transactions (
+              idempotency_key TEXT PRIMARY KEY NOT NULL, operation_id TEXT NOT NULL,
+              manifest_fingerprint TEXT NOT NULL, stage TEXT NOT NULL, registry_event_id TEXT,
+              calendar_event_id TEXT, calendar_id TEXT, provider_external_id TEXT,
+              created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_verified_at TEXT,
+              last_error TEXT, partial_effects_json TEXT NOT NULL, revision INTEGER NOT NULL DEFAULT 1,
+              lease_owner TEXT, lease_token TEXT, lease_expires_at REAL, heartbeat_at REAL
+            );
+            INSERT INTO calendar_registry_transactions VALUES(
+              'legacy','op','fingerprint','registryCreated','page',NULL,NULL,NULL,
+              '2027-01-01T00:00:00.000Z','2027-01-01T00:00:00.000Z',NULL,NULL,'[]',1,NULL,NULL,NULL,NULL
+            );
+            """
+            try expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+            if let db { sqlite3_close_v2(db) }
+            db = nil
+            let store = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let migrated = try await store.get(idempotencyKey: "legacy")
+            try expect(migrated?.stage == .registryVerified)
+        }
+    }
+
+    await test("CR45 unknown future ledger schema is refused") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("future.sqlite3")
+            var db: OpaquePointer?
+            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+            try expect(sqlite3_exec(db, "CREATE TABLE calendar_registry_schema (id INTEGER PRIMARY KEY, version INTEGER NOT NULL); INSERT INTO calendar_registry_schema(id,version) VALUES(1,99);", nil, nil, nil) == SQLITE_OK)
+            if let db { sqlite3_close_v2(db) }
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: url)
+                throw TestError.assertion("future schema should fail")
+            } catch CalendarRegistryTransactionStoreError.corruptLedger {}
+        }
+    }
+
+    await test("CR46 corrupted partial-effect evidence is refused") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("corrupt.sqlite3")
+            let store = try SQLiteCalendarRegistryTransactionStore(url: url)
+            _ = try await claim(store, key: "corrupt", exclusive: true)
+            var db: OpaquePointer?
+            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+            defer { if let db { sqlite3_close_v2(db) } }
+            try expect(sqlite3_exec(db, "UPDATE calendar_registry_transactions SET partial_effects_json='bad' WHERE idempotency_key='corrupt';", nil, nil, nil) == SQLITE_OK)
+            do {
+                _ = try await store.get(idempotencyKey: "corrupt")
+                throw TestError.assertion("corrupt evidence should fail")
+            } catch CalendarRegistryTransactionStoreError.corruptLedger {}
+        }
+    }
+
+    await test("CR47 OS lock permits exclusive takeover despite stale SQLite lease") {
+        try await withTempDirectory { directory in
+            let store = try SQLiteCalendarRegistryTransactionStore(url: directory.appendingPathComponent("ledger.sqlite3"))
+            let first = try await claim(store, key: "takeover", operation: "first", token: "first", exclusive: false, duration: 600)
+            let second = try await claim(store, key: "takeover", operation: "second", token: "second", exclusive: true, duration: 600)
+            try expect(second.revision > first.revision)
+            try expect(second.leaseToken == "second")
+        }
+    }
+
+    await test("CR48 expired lease alone does not authorize a second writer") {
+        try await withTempDirectory { directory in
+            let store = try SQLiteCalendarRegistryTransactionStore(url: directory.appendingPathComponent("ledger.sqlite3"))
+            _ = try await claim(store, key: "no-exclusive", operation: "first", token: "first", exclusive: false, duration: 600)
+            do {
+                _ = try await claim(store, key: "no-exclusive", operation: "second", token: "second", exclusive: false, duration: 600)
+                throw TestError.assertion("active lease should fail without OS ownership")
+            } catch CalendarRegistryTransactionStoreError.operationActive {}
+        }
+    }
+
+    await test("CR49 route ownership remains explicit") {
+        try expect(CalendarRegistryRouteClassifier.owner(for: .semanticScheduling) == .timeKeepr)
+        try expect(CalendarRegistryRouteClassifier.owner(for: .calendarMechanics) == .macKeepr)
+        try expect(CalendarRegistryRouteClassifier.owner(for: .schemaChange) == .notionKeepr)
+    }
+
+    await test("CR50 child processes hold one external writer beyond lease duration") {
+        try await withTempDirectory { directory in
+            let binary = URL(fileURLWithPath: CommandLine.arguments[0]).standardizedFileURL
+            let key = "child-process-lock"
+            let first = Process()
+            first.executableURL = binary
+            first.arguments = ["--calendar-registry-process-probe", directory.path, key, "1500"]
+            try first.run()
+
+            let entered = directory.appendingPathComponent("provider-entered")
+            let deadline = Date().addingTimeInterval(10)
+            while !FileManager.default.fileExists(atPath: entered.path), Date() < deadline {
+                try await Task.sleep(nanoseconds: 20_000_000)
+            }
+            try expect(FileManager.default.fileExists(atPath: entered.path), "first child did not enter provider create")
+
+            let second = Process()
+            second.executableURL = binary
+            second.arguments = ["--calendar-registry-process-probe", directory.path, key, "0"]
+            try second.run()
+            second.waitUntilExit()
+            first.waitUntilExit()
+
+            try expect(first.terminationStatus == 0)
+            try expect(second.terminationStatus == 42)
+            let countURL = directory.appendingPathComponent("calendar-create-count")
+            let count = Int((try String(contentsOf: countURL, encoding: .utf8)).trimmingCharacters(in: .whitespacesAndNewlines))
+            try expect(count == 1)
+        }
+    }
+}
+
+// MARK: - Child-process probe
+
+func calendarRegistryProcessProbeExitCodeIfRequested() -> Int32? {
+    let args = CommandLine.arguments
+    guard let index = args.firstIndex(of: "--calendar-registry-process-probe"), args.count >= index + 4 else {
+        return nil
+    }
+    let root = URL(fileURLWithPath: args[index + 1], isDirectory: true)
+    let key = args[index + 2]
+    let holdMilliseconds = UInt64(args[index + 3]) ?? 0
+    let semaphore = DispatchSemaphore(value: 0)
+    nonisolated(unsafe) var result: Int32 = 1
+    Task.detached {
+        do {
+            let request = RegistryFirstTimeInstanceRequest(
+                idempotencyKey: key,
+                registryEventId: "probe-event",
+                title: "Probe",
+                start: Date(timeIntervalSince1970: 1_800_010_000),
+                end: Date(timeIntervalSince1970: 1_800_013_600),
+                timeZoneIdentifier: "America/Chicago",
+                calendarId: "cal-private",
+                notes: "Probe",
+                semantics: TimeInstanceSemantics(eventClass: .focus, primaryBlockId: "block-probe")
+            )
+            let registry = ProbeRegistry(request: request)
+            let calendar = ProbeCalendar(root: root, holdMilliseconds: holdMilliseconds)
+            let ledger = try SQLiteCalendarRegistryTransactionStore(url: root.appendingPathComponent("probe.sqlite3"))
+            let locks = try FileCalendarRegistryProcessLockCoordinator(
+                rootURL: root.appendingPathComponent("locks", isDirectory: true)
+            )
+            let engine = CalendarRegistrySyncEngine(
+                registry: registry,
+                calendar: calendar,
+                transactions: ledger,
+                processLocks: locks,
+                operationGate: CalendarRegistryOperationGate(),
+                clock: { Date(timeIntervalSince1970: 1_800_000_000) },
+                leaseDuration: 0.1
+            )
+            let receipt = try await engine.registryFirstCreate(request)
+            if receipt.succeeded { result = 0 }
+            else if receipt.discrepancy?.contains("already active in another process") == true { result = 42 }
+            else { result = 2 }
+        } catch {
+            fputs("probe failed: \(error)\n", stderr)
+            result = 3
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result
+}
+
+private actor ProbeRegistry: TimeInstanceRegistryStoring {
+    private var record: TimeInstanceRecord
+    init(request: RegistryFirstTimeInstanceRequest) { record = canonicalRecord(request) }
+    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
+        RegistryIdentityLookup(records: record.syncKey == syncKey ? [record] : [], source: .live)
+    }
+    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
+        _ = forceRefresh
+        return id == record.id ? .decoded(record) : .missing
+    }
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        _ = forceRefresh
+        return id == record.id ? record : nil
+    }
+    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        self.record = record
+        return record
+    }
+}
+
+private actor ProbeCalendar: CalendarSyncProviding {
+    private let root: URL
+    private let holdMilliseconds: UInt64
+    init(root: URL, holdMilliseconds: UInt64) {
+        self.root = root
+        self.holdMilliseconds = holdMilliseconds
+    }
+    func qualify(calendarId: String) async throws -> CalendarQualification {
+        CalendarQualification(
+            calendarId: calendarId, title: "Private", allowsModify: true,
+            explicitlyAllowlisted: true, calendarType: "local", sourceType: "local",
+            qualifiedForPrivateSmoke: true
+        )
+    }
+    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
+        let item = ExternalCalendarItem(
+            provider: "Probe Calendar",
+            calendarId: draft.calendarId,
+            localEventId: "probe-calendar-event",
+            providerExternalId: "probe-external",
+            syncKey: draft.syncKey,
+            operationFingerprint: draft.operationFingerprint,
+            title: draft.title,
+            start: draft.start,
+            end: draft.end,
+            timeZoneIdentifier: draft.timeZoneIdentifier,
+            location: draft.location,
+            notes: draft.notes,
+            updatedAt: nil
+        )
+        let payload: [String: Any] = [
+            "syncKey": draft.syncKey,
+            "fingerprint": draft.operationFingerprint,
+            "title": draft.title,
+            "start": CalendarRegistryISO.string(draft.start),
+            "end": CalendarRegistryISO.string(draft.end),
+            "timezone": draft.timeZoneIdentifier,
+            "calendarId": draft.calendarId,
+            "location": draft.location as Any,
+            "notes": draft.notes as Any
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        try data.write(to: root.appendingPathComponent("calendar-item.json"), options: .atomic)
+        let countURL = root.appendingPathComponent("calendar-create-count")
+        let old = (try? String(contentsOf: countURL, encoding: .utf8)).flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+        try String(old + 1).write(to: countURL, atomically: true, encoding: .utf8)
+        try Data().write(to: root.appendingPathComponent("provider-entered"), options: .atomic)
+        if holdMilliseconds > 0 {
+            try await Task.sleep(nanoseconds: holdMilliseconds * 1_000_000)
+        }
+        return item
+    }
+    func item(id: String) async throws -> ExternalCalendarItem? {
+        guard id == "probe-calendar-event" else { return nil }
+        return try load()
+    }
+    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
+        guard let item = try load() else { return [] }
+        return item.syncKey == query.syncKey && item.operationFingerprint == query.operationFingerprint ? [item] : []
+    }
+    private func load() throws -> ExternalCalendarItem? {
+        let url = root.appendingPathComponent("calendar-item.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        guard let object,
+              let key = object["syncKey"] as? String,
+              let fingerprint = object["fingerprint"] as? String,
+              let title = object["title"] as? String,
+              let startRaw = object["start"] as? String,
+              let endRaw = object["end"] as? String,
+              let start = CalendarRegistryISO.date(startRaw),
+              let end = CalendarRegistryISO.date(endRaw),
+              let timezone = object["timezone"] as? String,
+              let calendarId = object["calendarId"] as? String else { return nil }
+        return ExternalCalendarItem(
+            provider: "Probe Calendar",
+            calendarId: calendarId,
+            localEventId: "probe-calendar-event",
+            providerExternalId: "probe-external",
+            syncKey: key,
+            operationFingerprint: fingerprint,
+            title: title,
+            start: start,
+            end: end,
+            timeZoneIdentifier: timezone,
+            location: object["location"] as? String,
+            notes: object["notes"] as? String,
+            updatedAt: nil
+        )
+    }
 }

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -1,0 +1,563 @@
+// CalendarRegistrySyncEngineTests.swift — reduced registry-first durability matrix
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+private actor SyncTestRegistry: TimeInstanceRegistryStoring {
+    private var records: [String: TimeInstanceRecord] = [:]
+    private var sequence = 0
+    private var failNextSave = false
+    private var lookupSource: RegistryLookupSource = .live
+    private(set) var createCount = 0
+
+    func setFailNextSave(_ value: Bool) { failNextSave = value }
+    func setLookupSource(_ source: RegistryLookupSource) { lookupSource = source }
+    func count() -> Int { records.count }
+    func createdCount() -> Int { createCount }
+    func allRecords() -> [TimeInstanceRecord] { Array(records.values) }
+
+    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
+        RegistryIdentityLookup(
+            records: records.values.filter { $0.syncKey == syncKey },
+            source: lookupSource
+        )
+    }
+
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        _ = forceRefresh
+        return records[id]
+    }
+
+    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        sequence += 1
+        createCount += 1
+        var created = record
+        created.id = "notion-event-\(sequence)"
+        records[created.id] = created
+        return created
+    }
+
+    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+        if failNextSave {
+            failNextSave = false
+            throw SyncTestError.forcedRegistrySave
+        }
+        records[record.id] = record
+        return record
+    }
+}
+
+private enum SyncTestError: Error, LocalizedError {
+    case forcedCalendarCreate
+    case forcedRegistrySave
+    case forcedVerificationMiss
+
+    var errorDescription: String? {
+        switch self {
+        case .forcedCalendarCreate: return "forced calendar create failure"
+        case .forcedRegistrySave: return "forced registry save failure"
+        case .forcedVerificationMiss: return "forced verification miss"
+        }
+    }
+}
+
+private actor SyncTestCalendar: CalendarSyncProviding {
+    private var items: [String: ExternalCalendarItem] = [:]
+    private var sequence = 0
+    private var failNextCreate = false
+    private var missNextItem = false
+    private var ambiguousRecovery = false
+    private(set) var createCount = 0
+
+    func setFailNextCreate(_ value: Bool) { failNextCreate = value }
+    func setMissNextItem(_ value: Bool) { missNextItem = value }
+    func setAmbiguousRecovery(_ value: Bool) { ambiguousRecovery = value }
+    func createdCount() -> Int { createCount }
+    func count() -> Int { items.count }
+
+    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
+        if failNextCreate {
+            failNextCreate = false
+            throw SyncTestError.forcedCalendarCreate
+        }
+        sequence += 1
+        createCount += 1
+        let id = "calendar-event-\(sequence)"
+        let item = ExternalCalendarItem(
+            provider: "Fixture Calendar",
+            calendarId: draft.calendarId ?? "cal-private",
+            localEventId: id,
+            providerExternalId: "provider-\(sequence)",
+            syncKey: draft.syncKey,
+            title: draft.title,
+            start: draft.start,
+            end: draft.end,
+            timeZoneIdentifier: draft.timeZoneIdentifier,
+            location: draft.location,
+            notes: draft.notes,
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        items[id] = item
+        return item
+    }
+
+    func item(id: String) async throws -> ExternalCalendarItem? {
+        if missNextItem {
+            missNextItem = false
+            return nil
+        }
+        return items[id]
+    }
+
+    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
+        if ambiguousRecovery {
+            let base = ExternalCalendarItem(
+                provider: "Fixture Calendar", calendarId: query.calendarId ?? "cal-private",
+                localEventId: "ambiguous-a", syncKey: query.syncKey,
+                title: query.title, start: query.start, end: query.end,
+                updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+            )
+            var other = base
+            other.localEventId = "ambiguous-b"
+            return [base, other]
+        }
+        if let id = query.localEventId, let direct = items[id] { return [direct] }
+        let byKey = items.values.filter { $0.syncKey == query.syncKey }
+        if !byKey.isEmpty { return Array(byKey) }
+        if let external = query.providerExternalId {
+            let byExternal = items.values.filter { $0.providerExternalId == external }
+            if !byExternal.isEmpty { return Array(byExternal) }
+        }
+        return items.values.filter {
+            $0.title == query.title && $0.start == query.start && $0.end == query.end
+        }
+    }
+}
+
+private func syncRequest(
+    key: String = "operation-lift-2027-01-15",
+    title: String = "LIFT"
+) -> RegistryFirstTimeInstanceRequest {
+    RegistryFirstTimeInstanceRequest(
+        idempotencyKey: key,
+        title: title,
+        start: Date(timeIntervalSince1970: 1_800_010_000),
+        end: Date(timeIntervalSince1970: 1_800_013_600),
+        timeZoneIdentifier: "America/Chicago",
+        calendarId: "cal-private",
+        location: "Private Gym",
+        notes: "Disposable fixture",
+        semantics: TimeInstanceSemantics(
+            eventClass: .focus,
+            primaryBlockId: "block-lift",
+            blockIds: ["block-lift"]
+        )
+    )
+}
+
+private func makeSyncEngine(
+    registry: SyncTestRegistry = SyncTestRegistry(),
+    calendar: SyncTestCalendar = SyncTestCalendar(),
+    transactions: any CalendarRegistryTransactionStoring = InMemoryCalendarRegistryTransactionStore(),
+    operationGate: CalendarRegistryOperationGate = CalendarRegistryOperationGate()
+) -> CalendarRegistrySyncEngine {
+    CalendarRegistrySyncEngine(
+        registry: registry,
+        calendar: calendar,
+        transactions: transactions,
+        operationGate: operationGate,
+        clock: { Date(timeIntervalSince1970: 1_800_000_000) },
+        makeOperationId: { "operation-id-fixture" }
+    )
+}
+
+private func withTempTransactionJournal(
+    _ body: (URL) async throws -> Void
+) async throws {
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("bridge-calendar-sync-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    try await body(directory.appendingPathComponent("transactions.json"))
+}
+
+// MARK: - Notion adapter fixture
+
+private actor SyncRegistryGateway: RegistryNotionGateway {
+    nonisolated var supportsAuthoritativeFiltering: Bool { true }
+    var pages: [String: NotionRow] = [:]
+    var failUpdate = false
+    var filteredQueryCalls = 0
+    var lastFilter: Data?
+    private var sequence = 0
+    private(set) var lastUpdatedFields: [BoundField] = []
+
+    func setFailUpdate(_ value: Bool) { failUpdate = value }
+    func updatedFields() -> [BoundField] { lastUpdatedFields }
+
+    func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema {
+        _ = dataSourceId; _ = workspace
+        return DataSourceSchema(columnsByName: [:])
+    }
+
+    func query(dataSourceId: String, workspace: String?, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
+        _ = dataSourceId; _ = workspace; _ = pageSize; _ = startCursor
+        return (Array(pages.values), nil)
+    }
+
+    func query(dataSourceId: String, workspace: String?, filter: Data, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
+        _ = dataSourceId; _ = workspace; _ = pageSize; _ = startCursor
+        filteredQueryCalls += 1
+        lastFilter = filter
+        let object = (try? JSONSerialization.jsonObject(with: filter) as? [String: Any]) ?? [:]
+        let rich = object["rich_text"] as? [String: Any]
+        let wanted = rich?["equals"] as? String
+        let rows = pages.values.filter { row in
+            row.cells.values.contains { cell in
+                cell.type == "rich_text" && cell.value == .string(wanted ?? "")
+            }
+        }
+        return (Array(rows), nil)
+    }
+
+    func page(pageId: String, workspace: String?) async throws -> NotionRow {
+        _ = workspace
+        guard let row = pages[pageId] ?? pages[CachedRow.normalize(pageId)] else {
+            throw SyncTestError.forcedVerificationMiss
+        }
+        return row
+    }
+
+    func create(dataSourceId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
+        _ = dataSourceId; _ = workspace
+        sequence += 1
+        let id = String(format: "%032d", sequence)
+        let row = Self.row(id: id, existing: nil, fields: fields)
+        pages[id] = row
+        return row
+    }
+
+    func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
+        _ = workspace
+        if failUpdate {
+            failUpdate = false
+            throw SyncTestError.forcedRegistrySave
+        }
+        lastUpdatedFields = fields
+        let row = Self.row(id: pageId, existing: pages[pageId], fields: fields)
+        pages[pageId] = row
+        return row
+    }
+
+    func archive(pageId: String, workspace: String?) async throws { pages[pageId] = nil }
+    func markdown(pageId: String, workspace: String?) async throws -> String { "" }
+    func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {}
+
+    private static func row(id: String, existing: NotionRow?, fields: [BoundField]) -> NotionRow {
+        var cells = existing?.cells ?? [:]
+        for field in fields {
+            cells[field.notionName] = NotionCell(
+                id: field.propertyId, type: field.type, value: field.value
+            )
+        }
+        return NotionRow(
+            id: id, url: "https://notion.fixture/\(id)",
+            lastEditedTime: "2027-01-15T08:00:00.000Z", cells: cells
+        )
+    }
+}
+
+private func scheduleEntityForSyncTests() -> RegistryEntity {
+    let definitions: [(String, String, String, RegistryPropertyRole)] = [
+        ("title", "EVENT TITLE", "title", .title),
+        ("date", "EVENT DATE", "date", .date),
+        ("status", "Status", "status", .status),
+        ("syncKey", "Sync Key", "rich_text", .generic),
+        ("eventClass", "Event Class", "select", .generic),
+        ("meetingType", "Meeting Type", "select", .generic),
+        ("primaryBlock", "Primary BLOCK", "relation", .relation),
+        ("blocks", "BLOCKS", "relation", .relation),
+        ("projects", "PROJECTS", "relation", .relation),
+        ("contacts", "CONTACTS", "relation", .relation),
+        ("schedulingAuthority", "Scheduling Authority", "select", .generic),
+        ("syncState", "Sync State", "select", .generic),
+        ("registryUpdatedAt", "Registry Updated At", "date", .date),
+        ("syncHash", "Sync Hash", "rich_text", .generic),
+        ("scheduledDuration", "Scheduled Duration", "number", .generic),
+        ("description", "Description", "rich_text", .generic),
+        ("calendarLocation", "Calendar Location", "rich_text", .generic),
+        ("calendarProvider", "Calendar Provider", "select", .generic),
+        ("calendarId", "Calendar ID", "rich_text", .generic),
+        ("calendarEventId", "Calendar Event ID", "rich_text", .generic),
+        ("providerExternalId", "Provider External ID", "rich_text", .generic),
+        ("calendarUrl", "Calendar URL", "url", .generic),
+        ("lastSyncError", "Last Sync Error", "rich_text", .generic),
+        ("lastSyncedAt", "Last Synced At", "date", .date),
+        ("calendarUpdatedAt", "Calendar Updated At", "date", .date)
+    ]
+    return RegistryEntity(
+        key: "schedule", displayName: "EVENTS", dataSourceId: "events-ds",
+        properties: definitions.enumerated().map { index, item in
+            RegistryProperty(
+                key: item.0, notionName: item.1,
+                notionPropertyId: "property-\(index)", type: item.2, role: item.3
+            )
+        },
+        cacheTTLSeconds: 0
+    )
+}
+
+func runCalendarRegistrySyncEngineTests() async {
+    print("\n🗓 Calendar–Registry Sync — reduced durability slice")
+
+    await test("CR1 atomic transaction journal survives store reconstruction") {
+        try await withTempTransactionJournal { url in
+            let first = try JSONCalendarRegistryTransactionStore(url: url)
+            var transaction = try await first.claim(
+                idempotencyKey: "same-key", manifestFingerprint: "manifest",
+                operationId: "op-1", now: Date(timeIntervalSince1970: 100)
+            )
+            transaction.stage = .calendarCreated
+            transaction.calendarEventId = "calendar-1"
+            try await first.save(transaction)
+
+            let second = try JSONCalendarRegistryTransactionStore(url: url)
+            let loaded = try await second.get(idempotencyKey: "same-key")
+            try expect(loaded?.stage == .calendarCreated)
+            try expect(loaded?.calendarEventId == "calendar-1")
+        }
+    }
+
+    await test("CR2 ten sequential retries create exactly one pair") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        for _ in 0..<10 {
+            let receipt = try await engine.registryFirstCreate(syncRequest())
+            try expect(receipt.succeeded)
+            try expect(receipt.stageAfter == .synced)
+        }
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 1)
+    }
+
+    await test("CR3 concurrent same-key calls across engines create one pair") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        let transactions = InMemoryCalendarRegistryTransactionStore()
+        let gate = CalendarRegistryOperationGate()
+        let first = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions, operationGate: gate)
+        let second = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions, operationGate: gate)
+        async let a = first.registryFirstCreate(syncRequest())
+        async let b = second.registryFirstCreate(syncRequest())
+        let receipts = try await [a, b]
+        try expect(receipts.allSatisfy(\.succeeded))
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 1)
+    }
+
+    await test("CR4 reusing an idempotency key for a different manifest conflicts") {
+        let engine = makeSyncEngine()
+        _ = try await engine.registryFirstCreate(syncRequest())
+        let receipt = try await engine.registryFirstCreate(syncRequest(title: "Different"))
+        try expect(!receipt.succeeded)
+        try expect(receipt.stageAfter == .conflict)
+        try expect(receipt.discrepancy?.contains("different manifest") == true)
+    }
+
+    await test("CR5 calendar create failure resumes without a second EVENT") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        await calendar.setFailNextCreate(true)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let first = try await engine.registryFirstCreate(syncRequest())
+        try expect(!first.succeeded)
+        let second = try await engine.registryFirstCreate(syncRequest())
+        try expect(second.succeeded)
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 1)
+    }
+
+    await test("CR6 failure after calendar creation recovers the calendar item") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        await registry.setFailNextSave(true)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let first = try await engine.registryFirstCreate(syncRequest())
+        try expect(!first.succeeded)
+        try expect(first.partialEffects.contains(where: { $0.contains("calendar") }))
+        let second = try await engine.registryFirstCreate(syncRequest())
+        try expect(second.succeeded)
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 1)
+    }
+
+    await test("CR7 failed verification never reports Synced") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        await calendar.setMissNextItem(true)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let receipt = try await engine.registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.stageAfter == .recoverableError)
+        let records = await registry.allRecords()
+        try expect(records.allSatisfy { $0.syncState != .synced })
+    }
+
+    await test("CR8 fresh EventKit provider recovers an event after provider restart") {
+        let store = MockCalendarStore()
+        let firstProvider = CalendarStoringSyncProvider(store: store)
+        var request = syncRequest()
+        request.calendarId = "cal-home"
+        let created = try await firstProvider.create(ExternalCalendarDraft(
+            title: request.title, start: request.start, end: request.end,
+            timeZoneIdentifier: request.timeZoneIdentifier,
+            calendarId: request.calendarId, location: request.location,
+            notes: request.notes, syncKey: request.idempotencyKey
+        ))
+        let restartedProvider = CalendarStoringSyncProvider(store: store)
+        let recovered = try await restartedProvider.recover(CalendarRecoveryQuery(
+            localEventId: created.localEventId,
+            providerExternalId: created.providerExternalId,
+            syncKey: request.idempotencyKey,
+            calendarId: request.calendarId,
+            title: request.title, start: request.start, end: request.end
+        ))
+        try expect(recovered.count == 1)
+        try expect(recovered.first?.syncKey == request.idempotencyKey)
+    }
+
+    await test("CR9 ambiguous provider recovery stops in Conflict") {
+        let registry = SyncTestRegistry()
+        let calendar = SyncTestCalendar()
+        await calendar.setAmbiguousRecovery(true)
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let receipt = try await engine.registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.stageAfter == .conflict)
+        try expect(await calendar.createdCount() == 0)
+    }
+
+    await test("CR10 degraded registry identity lookup refuses creation") {
+        let registry = SyncTestRegistry()
+        await registry.setLookupSource(.staleCache)
+        let calendar = SyncTestCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let receipt = try await engine.registryFirstCreate(syncRequest())
+        try expect(!receipt.succeeded)
+        try expect(receipt.discrepancy?.contains("not live") == true)
+        try expect(await registry.createdCount() == 0)
+        try expect(await calendar.createdCount() == 0)
+    }
+
+    await test("CR11 date ranges preserve start, end, and timezone") {
+        let property: [String: Any] = [
+            "date": [
+                "start": "2027-01-15T08:00:00-06:00",
+                "end": "2027-01-15T09:00:00-06:00",
+                "time_zone": "America/Chicago"
+            ]
+        ]
+        let decoded = RegistryPropertyCodec.decode(type: "date", property: property)
+        guard case .object(let range) = decoded else {
+            throw TestError.assertion("date range did not decode as an object")
+        }
+        try expect(range["start"] == .string("2027-01-15T08:00:00-06:00"))
+        try expect(range["end"] == .string("2027-01-15T09:00:00-06:00"))
+        try expect(range["timeZone"] == .string("America/Chicago"))
+    }
+
+    await test("CR12 Notion adapter uses filtered identity lookup beyond list caps") {
+        let gateway = SyncRegistryGateway()
+        let entity = scheduleEntityForSyncTests()
+        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+        let record = TimeInstanceRecord(
+            title: "LIFT", scheduledStart: syncRequest().start,
+            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
+            syncKey: "target-key", semantics: syncRequest().semantics,
+            schedulingAuthority: .registry, syncState: .pendingCreate,
+            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        let created = try await store.create(record)
+        let found = try await store.findBySyncKey("target-key")
+        try expect(found.source == .live)
+        try expect(found.records.map(\.id) == [created.id])
+        try expect(await gateway.filteredQueryCalls == 1)
+    }
+
+    await test("CR13 Notion adapter emits explicit clears for nullable fields") {
+        let gateway = SyncRegistryGateway()
+        let entity = scheduleEntityForSyncTests()
+        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+        var record = TimeInstanceRecord(
+            id: "existing", title: "LIFT", scheduledStart: syncRequest().start,
+            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
+            syncKey: "clear-key", semantics: syncRequest().semantics,
+            schedulingAuthority: .registry, syncState: .error,
+            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            lastSyncError: "old error"
+        )
+        _ = try await gateway.create(dataSourceId: "events-ds", workspace: nil, fields: [
+            BoundField(propertyId: "property-0", notionName: "EVENT TITLE", type: "title", value: .string("LIFT"), isTitle: true)
+        ])
+        record.notes = nil
+        record.location = nil
+        record.lastSyncError = nil
+        _ = try await store.save(record)
+        let fields = await gateway.updatedFields()
+        let values = Dictionary(uniqueKeysWithValues: fields.map { ($0.notionName, $0.value) })
+        try expect(values["Description"] == .null)
+        try expect(values["Calendar Location"] == .null)
+        try expect(values["Last Sync Error"] == .null)
+    }
+
+    await test("CR14 partial Notion create exposes the created page identity") {
+        let gateway = SyncRegistryGateway()
+        await gateway.setFailUpdate(true)
+        let store = NotionTimeInstanceRegistryStore(
+            entity: scheduleEntityForSyncTests(), gateway: gateway
+        )
+        let record = TimeInstanceRecord(
+            title: "LIFT", scheduledStart: syncRequest().start,
+            scheduledEnd: syncRequest().end, timeZoneIdentifier: "America/Chicago",
+            syncKey: "partial-key", semantics: syncRequest().semantics,
+            schedulingAuthority: .registry, syncState: .pendingCreate,
+            registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        do {
+            _ = try await store.create(record)
+            throw TestError.assertion("expected partial create failure")
+        } catch let error as PartialRegistryCreateError {
+            try expect(!error.pageId.isEmpty)
+        }
+    }
+
+    await test("CR15 internal composition is disabled by default and validates bindings") {
+        let entity = scheduleEntityForSyncTests()
+        let gateway = SyncRegistryGateway()
+        do {
+            _ = try CalendarRegistrySyncComposition.build(
+                entity: entity, registryGateway: gateway,
+                calendarStore: MockCalendarStore(), environment: [:]
+            )
+            throw TestError.assertion("composition should be disabled")
+        } catch CalendarRegistrySyncCompositionError.disabled {
+            // expected
+        }
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("calendar-composition-\(UUID().uuidString)")
+        _ = try CalendarRegistrySyncComposition.build(
+            entity: entity, registryGateway: gateway,
+            calendarStore: MockCalendarStore(),
+            environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"],
+            journalURL: directory.appendingPathComponent("journal.json")
+        )
+    }
+
+    await test("CR16 route ownership remains explicit") {
+        try expect(CalendarRegistryRouteClassifier.owner(for: .semanticScheduling) == .timeKeepr)
+        try expect(CalendarRegistryRouteClassifier.owner(for: .calendarMechanics) == .macKeepr)
+        try expect(CalendarRegistryRouteClassifier.owner(for: .schemaChange) == .notionKeepr)
+    }
+}

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import Darwin
 import MCP
 import SQLite3
+import Synchronization
 import TheBridgeLib
 
 private enum SyncTestError: Error, LocalizedError {
@@ -2002,7 +2003,7 @@ func calendarRegistryProcessProbeExitCodeIfRequested() -> Int32? {
     let key = args[index + 2]
     let holdMilliseconds = UInt64(args[index + 3]) ?? 0
     let semaphore = DispatchSemaphore(value: 0)
-    nonisolated(unsafe) var result: Int32 = 1
+    let result = Mutex<Int32>(1)
     Task.detached {
         do {
             let request = RegistryFirstTimeInstanceRequest(
@@ -2032,17 +2033,19 @@ func calendarRegistryProcessProbeExitCodeIfRequested() -> Int32? {
                 leaseDuration: 0.1
             )
             let receipt = try await engine.registryFirstCreate(request)
-            if receipt.succeeded { result = 0 }
-            else if receipt.discrepancy?.contains("already active in another process") == true { result = 42 }
-            else { result = 2 }
+            result.withLock { value in
+                if receipt.succeeded { value = 0 }
+                else if receipt.discrepancy?.contains("already active in another process") == true { value = 42 }
+                else { value = 2 }
+            }
         } catch {
             fputs("probe failed: \(error)\n", stderr)
-            result = 3
+            result.withLock { $0 = 3 }
         }
         semaphore.signal()
     }
     semaphore.wait()
-    return result
+    return result.withLock { $0 }
 }
 
 private struct CrashProbeOutcome: Codable {
@@ -2113,7 +2116,7 @@ private func calendarRegistryCrashProbeExitCode(
     checkpointRawValue: String
 ) -> Int32 {
     let semaphore = DispatchSemaphore(value: 0)
-    nonisolated(unsafe) var result: Int32 = 1
+    let result = Mutex<Int32>(1)
     Task.detached {
         do {
             let request = RegistryFirstTimeInstanceRequest(
@@ -2158,21 +2161,23 @@ private func calendarRegistryCrashProbeExitCode(
             try JSONEncoder().encode(outcome).write(
                 to: root.appendingPathComponent("crash-probe-outcome.json"), options: .atomic
             )
-            if selected != nil {
-                result = 4
-            } else if receipt.succeeded || receipt.stageAfter == .operatorReview {
-                result = count <= 1 ? 0 : 5
-            } else {
-                result = 6
+            result.withLock { value in
+                if selected != nil {
+                    value = 4
+                } else if receipt.succeeded || receipt.stageAfter == .operatorReview {
+                    value = count <= 1 ? 0 : 5
+                } else {
+                    value = 6
+                }
             }
         } catch {
             fputs("crash probe failed: \(error)\n", stderr)
-            result = 7
+            result.withLock { $0 = 7 }
         }
         semaphore.signal()
     }
     semaphore.wait()
-    return result
+    return result.withLock { $0 }
 }
 
 private func crashProbeCalendarCreateCount(root: URL) -> Int {

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -1,6 +1,7 @@
 // CalendarRegistrySyncEngineTests.swift — forward-only registry-first pairing contract
 
 import Foundation
+import Darwin
 import MCP
 import SQLite3
 import TheBridgeLib
@@ -1925,12 +1926,75 @@ func runCalendarRegistrySyncEngineTests() async {
         }
     }
 
+    let crashCheckpoints = CalendarRegistryDurableCheckpoint.allCases
+    for (offset, checkpoint) in crashCheckpoints.enumerated() {
+        await test("CR\(81 + offset) process termination after \(checkpoint.rawValue) remains at-most-once") {
+            try await withTempDirectory { directory in
+                let binary = URL(fileURLWithPath: CommandLine.arguments[0]).standardizedFileURL
+                let key = "crash-\(checkpoint.rawValue)"
+
+                let crashed = Process()
+                crashed.executableURL = binary
+                crashed.arguments = [
+                    "--calendar-registry-crash-probe", directory.path, key, checkpoint.rawValue
+                ]
+                try crashed.run()
+                crashed.waitUntilExit()
+                try expect(
+                    crashed.terminationReason == .exit && crashed.terminationStatus == 86,
+                    "checkpoint child did not terminate at \(checkpoint.rawValue): reason=\(crashed.terminationReason) status=\(crashed.terminationStatus)"
+                )
+
+                for attempt in 1...2 {
+                    let recovery = Process()
+                    recovery.executableURL = binary
+                    recovery.arguments = [
+                        "--calendar-registry-crash-probe", directory.path, key, "recover"
+                    ]
+                    try recovery.run()
+                    recovery.waitUntilExit()
+                    try expect(
+                        recovery.terminationReason == .exit && recovery.terminationStatus == 0,
+                        "recovery \(attempt) failed after \(checkpoint.rawValue): reason=\(recovery.terminationReason) status=\(recovery.terminationStatus)"
+                    )
+                }
+
+                let outcomeURL = directory.appendingPathComponent("crash-probe-outcome.json")
+                let outcome = try JSONDecoder().decode(
+                    CrashProbeOutcome.self, from: Data(contentsOf: outcomeURL)
+                )
+                let reviewOnly = checkpoint == .createInvocationRegistryPersisted
+                    || checkpoint == .createInvocationLedgerPersisted
+                try expect(outcome.calendarCreateCount == (reviewOnly ? 0 : 1))
+                try expect(outcome.succeeded == !reviewOnly)
+                try expect(outcome.stage == (reviewOnly
+                    ? CalendarRegistryTransactionStage.operatorReview.rawValue
+                    : CalendarRegistryTransactionStage.complete.rawValue))
+            }
+        }
+    }
+
+    await test("CR96 legacy procedural recovery helpers are absent") {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        try expect(!source.contains("func resolveOrCreateCalendar("))
+        try expect(!source.contains("func adoptExistingCalendarIdentity("))
+    }
+
 }
 
 // MARK: - Child-process probe
 
 func calendarRegistryProcessProbeExitCodeIfRequested() -> Int32? {
     let args = CommandLine.arguments
+    if let index = args.firstIndex(of: "--calendar-registry-crash-probe"), args.count >= index + 4 {
+        return calendarRegistryCrashProbeExitCode(
+            root: URL(fileURLWithPath: args[index + 1], isDirectory: true),
+            key: args[index + 2],
+            checkpointRawValue: args[index + 3]
+        )
+    }
     guard let index = args.firstIndex(of: "--calendar-registry-process-probe"), args.count >= index + 4 else {
         return nil
     }
@@ -1979,6 +2043,208 @@ func calendarRegistryProcessProbeExitCodeIfRequested() -> Int32? {
     }
     semaphore.wait()
     return result
+}
+
+private struct CrashProbeOutcome: Codable {
+    var succeeded: Bool
+    var stage: String
+    var calendarCreateCount: Int
+}
+
+private struct CrashRegistryState: Codable {
+    var calendarProvider: String?
+    var calendarId: String?
+    var calendarEventId: String?
+    var providerExternalId: String?
+    var calendarItemURL: String?
+    var createInvocationId: String?
+    var syncWriterToken: String?
+    var syncRevision: Int
+    var syncState: TimeInstanceSyncState
+    var lastSyncedAt: Date?
+    var registryUpdatedAt: Date
+    var calendarUpdatedAt: Date?
+    var syncHash: String
+    var lastSyncError: String?
+    var registryRevision: String?
+
+    init(_ record: TimeInstanceRecord) {
+        calendarProvider = record.calendarProvider
+        calendarId = record.calendarId
+        calendarEventId = record.calendarEventId
+        providerExternalId = record.providerExternalId
+        calendarItemURL = record.calendarItemURL
+        createInvocationId = record.createInvocationId
+        syncWriterToken = record.syncWriterToken
+        syncRevision = record.syncRevision
+        syncState = record.syncState
+        lastSyncedAt = record.lastSyncedAt
+        registryUpdatedAt = record.registryUpdatedAt
+        calendarUpdatedAt = record.calendarUpdatedAt
+        syncHash = record.syncHash
+        lastSyncError = record.lastSyncError
+        registryRevision = record.registryRevision
+    }
+
+    func applying(to base: TimeInstanceRecord) -> TimeInstanceRecord {
+        var record = base
+        record.calendarProvider = calendarProvider
+        record.calendarId = calendarId
+        record.calendarEventId = calendarEventId
+        record.providerExternalId = providerExternalId
+        record.calendarItemURL = calendarItemURL
+        record.createInvocationId = createInvocationId
+        record.syncWriterToken = syncWriterToken
+        record.syncRevision = syncRevision
+        record.syncState = syncState
+        record.lastSyncedAt = lastSyncedAt
+        record.registryUpdatedAt = registryUpdatedAt
+        record.calendarUpdatedAt = calendarUpdatedAt
+        record.syncHash = syncHash
+        record.lastSyncError = lastSyncError
+        record.registryRevision = registryRevision
+        return record
+    }
+}
+
+private func calendarRegistryCrashProbeExitCode(
+    root: URL,
+    key: String,
+    checkpointRawValue: String
+) -> Int32 {
+    let semaphore = DispatchSemaphore(value: 0)
+    nonisolated(unsafe) var result: Int32 = 1
+    Task.detached {
+        do {
+            let request = RegistryFirstTimeInstanceRequest(
+                idempotencyKey: key,
+                registryEventId: "crash-probe-event",
+                title: "Crash Probe",
+                start: Date(timeIntervalSince1970: 1_800_020_000),
+                end: Date(timeIntervalSince1970: 1_800_023_600),
+                timeZoneIdentifier: "America/Chicago",
+                calendarId: "cal-private",
+                notes: "Crash Probe",
+                semantics: TimeInstanceSemantics(eventClass: .focus, primaryBlockId: "block-crash-probe")
+            )
+            let registry = try CrashProbeRegistry(root: root, request: request)
+            let calendar = ProbeCalendar(root: root, holdMilliseconds: 0)
+            let ledger = try SQLiteCalendarRegistryTransactionStore(
+                url: root.appendingPathComponent("crash-ledger.sqlite3")
+            )
+            let locks = try FileCalendarRegistryProcessLockCoordinator(
+                rootURL: root.appendingPathComponent("crash-locks", isDirectory: true)
+            )
+            let selected = CalendarRegistryDurableCheckpoint(rawValue: checkpointRawValue)
+            let engine = CalendarRegistrySyncEngine(
+                registry: registry,
+                calendar: calendar,
+                transactions: ledger,
+                processLocks: locks,
+                operationGate: CalendarRegistryOperationGate(),
+                clock: { Date(timeIntervalSince1970: 1_800_000_000) },
+                durableCheckpoint: { observed in
+                    if observed == selected { _exit(86) }
+                },
+                leaseDuration: 0.1
+            )
+            let receipt = try await engine.registryFirstCreate(request)
+            let count = crashProbeCalendarCreateCount(root: root)
+            let outcome = CrashProbeOutcome(
+                succeeded: receipt.succeeded,
+                stage: receipt.stageAfter.rawValue,
+                calendarCreateCount: count
+            )
+            try JSONEncoder().encode(outcome).write(
+                to: root.appendingPathComponent("crash-probe-outcome.json"), options: .atomic
+            )
+            if selected != nil {
+                result = 4
+            } else if receipt.succeeded || receipt.stageAfter == .operatorReview {
+                result = count <= 1 ? 0 : 5
+            } else {
+                result = 6
+            }
+        } catch {
+            fputs("crash probe failed: \(error)\n", stderr)
+            result = 7
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return result
+}
+
+private func crashProbeCalendarCreateCount(root: URL) -> Int {
+    let url = root.appendingPathComponent("calendar-create-count")
+    return (try? String(contentsOf: url, encoding: .utf8))
+        .flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+}
+
+private actor CrashProbeRegistry: TimeInstanceRegistryStoring {
+    private let stateURL: URL
+    private let request: RegistryFirstTimeInstanceRequest
+
+    init(root: URL, request: RegistryFirstTimeInstanceRequest) throws {
+        self.stateURL = root.appendingPathComponent("crash-registry-state.json")
+        self.request = request
+        if !FileManager.default.fileExists(atPath: stateURL.path) {
+            try JSONEncoder().encode(CrashRegistryState(canonicalRecord(request)))
+                .write(to: stateURL, options: .atomic)
+        }
+    }
+
+    private func load() throws -> TimeInstanceRecord {
+        let state = try JSONDecoder().decode(
+            CrashRegistryState.self, from: Data(contentsOf: stateURL)
+        )
+        return state.applying(to: canonicalRecord(request))
+    }
+
+    private func persist(_ record: TimeInstanceRecord) throws {
+        try JSONEncoder().encode(CrashRegistryState(record)).write(to: stateURL, options: .atomic)
+    }
+
+    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
+        let record = try load()
+        return RegistryIdentityLookup(records: record.syncKey == syncKey ? [record] : [], source: .live)
+    }
+
+    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
+        _ = forceRefresh
+        let record = try load()
+        return id == record.id ? .decoded(record) : .missing
+    }
+
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        _ = forceRefresh
+        let record = try load()
+        return id == record.id ? record : nil
+    }
+
+    func savePairing(_ proposed: TimeInstanceRecord, expectedRevision: String?) async throws -> TimeInstanceRecord {
+        var saved = try load()
+        guard saved.registryRevision == expectedRevision else {
+            throw CalendarRegistrySyncError.identityConflict("crash probe revision mismatch")
+        }
+        saved.calendarProvider = proposed.calendarProvider
+        saved.calendarId = proposed.calendarId
+        saved.calendarEventId = proposed.calendarEventId
+        saved.providerExternalId = proposed.providerExternalId
+        saved.calendarItemURL = proposed.calendarItemURL
+        saved.createInvocationId = proposed.createInvocationId
+        saved.syncWriterToken = proposed.syncWriterToken
+        saved.syncRevision = proposed.syncRevision
+        saved.syncState = proposed.syncState
+        saved.registryUpdatedAt = proposed.registryUpdatedAt
+        saved.syncHash = proposed.syncHash
+        saved.lastSyncError = proposed.lastSyncError
+        saved.lastSyncedAt = proposed.lastSyncedAt
+        saved.calendarUpdatedAt = proposed.calendarUpdatedAt
+        saved.registryRevision = "crash-revision-\(UUID().uuidString.lowercased())"
+        try persist(saved)
+        return saved
+    }
 }
 
 private actor ProbeRegistry: TimeInstanceRegistryStoring {

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -1,4 +1,4 @@
-// CalendarRegistrySyncEngineTests.swift — fail-closed registry-first smoke contract
+// CalendarRegistrySyncEngineTests.swift — forward-only registry-first pairing contract
 
 import Foundation
 import MCP
@@ -112,6 +112,9 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         saved.calendarEventId = record.calendarEventId
         saved.providerExternalId = record.providerExternalId
         saved.calendarItemURL = record.calendarItemURL
+        saved.createInvocationId = record.createInvocationId
+        saved.syncWriterToken = record.syncWriterToken
+        saved.syncRevision = record.syncRevision
         saved.syncState = record.syncState
         saved.registryUpdatedAt = record.registryUpdatedAt
         saved.syncHash = record.syncHash
@@ -139,6 +142,8 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     private var mutateProviderOnFinalRead = false
     private var mutateURLOnFinalRead = false
     private var itemReadCount = 0
+    private var itemCallCount = 0
+    private var qualifyCallCount = 0
     private var recoverCallCount = 0
     private var injectDuplicateOnRecoverCall: Int?
     private(set) var createAttempts = 0
@@ -162,9 +167,13 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     func attempts() -> Int { createAttempts }
     func persistedCount() -> Int { persistedCreates }
     func count() -> Int { items.count }
+    func accessCounts() -> (qualify: Int, item: Int, recover: Int, create: Int) {
+        (qualifyCallCount, itemCallCount, recoverCallCount, createAttempts)
+    }
 
     func qualify(calendarId: String) async throws -> CalendarQualification {
-        CalendarQualification(
+        qualifyCallCount += 1
+        return CalendarQualification(
             calendarId: calendarId,
             title: "Private Smoke",
             allowsModify: qualified,
@@ -191,6 +200,7 @@ private actor SyncTestCalendar: CalendarSyncProviding {
             itemURL: "calshow:\(id)",
             syncKey: draft.syncKey,
             operationFingerprint: draft.operationFingerprint,
+            createInvocationId: draft.createInvocationId,
             title: draft.title,
             start: draft.start,
             end: draft.end,
@@ -217,6 +227,7 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     }
 
     func item(id: String) async throws -> ExternalCalendarItem? {
+        itemCallCount += 1
         guard var item = items[id] else { return nil }
         itemReadCount += 1
         if mutateProviderOnFinalRead && itemReadCount >= 2 { item.provider = "Mutated Provider" }
@@ -236,11 +247,12 @@ private actor SyncTestCalendar: CalendarSyncProviding {
         for item in items.values {
             let identity = item.syncKey == query.syncKey
                 && item.operationFingerprint == query.operationFingerprint
+            let invocation = query.createInvocationId.map { item.createInvocationId == $0 } ?? false
             let external = query.providerExternalId.map { item.providerExternalId == $0 } ?? false
             let fallback = item.calendarId == query.calendarId && item.title == query.title
                 && abs(item.start.timeIntervalSince(query.start)) < 1
                 && abs(item.end.timeIntervalSince(query.end)) < 1
-            if identity || external || fallback { matches[item.localEventId] = item }
+            if identity || invocation || external || fallback { matches[item.localEventId] = item }
         }
         return matches.values.sorted { $0.localEventId < $1.localEventId }
     }
@@ -376,6 +388,7 @@ private func calendarItem(
         itemURL: url,
         syncKey: request.idempotencyKey,
         operationFingerprint: request.manifest.fingerprint,
+        createInvocationId: "create-invocation",
         title: request.title,
         start: request.start,
         end: request.end,
@@ -408,6 +421,8 @@ private func makeSyncEngine(
         clock: { Date(timeIntervalSince1970: 1_800_000_000) },
         makeOperationId: { UUID().uuidString.lowercased() },
         makeLeaseToken: { UUID().uuidString.lowercased() },
+        makeCreateInvocationId: { "create-invocation" },
+        makeSyncWriterToken: { UUID().uuidString.lowercased() },
         leaseDuration: leaseDuration
     )
 }
@@ -420,6 +435,7 @@ private func seededRegistry(_ request: RegistryFirstTimeInstanceRequest) async -
 
 private func withTempDirectory(_ body: (URL) async throws -> Void) async throws {
     let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+        .resolvingSymlinksInPath()
         .appendingPathComponent("bridge-calendar-sync-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: directory) }
@@ -454,6 +470,8 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     private(set) var createCalls = 0
     private(set) var updateCalls = 0
     private var lastUpdateNames: [String] = []
+    private var dropWriterTokenOnUpdate = false
+    private var revisionSequence = 1
 
     func seed(_ row: NotionRow) {
         pages[row.id] = row
@@ -462,6 +480,7 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     func createCount() -> Int { createCalls }
     func updateCount() -> Int { updateCalls }
     func updatedFieldNames() -> [String] { lastUpdateNames }
+    func setDropWriterTokenOnUpdate(_ value: Bool) { dropWriterTokenOnUpdate = value }
 
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema {
         _ = dataSourceId; _ = workspace
@@ -495,7 +514,14 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
         _ = workspace
         updateCalls += 1
         lastUpdateNames = fields.map(\.notionName).sorted()
-        let row = Self.row(id: pageId, existing: pages[pageId], fields: fields)
+        let applied = dropWriterTokenOnUpdate
+            ? fields.filter { $0.notionName != "Sync Writer Token" }
+            : fields
+        revisionSequence += 1
+        let row = Self.row(
+            id: pageId, existing: pages[pageId], fields: applied,
+            lastEditedTime: String(format: "2027-01-15T08:00:%02d.000Z", revisionSequence)
+        )
         pages[pageId] = row
         return row
     }
@@ -503,7 +529,10 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     func markdown(pageId: String, workspace: String?) async throws -> String { "" }
     func writeMarkdown(pageId: String, workspace: String?, markdown: String) async throws {}
 
-    static func row(id: String, existing: NotionRow?, fields: [BoundField]) -> NotionRow {
+    static func row(
+        id: String, existing: NotionRow?, fields: [BoundField],
+        lastEditedTime: String = "2027-01-15T08:00:00.000Z"
+    ) -> NotionRow {
         var cells = existing?.cells ?? [:]
         for field in fields {
             cells[field.notionName] = NotionCell(id: field.propertyId, type: field.type, value: field.value)
@@ -511,7 +540,7 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
         return NotionRow(
             id: id,
             url: "https://notion.fixture/\(id)",
-            lastEditedTime: "2027-01-15T08:00:00.000Z",
+            lastEditedTime: lastEditedTime,
             cells: cells
         )
     }
@@ -542,6 +571,9 @@ private func scheduleEntityForSyncTests() -> RegistryEntity {
         ("calendarEventId", "Calendar Event ID", "rich_text", .generic),
         ("providerExternalId", "Provider External ID", "rich_text", .generic),
         ("calendarUrl", "Calendar URL", "url", .generic),
+        ("createInvocationId", "Calendar Create Invocation ID", "rich_text", .generic),
+        ("syncWriterToken", "Sync Writer Token", "rich_text", .generic),
+        ("syncRevision", "Sync Revision", "number", .generic),
         ("lastSyncError", "Last Sync Error", "rich_text", .generic),
         ("lastSyncedAt", "Last Synced At", "date", .date),
         ("calendarUpdatedAt", "Calendar Updated At", "date", .date)
@@ -597,6 +629,9 @@ private func notionRow(for record: TimeInstanceRecord, entity: RegistryEntity) t
         "calendarEventId": record.calendarEventId.map(Value.string) ?? .null,
         "providerExternalId": record.providerExternalId.map(Value.string) ?? .null,
         "calendarUrl": record.calendarItemURL.map(Value.string) ?? .null,
+        "createInvocationId": record.createInvocationId.map(Value.string) ?? .null,
+        "syncWriterToken": record.syncWriterToken.map(Value.string) ?? .null,
+        "syncRevision": .double(Double(record.syncRevision)),
         "lastSyncError": record.lastSyncError.map(Value.string) ?? .null,
         "lastSyncedAt": record.lastSyncedAt.map { .string(CalendarRegistryISO.string($0)) } ?? .null,
         "calendarUpdatedAt": record.calendarUpdatedAt.map { .string(CalendarRegistryISO.string($0)) } ?? .null
@@ -604,6 +639,36 @@ private func notionRow(for record: TimeInstanceRecord, entity: RegistryEntity) t
     let bound = RegistryWriter.resolve(fields, entity: entity).fields
     return SyncRegistryGateway.row(id: record.id, existing: nil, fields: bound)
 }
+
+private func mutateNotionRow(
+    _ row: NotionRow,
+    cellName: String? = nil,
+    value: Value? = nil,
+    remove: Bool = false,
+    lastEditedTime: String? = nil
+) -> NotionRow {
+    var cells = row.cells
+    if let cellName {
+        if remove {
+            cells[cellName] = nil
+        } else {
+            let existing = cells[cellName]
+            cells[cellName] = NotionCell(
+                id: existing?.id ?? "mutated-property",
+                type: existing?.type ?? "rich_text",
+                value: value ?? .null
+            )
+        }
+    }
+    return NotionRow(
+        id: row.id,
+        url: row.url,
+        lastEditedTime: lastEditedTime ?? row.lastEditedTime,
+        cells: cells,
+        archived: row.archived
+    )
+}
+
 
 // MARK: - Calendar store fixture
 
@@ -626,7 +691,14 @@ private actor PersistentCalendarStore: CalendarStoring {
         )]
     }
     func events(_ query: CalendarEventQuery) async throws -> [CalendarEvent] {
-        eventsById.values.filter { query.calendarId == nil || $0.calendarId == query.calendarId }
+        let lower = try CalendarISOParsing.parse(query.start)
+        let upper = try CalendarISOParsing.parse(query.end)
+        return eventsById.values.filter { event in
+            guard query.calendarId == nil || event.calendarId == query.calendarId,
+                  let start = try? CalendarISOParsing.parse(event.start),
+                  let end = try? CalendarISOParsing.parse(event.end) else { return false }
+            return end >= lower && start <= upper
+        }
     }
     func event(id: String) async throws -> CalendarEvent? { eventsById[id] }
     func create(_ draft: CalendarEventDraft) async throws -> CalendarEvent {
@@ -842,9 +914,9 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
             .registryFirstCreate(request)
-        let tx = try await store.get(idempotencyKey: request.idempotencyKey)
+        let tx = await store.get(idempotencyKey: request.idempotencyKey)
         try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
-        try expect(tx?.partialEffects.contains("persisted EventKit create intent") == true)
+        try expect(tx?.partialEffects.contains { $0.contains("persisted Create Invocation ID") } == true)
     }
 
     await test("CR17 provider persist-then-error records unknown effect") {
@@ -885,13 +957,18 @@ func runCalendarRegistrySyncEngineTests() async {
         try expect(first.stageAfter == .calendarEffectUnknown)
         await calendar.setCreateMode(.normal)
         let second = try await engine.registryFirstCreate(request)
-        try expect(!second.succeeded && second.stageAfter == .calendarEffectUnknown)
+        try expect(!second.succeeded && second.stageAfter == .operatorReview)
         try expect(await calendar.attempts() == 1)
     }
 
     await test("CR20 restart after create intent is recovery-only") {
         let request = syncRequest(key: "intent-restart")
         let registry = await seededRegistry(request)
+        var invoked = canonicalRecord(request)
+        invoked.createInvocationId = "create-invocation"
+        invoked.syncWriterToken = "writer-intent-restart"
+        invoked.syncRevision = 1
+        await registry.put(invoked)
         let calendar = SyncTestCalendar()
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(
@@ -901,14 +978,18 @@ func runCalendarRegistrySyncEngineTests() async {
             exclusive: true
         )
         tx.registryEventId = request.registryEventId
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
-        tx.stage = .calendarCreateIntent
+        tx.createInvocationId = "create-invocation"
+        tx.syncWriterToken = "writer-intent-restart"
+        tx.syncRevision = 1
+        tx.stage = .createInvocationPersisted
         tx = try await store.save(tx)
         _ = try await store.release(tx)
         let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
             .registryFirstCreate(request)
-        try expect(!receipt.succeeded && receipt.stageAfter == .calendarEffectUnknown)
+        try expect(!receipt.succeeded && receipt.stageAfter == .operatorReview)
+        try expect(receipt.recoveryAction?.contains("operator review") == true)
         try expect(await calendar.attempts() == 0)
     }
 
@@ -946,7 +1027,7 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(store, key: "immutable-registry", exclusive: true)
         tx.registryEventId = "page-a"
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
         tx.registryEventId = "page-b"
         do { _ = try await store.save(tx); throw TestError.assertion("substitution should fail") }
@@ -957,9 +1038,9 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(store, key: "immutable-event", exclusive: true)
         tx.registryEventId = "page"
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
-        tx.stage = .calendarCreated
+        tx.stage = .calendarIdentified
         tx.calendarEventId = "event-a"
         tx.calendarId = "cal"
         tx = try await store.save(tx)
@@ -972,9 +1053,9 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(store, key: "immutable-cal", exclusive: true)
         tx.registryEventId = "page"
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
-        tx.stage = .calendarCreated
+        tx.stage = .calendarIdentified
         tx.calendarEventId = "event"
         tx.calendarId = "cal-a"
         tx = try await store.save(tx)
@@ -987,9 +1068,9 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(store, key: "immutable-provider", exclusive: true)
         tx.registryEventId = "page"
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
-        tx.stage = .calendarCreated
+        tx.stage = .calendarIdentified
         tx.calendarEventId = "event"
         tx.calendarId = "cal"
         tx.providerExternalId = "external-a"
@@ -1003,7 +1084,7 @@ func runCalendarRegistrySyncEngineTests() async {
         let store = InMemoryCalendarRegistryTransactionStore()
         var tx = try await claim(store, key: "immutable-clear", exclusive: true)
         tx.registryEventId = "page"
-        tx.stage = .registryVerified
+        tx.stage = .registryAuthorized
         tx = try await store.save(tx)
         tx.registryEventId = nil
         do { _ = try await store.save(tx); throw TestError.assertion("clearing should fail") }
@@ -1165,7 +1246,8 @@ func runCalendarRegistrySyncEngineTests() async {
             location: request.location,
             notes: request.notes,
             syncKey: request.idempotencyKey,
-            operationFingerprint: request.manifest.fingerprint
+            operationFingerprint: request.manifest.fingerprint,
+            createInvocationId: "create-invocation"
         ))
         try expect(created.updatedAt == nil)
     }
@@ -1192,7 +1274,8 @@ func runCalendarRegistrySyncEngineTests() async {
                 allowedCalendarIds: ["cal-private"]
             )
             _ = engine
-            try expect(CalendarRegistrySyncComposition.canonicalLedgerURL.lastPathComponent == "calendar-registry-transactions.sqlite3")
+            try expect(CalendarRegistrySyncComposition.canonicalLedgerURL.lastPathComponent == "transactions.sqlite3")
+            try expect(CalendarRegistrySyncComposition.canonicalCoordinatorDirectory.lastPathComponent == "calendar-registry-coordinator")
         }
     }
 
@@ -1201,8 +1284,15 @@ func runCalendarRegistrySyncEngineTests() async {
             .appendingPathComponent("docs/migrations/calendar-registry-v1/registry-entity-patch.json")
         let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
         let properties = object?["additiveProperties"] as? [[String: Any]] ?? []
-        try expect(object?["schemaVersion"] as? Int == 2)
-        try expect(properties.count == 2)
+        try expect(object?["schemaVersion"] as? Int == 3)
+        try expect(properties.count == 5)
+        let byKey = Dictionary(uniqueKeysWithValues: properties.compactMap { property -> (String, [String: Any])? in
+            guard let key = property["key"] as? String else { return nil }
+            return (key, property)
+        })
+        try expect(byKey["createInvocationId"]?["type"] as? String == "rich_text")
+        try expect(byKey["syncWriterToken"]?["type"] as? String == "rich_text")
+        try expect(byKey["syncRevision"]?["type"] as? String == "number")
         for property in properties {
             let role = property["role"] as? String
             try expect(role == RegistryPropertyRole.generic.rawValue)
@@ -1244,9 +1334,10 @@ func runCalendarRegistrySyncEngineTests() async {
             try expect(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
             if let db { sqlite3_close_v2(db) }
             db = nil
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
             let store = try SQLiteCalendarRegistryTransactionStore(url: url)
             let migrated = try await store.get(idempotencyKey: "legacy")
-            try expect(migrated?.stage == .registryVerified)
+            try expect(migrated?.stage == .registryAuthorized)
         }
     }
 
@@ -1257,6 +1348,7 @@ func runCalendarRegistrySyncEngineTests() async {
             try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
             try expect(sqlite3_exec(db, "CREATE TABLE calendar_registry_schema (id INTEGER PRIMARY KEY, version INTEGER NOT NULL); INSERT INTO calendar_registry_schema(id,version) VALUES(1,99);", nil, nil, nil) == SQLITE_OK)
             if let db { sqlite3_close_v2(db) }
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
             do {
                 _ = try SQLiteCalendarRegistryTransactionStore(url: url)
                 throw TestError.assertion("future schema should fail")
@@ -1345,18 +1437,20 @@ func runCalendarRegistrySyncEngineTests() async {
         await calendar.setInjectDuplicateOnRecoverCall(3)
         let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
         try expect(!receipt.succeeded)
-        try expect(receipt.discrepancy?.contains("final calendar uniqueness proof") == true)
+        try expect(receipt.stageAfter == .conflict)
+        try expect(receipt.recoveryAction?.contains("automatic retry is prohibited") == true)
         try expect(await calendar.count() == 2)
     }
 
     await test("CR52 final registry uniqueness detects a late duplicate") {
         let request = syncRequest(key: "late-registry-duplicate")
         let registry = await seededRegistry(request)
-        await registry.setInjectDuplicateOnLookupCall(3)
+        await registry.setInjectDuplicateOnLookupCall(6)
         let calendar = SyncTestCalendar()
         let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
         try expect(!receipt.succeeded)
-        try expect(receipt.discrepancy?.contains("final registry uniqueness proof") == true)
+        try expect(receipt.stageAfter == .conflict)
+        try expect(receipt.recoveryAction?.contains("automatic retry is prohibited") == true)
         try expect(await calendar.count() == 1)
     }
 
@@ -1477,6 +1571,360 @@ func runCalendarRegistrySyncEngineTests() async {
         try expect(!receipt.registryFailureStatePersisted)
     }
 
+    await test("CR62 strict production decoding blocks malformed authority state and revision before EventKit") {
+        let entity = scheduleEntityForSyncTests()
+        let request = syncRequest(key: "strict-production-decode", registryEventId: "6168af95-595f-4fa1-81d8-7ccdeeee6262")
+        let base = try notionRow(for: canonicalRecord(request), entity: entity)
+        let variants: [NotionRow] = [
+            mutateNotionRow(base, cellName: "Scheduling Authority", remove: true),
+            mutateNotionRow(base, cellName: "Scheduling Authority", value: .string("Unknown Authority")),
+            mutateNotionRow(base, cellName: "Sync State", remove: true),
+            mutateNotionRow(base, cellName: "Sync State", value: .string("Unknown State")),
+            mutateNotionRow(base, lastEditedTime: ""),
+            mutateNotionRow(base, lastEditedTime: "not-a-date")
+        ]
+        for row in variants {
+            let gateway = SyncRegistryGateway()
+            await gateway.seed(row)
+            let calendar = SyncTestCalendar()
+            let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+            let receipt = try await makeSyncEngine(registry: store, calendar: calendar).registryFirstCreate(request)
+            try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+            let counts = await calendar.accessCounts()
+            try expect(counts.qualify == 0 && counts.item == 0 && counts.recover == 0 && counts.create == 0)
+        }
+    }
+
+    await test("CR63 non-registry authority performs zero EventKit calls") {
+        let request = syncRequest(key: "authority-zero-access")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.schedulingAuthority = .externalOrganizer
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        let counts = await calendar.accessCounts()
+        try expect(counts.qualify == 0 && counts.item == 0 && counts.recover == 0 && counts.create == 0)
+    }
+
+    await test("CR64 ledger loss with durable Notion invocation enters operator review") {
+        let request = syncRequest(key: "ledger-loss-invocation")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.createInvocationId = "create-invocation"
+        record.syncWriterToken = "writer-ledger-loss"
+        record.syncRevision = 1
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .operatorReview)
+        try expect(receipt.recoveryAction?.contains("operator review") == true)
+        let counts = await calendar.accessCounts()
+        try expect(counts.qualify == 0 && counts.item == 0 && counts.recover == 0 && counts.create == 0)
+    }
+
+    await test("CR65 restart from pair identity persisted continues forward without recreate") {
+        let request = syncRequest(key: "restart-pair-persisted")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.createInvocationId = "create-invocation"
+        record.syncWriterToken = "writer-pair"
+        record.syncRevision = 2
+        record.calendarProvider = "Fixture Calendar"
+        record.calendarId = request.calendarId
+        record.calendarEventId = "calendar-existing"
+        record.providerExternalId = "provider-existing"
+        record.calendarItemURL = "calshow:existing"
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        await calendar.seed(calendarItem(request))
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: request.idempotencyKey, fingerprint: request.manifest.fingerprint, exclusive: true)
+        tx.registryEventId = request.registryEventId
+        tx.stage = .registryAuthorized
+        tx = try await store.save(tx)
+        tx.createInvocationId = "create-invocation"
+        tx.syncWriterToken = "writer-pair"
+        tx.syncRevision = 2
+        tx.stage = .createInvocationPersisted
+        tx = try await store.save(tx)
+        tx.calendarEventId = "calendar-existing"
+        tx.calendarId = request.calendarId
+        tx.providerExternalId = "provider-existing"
+        tx.stage = .calendarIdentified
+        tx = try await store.save(tx)
+        tx.stage = .pairIdentityPersisted
+        tx = try await store.save(tx)
+        _ = try await store.release(tx)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+            .registryFirstCreate(request)
+        try expect(receipt.succeeded && receipt.stageAfter == .complete)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR66 restart from synced Notion and sync-evidence ledger reconciles complete") {
+        let request = syncRequest(key: "restart-sync-evidence")
+        let sourceRegistry = await seededRegistry(request)
+        let sourceCalendar = SyncTestCalendar()
+        let first = try await makeSyncEngine(registry: sourceRegistry, calendar: sourceCalendar).registryFirstCreate(request)
+        guard let finalRecord = first.record, let finalItem = first.calendarItem else {
+            throw TestError.assertion("source pair did not complete")
+        }
+        let registry = SyncTestRegistry()
+        await registry.put(finalRecord)
+        let calendar = SyncTestCalendar()
+        await calendar.seed(finalItem)
+        let store = InMemoryCalendarRegistryTransactionStore()
+        var tx = try await claim(store, key: request.idempotencyKey, fingerprint: request.manifest.fingerprint, exclusive: true)
+        tx.registryEventId = request.registryEventId
+        tx.stage = .registryAuthorized
+        tx = try await store.save(tx)
+        tx.createInvocationId = finalRecord.createInvocationId
+        tx.syncWriterToken = finalRecord.syncWriterToken
+        tx.syncRevision = finalRecord.syncRevision
+        tx.stage = .createInvocationPersisted
+        tx = try await store.save(tx)
+        tx.calendarEventId = finalItem.localEventId
+        tx.calendarId = finalItem.calendarId
+        tx.providerExternalId = finalItem.providerExternalId
+        tx.stage = .calendarIdentified
+        tx = try await store.save(tx)
+        tx.stage = .pairIdentityPersisted
+        tx = try await store.save(tx)
+        tx.lastVerifiedAt = finalRecord.lastSyncedAt
+        tx.stage = .syncEvidencePersisted
+        tx = try await store.save(tx)
+        _ = try await store.release(tx)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+            .registryFirstCreate(request)
+        try expect(receipt.succeeded && receipt.stageAfter == .complete)
+        try expect(await calendar.attempts() == 0)
+        try expect(await registry.savedCount() == 0)
+    }
+
+    await test("CR67 production pairing PATCH refuses lost writer token") {
+        let entity = scheduleEntityForSyncTests()
+        let request = syncRequest(key: "lost-writer-token", registryEventId: "6168af95-595f-4fa1-81d8-7ccdeeee6767")
+        let gateway = SyncRegistryGateway()
+        await gateway.seed(try notionRow(for: canonicalRecord(request), entity: entity))
+        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+        guard var desired = try await store.get(id: request.registryEventId, forceRefresh: true) else {
+            throw TestError.assertion("strict fixture did not decode")
+        }
+        let expectedRevision = desired.registryRevision
+        desired.createInvocationId = "create-invocation"
+        desired.syncWriterToken = "writer-expected"
+        desired.syncRevision = 1
+        await gateway.setDropWriterTokenOnUpdate(true)
+        do {
+            _ = try await store.savePairing(desired, expectedRevision: expectedRevision)
+            throw TestError.assertion("lost writer token should conflict")
+        } catch CalendarRegistrySyncError.identityConflict {}
+    }
+
+    await test("CR68 EventKit metadata v2 round-trips Create Invocation ID") {
+        let request = syncRequest(key: "metadata-v2")
+        let identity = CalendarRegistryCalendarMetadata.Identity(
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            createInvocationId: "create-invocation"
+        )
+        let notes = try CalendarRegistryCalendarMetadata.append(to: "User note", identity: identity)
+        try expect(try CalendarRegistryCalendarMetadata.parse(notes) == identity)
+        try expect(try CalendarRegistryCalendarMetadata.userNotes(from: notes) == "User note")
+        try expect(notes.contains("BRIDGE-CALENDAR-REGISTRY v2"))
+    }
+
+    await test("CR69 production EventKit recovery is bounded and does not claim global absence") {
+        let request = syncRequest(key: "bounded-recovery")
+        let store = PersistentCalendarStore()
+        let farStart = request.start.addingTimeInterval(90 * 86_400)
+        let farEnd = request.end.addingTimeInterval(90 * 86_400)
+        let notes = try CalendarRegistryCalendarMetadata.append(
+            to: request.notes,
+            identity: .init(
+                syncKey: request.idempotencyKey,
+                operationFingerprint: request.manifest.fingerprint,
+                createInvocationId: "create-invocation"
+            )
+        )
+        await store.seed(CalendarEvent(
+            id: "far-event",
+            title: request.title,
+            start: CalendarRegistryISO.string(farStart),
+            end: CalendarRegistryISO.string(farEnd),
+            allDay: false,
+            calendarId: request.calendarId,
+            calendarTitle: "Private Smoke",
+            location: request.location,
+            notes: notes,
+            timeZoneIdentifier: request.timeZoneIdentifier,
+            externalId: "far-external"
+        ))
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        let matches = try await provider.recover(CalendarRecoveryQuery(
+            syncKey: request.idempotencyKey,
+            operationFingerprint: request.manifest.fingerprint,
+            createInvocationId: "create-invocation",
+            calendarId: request.calendarId,
+            title: request.title,
+            start: request.start,
+            end: request.end
+        ))
+        try expect(matches.isEmpty)
+    }
+
+    await test("CR70 success receipt reports bounded owned-identity evidence") {
+        let request = syncRequest(key: "bounded-receipt")
+        let registry = await seededRegistry(request)
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(receipt.createInvocationId == "create-invocation")
+        try expect(receipt.syncWriterToken?.isEmpty == false && (receipt.syncRevision ?? 0) > 0)
+        try expect(receipt.calendarSearchScopes.contains { $0.contains("window=") && $0.contains("channels=") })
+        try expect(!receipt.calendarSearchScopes.contains { $0.lowercased().contains("global") })
+    }
+
+    await test("CR71 permissive pre-existing ledger is refused") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("permissive.sqlite3")
+            try Data().write(to: url)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: url)
+                throw TestError.assertion("permissive ledger should fail trust validation")
+            } catch CalendarRegistryTransactionStoreError.storageFailure {}
+        }
+    }
+
+    await test("CR72 symlinked ledger is refused") {
+        try await withTempDirectory { directory in
+            let target = directory.appendingPathComponent("target.sqlite3")
+            let link = directory.appendingPathComponent("linked.sqlite3")
+            try Data().write(to: target)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: link)
+                throw TestError.assertion("symlinked ledger should fail trust validation")
+            } catch CalendarRegistryTransactionStoreError.storageFailure {}
+        }
+    }
+
+    await test("CR73 hard-linked ledger is refused") {
+        try await withTempDirectory { directory in
+            let target = directory.appendingPathComponent("target.sqlite3")
+            let link = directory.appendingPathComponent("hard.sqlite3")
+            try Data().write(to: target)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
+            try FileManager.default.linkItem(at: target, to: link)
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: link)
+                throw TestError.assertion("hard-linked ledger should fail trust validation")
+            } catch CalendarRegistryTransactionStoreError.storageFailure {}
+        }
+    }
+
+    await test("CR74 coordinator namespace derives from filesystem identity") {
+        try await withTempDirectory { directory in
+            let aRoot = directory.appendingPathComponent("a", isDirectory: true)
+            let bRoot = directory.appendingPathComponent("b", isDirectory: true)
+            let first = try FileCalendarRegistryProcessLockCoordinator(rootURL: aRoot)
+            let second = try FileCalendarRegistryProcessLockCoordinator(rootURL: aRoot)
+            let other = try FileCalendarRegistryProcessLockCoordinator(rootURL: bRoot)
+            try expect(first.coordinatorNamespace == second.coordinatorNamespace)
+            try expect(first.coordinatorNamespace != other.coordinatorNamespace)
+        }
+    }
+
+    await test("CR75 SQLite v4 round-trips invocation and writer evidence") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("v4.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            var tx = try await claim(first, key: "v4-roundtrip", exclusive: true)
+            tx.registryEventId = "page-v4"
+            tx.stage = .registryAuthorized
+            tx = try await first.save(tx)
+            tx.createInvocationId = "create-v4"
+            tx.syncWriterToken = "writer-v4"
+            tx.syncRevision = 3
+            tx.stage = .createInvocationPersisted
+            tx = try await first.save(tx)
+            _ = try await first.release(tx)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let stored = try await second.get(idempotencyKey: "v4-roundtrip")
+            try expect(stored?.createInvocationId == "create-v4")
+            try expect(stored?.syncWriterToken == "writer-v4")
+            try expect(stored?.syncRevision == 3)
+        }
+    }
+
+    await test("CR76 pairing source exposes no public Notion create or repair") {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("TheBridge/Modules/Time/CalendarRegistrySyncEngine.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        try expect(!source.contains("public func create(_ record: TimeInstanceRecord)"))
+        try expect(!source.contains("public func repair(id: String, from record: TimeInstanceRecord)"))
+        try expect(!source.contains("public struct PartialRegistryCreateError"))
+    }
+
+    await test("CR77 symlinked coordinator root is refused") {
+        try await withTempDirectory { directory in
+            let target = directory.appendingPathComponent("real-root", isDirectory: true)
+            let link = directory.appendingPathComponent("linked-root", isDirectory: true)
+            try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+            do {
+                _ = try FileCalendarRegistryProcessLockCoordinator(rootURL: link)
+                throw TestError.assertion("symlinked coordinator root should fail")
+            } catch CalendarRegistryProcessLockError.storageFailure {}
+        }
+    }
+
+    await test("CR78 unsafe SQLite WAL sidecar is refused") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("sidecar.sqlite3")
+            do {
+                let store = try SQLiteCalendarRegistryTransactionStore(url: url)
+                let tx = try await claim(store, key: "sidecar-seed", exclusive: true)
+                _ = try await store.release(tx)
+            }
+            let sidecar = URL(fileURLWithPath: url.path + "-wal")
+            try Data("unsafe".utf8).write(to: sidecar)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: sidecar.path)
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: url)
+                throw TestError.assertion("unsafe WAL sidecar should fail")
+            } catch CalendarRegistryTransactionStoreError.storageFailure {}
+        }
+    }
+
+    await test("CR79 owned coordinator directory permissions are repaired to 0700") {
+        try await withTempDirectory { directory in
+            let root = directory.appendingPathComponent("repair-root", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: root.path)
+            _ = try FileCalendarRegistryProcessLockCoordinator(rootURL: root)
+            let attributes = try FileManager.default.attributesOfItem(atPath: root.path)
+            let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+            try expect(mode & 0o077 == 0)
+        }
+    }
+
+    await test("CR80 lock owner evidence omits raw idempotency key") {
+        try await withTempDirectory { directory in
+            let locks = try FileCalendarRegistryProcessLockCoordinator(rootURL: directory)
+            let key = "sensitive-operation-label"
+            let handle = try locks.acquire(idempotencyKey: key)
+            defer { try? handle.release() }
+            let lockURL = locks.lockURL(idempotencyKey: key)
+            let evidence = try String(contentsOf: lockURL, encoding: .utf8)
+            try expect(!evidence.contains(key))
+            try expect(evidence.contains("pid=") && evidence.contains("lock="))
+        }
+    }
+
 }
 
 // MARK: - Child-process probe
@@ -1557,6 +2005,9 @@ private actor ProbeRegistry: TimeInstanceRegistryStoring {
         saved.calendarEventId = record.calendarEventId
         saved.providerExternalId = record.providerExternalId
         saved.calendarItemURL = record.calendarItemURL
+        saved.createInvocationId = record.createInvocationId
+        saved.syncWriterToken = record.syncWriterToken
+        saved.syncRevision = record.syncRevision
         saved.syncState = record.syncState
         saved.registryUpdatedAt = record.registryUpdatedAt
         saved.syncHash = record.syncHash
@@ -1591,6 +2042,7 @@ private actor ProbeCalendar: CalendarSyncProviding {
             providerExternalId: "probe-external",
             syncKey: draft.syncKey,
             operationFingerprint: draft.operationFingerprint,
+            createInvocationId: draft.createInvocationId,
             title: draft.title,
             start: draft.start,
             end: draft.end,
@@ -1602,6 +2054,7 @@ private actor ProbeCalendar: CalendarSyncProviding {
         let payload: [String: Any] = [
             "syncKey": draft.syncKey,
             "fingerprint": draft.operationFingerprint,
+            "createInvocationId": draft.createInvocationId,
             "title": draft.title,
             "start": CalendarRegistryISO.string(draft.start),
             "end": CalendarRegistryISO.string(draft.end),
@@ -1627,7 +2080,9 @@ private actor ProbeCalendar: CalendarSyncProviding {
     }
     func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
         guard let item = try load() else { return [] }
-        return item.syncKey == query.syncKey && item.operationFingerprint == query.operationFingerprint ? [item] : []
+        return item.syncKey == query.syncKey
+            && item.operationFingerprint == query.operationFingerprint
+            && (query.createInvocationId == nil || item.createInvocationId == query.createInvocationId) ? [item] : []
     }
     private func load() throws -> ExternalCalendarItem? {
         let url = root.appendingPathComponent("calendar-item.json")
@@ -1636,6 +2091,7 @@ private actor ProbeCalendar: CalendarSyncProviding {
         guard let object,
               let key = object["syncKey"] as? String,
               let fingerprint = object["fingerprint"] as? String,
+              let createInvocationId = object["createInvocationId"] as? String,
               let title = object["title"] as? String,
               let startRaw = object["start"] as? String,
               let endRaw = object["end"] as? String,
@@ -1650,6 +2106,7 @@ private actor ProbeCalendar: CalendarSyncProviding {
             providerExternalId: "probe-external",
             syncKey: key,
             operationFingerprint: fingerprint,
+            createInvocationId: createInvocationId,
             title: title,
             start: start,
             end: end,

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -27,18 +27,36 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     private var lookupExtras: [TimeInstanceRecord] = []
     private var lookupUnresolved: [RegistryUnresolvedIdentity] = []
     private var lookupSource: RegistryLookupSource = .live
+    private var lookupCallCount = 0
+    private var injectDuplicateOnLookupCall: Int?
     private var failAllSaves = false
     private var dropFinalSyncHash = false
     private var mutateProviderOnFinalRead = false
     private var mutateSyncedAtOnFinalRead = false
     private var syncedReadCount = 0
+    private var revisionSequence = 1
     private(set) var saveCount = 0
 
-    func put(_ record: TimeInstanceRecord) { records[record.id] = record }
+    func put(_ record: TimeInstanceRecord) {
+        var stored = record
+        if stored.registryRevision == nil {
+            stored.registryRevision = "revision-\(revisionSequence)"
+            revisionSequence += 1
+        }
+        records[stored.id] = stored
+    }
     func setIdentityOverride(id: String, value: RegistryRecordIdentityRead?) { identityOverrides[id] = value }
     func setLookupExtras(_ values: [TimeInstanceRecord]) { lookupExtras = values }
     func setLookupUnresolved(_ values: [RegistryUnresolvedIdentity]) { lookupUnresolved = values }
     func setLookupSource(_ value: RegistryLookupSource) { lookupSource = value }
+    func setInjectDuplicateOnLookupCall(_ value: Int?) { injectDuplicateOnLookupCall = value }
+    func mutateTitle(_ value: String) {
+        guard var current = records.values.first else { return }
+        current.title = value
+        current.registryRevision = "revision-\(revisionSequence)"
+        revisionSequence += 1
+        records[current.id] = current
+    }
     func setFailAllSaves(_ value: Bool) { failAllSaves = value }
     func setDropFinalSyncHash(_ value: Bool) { dropFinalSyncHash = value }
     func setMutateProviderOnFinalRead(_ value: Bool) { mutateProviderOnFinalRead = value }
@@ -47,8 +65,16 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     func savedCount() -> Int { saveCount }
 
     func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
-        RegistryIdentityLookup(
-            records: records.values.filter { $0.syncKey == syncKey } + lookupExtras.filter { $0.syncKey == syncKey },
+        lookupCallCount += 1
+        var matches = records.values.filter { $0.syncKey == syncKey }
+            + lookupExtras.filter { $0.syncKey == syncKey }
+        if injectDuplicateOnLookupCall == lookupCallCount, var duplicate = matches.first {
+            duplicate.id += "-duplicate"
+            duplicate.registryRevision = "duplicate-revision"
+            matches.append(duplicate)
+        }
+        return RegistryIdentityLookup(
+            records: matches,
             unresolvedIdentities: lookupUnresolved.filter { $0.syncKey == syncKey },
             source: lookupSource
         )
@@ -76,10 +102,25 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         return record
     }
 
-    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
+    func savePairing(_ record: TimeInstanceRecord, expectedRevision: String?) async throws -> TimeInstanceRecord {
         if failAllSaves { throw SyncTestError.forcedRegistrySave }
-        var saved = record
+        guard var saved = records[record.id], saved.registryRevision == expectedRevision else {
+            throw CalendarRegistrySyncError.identityConflict("fixture revision mismatch")
+        }
+        saved.calendarProvider = record.calendarProvider
+        saved.calendarId = record.calendarId
+        saved.calendarEventId = record.calendarEventId
+        saved.providerExternalId = record.providerExternalId
+        saved.calendarItemURL = record.calendarItemURL
+        saved.syncState = record.syncState
+        saved.registryUpdatedAt = record.registryUpdatedAt
+        saved.syncHash = record.syncHash
+        saved.lastSyncError = record.lastSyncError
+        saved.lastSyncedAt = record.lastSyncedAt
+        saved.calendarUpdatedAt = record.calendarUpdatedAt
         if dropFinalSyncHash && saved.syncState == .synced { saved.syncHash = "" }
+        saved.registryRevision = "revision-\(revisionSequence)"
+        revisionSequence += 1
         records[saved.id] = saved
         saveCount += 1
         return saved
@@ -87,7 +128,7 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
 }
 
 private actor SyncTestCalendar: CalendarSyncProviding {
-    enum CreateMode { case normal, throwWithoutPersist, persistThenThrow, persistThenSuspend }
+    enum CreateMode { case normal, throwWithoutPersist, persistThenThrow, persistThenSuspend, delayReturn }
 
     private var items: [String: ExternalCalendarItem] = [:]
     private var sequence = 0
@@ -98,6 +139,8 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     private var mutateProviderOnFinalRead = false
     private var mutateURLOnFinalRead = false
     private var itemReadCount = 0
+    private var recoverCallCount = 0
+    private var injectDuplicateOnRecoverCall: Int?
     private(set) var createAttempts = 0
     private(set) var persistedCreates = 0
     let createEntered = AsyncTestLatch()
@@ -113,6 +156,7 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     ) { nextShape = (recurring, allDay, detached, organizer, attendees) }
     func setMutateProviderOnFinalRead(_ value: Bool) { mutateProviderOnFinalRead = value }
     func setMutateURLOnFinalRead(_ value: Bool) { mutateURLOnFinalRead = value }
+    func setInjectDuplicateOnRecoverCall(_ value: Int?) { injectDuplicateOnRecoverCall = value }
     func seed(_ item: ExternalCalendarItem) { items[item.localEventId] = item }
     func removeAll() { items.removeAll() }
     func attempts() -> Int { createAttempts }
@@ -166,6 +210,9 @@ private actor SyncTestCalendar: CalendarSyncProviding {
         if createMode == .persistThenSuspend {
             try await Task.sleep(nanoseconds: 10_000_000_000)
         }
+        if createMode == .delayReturn {
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
         return item
     }
 
@@ -178,20 +225,24 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     }
 
     func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
-        if let id = query.localEventId, let direct = items[id] { return [direct] }
-        let identity = items.values.filter {
-            $0.syncKey == query.syncKey && $0.operationFingerprint == query.operationFingerprint
+        recoverCallCount += 1
+        if injectDuplicateOnRecoverCall == recoverCallCount, var duplicate = items.values.first {
+            duplicate.localEventId += "-duplicate"
+            duplicate.providerExternalId = (duplicate.providerExternalId ?? "provider") + "-duplicate"
+            items[duplicate.localEventId] = duplicate
         }
-        if !identity.isEmpty { return Array(identity) }
-        if let external = query.providerExternalId {
-            let externalMatches = items.values.filter { $0.providerExternalId == external }
-            if !externalMatches.isEmpty { return Array(externalMatches) }
+        var matches: [String: ExternalCalendarItem] = [:]
+        if let id = query.localEventId, let direct = items[id] { matches[id] = direct }
+        for item in items.values {
+            let identity = item.syncKey == query.syncKey
+                && item.operationFingerprint == query.operationFingerprint
+            let external = query.providerExternalId.map { item.providerExternalId == $0 } ?? false
+            let fallback = item.calendarId == query.calendarId && item.title == query.title
+                && abs(item.start.timeIntervalSince(query.start)) < 1
+                && abs(item.end.timeIntervalSince(query.end)) < 1
+            if identity || external || fallback { matches[item.localEventId] = item }
         }
-        return items.values.filter {
-            $0.calendarId == query.calendarId && $0.title == query.title
-                && abs($0.start.timeIntervalSince(query.start)) < 1
-                && abs($0.end.timeIntervalSince(query.end)) < 1
-        }
+        return matches.values.sorted { $0.localEventId < $1.localEventId }
     }
 }
 
@@ -299,7 +350,8 @@ private func canonicalRecord(_ request: RegistryFirstTimeInstanceRequest) -> Tim
         semantics: request.semantics,
         schedulingAuthority: .registry,
         syncState: .pendingCreate,
-        registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        registryUpdatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+        registryRevision: "revision-initial"
     )
 }
 
@@ -401,10 +453,15 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     private var pages: [String: NotionRow] = [:]
     private(set) var createCalls = 0
     private(set) var updateCalls = 0
+    private var lastUpdateNames: [String] = []
 
-    func seed(_ row: NotionRow) { pages[row.id] = row }
+    func seed(_ row: NotionRow) {
+        pages[row.id] = row
+        pages[CachedRow.normalize(row.id)] = row
+    }
     func createCount() -> Int { createCalls }
     func updateCount() -> Int { updateCalls }
+    func updatedFieldNames() -> [String] { lastUpdateNames }
 
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema {
         _ = dataSourceId; _ = workspace
@@ -437,6 +494,7 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     func update(pageId: String, workspace: String?, fields: [BoundField]) async throws -> NotionRow {
         _ = workspace
         updateCalls += 1
+        lastUpdateNames = fields.map(\.notionName).sorted()
         let row = Self.row(id: pageId, existing: pages[pageId], fields: fields)
         pages[pageId] = row
         return row
@@ -1131,12 +1189,10 @@ func runCalendarRegistrySyncEngineTests() async {
                 registryGateway: SyncRegistryGateway(),
                 calendarStore: PersistentCalendarStore(),
                 environment: [CalendarRegistrySyncComposition.enableEnvironmentKey: "1"],
-                allowedCalendarIds: ["cal-private"],
-                ledgerURL: directory.appendingPathComponent("ledger.sqlite3")
+                allowedCalendarIds: ["cal-private"]
             )
             _ = engine
-            let lockRoot = directory.appendingPathComponent("calendar-registry-locks")
-            try expect(FileManager.default.fileExists(atPath: lockRoot.path))
+            try expect(CalendarRegistrySyncComposition.canonicalLedgerURL.lastPathComponent == "calendar-registry-transactions.sqlite3")
         }
     }
 
@@ -1281,6 +1337,146 @@ func runCalendarRegistrySyncEngineTests() async {
             try expect(count == 1)
         }
     }
+
+    await test("CR51 final calendar uniqueness detects a late duplicate") {
+        let request = syncRequest(key: "late-calendar-duplicate")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setInjectDuplicateOnRecoverCall(3)
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+        try expect(receipt.discrepancy?.contains("final calendar uniqueness proof") == true)
+        try expect(await calendar.count() == 2)
+    }
+
+    await test("CR52 final registry uniqueness detects a late duplicate") {
+        let request = syncRequest(key: "late-registry-duplicate")
+        let registry = await seededRegistry(request)
+        await registry.setInjectDuplicateOnLookupCall(3)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded)
+        try expect(receipt.discrepancy?.contains("final registry uniqueness proof") == true)
+        try expect(await calendar.count() == 1)
+    }
+
+    await test("CR53 external-organizer authority fails before calendar access") {
+        let request = syncRequest(key: "external-authority")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.schedulingAuthority = .externalOrganizer
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR54 partial Notion pair identity fails before calendar access") {
+        let request = syncRequest(key: "partial-pair")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.calendarProvider = "Fixture Calendar"
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR55 false pre-existing Synced state fails before calendar access") {
+        let request = syncRequest(key: "false-synced")
+        let registry = SyncTestRegistry()
+        var record = canonicalRecord(request)
+        record.syncState = .synced
+        await registry.put(record)
+        let calendar = SyncTestCalendar()
+        let receipt = try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request)
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await calendar.attempts() == 0)
+    }
+
+    await test("CR56 concurrent semantic edit is preserved and conflicts") {
+        let request = syncRequest(key: "concurrent-notion-edit")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        await calendar.setCreateMode(.delayReturn)
+        let task = Task { try await makeSyncEngine(registry: registry, calendar: calendar).registryFirstCreate(request) }
+        await calendar.createEntered.wait()
+        await registry.mutateTitle("USER EDIT")
+        let receipt = try await task.value
+        try expect(!receipt.succeeded && receipt.stageAfter == .conflict)
+        try expect(await registry.record(id: request.registryEventId)?.title == "USER EDIT")
+        try expect(await calendar.count() == 1)
+    }
+
+    await test("CR57 production pairing patch never rewrites semantic fields") {
+        let entity = scheduleEntityForSyncTests()
+        let gateway = SyncRegistryGateway()
+        let request = syncRequest(key: "narrow-pairing-patch", registryEventId: "6168af95-595f-4fa1-81d8-7ccdeeee7777")
+        let original = canonicalRecord(request)
+        await gateway.seed(try notionRow(for: original, entity: entity))
+        let store = NotionTimeInstanceRegistryStore(entity: entity, gateway: gateway)
+        guard var desired = try await store.get(id: original.id, forceRefresh: true) else {
+            throw TestError.assertion("fixture row did not decode")
+        }
+        let expectedRevision = desired.registryRevision
+        desired.title = "SHOULD NOT WRITE"
+        desired.semantics = TimeInstanceSemantics(eventClass: .meeting, primaryBlockId: "different-block")
+        desired.calendarProvider = "Fixture Calendar"
+        desired.calendarId = request.calendarId
+        desired.calendarEventId = "calendar-narrow"
+        desired.providerExternalId = "provider-narrow"
+        desired.syncState = .pendingCreate
+        let saved = try await store.savePairing(desired, expectedRevision: expectedRevision)
+        try expect(saved.title == original.title)
+        try expect(saved.semantics == original.semantics)
+        let names = await gateway.updatedFieldNames()
+        try expect(!names.contains("EVENT TITLE") && !names.contains("EVENT DATE"))
+        try expect(!names.contains("BLOCKS") && !names.contains("Primary BLOCK"))
+        try expect(names.contains("Calendar Event ID"))
+    }
+
+    await test("CR58 authority participates in the immutable fingerprint") {
+        let request = syncRequest(key: "authority-fingerprint")
+        var changed = request.manifest
+        changed.schedulingAuthority = TimeInstanceSchedulingAuthority.calendar.rawValue
+        try expect(changed.fingerprint != request.manifest.fingerprint)
+    }
+
+    await test("CR59 transaction identity is stable while attempt identity rotates") {
+        let request = syncRequest(key: "stable-transaction-id")
+        let registry = await seededRegistry(request)
+        let calendar = SyncTestCalendar()
+        let store = InMemoryCalendarRegistryTransactionStore()
+        let locks = InMemoryCalendarRegistryProcessLockCoordinator(coordinatorNamespace: "receipt-test")
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: store, processLocks: locks)
+        let first = try await engine.registryFirstCreate(request)
+        let second = try await engine.registryFirstCreate(request)
+        try expect(first.succeeded && second.succeeded)
+        try expect(!first.operationId.isEmpty && first.operationId == second.operationId)
+        try expect(first.attemptId != nil && second.attemptId != nil && first.attemptId != second.attemptId)
+    }
+
+    await test("CR60 success receipt exposes coordinator and uniqueness evidence") {
+        let request = syncRequest(key: "receipt-evidence")
+        let registry = await seededRegistry(request)
+        let locks = InMemoryCalendarRegistryProcessLockCoordinator(coordinatorNamespace: "receipt-namespace")
+        let receipt = try await makeSyncEngine(registry: registry, processLocks: locks).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(receipt.coordinatorNamespace == "receipt-namespace")
+        try expect(receipt.registryIdentityCount == 1 && receipt.calendarIdentityCount == 1)
+        try expect(receipt.finalRegistryRevision?.isEmpty == false)
+    }
+
+    await test("CR61 successful receipt does not claim a failure-state write") {
+        let request = syncRequest(key: "receipt-failure-state-na")
+        let registry = await seededRegistry(request)
+        let receipt = try await makeSyncEngine(registry: registry).registryFirstCreate(request)
+        try expect(receipt.succeeded)
+        try expect(!receipt.registryFailureStatePersisted)
+    }
+
 }
 
 // MARK: - Child-process probe
@@ -1351,9 +1547,25 @@ private actor ProbeRegistry: TimeInstanceRegistryStoring {
         _ = forceRefresh
         return id == record.id ? record : nil
     }
-    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
-        self.record = record
-        return record
+    func savePairing(_ record: TimeInstanceRecord, expectedRevision: String?) async throws -> TimeInstanceRecord {
+        guard self.record.registryRevision == expectedRevision else {
+            throw CalendarRegistrySyncError.identityConflict("probe revision mismatch")
+        }
+        var saved = self.record
+        saved.calendarProvider = record.calendarProvider
+        saved.calendarId = record.calendarId
+        saved.calendarEventId = record.calendarEventId
+        saved.providerExternalId = record.providerExternalId
+        saved.calendarItemURL = record.calendarItemURL
+        saved.syncState = record.syncState
+        saved.registryUpdatedAt = record.registryUpdatedAt
+        saved.syncHash = record.syncHash
+        saved.lastSyncError = record.lastSyncError
+        saved.lastSyncedAt = record.lastSyncedAt
+        saved.calendarUpdatedAt = record.calendarUpdatedAt
+        saved.registryRevision = UUID().uuidString
+        self.record = saved
+        return saved
     }
 }
 

--- a/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
+++ b/TheBridgeTests/CalendarRegistrySyncEngineTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MCP
+import SQLite3
 import TheBridgeLib
 
 private enum SyncTestError: Error, LocalizedError {
@@ -23,15 +24,20 @@ private enum SyncTestError: Error, LocalizedError {
 private actor SyncTestRegistry: TimeInstanceRegistryStoring {
     private var records: [String: TimeInstanceRecord] = [:]
     private var partialByKey: [String: (id: String, fingerprint: String)] = [:]
+    private var identityOverrides: [String: RegistryRecordIdentityRead] = [:]
     private var sequence = 0
     private var failNextCreatePatch = false
     private var failAllSaves = false
     private var lookupSource: RegistryLookupSource = .live
+    private var dropFinalSyncHash = false
     private(set) var createCount = 0
 
     func setFailNextCreatePatch(_ value: Bool) { failNextCreatePatch = value }
     func setFailAllSaves(_ value: Bool) { failAllSaves = value }
     func setLookupSource(_ source: RegistryLookupSource) { lookupSource = source }
+    func setDropFinalSyncHash(_ value: Bool) { dropFinalSyncHash = value }
+    func put(_ record: TimeInstanceRecord) { records[record.id] = record }
+    func setIdentityOverride(id: String, value: RegistryRecordIdentityRead?) { identityOverrides[id] = value }
     func count() -> Int { records.count + partialByKey.count }
     func createdCount() -> Int { createCount }
     func allRecords() -> [TimeInstanceRecord] { Array(records.values) }
@@ -41,15 +47,25 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         RegistryIdentityLookup(
             records: records.values.filter { $0.syncKey == syncKey },
             unresolvedIdentities: partialByKey[syncKey].map {
-                [RegistryUnresolvedIdentity(pageId: $0.id, operationFingerprint: $0.fingerprint)]
+                [RegistryUnresolvedIdentity(pageId: $0.id, syncKey: syncKey, operationFingerprint: $0.fingerprint)]
             } ?? [],
             source: lookupSource
         )
     }
 
-    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
         _ = forceRefresh
-        return records[id]
+        if let override = identityOverrides[id] { return override }
+        if let record = records[id] { return .decoded(record) }
+        if let partial = partialByKey.first(where: { $0.value.id == id }) {
+            return .partial(pageId: id, syncKey: partial.key, operationFingerprint: partial.value.fingerprint)
+        }
+        return .missing
+    }
+
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        if case .decoded(let record) = try await readIdentity(id: id, forceRefresh: forceRefresh) { return record }
+        return nil
     }
 
     func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
@@ -71,14 +87,17 @@ private actor SyncTestRegistry: TimeInstanceRegistryStoring {
         var repaired = record
         repaired.id = id
         partialByKey[record.syncKey] = nil
+        identityOverrides[id] = nil
         records[id] = repaired
         return repaired
     }
 
     func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord {
         if failAllSaves { throw SyncTestError.forcedRegistrySave }
-        records[record.id] = record
-        return record
+        var saved = record
+        if dropFinalSyncHash && saved.syncState == .synced { saved.syncHash = "" }
+        records[saved.id] = saved
+        return saved
     }
 
     func mutateCalendarRange(key: String, start: Date, end: Date) {
@@ -179,6 +198,112 @@ private actor SyncTestCalendar: CalendarSyncProviding {
     }
 }
 
+
+private actor AsyncTestLatch {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        guard !opened else { return }
+        opened = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor PausingRegistry: TimeInstanceRegistryStoring {
+    let base: SyncTestRegistry
+    let entered: AsyncTestLatch
+    let release: AsyncTestLatch
+    private var hasPaused = false
+
+    init(base: SyncTestRegistry, entered: AsyncTestLatch, release: AsyncTestLatch) {
+        self.base = base
+        self.entered = entered
+        self.release = release
+    }
+
+    func findBySyncKey(_ syncKey: String) async throws -> RegistryIdentityLookup {
+        if !hasPaused {
+            hasPaused = true
+            await entered.open()
+            await release.wait()
+        }
+        return try await base.findBySyncKey(syncKey)
+    }
+    func readIdentity(id: String, forceRefresh: Bool) async throws -> RegistryRecordIdentityRead {
+        try await base.readIdentity(id: id, forceRefresh: forceRefresh)
+    }
+    func get(id: String, forceRefresh: Bool) async throws -> TimeInstanceRecord? {
+        try await base.get(id: id, forceRefresh: forceRefresh)
+    }
+    func create(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.create(record) }
+    func repair(id: String, from record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.repair(id: id, from: record) }
+    func save(_ record: TimeInstanceRecord) async throws -> TimeInstanceRecord { try await base.save(record) }
+}
+
+
+private actor PausingCalendarBeforeCreate: CalendarSyncProviding {
+    private let base = SyncTestCalendar()
+    let entered = AsyncTestLatch()
+    let release = AsyncTestLatch()
+    private var paused = false
+
+    func qualify(calendarId: String) async throws -> CalendarQualification { try await base.qualify(calendarId: calendarId) }
+    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem { try await base.create(draft) }
+    func item(id: String) async throws -> ExternalCalendarItem? { try await base.item(id: id) }
+    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] {
+        if !paused {
+            paused = true
+            await entered.open()
+            await release.wait()
+        }
+        return try await base.recover(query)
+    }
+    func createdCount() async -> Int { await base.createdCount() }
+}
+
+private actor PostEffectCancellingCalendar: CalendarSyncProviding {
+    private let base = SyncTestCalendar()
+    let created = AsyncTestLatch()
+
+    func qualify(calendarId: String) async throws -> CalendarQualification { try await base.qualify(calendarId: calendarId) }
+    func create(_ draft: ExternalCalendarDraft) async throws -> ExternalCalendarItem {
+        let item = try await base.create(draft)
+        await created.open()
+        try await Task.sleep(nanoseconds: 10_000_000_000)
+        return item
+    }
+    func item(id: String) async throws -> ExternalCalendarItem? { try await base.item(id: id) }
+    func recover(_ query: CalendarRecoveryQuery) async throws -> [ExternalCalendarItem] { try await base.recover(query) }
+    func count() async -> Int { await base.count() }
+}
+
+private func seedTransaction(
+    _ store: any CalendarRegistryTransactionStoring,
+    request: RegistryFirstTimeInstanceRequest,
+    registryEventId: String
+) async throws {
+    var tx = try await store.claim(
+        idempotencyKey: request.idempotencyKey,
+        manifestFingerprint: request.manifest.fingerprint,
+        operationId: "seed-operation",
+        leaseOwner: "seed-owner",
+        leaseToken: "seed-token",
+        leaseDuration: 600
+    )
+    tx.registryEventId = registryEventId
+    tx.stage = .registryCreated
+    tx = try await store.save(tx)
+    _ = try await store.release(tx)
+}
+
 private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring {
     private var transaction: CalendarRegistryTransaction?
 
@@ -186,18 +311,31 @@ private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring 
         idempotencyKey: String,
         manifestFingerprint: String,
         operationId: String,
-        now: Date
+        leaseOwner: String,
+        leaseToken: String,
+        leaseDuration: TimeInterval
     ) async throws -> CalendarRegistryTransaction {
         if let transaction { return transaction }
+        let now = Date()
         let created = CalendarRegistryTransaction(
             operationId: operationId,
             idempotencyKey: idempotencyKey,
             manifestFingerprint: manifestFingerprint,
             createdAt: now,
-            updatedAt: now
+            updatedAt: now,
+            revision: 1,
+            leaseOwner: leaseOwner,
+            leaseToken: leaseToken,
+            leaseExpiresAt: now.addingTimeInterval(leaseDuration),
+            heartbeatAt: now
         )
         transaction = created
         return created
+    }
+
+    func renew(_ transaction: CalendarRegistryTransaction, leaseDuration: TimeInterval) async throws -> CalendarRegistryTransaction {
+        _ = leaseDuration
+        throw SyncTestError.forcedLedgerSave
     }
 
     func get(idempotencyKey: String) async throws -> CalendarRegistryTransaction? {
@@ -205,7 +343,11 @@ private actor AlwaysFailingTransactionStore: CalendarRegistryTransactionStoring 
         return transaction
     }
 
-    func save(_ transaction: CalendarRegistryTransaction) async throws {
+    func save(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction {
+        throw SyncTestError.forcedLedgerSave
+    }
+
+    func release(_ transaction: CalendarRegistryTransaction) async throws -> CalendarRegistryTransaction {
         throw SyncTestError.forcedLedgerSave
     }
 }
@@ -236,8 +378,8 @@ private func syncRequest(
 }
 
 private func makeSyncEngine(
-    registry: SyncTestRegistry = SyncTestRegistry(),
-    calendar: SyncTestCalendar = SyncTestCalendar(),
+    registry: any TimeInstanceRegistryStoring = SyncTestRegistry(),
+    calendar: any CalendarSyncProviding = SyncTestCalendar(),
     transactions: any CalendarRegistryTransactionStoring = InMemoryCalendarRegistryTransactionStore(),
     operationGate: CalendarRegistryOperationGate = CalendarRegistryOperationGate()
 ) -> CalendarRegistrySyncEngine {
@@ -247,7 +389,9 @@ private func makeSyncEngine(
         transactions: transactions,
         operationGate: operationGate,
         clock: { Date(timeIntervalSince1970: 1_800_000_000) },
-        makeOperationId: { UUID().uuidString.lowercased() }
+        makeOperationId: { UUID().uuidString.lowercased() },
+        makeLeaseToken: { UUID().uuidString.lowercased() },
+        leaseDuration: 600
     )
 }
 
@@ -265,12 +409,14 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
     nonisolated var supportsAuthoritativeFiltering: Bool { true }
     var pages: [String: NotionRow] = [:]
     var failUpdate = false
+    var failCreateResponseAfterPersist = false
     var filteredQueryCalls = 0
     private var sequence = 0
     private(set) var lastCreatedFields: [BoundField] = []
     private(set) var lastUpdatedFields: [BoundField] = []
 
     func setFailUpdate(_ value: Bool) { failUpdate = value }
+    func setFailCreateResponseAfterPersist(_ value: Bool) { failCreateResponseAfterPersist = value }
     func pageCount() -> Int { pages.count }
     func createdFields() -> [BoundField] { lastCreatedFields }
 
@@ -313,6 +459,10 @@ private actor SyncRegistryGateway: RegistryNotionGateway {
         lastCreatedFields = fields
         let row = Self.row(id: id, existing: nil, fields: fields)
         pages[id] = row
+        if failCreateResponseAfterPersist {
+            failCreateResponseAfterPersist = false
+            throw RegistryGatewayError.invalidResponse("simulated malformed create response after remote success")
+        }
         return row
     }
 
@@ -423,12 +573,12 @@ func runCalendarRegistrySyncEngineTests() async {
                 idempotencyKey: "same-key",
                 manifestFingerprint: "fingerprint-a",
                 operationId: "op-1",
-                now: Date(timeIntervalSince1970: 100)
+                leaseOwner: "worker-1", leaseToken: "token-1", leaseDuration: 600
             )
             var updated = created
             updated.stage = .calendarCreated
             updated.calendarEventId = "event-1"
-            try await first.save(updated)
+            _ = try await first.save(updated)
 
             let second = try SQLiteCalendarRegistryTransactionStore(url: url)
             let loaded = try await second.get(idempotencyKey: "same-key")
@@ -446,14 +596,14 @@ func runCalendarRegistrySyncEngineTests() async {
                 idempotencyKey: "same-key",
                 manifestFingerprint: "fingerprint-a",
                 operationId: "op-a",
-                now: Date()
+                leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 600
             )
             do {
                 _ = try await second.claim(
                     idempotencyKey: "same-key",
                     manifestFingerprint: "fingerprint-b",
                     operationId: "op-b",
-                    now: Date()
+                    leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
                 )
                 throw TestError.assertion("expected idempotency conflict")
             } catch CalendarRegistryTransactionStoreError.idempotencyConflict("same-key") {
@@ -469,11 +619,11 @@ func runCalendarRegistrySyncEngineTests() async {
             let second = try SQLiteCalendarRegistryTransactionStore(url: url)
             async let a = first.claim(
                 idempotencyKey: "key-a", manifestFingerprint: "fp-a",
-                operationId: "op-a", now: Date()
+                operationId: "op-a", leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 600
             )
             async let b = second.claim(
                 idempotencyKey: "key-b", manifestFingerprint: "fp-b",
-                operationId: "op-b", now: Date()
+                operationId: "op-b", leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
             )
             _ = try await [a, b]
             try expect(try await first.get(idempotencyKey: "key-a") != nil)
@@ -592,7 +742,7 @@ func runCalendarRegistrySyncEngineTests() async {
             let receipt = try await makeSyncEngine(registry: registry, calendar: calendar)
                 .registryFirstCreate(syncRequest(key: "shape-\(shape.0)-\(shape.1)-\(shape.2)"))
             try expect(!receipt.succeeded)
-            try expect(receipt.stageAfter == .recoverableError)
+            try expect(receipt.stageAfter == .conflict)
         }
     }
 
@@ -737,7 +887,383 @@ func runCalendarRegistrySyncEngineTests() async {
         } catch CalendarRegistrySyncCompositionError.missingAllowedCalendars {}
     }
 
-    await test("CR22 route ownership remains explicit") {
+
+    await test("CR22 same-key independent engines permit one external writer") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("race.sqlite3")
+            let firstStore = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let secondStore = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let baseRegistry = SyncTestRegistry()
+            let entered = AsyncTestLatch()
+            let release = AsyncTestLatch()
+            let registry = PausingRegistry(base: baseRegistry, entered: entered, release: release)
+            let calendar = SyncTestCalendar()
+            let firstEngine = makeSyncEngine(registry: registry, calendar: calendar, transactions: firstStore)
+            let secondEngine = makeSyncEngine(registry: registry, calendar: calendar, transactions: secondStore)
+
+            let first = Task { try await firstEngine.registryFirstCreate(syncRequest(key: "race-key")) }
+            await entered.wait()
+            let second = Task { try await secondEngine.registryFirstCreate(syncRequest(key: "race-key")) }
+            try await Task.sleep(nanoseconds: 50_000_000)
+            await release.open()
+            let receipts = try await [first.value, second.value]
+            try expect(receipts.filter(\.succeeded).count == 1)
+            try expect(receipts.contains { $0.discrepancy?.contains("already active") == true })
+            try expect(await baseRegistry.createdCount() == 1)
+            try expect(await calendar.createdCount() == 1)
+        }
+    }
+
+    await test("CR23 stale revisions, fencing tokens, stage regression, and identity clearing are refused") {
+        try await withTempDirectory { directory in
+            let store = try SQLiteCalendarRegistryTransactionStore(url: directory.appendingPathComponent("cas.sqlite3"))
+            let claimed = try await store.claim(
+                idempotencyKey: "cas-key", manifestFingerprint: "fingerprint",
+                operationId: "op", leaseOwner: "worker", leaseToken: "fence-a", leaseDuration: 600
+            )
+            var progressed = claimed
+            progressed.stage = .calendarCreated
+            progressed.calendarEventId = "event-1"
+            let saved = try await store.save(progressed)
+
+            var stale = claimed
+            stale.stage = .registryCreated
+            do { _ = try await store.save(stale); throw TestError.assertion("stale revision should fail") }
+            catch CalendarRegistryTransactionStoreError.staleRevision("cas-key") {}
+
+            var wrongFence = saved
+            wrongFence.leaseToken = "fence-b"
+            do { _ = try await store.save(wrongFence); throw TestError.assertion("wrong fence should fail") }
+            catch CalendarRegistryTransactionStoreError.leaseLost("cas-key") {}
+
+            var regressed = saved
+            regressed.stage = .registryCreated
+            do { _ = try await store.save(regressed); throw TestError.assertion("stage regression should fail") }
+            catch CalendarRegistryTransactionStoreError.stageRegression {}
+
+            var cleared = saved
+            cleared.stage = .pairPersisted
+            cleared.calendarEventId = nil
+            do { _ = try await store.save(cleared); throw TestError.assertion("identity clearing should fail") }
+            catch CalendarRegistryTransactionStoreError.identityRegression {}
+        }
+    }
+
+    await test("CR24 expired lease can be fenced and resumed once") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("expiry.sqlite3")
+            let first = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let second = try SQLiteCalendarRegistryTransactionStore(url: url)
+            let original = try await first.claim(
+                idempotencyKey: "expiry-key", manifestFingerprint: "fingerprint",
+                operationId: "op-a", leaseOwner: "worker-a", leaseToken: "token-a", leaseDuration: 0.1
+            )
+            try await Task.sleep(nanoseconds: 1_100_000_000)
+            let resumed = try await second.claim(
+                idempotencyKey: "expiry-key", manifestFingerprint: "fingerprint",
+                operationId: "op-b", leaseOwner: "worker-b", leaseToken: "token-b", leaseDuration: 600
+            )
+            try expect(resumed.leaseToken == "token-b")
+            try expect(resumed.revision > original.revision)
+            do { _ = try await first.save(original); throw TestError.assertion("expired worker should be fenced") }
+            catch CalendarRegistryTransactionStoreError.staleRevision("expiry-key") {}
+        }
+    }
+
+    await test("CR25 canonical manifest normalizes relations, primary block, and empty optionals") {
+        let requestA = RegistryFirstTimeInstanceRequest(
+            idempotencyKey: "canonical-key", title: "  LIFT  ",
+            start: syncRequest().start, end: syncRequest().end,
+            timeZoneIdentifier: " America/Chicago ", calendarId: " cal-private ",
+            location: "   ", notes: " note ",
+            semantics: TimeInstanceSemantics(
+                eventClass: .focus, meetingType: " ", primaryBlockId: " block-primary ",
+                blockIds: ["block-b", "block-primary", "block-b"],
+                projectIds: ["project-b", "project-a", "project-b"],
+                contactIds: ["contact-b", "contact-a"]
+            )
+        ).canonicalized
+        let requestB = RegistryFirstTimeInstanceRequest(
+            idempotencyKey: "canonical-key", title: "LIFT",
+            start: syncRequest().start, end: syncRequest().end,
+            timeZoneIdentifier: "America/Chicago", calendarId: "cal-private",
+            location: nil, notes: "note",
+            semantics: TimeInstanceSemantics(
+                eventClass: .focus, primaryBlockId: "block-primary",
+                blockIds: ["block-primary", "block-b"],
+                projectIds: ["project-a", "project-b"],
+                contactIds: ["contact-a", "contact-b"]
+            )
+        ).canonicalized
+        try expect(requestA == requestB)
+        try expect(requestA.manifest.fingerprint == requestB.manifest.fingerprint)
+        try expect(requestA.semantics.blockIds == ["block-b", "block-primary"])
+        try expect(requestA.location == nil && requestA.semantics.meetingType == nil)
+    }
+
+    await test("CR26 final success verifies Sync Hash and Last Synced At") {
+        let receipt = try await makeSyncEngine().registryFirstCreate(syncRequest(key: "evidence-key"))
+        try expect(receipt.succeeded)
+        try expect(receipt.verifiedSyncHash?.count == 64)
+        try expect(receipt.record?.syncHash == receipt.verifiedSyncHash)
+        try expect(receipt.record?.lastSyncedAt == receipt.verifiedAt)
+        try expect(receipt.fencingToken?.isEmpty == false)
+        try expect((receipt.ledgerRevision ?? 0) > 1)
+    }
+
+    await test("CR27 a dropped final Sync Hash prevents success") {
+        let registry = SyncTestRegistry()
+        await registry.setDropFinalSyncHash(true)
+        let receipt = try await makeSyncEngine(registry: registry)
+            .registryFirstCreate(syncRequest(key: "dropped-hash"))
+        try expect(!receipt.succeeded)
+        try expect(receipt.discrepancy?.contains("Synced evidence") == true)
+    }
+
+    await test("CR28 ledger-known matching partial page repairs; mismatched, malformed, and missing pages do not") {
+        for mode in ["matching", "mismatch", "malformed", "missing"] {
+            let request = syncRequest(key: "known-\(mode)")
+            let registry = SyncTestRegistry()
+            let calendar = SyncTestCalendar()
+            let store = InMemoryCalendarRegistryTransactionStore()
+            let id = "known-page-\(mode)"
+            switch mode {
+            case "matching":
+                await registry.setIdentityOverride(id: id, value: .partial(
+                    pageId: id, syncKey: request.idempotencyKey,
+                    operationFingerprint: request.manifest.fingerprint
+                ))
+            case "mismatch":
+                await registry.setIdentityOverride(id: id, value: .partial(
+                    pageId: id, syncKey: request.idempotencyKey,
+                    operationFingerprint: String(repeating: "b", count: 64)
+                ))
+            case "malformed":
+                await registry.setIdentityOverride(id: id, value: .malformed(pageId: id, reason: "broken relation"))
+            default:
+                await registry.setIdentityOverride(id: id, value: .missing)
+            }
+            try await seedTransaction(store, request: request, registryEventId: id)
+            let receipt = try await makeSyncEngine(registry: registry, calendar: calendar, transactions: store)
+                .registryFirstCreate(request)
+            if mode == "matching" {
+                try expect(receipt.succeeded)
+                try expect(await registry.createdCount() == 0)
+                try expect(await calendar.createdCount() == 1)
+            } else {
+                try expect(!receipt.succeeded)
+                try expect(receipt.stageAfter == .conflict)
+                try expect(await registry.createdCount() == 0)
+                try expect(await calendar.createdCount() == 0)
+            }
+        }
+    }
+
+    await test("CR29 remotely successful Notion create with invalid response recovers without duplication") {
+        let gateway = SyncRegistryGateway()
+        await gateway.setFailCreateResponseAfterPersist(true)
+        let registry = NotionTimeInstanceRegistryStore(entity: scheduleEntityForSyncTests(), gateway: gateway)
+        let calendar = SyncTestCalendar()
+        let transactions = InMemoryCalendarRegistryTransactionStore()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar, transactions: transactions)
+        let request = syncRequest(key: "uncertain-create")
+        let first = try await engine.registryFirstCreate(request)
+        try expect(!first.succeeded)
+        let second = try await engine.registryFirstCreate(request)
+        try expect(second.succeeded)
+        try expect(await gateway.pageCount() == 1)
+        try expect(await calendar.createdCount() == 1)
+    }
+
+    await test("CR30 strict row decoders reject malformed synchronization responses") {
+        for data in [Data("{}".utf8), Data("{\"id\":\"page\"}".utf8)] {
+            do {
+                _ = try RegistryRowResponseDecoder.decode(data, context: "test")
+                throw TestError.assertion("malformed row should fail")
+            } catch RegistryGatewayError.invalidResponse {}
+        }
+        let malformedResult = try JSONSerialization.data(withJSONObject: [
+            "results": [["id": "page-without-properties"]], "has_more": false
+        ])
+        do {
+            _ = try RegistryQueryResponseDecoder.decode(malformedResult)
+            throw TestError.assertion("malformed query row should fail")
+        } catch RegistryGatewayError.invalidResponse {}
+    }
+
+    await test("CR31 identity-bearing unsupported calendar shapes conflict instead of duplicating") {
+        for shape in ["recurring", "all-day", "detached", "participant"] {
+            let request = syncRequest(key: "shape-existing-\(shape)")
+            let store = PersistentCalendarStore()
+            let identity = CalendarRegistryCalendarMetadata.Identity(
+                syncKey: request.idempotencyKey,
+                operationFingerprint: request.manifest.fingerprint
+            )
+            let notes = try CalendarRegistryCalendarMetadata.append(to: request.notes, identity: identity)
+            await store.seed(CalendarEvent(
+                id: "existing-\(shape)", title: request.title,
+                start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
+                allDay: shape == "all-day", calendarId: request.calendarId,
+                calendarTitle: "Private Smoke", location: request.location, notes: notes,
+                timeZoneIdentifier: request.timeZoneIdentifier, externalId: "external-\(shape)",
+                organizer: shape == "participant" ? "owner@example.com" : nil,
+                attendees: shape == "participant" ? ["person@example.com"] : [],
+                lastModified: CalendarRegistryISO.string(Date()),
+                isRecurring: shape == "recurring", isDetached: shape == "detached"
+            ))
+            let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+            let receipt = try await makeSyncEngine(registry: SyncTestRegistry(), calendar: provider)
+                .registryFirstCreate(request)
+            try expect(!receipt.succeeded)
+            try expect(receipt.stageAfter == .conflict)
+            try expect(await store.count() == 1)
+        }
+    }
+
+    await test("CR32 unrelated malformed calendar metadata does not poison target recovery") {
+        let request = syncRequest(key: "target-metadata")
+        let store = PersistentCalendarStore()
+        await store.seed(CalendarEvent(
+            id: "unrelated", title: "Other", start: CalendarRegistryISO.string(request.start),
+            end: CalendarRegistryISO.string(request.end), allDay: false,
+            calendarId: request.calendarId, calendarTitle: "Private Smoke", location: nil,
+            notes: CalendarRegistryCalendarMetadata.beginMarker + "\ninvalid",
+            timeZoneIdentifier: request.timeZoneIdentifier
+        ))
+        let identity = CalendarRegistryCalendarMetadata.Identity(
+            syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint
+        )
+        await store.seed(CalendarEvent(
+            id: "target", title: request.title, start: CalendarRegistryISO.string(request.start),
+            end: CalendarRegistryISO.string(request.end), allDay: false,
+            calendarId: request.calendarId, calendarTitle: "Private Smoke", location: request.location,
+            notes: try CalendarRegistryCalendarMetadata.append(to: request.notes, identity: identity),
+            timeZoneIdentifier: request.timeZoneIdentifier, externalId: "target-external"
+        ))
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        let recovered = try await provider.recover(CalendarRecoveryQuery(
+            syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint,
+            calendarId: request.calendarId, title: request.title, start: request.start, end: request.end
+        ))
+        try expect(recovered.map(\.localEventId) == ["target"])
+    }
+
+    await test("CR33 invalid partial-effect JSON is ledger corruption") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("corrupt.sqlite3")
+            let store = try SQLiteCalendarRegistryTransactionStore(url: url)
+            _ = try await store.claim(
+                idempotencyKey: "corrupt-key", manifestFingerprint: "fingerprint",
+                operationId: "op", leaseOwner: "worker", leaseToken: "token", leaseDuration: 600
+            )
+            var db: OpaquePointer?
+            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK)
+            defer { if let db { sqlite3_close_v2(db) } }
+            try expect(sqlite3_exec(db, "UPDATE calendar_registry_transactions SET partial_effects_json='not-json' WHERE idempotency_key='corrupt-key';", nil, nil, nil) == SQLITE_OK)
+            do {
+                _ = try await store.get(idempotencyKey: "corrupt-key")
+                throw TestError.assertion("corrupt effects should fail")
+            } catch CalendarRegistryTransactionStoreError.corruptLedger {}
+        }
+    }
+
+    await test("CR34 cancelled gate waiter never acquires later") {
+        let gate = CalendarRegistryOperationGate()
+        try await gate.acquire("cancel-key")
+        let waiter = Task { try await gate.acquire("cancel-key") }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        waiter.cancel()
+        await gate.release("cancel-key")
+        do { try await waiter.value; throw TestError.assertion("cancelled waiter should fail") }
+        catch is CancellationError {}
+        try await gate.acquire("cancel-key")
+        await gate.release("cancel-key")
+    }
+
+    await test("CR35 cancellation before Notion create produces no external write") {
+        let base = SyncTestRegistry()
+        let entered = AsyncTestLatch()
+        let release = AsyncTestLatch()
+        let registry = PausingRegistry(base: base, entered: entered, release: release)
+        let calendar = SyncTestCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-before-create")) }
+        await entered.wait()
+        task.cancel()
+        await release.open()
+        let receipt = try await task.value
+        try expect(!receipt.succeeded)
+        try expect(await base.createdCount() == 0)
+        try expect(await calendar.createdCount() == 0)
+    }
+
+    await test("CR36 cancellation after calendar side effect persists recovery evidence") {
+        let registry = SyncTestRegistry()
+        let calendar = PostEffectCancellingCalendar()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-after-calendar")) }
+        await calendar.created.wait()
+        task.cancel()
+        let receipt = try await task.value
+        try expect(!receipt.succeeded)
+        try expect(receipt.recoveryStatePersisted)
+        try expect(await calendar.count() == 1)
+    }
+
+
+    await test("CR37 cancellation before EventKit create produces no calendar write") {
+        let registry = SyncTestRegistry()
+        let calendar = PausingCalendarBeforeCreate()
+        let engine = makeSyncEngine(registry: registry, calendar: calendar)
+        let task = Task { try await engine.registryFirstCreate(syncRequest(key: "cancel-before-calendar")) }
+        await calendar.entered.wait()
+        task.cancel()
+        await calendar.release.open()
+        let receipt = try await task.value
+        try expect(!receipt.succeeded)
+        try expect(receipt.recoveryStatePersisted)
+        try expect(await registry.createdCount() == 1)
+        try expect(await calendar.createdCount() == 0)
+    }
+
+    await test("CR38 target-related malformed calendar metadata conflicts") {
+        let request = syncRequest(key: "target-malformed")
+        let store = PersistentCalendarStore()
+        await store.seed(CalendarEvent(
+            id: "target-malformed-event", title: request.title,
+            start: CalendarRegistryISO.string(request.start), end: CalendarRegistryISO.string(request.end),
+            allDay: false, calendarId: request.calendarId, calendarTitle: "Private Smoke",
+            location: request.location,
+            notes: CalendarRegistryCalendarMetadata.beginMarker + "\nSync-Key: \(request.idempotencyKey)",
+            timeZoneIdentifier: request.timeZoneIdentifier
+        ))
+        let provider = CalendarStoringSyncProvider(store: store, allowlistedCalendarIds: [request.calendarId])
+        do {
+            _ = try await provider.recover(CalendarRecoveryQuery(
+                syncKey: request.idempotencyKey, operationFingerprint: request.manifest.fingerprint,
+                calendarId: request.calendarId, title: request.title, start: request.start, end: request.end
+            ))
+            throw TestError.assertion("target-related malformed metadata should conflict")
+        } catch CalendarRegistrySyncError.identityConflict {}
+    }
+
+    await test("CR39 unknown future ledger schema is refused without downgrade") {
+        try await withTempDirectory { directory in
+            let url = directory.appendingPathComponent("future.sqlite3")
+            var db: OpaquePointer?
+            try expect(sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil) == SQLITE_OK)
+            try expect(sqlite3_exec(db, "CREATE TABLE calendar_registry_schema (id INTEGER PRIMARY KEY, version INTEGER NOT NULL); INSERT INTO calendar_registry_schema(id,version) VALUES(1,99);", nil, nil, nil) == SQLITE_OK)
+            if let db { sqlite3_close_v2(db) }
+            do {
+                _ = try SQLiteCalendarRegistryTransactionStore(url: url)
+                throw TestError.assertion("future schema should be refused")
+            } catch CalendarRegistryTransactionStoreError.corruptLedger(let reason) {
+                try expect(reason.contains("unsupported schema version 99"))
+            }
+        }
+    }
+
+    await test("CR40 route ownership remains explicit") {
         try expect(CalendarRegistryRouteClassifier.owner(for: .semanticScheduling) == .timeKeepr)
         try expect(CalendarRegistryRouteClassifier.owner(for: .calendarMechanics) == .macKeepr)
         try expect(CalendarRegistryRouteClassifier.owner(for: .schemaChange) == .notionKeepr)
@@ -746,6 +1272,9 @@ func runCalendarRegistrySyncEngineTests() async {
 
 private actor PersistentCalendarStore: CalendarStoring {
     private var eventsById: [String: CalendarEvent] = [:]
+
+    func seed(_ event: CalendarEvent) { eventsById[event.id] = event }
+    func count() -> Int { eventsById.count }
 
     nonisolated func authorizationStatus() -> CalendarAuthStatus { .authorized }
     func ensureAccess() async throws {}

--- a/TheBridgeTests/CallHistoryModuleTests.swift
+++ b/TheBridgeTests/CallHistoryModuleTests.swift
@@ -1,0 +1,222 @@
+// CallHistoryModuleTests.swift — Bridge v4 stabilization · calls_recent Wave 1
+
+import Foundation
+import MCP
+import SQLite3
+import TheBridgeLib
+
+private func callRecord(
+    id: Int64,
+    seconds: TimeInterval,
+    number: String?,
+    outbound: Bool
+) -> CallHistoryRawRecord {
+    CallHistoryRawRecord(
+        primaryKey: id,
+        uniqueID: "call-\(id)",
+        date: Date(timeIntervalSince1970: seconds),
+        durationSeconds: Double(id),
+        address: number,
+        originated: outbound,
+        answered: id.isMultiple(of: 2),
+        callType: Int(id),
+        serviceProvider: "provider"
+    )
+}
+
+private func object(_ value: Value) throws -> [String: Value] {
+    guard case .object(let result) = value else {
+        throw TestError.assertion("Expected object response")
+    }
+    return result
+}
+
+func runCallHistoryModuleTests() async {
+    print("\n☎️ CallHistoryModule Tests")
+
+    let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+    await CallHistoryModule.register(on: router)
+
+    await test("calls_recent registers as one open-tier calls tool") {
+        let tools = await router.registrations(forModule: "calls")
+        try expect(tools.count == 1)
+        try expect(tools.first?.name == "calls_recent")
+        try expect(tools.first?.tier == .open)
+    }
+
+    await test("calls_recent schema exposes every locked Wave 1 filter") {
+        let registrations = await router.registrations(forModule: "calls")
+        guard let tool = registrations.first(where: { $0.name == "calls_recent" }) else {
+            throw TestError.assertion("Missing calls_recent registration")
+        }
+        guard case .object(let schema) = tool.inputSchema,
+              case .object(let properties) = schema["properties"] else {
+            throw TestError.assertion("Missing input properties")
+        }
+        try expect(Set(properties.keys) == Set(["limit", "since", "number", "direction"]))
+        guard case .object(let direction) = properties["direction"],
+              case .array(let values) = direction["enum"] else {
+            throw TestError.assertion("Missing direction enum")
+        }
+        try expect(Set(values) == Set([.string("inbound"), .string("outbound"), .string("all")]))
+    }
+
+    await test("calls_recent annotation is read-only, ungated, and time-dependent") {
+        guard let annotation = ToolAnnotationCatalog.annotations(for: "calls_recent") else {
+            throw TestError.assertion("Missing calls_recent annotation")
+        }
+        try expect(annotation.readOnlyHint)
+        try expect(!annotation.destructiveHint)
+        try expect(!annotation.idempotentHint)
+        try expect(!annotation.requiresConfirmation)
+        try expect(annotation.openWorld)
+    }
+
+    await test("phone normalization removes punctuation without resolving identity") {
+        try expect(CallHistoryModule.normalizePhoneNumber("+1 (605) 555-0123") == "16055550123")
+        try expect(CallHistoryModule.normalizePhoneNumber("abc") == "")
+    }
+
+    await test("query parser defaults and hard-clamps the limit") {
+        let defaults = try CallHistoryModule.parseQuery(.object([:]))
+        try expect(defaults.limit == 20)
+        try expect(defaults.direction == .all)
+        let clamped = try CallHistoryModule.parseQuery(.object(["limit": .int(1_000)]))
+        try expect(clamped.limit == 100)
+    }
+
+    await test("query parser rejects invalid limit, since, number, and direction") {
+        for args: Value in [
+            .object(["limit": .int(0)]),
+            .object(["since": .string("yesterday-ish")]),
+            .object(["number": .string("no digits")]),
+            .object(["direction": .string("sideways")])
+        ] {
+            do {
+                _ = try CallHistoryModule.parseQuery(args)
+                throw TestError.assertion("Expected invalid arguments")
+            } catch is ToolRouterError {
+                // Expected.
+            }
+        }
+    }
+
+    let records = [
+        callRecord(id: 1, seconds: 100, number: "+1 (605) 555-0100", outbound: false),
+        callRecord(id: 2, seconds: 300, number: "+1 605 555 0200", outbound: true),
+        callRecord(id: 3, seconds: 200, number: "16055550100", outbound: true)
+    ]
+
+    await test("records are newest-first and limit is applied after sorting") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 2, since: nil, number: nil, direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [2, 3])
+    }
+
+    await test("since filter is inclusive") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: Date(timeIntervalSince1970: 200), number: nil, direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [2, 3])
+    }
+
+    await test("normalized-number filter is exact and formatting-insensitive") {
+        let result = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: "16055550100", direction: .all)
+        )
+        try expect(result.map(\.primaryKey) == [3, 1])
+    }
+
+    await test("direction filters distinguish inbound, outbound, and all") {
+        let inbound = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .inbound)
+        )
+        let outbound = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .outbound)
+        )
+        let all = CallHistoryModule.filteredRecords(
+            records,
+            query: CallHistoryQuery(limit: 10, since: nil, number: nil, direction: .all)
+        )
+        try expect(inbound.map(\.primaryKey) == [1])
+        try expect(outbound.map(\.primaryKey) == [2, 3])
+        try expect(all.map(\.primaryKey) == [2, 3, 1])
+    }
+
+    await test("successful response is structured and makes no identity claim") {
+        let value = try CallHistoryModule.response(
+            arguments: .object(["limit": .int(1)]),
+            databasePath: "/fixture",
+            reader: { _ in records }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(true))
+        try expect(result["identityResolved"] == .bool(false))
+        guard case .array(let calls) = result["calls"],
+              case .object(let first) = calls.first else {
+            throw TestError.assertion("Missing calls array")
+        }
+        try expect(first["id"] == .string("call-2"))
+        try expect(first["name"] == nil)
+        try expect(first["resolvedName"] == nil)
+    }
+
+    await test("database denial returns structured Full Disk Access guidance") {
+        let value = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/denied",
+            reader: { _ in throw CallHistoryReadError.unavailable("authorization denied") }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(false))
+        guard case .object(let error) = result["error"] else {
+            throw TestError.assertion("Missing error object")
+        }
+        try expect(error["code"] == .string("full_disk_access_required"))
+        guard case .string(let remediation) = error["remediation"] else {
+            throw TestError.assertion("Missing remediation")
+        }
+        try expect(remediation.contains("Full Disk Access"))
+    }
+
+    await test("schema drift fails explicitly instead of returning an empty success") {
+        let value = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/fixture",
+            reader: { _ in throw CallHistoryReadError.unsupportedSchema(missingColumns: ["ZDATE", "ZADDRESS"]) }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(false))
+        try expect(result["calls"] == nil)
+        guard case .object(let error) = result["error"],
+              case .array(let missing) = error["missingColumns"] else {
+            throw TestError.assertion("Missing structured schema error")
+        }
+        try expect(Set(missing) == Set([.string("ZADDRESS"), .string("ZDATE")]))
+    }
+
+    await test("real SQLite adapter rejects an incompatible fixture schema") {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calls-recent-schema-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("CallHistory.storedata").path
+        var database: OpaquePointer?
+        try expect(sqlite3_open(path, &database) == SQLITE_OK)
+        defer { if let database { sqlite3_close(database) } }
+        try expect(sqlite3_exec(database, "CREATE TABLE ZCALLRECORD (Z_PK INTEGER)", nil, nil, nil) == SQLITE_OK)
+        do {
+            _ = try CallHistoryModule.readDatabase(at: path)
+            throw TestError.assertion("Expected unsupported schema")
+        } catch CallHistoryReadError.unsupportedSchema(let missing) {
+            try expect(missing.contains("ZDATE"))
+            try expect(missing.contains("ZADDRESS"))
+        }
+    }
+}

--- a/TheBridgeTests/FetchSkillPropertiesTests.swift
+++ b/TheBridgeTests/FetchSkillPropertiesTests.swift
@@ -443,7 +443,8 @@ func runFetchSkillPropertiesTests() async {
         "summary", "triggerPhrases", "antiTriggerPhrases"
     ]
     let additiveEnvelopeKeys: Set<String> = [
-        "properties", "uuid", "slug", "version", "status", "maturity"
+        "properties", "uuid", "slug", "version", "status", "maturity",
+        "authoritativeMetadataSource"
     ]
 
     await test("cu-sa (d): legacy keys byte-identical empty↔populated; doctrine identity is additive") {
@@ -686,5 +687,28 @@ func runFetchSkillPropertiesTests() async {
             default: throw TestError.assertion("real fixture produced a non-modelled Value for `\(k)`: \(v)")
             }
         }
+    }
+
+    await test("fetch_skill surfaces body/property metadata drift with one authoritative source") {
+        let result = await SkillsModule.buildSkillResultForTesting(
+            name: "close-agent",
+            title: "Close Agent",
+            url: "https://www.notion.so/example",
+            markdownJSONOrText: "**Version:** 3.3.2\n**Status:** Proven\n\n# Closeout",
+            pageProperties: [
+                "Version": richText("3.3.1"),
+                "Status": statusProp("Testing")
+            ]
+        ) { _ in nil }
+        guard case .object(let envelope) = result,
+              case .object(let drift) = envelope["metadataDrift"],
+              case .array(let fields) = drift["fields"] else {
+            throw TestError.assertion("expected structured metadata drift warning")
+        }
+        try expect(envelope["version"] == .string("3.3.1"))
+        try expect(envelope["status"] == .string("Testing"))
+        try expect(envelope["authoritativeMetadataSource"] == .string("notion_properties"))
+        try expect(drift["detected"] == .bool(true))
+        try expect(fields.count == 2)
     }
 }

--- a/TheBridgeTests/FieldsFilterTests.swift
+++ b/TheBridgeTests/FieldsFilterTests.swift
@@ -71,20 +71,29 @@ func runFieldsFilterTests() async {
     // MARK: #3 — top-level key selection
     // ============================================================
 
-    await test("FieldsFilter: single top-level key narrows to just that key") {
+    await test("FieldsFilter: single top-level key retains identity keys by default") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title"]))
+        // title was requested; id+entity re-attached as identity keys.
+        try expect(Set(projected.keys) == ["title", "id", "entity"], "got \(projected.keys.sorted())")
+        try expect(projected["title"] == .string("Alpha"), "title value preserved")
+        try expect(projected["id"] == .string("aaaa0000000000000000000000000001"), "id retained")
+        try expect(projected["entity"] == .string("skill"), "entity retained")
+    }
+
+    await test("FieldsFilter: includeIdentity:false allows pure single-key projection") {
+        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title"], includeIdentity: false))
         try expect(projected.count == 1, "expected exactly 1 key, got \(projected.count): \(projected.keys.sorted())")
         try expect(projected["title"] == .string("Alpha"), "title value preserved")
     }
 
     await test("FieldsFilter: multiple top-level keys all survive") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title", "id", "stale"]))
-        try expect(Set(projected.keys) == ["title", "id", "stale"], "got \(projected.keys.sorted())")
+        try expect(Set(projected.keys) == ["title", "id", "stale", "entity"], "got \(projected.keys.sorted())")
     }
 
-    await test("FieldsFilter: bare 'properties' keeps the WHOLE properties map") {
+    await test("FieldsFilter: bare 'properties' keeps the WHOLE properties map + identity") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties"]))
-        try expect(projected.count == 1, "only properties key expected")
+        try expect(Set(projected.keys) == ["properties", "id", "entity", "title"], "got \(projected.keys.sorted())")
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be an object")
         }
@@ -97,6 +106,7 @@ func runFieldsFilterTests() async {
 
     await test("FieldsFilter: properties.X sub-selects ONE property out of the map") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.summary"]))
+        try expect(projected["id"] != nil, "identity id retained with properties.X projection")
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be present as an object")
         }
@@ -129,8 +139,11 @@ func runFieldsFilterTests() async {
     // ============================================================
 
     await test("FieldsFilter: unknown top-level key → silently absent, no error") {
+        // With includeIdentity (default), only identity keys from the source remain.
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["doesNotExist"]))
-        try expect(projected.isEmpty, "unknown key must contribute nothing; got \(projected.keys.sorted())")
+        try expect(Set(projected.keys) == ["id", "entity", "title"], "got \(projected.keys.sorted())")
+        let pure = dict(FieldsFilter.project(sampleRow(), fields: ["doesNotExist"], includeIdentity: false))
+        try expect(pure.isEmpty, "unknown key must contribute nothing without identity; got \(pure.keys.sorted())")
     }
 
     await test("FieldsFilter: unknown property path → the requested property is silently absent (properties: {})") {
@@ -139,7 +152,7 @@ func runFieldsFilterTests() async {
         // and got zero matches" from "you never asked for properties at
         // all") — but it contains none of the sampleRow's real keys, i.e.
         // the unknown path silently contributes zero matches, never an error.
-        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.doesNotExist"]))
+        let projected = dict(FieldsFilter.project(sampleRow(), fields: ["properties.doesNotExist"], includeIdentity: false))
         guard case .object(let props)? = projected["properties"] else {
             throw TestError.assertion("properties must be present as an object when a properties.X path was requested")
         }
@@ -148,7 +161,8 @@ func runFieldsFilterTests() async {
 
     await test("FieldsFilter: known + unknown top-level keys mixed → only known survive") {
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["title", "ghost", "id"]))
-        try expect(Set(projected.keys) == ["title", "id"], "got \(projected.keys.sorted())")
+        // entity re-attached via includeIdentity even though not requested.
+        try expect(Set(projected.keys) == ["title", "id", "entity"], "got \(projected.keys.sorted())")
     }
 
     // ============================================================
@@ -176,8 +190,11 @@ func runFieldsFilterTests() async {
     await test("FieldsFilter: mixed-case top-level key is NOT matched case-insensitively (exact key match)") {
         // Top-level keys are exact-match (only the propertiesKey token itself
         // is treated case-insensitively) — this pins that distinction.
+        // Identity keys are still re-attached from the source envelope.
         let projected = dict(FieldsFilter.project(sampleRow(), fields: ["Title"]))
-        try expect(projected.isEmpty, "top-level keys are case-SENSITIVE except the properties token")
+        try expect(Set(projected.keys) == ["id", "entity", "title"], "got \(projected.keys.sorted())")
+        let pure = dict(FieldsFilter.project(sampleRow(), fields: ["Title"], includeIdentity: false))
+        try expect(pure.isEmpty, "top-level keys are case-SENSITIVE except the properties token")
     }
 
     // ============================================================

--- a/TheBridgeTests/IntegrationTests/EndToEndTests.swift
+++ b/TheBridgeTests/IntegrationTests/EndToEndTests.swift
@@ -366,7 +366,8 @@ func runEndToEndTests() async {
         try expect(contacts.count == 4, "ContactsModule: expected 4")
         // Sprint A · mcp-builder #1: notion_block_read removed (24 → 23).
         // FB-notionwrite: notion_page_edit added (23 → 24).
-        try expect(notion.count == 22, "NotionModule: expected 22 (FB-notionwrite)")
+        // 2026-07-15: notion_views_list + notion_view_get (22 → 24).
+        try expect(notion.count == 24, "NotionModule: expected 24 (views list/get)")
         try expect(screen.count == 4, "ScreenModule: expected 4")
         // v3.7.11 resurface: the ax_query deprecation alias was removed. Live set:
         // ax_tree, ax_inspect, ax_focused_app, ax_perform_action = 4.

--- a/TheBridgeTests/MessagesModuleTests.swift
+++ b/TheBridgeTests/MessagesModuleTests.swift
@@ -105,6 +105,35 @@ func runMessagesModuleTests() async {
         }
     }
 
+    await test("messages_recent attribution prefers Messages metadata over Contacts") {
+        let fields = MessagesModule.attributionFields(
+            messagesDisplayName: "Scott",
+            handle: "+16055550123",
+            contact: .init(resolvedName: "Different Contact", source: "contacts_exact_handle", confidence: "exact", failureReason: nil)
+        )
+        try expect(fields["resolvedName"] == .string("Scott"))
+        try expect(fields["attributionSource"] == .string("messages_chat_display_name"))
+        try expect(fields["attributionFailureReason"] == .null)
+    }
+
+    await test("messages_recent attribution uses exact Contacts result and exposes failure reason") {
+        let resolved = MessagesModule.attributionFields(
+            messagesDisplayName: nil,
+            handle: "+16055550123",
+            contact: .init(resolvedName: "Known Person", source: "contacts_exact_handle", confidence: "exact", failureReason: nil)
+        )
+        try expect(resolved["resolvedName"] == .string("Known Person"))
+        try expect(resolved["attributionConfidence"] == .string("exact"))
+
+        let unresolved = MessagesModule.attributionFields(
+            messagesDisplayName: nil,
+            handle: "+16055550123",
+            contact: .init(resolvedName: nil, source: "contacts", confidence: "none", failureReason: "no_exact_contact_match")
+        )
+        try expect(unresolved["resolvedName"] == .null)
+        try expect(unresolved["attributionFailureReason"] == .string("no_exact_contact_match"))
+    }
+
     // messages_send rejects without confirm
     await test("messages_send rejects without confirm='SEND'") {
         let result = try await router.dispatch(

--- a/TheBridgeTests/NotionModuleTests.swift
+++ b/TheBridgeTests/NotionModuleTests.swift
@@ -22,9 +22,9 @@ func runNotionModuleTests() async {
     // MARK: - Tool Registration (23 tools)
     // ============================================================
 
-    await test("NotionModule registers 22 tools (FB-notionwrite: notion_page_edit added)") {
+    await test("NotionModule registers 24 tools (views list/get + prior surface)") {
         let tools = await router.registrations(forModule: "notion")
-        try expect(tools.count == 22, "Expected 22 notion tools, got \(tools.count)")
+        try expect(tools.count == 24, "Expected 24 notion tools, got \(tools.count)")
     }
 
     let expectedTools: [String] = [
@@ -36,7 +36,8 @@ func runNotionModuleTests() async {
         "notion_page_move", "notion_file_upload", "notion_token_introspect",
         "notion_block_update",
         "notion_datasource_update", "notion_datasource_create",
-        "notion_discussion_create"
+        "notion_discussion_create",
+        "notion_views_list", "notion_view_get"
     ]
 
     for toolName in expectedTools {
@@ -55,7 +56,8 @@ func runNotionModuleTests() async {
         "notion_search", "notion_page_read", "notion_query",
         "notion_page_markdown_read", "notion_comments_list",
         "notion_users_list", "notion_token_introspect",
-        "notion_database_get", "notion_datasource_get"
+        "notion_database_get", "notion_datasource_get",
+        "notion_views_list", "notion_view_get"
     ]
     for toolName in openTools {
         await test("\(toolName) tier is open") {
@@ -234,6 +236,89 @@ func runNotionModuleTests() async {
             )
             throw TestError.assertion("Expected error for missing parentId/discussionId")
         } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_comment_create rejects both pageId and discussionId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_comment_create",
+                arguments: .object([
+                    "pageId": .string("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+                    "discussionId": .string("11111111-2222-3333-4444-555555555555"),
+                    "text": .string("nope")
+                ])
+            )
+            throw TestError.assertion("Expected error when both pageId and discussionId set")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_views_list rejects missing databaseId and dataSourceId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_views_list",
+                arguments: .object([:])
+            )
+            throw TestError.assertion("Expected error for missing databaseId/dataSourceId")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("notion_view_get rejects missing viewId") {
+        do {
+            _ = try await router.dispatch(
+                toolName: "notion_view_get",
+                arguments: .object([:])
+            )
+            throw TestError.assertion("Expected error for missing viewId")
+        } catch is ToolRouterError {
+            // Expected
+        }
+    }
+
+    await test("buildCreateCommentRequestBody: page path uses parent.page_id") {
+        let body = try NotionClient.buildCreateCommentRequestBody(
+            pageId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            discussionId: nil,
+            text: "hello"
+        )
+        let parent = body["parent"] as? [String: Any]
+        try expect(parent?["page_id"] as? String != nil, "page path must set parent.page_id")
+        try expect(body["discussion_id"] == nil, "page path must not set discussion_id")
+        let rt = body["rich_text"] as? [[String: Any]]
+        try expect(rt?.count == 1, "rich_text should have one run")
+    }
+
+    await test("buildCreateCommentRequestBody: discussion path uses discussion_id only") {
+        let body = try NotionClient.buildCreateCommentRequestBody(
+            pageId: nil,
+            discussionId: "11111111-2222-3333-4444-555555555555",
+            text: "reply"
+        )
+        try expect(body["parent"] == nil, "reply path must not set parent")
+        let did = body["discussion_id"] as? String
+        try expect(did == "11111111222233334444555555555555", "discussion_id should be dash-stripped, got \(did ?? "nil")")
+    }
+
+    await test("buildCreateCommentRequestBody rejects neither and both targets") {
+        do {
+            _ = try NotionClient.buildCreateCommentRequestBody(pageId: nil, discussionId: nil, text: "x")
+            throw TestError.assertion("neither target should throw")
+        } catch is NotionClientError {
+            // Expected
+        }
+        do {
+            _ = try NotionClient.buildCreateCommentRequestBody(
+                pageId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                discussionId: "11111111-2222-3333-4444-555555555555",
+                text: "x"
+            )
+            throw TestError.assertion("both targets should throw")
+        } catch is NotionClientError {
             // Expected
         }
     }

--- a/TheBridgeTests/NotionModuleTests.swift
+++ b/TheBridgeTests/NotionModuleTests.swift
@@ -215,6 +215,32 @@ func runNotionModuleTests() async {
         }
     }
 
+    await test("notion_page_markdown_read schema exposes bounded section selector") {
+        let tools = await router.registrations(forModule: "notion")
+        guard let tool = tools.first(where: { $0.name == "notion_page_markdown_read" }),
+              case .object(let schema) = tool.inputSchema,
+              case .object(let properties) = schema["properties"] else {
+            throw TestError.assertion("Missing notion_page_markdown_read schema")
+        }
+        try expect(properties["section"] != nil)
+    }
+
+    await test("block-level writes derive configured-skill cache eviction candidates") {
+        let candidates = NotionModule.skillCacheEvictionCandidates(
+            targetId: "child-block",
+            responseJSON: ["parent": ["type": "page_id", "page_id": "skill-page"]]
+        )
+        try expect(candidates == ["child-block", "skill-page"])
+        let direct = NotionModule.skillCacheEvictionCandidates(targetId: "skill-page")
+        try expect(direct == ["skill-page"])
+    }
+
+    await test("Notion 401 errors carry a concrete reauthorization path") {
+        let message = NotionClientError.httpError(401, "unauthorized").localizedDescription
+        try expect(message.contains("Settings > Connections"))
+        try expect(message.contains("notion_token_introspect"))
+    }
+
 
     await test("notion_comments_create rejects missing text") {
         do {

--- a/TheBridgeTests/RegistryConfigTests.swift
+++ b/TheBridgeTests/RegistryConfigTests.swift
@@ -28,6 +28,36 @@ private func withTempRegistryStore(_ body: (RegistryConfigStore, URL) async thro
 func runRegistryConfigTests() async {
     print("\n\u{1F5C3}\u{FE0F} Data-Source Registry — Config (model + store)")
 
+    await test("RegistryConfig: packet is canonical with session compatibility alias") {
+        let legacy = RegistryEntity(
+            key: "session",
+            displayName: "PACKETS",
+            dataSourceId: "packets-ds",
+            properties: [],
+            cacheTTLSeconds: 3600,
+            hasBody: true
+        )
+        let legacyConfig = RegistryConfig(entities: [legacy])
+        try expect(legacyConfig.entity("packet")?.key == "packet")
+        try expect(legacyConfig.entity("packet")?.dataSourceId == "packets-ds")
+
+        let canonical = RegistryEntity(
+            key: "packet",
+            displayName: legacy.displayName,
+            dataSourceId: legacy.dataSourceId,
+            properties: legacy.properties,
+            cacheTTLSeconds: legacy.cacheTTLSeconds,
+            hasBody: legacy.hasBody
+        )
+        let canonicalConfig = RegistryConfig(entities: [canonical])
+        try expect(canonicalConfig.entity("session")?.key == "session")
+
+        var actualSession = legacy
+        actualSession.displayName = "Sessions"
+        try expect(RegistryConfig(entities: [actualSession]).entity("packet") == nil,
+                   "a real Sessions entity must never be mistaken for PACKETS")
+    }
+
     // MARK: - Seed model
 
     await test("Seed: Skills is entity #1 with the expected shape") {

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -925,8 +925,10 @@ func runRegistryModuleTests() async {
                 "entity": .string("skill"), "id": .string("bbbb0000000000000000000000000001"),
                 "fields": .array([.string("title")]),
             ]))
-            try expect(obj(out).count == 1, "expected exactly 1 key, got \(obj(out).keys.sorted())")
+            // Identity keys (id/entity/title) retained with the requested projection.
             try expect(obj(out)["title"] == .string("Gamma"), "title value preserved")
+            try expect(obj(out)["id"] != nil, "id retained with projected fields")
+            try expect(obj(out)["entity"] != nil, "entity retained with projected fields")
         }
     }
 
@@ -974,7 +976,8 @@ func runRegistryModuleTests() async {
             guard case .array(let rows)? = obj(out)["rows"] else { throw TestError.assertion("rows missing") }
             try expect(rows.count == 2, "both rows present")
             for r in rows {
-                try expect(obj(r).count == 1 && obj(r)["title"] != nil, "each row projected to just title: \(obj(r))")
+                try expect(obj(r)["title"] != nil, "each row keeps title: \(obj(r))")
+                try expect(obj(r)["id"] != nil, "each projected row retains id: \(obj(r))")
             }
             // count/entity wrapper keys survive untouched (list has no write-status wrapper, but its own keys aren't row-shaped).
             try expect(obj(out)["count"] == .int(2), "count unaffected by fields")
@@ -991,7 +994,8 @@ func runRegistryModuleTests() async {
                 "fields": .array([.string("id")]),
             ]))
             guard case .array(let rows)? = obj(out)["rows"], let r0 = rows.first else { throw TestError.assertion("no rows") }
-            try expect(obj(r0).count == 1 && obj(r0)["id"] == .string("dddd0000000000000000000000000001"), "got \(obj(r0))")
+            try expect(obj(r0)["id"] == .string("dddd0000000000000000000000000001"), "id preserved: \(obj(r0))")
+            try expect(obj(r0)["title"] != nil || obj(r0)["entity"] != nil, "identity keys retained: \(obj(r0))")
         }
     }
 
@@ -1070,8 +1074,10 @@ func runRegistryModuleTests() async {
             try expect(obj(out)["updated"] == .bool(true), "wrapper key present")
             try expect(obj(out)["matchedId"] != nil, "wrapper key matchedId present")
             guard case .object(let row)? = obj(out)["row"] else { throw TestError.assertion("row missing") }
-            try expect(row.count == 1 && row["id"] == .string("ffff0000000000000000000000000010"),
-                       "row must be projected via resultFields to just id, got \(row)")
+            try expect(row["id"] == .string("ffff0000000000000000000000000010"),
+                       "row id preserved via resultFields, got \(row)")
+            try expect(row["entity"] != nil || row["title"] != nil,
+                       "identity keys retained on projected row, got \(row)")
         }
     }
 

--- a/TheBridgeTests/RegistryPropertyCodecTests.swift
+++ b/TheBridgeTests/RegistryPropertyCodecTests.swift
@@ -99,11 +99,20 @@ func runRegistryPropertyCodecTests() async {
                    "multi_select decode")
     }
 
-    await test("decode date → start only (or .null when unset)") {
+    await test("decode date → full range when end/timezone exist") {
         let prop: [String: Any] = ["type": "date",
-            "date": ["start": "2026-06-17", "end": "2026-06-18"]]
-        try expect(RegistryPropertyCodec.decode(type: "date", property: prop) == .string("2026-06-17"),
-                   "date decode (start only)")
+            "date": [
+                "start": "2026-06-17T09:00:00-05:00",
+                "end": "2026-06-17T10:00:00-05:00",
+                "time_zone": "America/Chicago"
+            ]]
+        try expect(RegistryPropertyCodec.decode(type: "date", property: prop) == .object([
+            "start": .string("2026-06-17T09:00:00-05:00"),
+            "end": .string("2026-06-17T10:00:00-05:00"),
+            "timeZone": .string("America/Chicago")
+        ]), "date range decode")
+        let startOnly: [String: Any] = ["type": "date", "date": ["start": "2026-06-17"]]
+        try expect(RegistryPropertyCodec.decode(type: "date", property: startOnly) == .string("2026-06-17"))
         let unset: [String: Any] = ["type": "date", "date": NSNull()]
         try expect(RegistryPropertyCodec.decode(type: "date", property: unset) == .null,
                    "date(unset) → .null")
@@ -390,4 +399,19 @@ func runRegistryPropertyCodecTests() async {
     }
 
     print("  (RegistryPropertyCodec: decode/encode/isWritable + round-trip matrix complete)")
+    await test("encode: date range object preserves start and end") {
+        let encoded = RegistryPropertyCodec.encode(
+            type: "date",
+            value: .object([
+                "start": .string("2026-07-17T09:00:00-05:00"),
+                "end": .string("2026-07-17T10:30:00-05:00")
+            ])
+        )
+        guard let date = encoded?["date"] as? [String: Any] else {
+            throw TestError.assertion("date range did not encode")
+        }
+        try expect(date["start"] as? String == "2026-07-17T09:00:00-05:00")
+        try expect(date["end"] as? String == "2026-07-17T10:30:00-05:00")
+    }
+
 }

--- a/TheBridgeTests/RegistryRowCacheTests.swift
+++ b/TheBridgeTests/RegistryRowCacheTests.swift
@@ -130,6 +130,21 @@ func runRegistryRowCacheTests() async {
         }
     }
 
+    await test("RowCache: direct Notion write evicts the same page across every entity") {
+        try await withTempHomeRows { _ in
+            let cache = RegistryRowCache()
+            let pageId = "aaaa1111111111111111111111111111"
+            try await cache.write(sampleRow(entity: "skill", pageId: pageId, title: "Skill"))
+            try await cache.write(sampleRow(entity: "packet", pageId: pageId, title: "Packet"))
+            try await cache.write(sampleRow(entity: "contact", pageId: "bbbb1111111111111111111111111111", title: "Other"))
+            let evicted = await cache.evictPageEverywhere(pageId: pageId)
+            try expect(evicted == ["packet", "skill"], "stable entity receipt, got \(evicted)")
+            try expect(await cache.read(entity: "skill", pageId: pageId) == nil)
+            try expect(await cache.read(entity: "packet", pageId: pageId) == nil)
+            try expect(await cache.read(entity: "contact", pageId: "bbbb1111111111111111111111111111") != nil)
+        }
+    }
+
     await test("RowCache: incrementCallCount bumps persisted counter; 0 when absent") {
         try await withTempHomeRows { _ in
             let cache = RegistryRowCache()

--- a/TheBridgeTests/ResultSizeControlsTests.swift
+++ b/TheBridgeTests/ResultSizeControlsTests.swift
@@ -76,9 +76,17 @@ func runResultSizeControlsTests() async {
         try expect(a == b, "case/whitespace variants should resolve identically")
     }
 
-    await test("fb-resultsize (1): no match → nil (caller falls back to full body)") {
+    await test("fb-resultsize (1): no match → nil for caller-controlled bounded response") {
         try expect(SkillsModule.extractMarkdownSection(doc, section: "Nonexistent") == nil,
                    "unknown heading must return nil, not an empty/wrong slice")
+    }
+
+    await test("fb-resultsize (1): section miss response is compact and lists real headings") {
+        let miss = SkillsModule.sectionMissMarkdown(requested: "Nonexistent", markdown: doc)
+        try expect(miss.contains("Section not found: Nonexistent"))
+        try expect(miss.contains("- Setup") && miss.contains("- Usage"))
+        try expect(!miss.contains("Setup line one."), "miss must not echo the oversized full body")
+        try expect(SkillsModule.markdownHeadings(doc) == ["Overview", "Setup", "Prereqs", "Usage", "Teardown"])
     }
 
     await test("fb-resultsize (1): empty section name → nil (no-op)") {

--- a/TheBridgeTests/SchedulerResilienceTests.swift
+++ b/TheBridgeTests/SchedulerResilienceTests.swift
@@ -448,7 +448,7 @@ func runSchedulerResilienceTests() async {
         try expect(job.actionChain.count == 2, "expected build-report + send-iMessage steps")
     }
 
-    await test("FirstJob: action chain is report-builder → iMessage with $prev_result wiring") {
+    await test("FirstJob: action chain is report-builder → iMessage with $prev_result.stdout wiring") {
         let chain = RunningReportJob.defaultActionChain()
         // Step 0 builds the report text.
         try expect(chain[0].tool == "shell_exec", "step 0 builds the running summary")
@@ -457,11 +457,38 @@ func runSchedulerResilienceTests() async {
         try expect(chain[1].tool == "messages_send", "step 1 delivers via iMessage")
         try expect(chain[1].onFail == .continue, "an un-wired placeholder records a failed send, not an abort")
         if case .string(let body)? = chain[1].arguments["body"] {
-            try expect(body == "$prev_result", "delivery body must read the previous step's report output")
+            try expect(body == "$prev_result.stdout", "delivery body must extract the previous step's stdout")
         } else { try expect(false, "messages_send must have a 'body'") }
         if case .string(let confirm)? = chain[1].arguments["confirm"] {
             try expect(confirm == "SEND", "unattended messages_send requires confirm: SEND")
         } else { try expect(false, "messages_send must carry the SEND gate") }
+    }
+
+    await test("Jobs: previous-result path extracts object fields and array members") {
+        let previous: JSONValue = .object([
+            "stdout": .string("report text"),
+            "content": .array([.object(["text": .string("nested text")])])
+        ])
+        let substituted = try JobsManager.substitutePrev([
+            "body": .string("$prev_result.stdout"),
+            "nested": .string("$prev_result.content[0].text"),
+            "whole": .string("$prev_result")
+        ], prev: previous)
+        try expect(substituted["body"] == .string("report text"))
+        try expect(substituted["nested"] == .string("nested text"))
+        try expect(substituted["whole"] == previous.toMCP())
+    }
+
+    await test("Jobs: unresolved previous-result paths fail closed before dispatch") {
+        do {
+            _ = try JobsManager.substitutePrev(
+                ["body": .string("$prev_result.missing")],
+                prev: .object(["stdout": .string("present")])
+            )
+            throw TestError.assertion("Expected unresolved path failure")
+        } catch let error as JobsModuleError {
+            try expect(String(describing: error).contains("could not resolve"))
+        }
     }
 
     await test("FirstJob: chain passes the same unattended validation as createJob") {

--- a/TheBridgeTests/SkillBodyCacheEvictionTests.swift
+++ b/TheBridgeTests/SkillBodyCacheEvictionTests.swift
@@ -45,8 +45,33 @@ func runSkillBodyCacheEvictionTests() async {
             let entry = evictionSampleBody(pageId: pageId, markdown: "# stale")
             try await SkillBodyCacheStore.shared.write(entry)
 
-            await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+            await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId, refreshRouting: false)
             try expect(await SkillBodyCacheStore.shared.read(pageId: pageId) == nil, "expected cache evicted")
+        }
+    }
+
+    await test("evictIfConfiguredSkillPage recognizes cached specialist pages") {
+        try await withTempHomeEviction {
+            UserDefaults.standard.removeObject(forKey: skillsDefaultsKey)
+            let parentId = "cccccccccccccccccccccccccccccccc"
+            let childId = "dddddddddddddddddddddddddddddddd"
+            try await SkillsCacheWriter.shared.write(parent: CachedParent(
+                writtenAt: Date(), ttlHours: 24,
+                parentId: parentId, parentTitle: "time-keepr",
+                children: [CachedSpecialist(id: childId, title: "events-admin")]
+            ))
+            try await SkillBodyCacheStore.shared.write(
+                evictionSampleBody(pageId: childId, markdown: "# stale specialist")
+            )
+
+            let changed = await SkillBodyCacheEviction.evictIfConfiguredSkillPage(
+                childId, refreshRouting: false
+            )
+            try expect(changed, "cached specialist should be classified as a skill page")
+            try expect(
+                await SkillBodyCacheStore.shared.read(pageId: childId) == nil,
+                "specialist body cache should be evicted"
+            )
         }
     }
 
@@ -57,8 +82,63 @@ func runSkillBodyCacheEvictionTests() async {
             let entry = evictionSampleBody(pageId: pageId, markdown: "# keep")
             try await SkillBodyCacheStore.shared.write(entry)
 
-            await SkillBodyCacheEviction.evictIfConfiguredSkillPage(pageId)
+            let changed = await SkillBodyCacheEviction.evictIfConfiguredSkillPage(
+                pageId, refreshRouting: false
+            )
+            try expect(!changed, "non-skill page should not be classified")
             try expect(await SkillBodyCacheStore.shared.read(pageId: pageId) != nil, "non-skill page cache should remain")
         }
     }
+
+    await test("cache refresh receipt separates eviction from routing refresh") {
+        try await withTempHomeEviction {
+            let pageId = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            await MainActor.run {
+                _ = SkillsManager().addSkill(name: "receipt-skill", notionPageId: pageId)
+            }
+            try await SkillBodyCacheStore.shared.write(
+                evictionSampleBody(pageId: pageId, markdown: "# stale")
+            )
+            let receipt = await SkillBodyCacheEviction.refreshReceipt(
+                pageId, refreshRouting: false
+            )
+            try expect(receipt.matchedSkillPage)
+            try expect(receipt.bodyEvicted)
+            try expect(!receipt.routingRefreshAttempted)
+            try expect(!receipt.routingRefreshSucceeded)
+        }
+    }
+
+    await test("metadata convergence preserves non-empty local values when Notion fields are empty") {
+        let merged = SkillBodyCacheEviction.mergedMetadata(
+            currentSummary: "local summary",
+            currentTriggers: ["local trigger"],
+            currentAntiTriggers: ["local anti"],
+            pulled: SkillNotionPulledMetadata(
+                summary: "",
+                triggerPhrases: [],
+                antiTriggerPhrases: []
+            )
+        )
+        try expect(merged.summary == "local summary")
+        try expect(merged.triggerPhrases == ["local trigger"])
+        try expect(merged.antiTriggerPhrases == ["local anti"])
+    }
+
+    await test("metadata convergence prefers canonical Notion values when present") {
+        let merged = SkillBodyCacheEviction.mergedMetadata(
+            currentSummary: "old",
+            currentTriggers: ["old trigger"],
+            currentAntiTriggers: ["old anti"],
+            pulled: SkillNotionPulledMetadata(
+                summary: "new",
+                triggerPhrases: ["new trigger"],
+                antiTriggerPhrases: ["new anti"]
+            )
+        )
+        try expect(merged.summary == "new")
+        try expect(merged.triggerPhrases == ["new trigger"])
+        try expect(merged.antiTriggerPhrases == ["new anti"])
+    }
+
 }

--- a/TheBridgeTests/SkillMutationTargetResolverTests.swift
+++ b/TheBridgeTests/SkillMutationTargetResolverTests.swift
@@ -1,0 +1,84 @@
+// SkillMutationTargetResolverTests.swift — parent/specialist mutation identity
+
+import Foundation
+import TheBridgeLib
+
+func runSkillMutationTargetResolverTests() async {
+    print("\n\u{1F9ED} SkillMutationTargetResolver")
+
+    let configured = [
+        SkillMutationConfiguredSkill(
+            name: "TIME Keepr",
+            pageId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+    ]
+    let cached = [
+        CachedParent(
+            writtenAt: Date(), ttlHours: 24,
+            parentId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            parentTitle: "time-keepr",
+            children: [
+                CachedSpecialist(
+                    id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    title: "events-admin",
+                    summary: "sync specialist",
+                    aliases: ["calendar-registry-sync"]
+                )
+            ]
+        )
+    ]
+
+    await test("configured parent resolves by normalized name") {
+        let result = SkillMutationTargetResolver.resolve(
+            "time-keepr", configured: configured, cachedParents: cached
+        )
+        guard case .found(let target) = result else {
+            throw TestError.assertion("expected configured parent, got \(result)")
+        }
+        try expect(target.kind == .configuredParent)
+        try expect(target.pageId == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+
+    await test("specialist resolves by explicit parent/child path") {
+        let result = SkillMutationTargetResolver.resolve(
+            "TIME Keepr/events-admin", configured: configured, cachedParents: cached
+        )
+        guard case .found(let target) = result else {
+            throw TestError.assertion("expected specialist, got \(result)")
+        }
+        try expect(target.kind == .cachedSpecialist)
+        try expect(target.pageId == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        try expect(target.parentPageId == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+
+    await test("specialist alias resolves without widening beyond routing cache") {
+        let result = SkillMutationTargetResolver.resolve(
+            "calendar registry sync", configured: configured, cachedParents: cached
+        )
+        guard case .found(let target) = result else {
+            throw TestError.assertion("expected alias hit, got \(result)")
+        }
+        try expect(target.name == "events-admin")
+    }
+
+    await test("duplicate specialist titles are reported as ambiguous") {
+        let duplicate = CachedParent(
+            writtenAt: Date(), ttlHours: 24,
+            parentId: "cccccccccccccccccccccccccccccccc",
+            parentTitle: "other-keepr",
+            children: [
+                CachedSpecialist(
+                    id: "dddddddddddddddddddddddddddddddd",
+                    title: "events-admin"
+                )
+            ]
+        )
+        let result = SkillMutationTargetResolver.resolve(
+            "events-admin", configured: configured, cachedParents: cached + [duplicate]
+        )
+        guard case .ambiguous(let candidates) = result else {
+            throw TestError.assertion("expected ambiguity, got \(result)")
+        }
+        try expect(candidates.count == 2)
+    }
+}

--- a/TheBridgeTests/SkillsModuleTests.swift
+++ b/TheBridgeTests/SkillsModuleTests.swift
@@ -178,7 +178,7 @@ func runSkillsModuleTests() async {
             name: "demo", title: "Demo", url: "https://n/demo",
             markdownJSONOrText: md, summary: "sum", triggerPhrases: ["t1"], antiTriggerPhrases: ["a1"]
         ) { _ in nil }
-        let projected = FieldsFilter.project(envelope, fields: ["content"])
+        let projected = FieldsFilter.project(envelope, fields: ["content"], includeIdentity: false)
         guard case .object(let dict) = projected else { throw TestError.assertion("expected object") }
         try expect(dict.count == 1, "expected exactly 1 key, got \(dict.keys.sorted())")
         guard case .string(let content)? = dict["content"] else { throw TestError.assertion("content missing") }
@@ -196,7 +196,7 @@ func runSkillsModuleTests() async {
             name: "demo2", title: "Demo2", url: "https://n/demo2",
             markdownJSONOrText: md, pageProperties: pageProps
         ) { _ in nil }
-        let projected = FieldsFilter.project(envelope, fields: ["properties.status"])
+        let projected = FieldsFilter.project(envelope, fields: ["properties.status"], includeIdentity: false)
         guard case .object(let dict) = projected,
               case .object(let props)? = dict["properties"] else {
             throw TestError.assertion("expected projected properties object")
@@ -226,7 +226,9 @@ func runSkillsModuleTests() async {
         ) { _ in nil }
         let projected = FieldsFilter.project(envelope, fields: ["ghostKey", "title"])
         guard case .object(let dict) = projected else { throw TestError.assertion("expected object") }
-        try expect(Set(dict.keys) == ["title"], "only known key survives, got \(dict.keys.sorted())")
+        // title requested; id/entity re-attached only if present on skill envelope.
+        try expect(dict["title"] != nil, "title must survive")
+        try expect(dict["ghostKey"] == nil, "unknown key must not survive")
     }
 
     // ============================================================

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -661,6 +661,7 @@ await runNotesModuleTests()
 await runSystemModuleTests()
 await runRemindersModuleTests()   // PKT-957 (v3.7·D): reminders_* EventKit module (mock seam)
 await runCalendarModuleTests()    // PKT-962 (v3.7·I): calendar_* EventKit module (mock seam; reuses v3.7·D store + entitlement)
+await runCalendarRegistrySyncEngineTests() // Calendar–Registry Sync reduced durability matrix
 await runPermissionsModuleTests() // fb-permissions: unified permissions_status TCC probe (pure assembler — no live TCC)
 await runNotionModuleTests()
 await runAccessibilityModuleTests()

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -642,6 +642,7 @@ await runRegistryDataPathTests()     // Data-Source Registry W2: live data path 
 await runRegistryModuleTests()       // Data-Source Registry W3: MCP tool surface (13 tools: generic CRUD + resolve_and_update + add/remove_entity + introspect + possess + hydrate, registration + handler behavior)
 await runRegistryAppendMergeTests()  // PKT-MEM-135: RegistryAppendMerge shared append-merge primitive (ported from VoiceMemoProcessor.mergeAppendRegistryFields)
 await runFieldsFilterTests()         // PKT: fields Param Across Registry Tools + fetch_skill — shared FieldsFilter primitive (parse + project), hermetic synthetic-Value fixtures
+await runVoiceMemoListQueryTests()   // Voice Memo Reliability: list date/transcript filters + cursor pagination
 await runDataSourcesViewModelTests() // Data-Source Registry W4: Settings pane scenarios (propose→confirm, TTL, drift, errors) + BE↔FE alignment
 await runRegistryEdgeCaseTests()     // Data-Source Registry: adversarial edge cases (codec chunking, pagination, cache concurrency, config race, writer)
 await runRegistryHydrationTests()    // Packet Runner v1 (FR-1/§8.3): packet-registry-v1 one-hop hydration envelope (primary+body+relations+provenance+warnings)

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -125,6 +125,10 @@ struct TheBridgeTestRunner {
     // a live run loop (that was the teardown SIGTRAP / hang). `runAllTests()` is
     // `nonisolated` so its body inherits the detached (non-main) executor.
     static func main() {
+        if let probeExitCode = calendarRegistryProcessProbeExitCodeIfRequested() {
+            exit(probeExitCode)
+        }
+
         // Line-buffer stdout. When this runner's output is a pipe (CI: `… | tee`),
         // stdout defaults to FULL buffering, so on an intermittent hang the buffered
         // tail never flushes and the CI log's last line is NOT where it actually hung —
@@ -661,7 +665,7 @@ await runNotesModuleTests()
 await runSystemModuleTests()
 await runRemindersModuleTests()   // PKT-957 (v3.7·D): reminders_* EventKit module (mock seam)
 await runCalendarModuleTests()    // PKT-962 (v3.7·I): calendar_* EventKit module (mock seam; reuses v3.7·D store + entitlement)
-await runCalendarRegistrySyncEngineTests() // Calendar–Registry Sync reduced durability matrix
+await runCalendarRegistrySyncEngineTests() // Calendar–Registry Sync fail-closed hermetic recovery matrix
 await runPermissionsModuleTests() // fb-permissions: unified permissions_status TCC probe (pure assembler — no live TCC)
 await runNotionModuleTests()
 await runAccessibilityModuleTests()

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -861,6 +861,7 @@ await runSkillsCacheTests()
 // envelope-equivalence between the cache-hit and network paths.
 await runSkillBodyCacheTests()
 await runSkillBodyCacheEvictionTests()
+await runSkillMutationTargetResolverTests()
 await runToolRouterListToolsReadyTests()
 await runAgentSurfaceReliabilityTests()
 

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -647,6 +647,7 @@ await runDataSourcesViewModelTests() // Data-Source Registry W4: Settings pane s
 await runRegistryEdgeCaseTests()     // Data-Source Registry: adversarial edge cases (codec chunking, pagination, cache concurrency, config race, writer)
 await runRegistryHydrationTests()    // Packet Runner v1 (FR-1/§8.3): packet-registry-v1 one-hop hydration envelope (primary+body+relations+provenance+warnings)
 await runMessagesModuleTests()
+await runCallHistoryModuleTests()      // Bridge v4 Wave 1: calls_recent filters, schema/FDA errors, annotations
 await runMessagesSuiteAuditTests()   // Messages-suite every-angle-of-attack audit
 await runVoiceMemoSuiteAuditTests()  // Voice memo suite audit (PKT-MEM-122)
 await runMailModuleTests()           // PKT-961 (v3.7·H): mail_* Apple Mail module (mock seam; send-guard)

--- a/TheBridgeTests/VoiceMemoListQueryTests.swift
+++ b/TheBridgeTests/VoiceMemoListQueryTests.swift
@@ -1,0 +1,104 @@
+// VoiceMemoListQueryTests.swift — list filters + pagination (Voice Memo Reliability)
+// TheBridge · Tests
+
+import Foundation
+import TheBridgeLib
+
+func runVoiceMemoListQueryTests() async {
+    print("\n📋 VoiceMemoListQuery Tests")
+
+    // Local fixtures rebuilt inside each test body so closures stay Sendable.
+    func makePool() -> (pool: [VoiceMemoRecording], isProcessed: @Sendable (String) -> Bool) {
+        func rec(id: String, title: String, daysAgo: Int, transcript: String? = nil) -> VoiceMemoRecording {
+            let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
+            return VoiceMemoRecording(
+                id: id,
+                path: "/tmp/\(id).m4a",
+                title: title,
+                recordedAt: date,
+                transcript: transcript,
+                transcriptSource: transcript == nil ? .none : .sidecar
+            )
+        }
+        let pool = [
+            rec(id: "p1", title: "Old done", daysAgo: 30, transcript: "done body"),
+            rec(id: "u1", title: "July memo", daysAgo: 8, transcript: "greg flicek follow up"),
+            rec(id: "u2", title: "June memo", daysAgo: 40, transcript: "unrelated"),
+            rec(id: "u3", title: "No transcript", daysAgo: 2),
+            rec(id: "u4", title: "Recent", daysAgo: 1, transcript: "short"),
+        ]
+        let isProcessed: @Sendable (String) -> Bool = { $0 == "p1" }
+        return (pool, isProcessed)
+    }
+
+    await test("list filter: default excludes processed and pages with default limit") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 2),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 4, "unprocessed only → 4, got \(page.totalMatched)")
+        try expect(page.memos.count == 2, "limit 2")
+        try expect(page.hasMore, "hasMore")
+        try expect(page.nextCursor != nil, "nextCursor present")
+        try expect(page.memos.first?.id == "u4", "newest first, got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: cursor resumes after prior page") {
+        let (pool, isProcessed) = makePool()
+        let page1 = VoiceMemoListFilter.page(recordings: pool, query: VoiceMemoListQuery(limit: 2), isProcessed: isProcessed)
+        let page2 = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 2, cursor: page1.nextCursor),
+            isProcessed: isProcessed
+        )
+        try expect(page2.memos.count == 2, "second page size")
+        let ids1 = Set(page1.memos.map(\.id))
+        let ids2 = Set(page2.memos.map(\.id))
+        try expect(ids1.isDisjoint(with: ids2), "pages must not overlap: \(ids1) vs \(ids2)")
+    }
+
+    await test("list filter: dateFrom/dateTo scopes to window") {
+        let (pool, isProcessed) = makePool()
+        let from = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
+        let to = Calendar.current.date(byAdding: .day, value: -5, to: Date())!
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(includeProcessed: true, dateFrom: from, dateTo: to),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 1, "only July memo in window, got \(page.totalMatched)")
+        try expect(page.memos.first?.id == "u1", "got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: hasTranscript + transcriptContains") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(hasTranscript: true, transcriptContains: "Greg"),
+            isProcessed: isProcessed
+        )
+        try expect(page.totalMatched == 1, "greg match")
+        try expect(page.memos.first?.id == "u1", "got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list filter: sort ascending") {
+        let (pool, isProcessed) = makePool()
+        let page = VoiceMemoListFilter.page(
+            recordings: pool,
+            query: VoiceMemoListQuery(limit: 10, sortAscending: true),
+            isProcessed: isProcessed
+        )
+        try expect(page.memos.first?.id == "u2", "oldest unprocessed first, got \(page.memos.first?.id ?? "?")")
+    }
+
+    await test("list cursor encode/decode round-trip") {
+        let (pool, _) = makePool()
+        let r = pool[0]
+        let c = VoiceMemoListFilter.encodeCursor(r)
+        let decoded = VoiceMemoListFilter.decodeCursor(c)
+        try expect(decoded?.id == r.id, "id round-trip")
+        try expect(decoded != nil, "decode ok")
+    }
+}

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -125,21 +125,18 @@ Source: `TheBridge/Modules/GitModule.swift`.
 
 ---
 
-## Not yet available
-
-These were referenced in friction reports as *proposals*. They are **not registered in
-the codebase** as of this writing — do not call them. Confirm with a fresh grep before
-relying on any of them later.
+## Availability notes
 
 - **`swift_build` / `swift_test`** — a first-class build/test wrapper has been *requested*
-  (`AGENT_FEEDBACK.md` 2026-05-10) but has **not landed**. Until it does, use
-  `bg_process_start` with `swift build` / `make test`.
-- **`bridge_settings_navigate(section)` / `bridge_focus_settings`** — proposed in
-  `AGENT_FEEDBACK.md` (2026-06-04) to make on-device Settings verification deterministic.
-  They **do not exist**. Today, on-device verification of the menu-bar app requires a
-  System Events re-`set frontmost` + `AXRaise` before each `screen_capture`, and note the
-  coordinate-space mismatch (AX reports logical points; `screen_capture` returns device
-  pixels) when computing `mouse_click` targets.
+  (`AGENT_FEEDBACK.md` 2026-05-10) but is intentionally replaced by the current
+  `bg_run` → `bg_poll` → optional `bg_kill` surface for long builds and tests.
+- **`bridge_settings_navigate(section)` / `bridge_open_settings` /
+  `bridge_focus_settings` are registered.** Use the open/focus helpers before
+  Settings screenshots; they verify the target app/window rather than reporting
+  coordinate-only success.
+- After changing branches across tool-surface commits, run **`make test-clean`**.
+  After any install/relaunch, reconnect MCP clients so they re-run initialize and
+  `tools/list`; an already-open client's descriptor cache is not live proof.
 
 ---
 

--- a/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
+++ b/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
@@ -1,0 +1,27 @@
+# Calendar–Registry v1 registry migration
+
+Status: prepared, not production-applied by this branch.
+
+## Purpose
+
+Add the rename-safe canonical binding `providerExternalId` to the `schedule` registry entity and bind it to the EVENTS rich-text property `Provider External ID`. This field stores EventKit's provider/server external identifier. It is deliberately not named `iCal UID`.
+
+## Apply
+
+1. Read the live EVENTS schema and current `schedule` registry entity.
+2. Confirm all `requiredExistingKeys` from `registry-entity-patch.json` are bound with the expected types.
+3. Add the Notion rich-text property `Provider External ID` only when absent.
+4. Add or update the local canonical property map:
+   - key: `providerExternalId`
+   - Notion name: `Provider External ID`
+   - type: `rich_text`
+   - bound property ID: the live introspected ID
+5. Re-read the schema and registry entity; require full binding and zero type drift.
+
+## Rollback
+
+Remove the local `providerExternalId` binding first. Remove the Notion property only after proving every row is empty. Removing a populated property destroys data and requires a separate destructive approval.
+
+## Activation boundary
+
+This migration does not register a public MCP tool, install a Bridge build, or authorize live calendar writes. The internal composition root remains disabled unless `BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC=1` is set in an isolated smoke environment.

--- a/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
+++ b/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
@@ -4,23 +4,19 @@ Status: prepared, not production-applied by this branch.
 
 ## Purpose
 
-Add the rename-safe canonical binding `providerExternalId` to the `schedule` registry entity and bind it to the EVENTS rich-text property `Provider External ID`. This field stores EventKit's provider/server external identifier. It is deliberately not named `iCal UID`.
+Add two rename-safe canonical bindings to the `schedule` registry entity: `providerExternalId` → `Provider External ID` and `operationFingerprint` → `Operation Fingerprint`. Both are rich text. The provider field stores EventKit's provider/server external identifier; the fingerprint stores the immutable SHA-256 operation manifest and is independent of the local recovery ledger.
 
 ## Apply
 
 1. Read the live EVENTS schema and current `schedule` registry entity.
 2. Confirm all `requiredExistingKeys` from `registry-entity-patch.json` are bound with the expected types.
-3. Add the Notion rich-text property `Provider External ID` only when absent.
-4. Add or update the local canonical property map:
-   - key: `providerExternalId`
-   - Notion name: `Provider External ID`
-   - type: `rich_text`
-   - bound property ID: the live introspected ID
+3. Add the Notion rich-text properties `Provider External ID` and `Operation Fingerprint` only when absent.
+4. Add or update both local canonical property mappings with role `generic` and their live introspected property IDs.
 5. Re-read the schema and registry entity; require full binding and zero type drift.
 
 ## Rollback
 
-Remove the local `providerExternalId` binding first. Remove the Notion property only after proving every row is empty. Removing a populated property destroys data and requires a separate destructive approval.
+Remove the local `providerExternalId` and `operationFingerprint` bindings first. Remove either Notion property only after proving every row is empty. Removing a populated property destroys data and requires a separate destructive approval.
 
 ## Activation boundary
 

--- a/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
+++ b/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
@@ -1,23 +1,50 @@
-# Calendar–Registry v1 registry migration
+# Calendar–Registry vNext registry migration
 
-Status: prepared, not production-applied by this branch.
+Status: prepared and source-validated; not applied to the live EVENTS data source by this branch.
 
 ## Purpose
 
-Add two rename-safe canonical bindings to the `schedule` registry entity: `providerExternalId` → `Provider External ID` and `operationFingerprint` → `Operation Fingerprint`. Both are rich text. The provider field stores EventKit's provider/server external identifier; the fingerprint stores the immutable SHA-256 operation manifest and is independent of the local recovery ledger.
+Add five rename-safe canonical bindings to the `schedule` registry entity:
+
+| Canonical key | Notion property | Type | Purpose |
+|---|---|---|---|
+| `providerExternalId` | `Provider External ID` | rich text | EventKit/provider external identity when available |
+| `operationFingerprint` | `Operation Fingerprint` | rich text | Immutable SHA-256 canonical operation manifest |
+| `createInvocationId` | `Calendar Create Invocation ID` | rich text | Durable one-time authorization for the sole automatic EventKit create invocation |
+| `syncWriterToken` | `Sync Writer Token` | rich text | Post-write optimistic fencing evidence for synchronization-owned Notion PATCHes |
+| `syncRevision` | `Sync Revision` | number | Monotonic synchronization-owned write revision |
+
+These fields are independent of the local SQLite ledger. The Create Invocation ID is the durable no-recreate boundary: once present on Notion or SQLite, automatic EventKit creation is prohibited on later attempts.
 
 ## Apply
 
+Applying this migration is a separate Ship Gate action.
+
 1. Read the live EVENTS schema and current `schedule` registry entity.
-2. Confirm all `requiredExistingKeys` from `registry-entity-patch.json` are bound with the expected types.
-3. Add the Notion rich-text properties `Provider External ID` and `Operation Fingerprint` only when absent.
-4. Add or update both local canonical property mappings with role `generic` and their live introspected property IDs.
-5. Re-read the schema and registry entity; require full binding and zero type drift.
+2. Confirm every `requiredExistingKeys` entry in `registry-entity-patch.json` is bound with its expected type.
+3. For each additive property, inspect by exact name before creating anything.
+4. If absent, add the property with the declared type. If present with another type, stop; do not coerce or replace it.
+5. Add or update the local canonical mappings using the live introspected property IDs and role `generic`.
+6. Re-read the live schema and registry entity.
+7. Require all five bindings, exact types, unique canonical keys, and zero unresolved required fields.
+8. Keep the Calendar–Registry composition disabled until installation and disposable smoke are separately approved.
 
 ## Rollback
 
-Remove the local `providerExternalId` and `operationFingerprint` bindings first. Remove either Notion property only after proving every row is empty. Removing a populated property destroys data and requires a separate destructive approval.
+1. Disable the internal composition.
+2. Remove local canonical mappings only after preserving any evidence needed for incident review.
+3. Remove a Notion property only after proving every row is empty and obtaining separate destructive approval.
+
+Removing a populated property destroys identity or synchronization evidence. No automatic rollback may clear Create Invocation ID, pair identity, Sync Writer Token, Sync Revision, Sync Hash, or Last Synced At.
 
 ## Activation boundary
 
-This migration does not register a public MCP tool, install a Bridge build, or authorize live calendar writes. The internal composition root remains disabled unless `BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC=1` is set in an isolated smoke environment.
+This artifact does not:
+
+- Apply a Notion schema change.
+- Register a public MCP operation.
+- Install or activate a Bridge build.
+- Create or modify an EVENT row.
+- Create, update, or delete an EventKit item.
+
+The internal composition remains disabled unless `BRIDGE_INTERNAL_CALENDAR_REGISTRY_SYNC=1` and an explicit private local calendar allowlist are supplied in a separately approved disposable-smoke environment.

--- a/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
+++ b/docs/migrations/calendar-registry-v1/MIGRATION_PLAN.md
@@ -1,6 +1,6 @@
 # Calendar–Registry vNext registry migration
 
-Status: prepared and source-validated; not applied to the live EVENTS data source by this branch.
+Status: applied and verified on 2026-07-18; activation remains disabled.
 
 ## Purpose
 
@@ -18,7 +18,7 @@ These fields are independent of the local SQLite ledger. The Create Invocation I
 
 ## Apply
 
-Applying this migration is a separate Ship Gate action.
+The live migration followed this Ship Gate sequence:
 
 1. Read the live EVENTS schema and current `schedule` registry entity.
 2. Confirm every `requiredExistingKeys` entry in `registry-entity-patch.json` is bound with its expected type.
@@ -39,9 +39,8 @@ Removing a populated property destroys identity or synchronization evidence. No 
 
 ## Activation boundary
 
-This artifact does not:
+Applying the migration did not:
 
-- Apply a Notion schema change.
 - Register a public MCP operation.
 - Install or activate a Bridge build.
 - Create or modify an EVENT row.

--- a/docs/migrations/calendar-registry-v1/registry-entity-patch.json
+++ b/docs/migrations/calendar-registry-v1/registry-entity-patch.json
@@ -1,0 +1,36 @@
+{
+  "entity": "schedule",
+  "additiveProperties": [
+    {
+      "key": "providerExternalId",
+      "notionName": "Provider External ID",
+      "type": "rich_text",
+      "role": "data"
+    }
+  ],
+  "requiredExistingKeys": [
+    "title",
+    "date",
+    "status",
+    "syncKey",
+    "calendarProvider",
+    "calendarId",
+    "calendarEventId",
+    "calendarUrl",
+    "eventClass",
+    "meetingType",
+    "primaryBlock",
+    "blocks",
+    "projects",
+    "contacts",
+    "schedulingAuthority",
+    "syncState",
+    "lastSyncedAt",
+    "registryUpdatedAt",
+    "calendarUpdatedAt",
+    "syncHash",
+    "lastSyncError",
+    "scheduledDuration",
+    "calendarLocation"
+  ]
+}

--- a/docs/migrations/calendar-registry-v1/registry-entity-patch.json
+++ b/docs/migrations/calendar-registry-v1/registry-entity-patch.json
@@ -1,11 +1,18 @@
 {
+  "schemaVersion": 2,
   "entity": "schedule",
   "additiveProperties": [
     {
       "key": "providerExternalId",
       "notionName": "Provider External ID",
       "type": "rich_text",
-      "role": "data"
+      "role": "generic"
+    },
+    {
+      "key": "operationFingerprint",
+      "notionName": "Operation Fingerprint",
+      "type": "rich_text",
+      "role": "generic"
     }
   ],
   "requiredExistingKeys": [

--- a/docs/migrations/calendar-registry-v1/registry-entity-patch.json
+++ b/docs/migrations/calendar-registry-v1/registry-entity-patch.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "entity": "schedule",
   "additiveProperties": [
     {
@@ -12,6 +12,24 @@
       "key": "operationFingerprint",
       "notionName": "Operation Fingerprint",
       "type": "rich_text",
+      "role": "generic"
+    },
+    {
+      "key": "createInvocationId",
+      "notionName": "Calendar Create Invocation ID",
+      "type": "rich_text",
+      "role": "generic"
+    },
+    {
+      "key": "syncWriterToken",
+      "notionName": "Sync Writer Token",
+      "type": "rich_text",
+      "role": "generic"
+    },
+    {
+      "key": "syncRevision",
+      "notionName": "Sync Revision",
+      "type": "number",
       "role": "generic"
     }
   ],

--- a/docs/operator/agent-feedback-audit-2026-07-17.md
+++ b/docs/operator/agent-feedback-audit-2026-07-17.md
@@ -1,0 +1,105 @@
+# Agent feedback disposition audit — 2026-07-17
+
+This audit closes the historical `AGENT_FEEDBACK.md` backlog without treating
+old observations as current defects. Every entry was checked against current
+`origin/main`, the open review branches, current tests, or its owning system.
+The original prose remains recoverable from git history.
+
+## Implemented in `codex/feedback-v4`
+
+| Feedback cluster | Resolution |
+|---|---|
+| Job `$prev_result` whole-object/blank-body failure | Added fail-closed `$prev_result.stdout` and indexed paths such as `$prev_result.content[0].text`; corrected the seeded running-report job. |
+| Test-floor log loss | Failed runs now retain the complete log under `~/Library/Logs/TheBridge/test-floor-failures`, print the stable path, and extract failure rows from the full output. The first validation run in this branch proved the retained-log path against a real failing assertion. |
+| Worktree cache contamination | Added `make test-clean`; operator guidance now names it for branch changes that alter the tool surface. |
+| Stale client catalog after install | Install banners and the playbook now require reconnect plus fresh `initialize`/`tools/list`. |
+| Oversized `fetch_skill` / markdown section misses | Section misses return a bounded heading index instead of the full body; `notion_page_markdown_read` now supports the same section contract; fenced code headings are ignored. |
+| Skill cache stale after writes | Successful page and block mutations evict affected skill bodies; page writes also evict the same page from every registry entity cache. An explicit invalidation tool was considered and rejected because correct automatic write-through invalidation removes the operator burden without expanding the public surface. |
+| Exact skill marked low-confidence / contradictory metadata | An exact canonical parent with no specialist roster is no longer marked low-confidence. Notion properties are named as the authoritative metadata source and body/property version, status, or maturity drift is returned as a structured warning. |
+| PACKETS exposed only as `session` | `packet` is canonical with a guarded `session` compatibility alias; a real Sessions data source is never misclassified. |
+| Recent Messages identity guess | `messages_recent` returns resolved name, source, confidence, and failure reason; it uses Messages metadata first and only attempts exact-handle Contacts lookup when permission already exists. Loose name inference is prohibited. |
+| Attachment-only Messages | `messages_content` returns attachment id, local path, MIME type, transfer name, count, mode, and a typed metadata-only limitation; bytes are never silently extracted. |
+| Invalid Notion token remediation | HTTP 401 guidance now points to Settings > Connections and `notion_token_introspect`. |
+| Operator docs drift | Corrected background-process, settings-tool, clean-test, install, and reconnect guidance. |
+
+## Verified already resolved on current main
+
+These entries required no duplicate code change:
+
+- Notion aliases and write ergonomics: comment `content` alias and chunking,
+  query data-source alias, blocks append aliases, bulk delete, create-body
+  materialization guidance, `appendKeys`, and projected registry identity.
+- Local tool correctness: shell PATH and `bg_run`/`bg_poll`/`bg_kill`, credential
+  sentinel detection, calendar parsing, Reminders/Calendar permission rows,
+  `bridge_focus_settings`, screen app identity, stale-PID AX errors, main-actor AX
+  execution, child/byte traversal caps, and coordinate-safe AX-path clicking.
+- Connection and governance: resumable session contract, registration gate,
+  `connections_reset`, same-session governance propagation tests, origin-aware
+  initialization, OAuth boot-order self-heal, git SHA/dirty provenance, and
+  dirty/non-main install guards.
+- Delivery and routing: messages send confirmation, fields identity retention,
+  routing archive/canonical precedence, routing cache refresh surfaces, tool
+  annotation audit, counter-collision checks, and packet/worktree playbook rules.
+- Security approval behavior: module-scoped Always Allow, coalesced prompts,
+  90-second timeout, time-sensitive delivery, visible/revocable grants, and
+  `neverAutoApprove` protection for destructive tools.
+
+## Considered and intentionally not implemented here
+
+These are handled by ownership or design disposition, not silently left open.
+
+### Client or host owned
+
+Client auto-reinitialize, cached tool descriptors, raw oversized-result dump
+format, dynamic UI click coordinates, the AskUserQuestion cap, spoken model
+identity, and capability claims are MCP client/host behavior. The Bridge now
+provides reconnect/reset primitives, current provenance, bounded responses, and
+explicit install instructions; it cannot force a third-party client to refresh
+or change its runtime self-description.
+
+### External service or another repository
+
+Google Drive connector authorization/CloudStorage writes, kup.solutions portal
+schema/deploy polling/dead-route status, GitHub stacked-PR detection, and macOS
+27 mouse-driver behavior belong to their respective connector, website, GitHub,
+or OS/driver owners. No Bridge code change can truthfully close them.
+
+### Live workspace doctrine or workflow data
+
+Stale `project-keepr` route text, close-agent path text, specialist relation
+content, packet lifecycle status, active-telemetry pointers, and initializer
+roster warnings depend on live Notion skill/standing-order data. They must be
+corrected through the governed skill/doctrine owner, not by baking a second
+copy into this repo. Current Bridge surfaces expose the detailed roster,
+telemetry event reference, cache refresh, and registry force-refresh needed for
+that owner to reconcile them.
+
+### Correct fail-closed behavior or low-evidence observations
+
+Malformed Notion table rows rejecting atomically, destructive delete approval
+timeouts, exact relation validation, TCC denial, and no-contact/no-message
+results are correct fail-closed outcomes. `job_delete` denial versus timeout was
+considered; the security boundary intentionally exposes one rejection result so
+callers do not infer notification-delivery internals or auto-retry a destructive
+operation. One-off transport drops and intermittent calendar updates have no
+current reproducible defect and retain the existing retry-once guidance.
+
+### Material product expansions outside the locked proposal
+
+Messages reactions, first-class Google Drive mutation, Memory Process UI
+redesign, voice-curator settings tools, service-by-port management, automatic
+packet lifecycle transitions, and richer telemetry continuation are valid
+product ideas, but each changes product scope or safety semantics. They were
+reviewed and not smuggled into the stabilization release. The source log is
+preserved in git history if the product owner chooses to contract any of them.
+
+## Verification contract
+
+- No open GitHub issues existed at audit time.
+- PR #106 and PR #107 were inspected separately; neither is merged without a
+  review decision.
+- Every changed behavior above has a focused regression test or a source-level
+  contract test.
+- Full `make test-floor`, integration-branch release build, installed MCP smoke,
+  and git/worktree reconciliation are required before this audit is considered
+  complete.

--- a/docs/operator/calendar-registry-candidate-readiness.md
+++ b/docs/operator/calendar-registry-candidate-readiness.md
@@ -1,13 +1,13 @@
 # Calendar–Registry Candidate-Readiness Receipt
 
-Status: **Candidate-Ready Source**. This is not a candidate build, install, activation, or live smoke receipt.
+Status: **Integrated Candidate-Ready Source**. This is not a candidate build, install, activation, or live smoke receipt.
 
 ## Integrated source
 
 - Base: current `origin/main` plus the six installed/review integration commits.
-- Calendar line: the six reviewed Calendar–Registry commits from `3785605` through `a8d15ac`.
-- Excluded: unrelated commit `21fc72c`.
-- Conflict surface: append-only test-floor provenance and the numeric floor only; Calendar source merged without a content conflict.
+- Calendar line: the six reviewed Calendar–Registry commits from `3785605` through `a8d15ac`, replayed onto the integration lineage, plus the literal crash-recovery proof.
+- Skills line: unique commit `21fc72c` is replayed after the Calendar candidate so specialist metadata mutations resolve and refresh the shared caches.
+- Conflict surface: the skills replay merged automatically; the Calendar replay changed only append-only test-floor provenance and its numeric floor outside the Calendar implementation.
 
 ## Safety contract
 
@@ -26,10 +26,12 @@ Candidate readiness requires all of the following on one clean commit:
 1. The focused Calendar–Registry matrix, including CR81–CR96, passes.
 2. `make test-floor` passes without lowering the inherited floor.
 3. `swift build -c release -Xswiftc -strict-concurrency=complete` succeeds.
-4. `git diff --check` is clean and the unrelated commit remains outside the candidate graph.
+4. `git diff --check` is clean and the unique skills fix is present exactly once on the candidate graph.
 5. The installed application and live EVENTS schema remain unchanged.
 
 The exact commit, assertion count, and command results belong in the final execution receipt because embedding a commit SHA in its own commit is self-referential.
+
+The first integrated-source run measured 3,355 passed and 0 failed. The locked floor advances by the eight net-new specialist-mutation tests, from 3,334 to 3,342; the final release SHA must rerun the gate.
 
 ## Deferred ship gates
 

--- a/docs/operator/calendar-registry-candidate-readiness.md
+++ b/docs/operator/calendar-registry-candidate-readiness.md
@@ -1,0 +1,41 @@
+# Calendar–Registry Candidate-Readiness Receipt
+
+Status: **Candidate-Ready Source**. This is not a candidate build, install, activation, or live smoke receipt.
+
+## Integrated source
+
+- Base: current `origin/main` plus the six installed/review integration commits.
+- Calendar line: the six reviewed Calendar–Registry commits from `3785605` through `a8d15ac`.
+- Excluded: unrelated commit `21fc72c`.
+- Conflict surface: append-only test-floor provenance and the numeric floor only; Calendar source merged without a content conflict.
+
+## Safety contract
+
+- Scope is one disabled, registry-first, single-machine transaction pairing one pre-existing Registry-authority Notion EVENT with at most one qualified private local EventKit item.
+- One canonical local coordinator owns an OS advisory lock plus a SQLite transaction ledger. SQLite provides atomic compare-and-swap progression.
+- Notion does not provide atomic compare-and-swap here. Each narrow pairing write uses optimistic fencing: a fresh `last_edited_time` expectation plus writer-token/read-back verification. A mismatch conflicts and preserves concurrent semantic edits.
+- Every material success-path durable-write or EventKit-effect boundary has a package-scoped, production-no-op crash checkpoint. The test executable terminates a child process at each checkpoint and performs two fresh-process recoveries.
+- Recovery never performs a second automatic create. Thirteen checkpoints recover to `Complete` with exactly one calendar item; the two gaps after Create Invocation reaches Notion but before complete ledger evidence stop at `Operator Review` with zero creates.
+- The source-controlled registry prerequisite is schema version 3 and contains five fields: rich-text `Provider External ID`, `Operation Fingerprint`, `Calendar Create Invocation ID`, and `Sync Writer Token`, plus numeric `Sync Revision`.
+- The local transaction ledger is schema version 4.
+
+## Verification contract
+
+Candidate readiness requires all of the following on one clean commit:
+
+1. The focused Calendar–Registry matrix, including CR81–CR96, passes.
+2. `make test-floor` passes without lowering the inherited floor.
+3. `swift build -c release -Xswiftc -strict-concurrency=complete` succeeds.
+4. `git diff --check` is clean and the unrelated commit remains outside the candidate graph.
+5. The installed application and live EVENTS schema remain unchanged.
+
+The exact commit, assertion count, and command results belong in the final execution receipt because embedding a commit SHA in its own commit is self-referential.
+
+## Deferred ship gates
+
+- Apply and bind the five-field EVENTS migration.
+- Build, sign, install, or activate the candidate.
+- Run an installed disposable Notion/EventKit smoke.
+- Register a public MCP operation or recurring/background job.
+- Push, merge, tag, publish, or release.
+- Expand beyond single-machine coordination or the narrow registry-first capability.

--- a/docs/operator/calendar-registry-candidate-readiness.md
+++ b/docs/operator/calendar-registry-candidate-readiness.md
@@ -27,15 +27,24 @@ Candidate readiness requires all of the following on one clean commit:
 2. `make test-floor` passes without lowering the inherited floor.
 3. `swift build -c release -Xswiftc -strict-concurrency=complete` succeeds.
 4. `git diff --check` is clean and the unique skills fix is present exactly once on the candidate graph.
-5. The installed application and live EVENTS schema remain unchanged.
+5. The installed application remains unchanged; the live EVENTS schema has all
+   five additive fields bound through the `schedule` registry with zero drift.
 
 The exact commit, assertion count, and command results belong in the final execution receipt because embedding a commit SHA in its own commit is self-referential.
 
 The first integrated-source run measured 3,355 passed and 0 failed. The locked floor advances by the eight net-new specialist-mutation tests, from 3,334 to 3,342; the final release SHA must rerun the gate.
 
+## Live migration receipt — 2026-07-18
+
+- EVENTS data source `898f03a6-abb2-486a-861e-3086466a0d06` received the five
+  additive properties with their declared types; no existing property changed.
+- `registry_introspect(entity: "schedule")` reported 41/41 canonical bindings,
+  `fullyBound: true`, and an empty drift list.
+- The internal composition remains disabled. No EVENT row or EventKit item was
+  created, updated, or deleted.
+
 ## Deferred ship gates
 
-- Apply and bind the five-field EVENTS migration.
 - Build, sign, install, or activate the candidate.
 - Run an installed disposable Notion/EventKit smoke.
 - Register a public MCP operation or recurring/background job.

--- a/docs/operator/calls-recent.md
+++ b/docs/operator/calls-recent.md
@@ -1,0 +1,42 @@
+# `calls_recent` operator guide
+
+`calls_recent` is The Bridge's read-only view of the local macOS CallHistoryDB.
+It returns phone records; it does not resolve a number to a person and does not
+modify call history.
+
+## Usage
+
+```json
+{
+  "limit": 20,
+  "since": "2026-07-17T00:00:00Z",
+  "number": "+1 (605) 555-0123",
+  "direction": "outbound"
+}
+```
+
+Every field is optional. `limit` defaults to 20 and is capped at 100.
+`direction` accepts `inbound`, `outbound`, or `all`. The number filter removes
+non-decimal characters and then requires an exact normalized match. Results are
+newest-first.
+
+The response includes `identityResolved: false`. Call direction, answered
+state, duration, and service-provider metadata are call facts only; none proves
+who owns the number.
+
+## Full Disk Access
+
+If the database cannot be opened, the tool returns
+`full_disk_access_required` with remediation instead of an empty list. Grant
+Full Disk Access to The Bridge in **System Settings > Privacy & Security > Full
+Disk Access**, relaunch The Bridge, reconnect MCP clients, and retry.
+
+An incompatible database returns `unsupported_call_history_schema` with the
+missing columns. Do not treat that response as evidence that there were no
+calls.
+
+## Scope boundary
+
+Wave 1 intentionally stops at read-only call truth. Prospect matching, outreach
+writes, dialing, message drafts, and next-action recommendations belong to later
+reviewed waves in `PKT-CALL-001`; they are not implied by this tool.

--- a/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
+++ b/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
@@ -1,0 +1,354 @@
+# PKT-CALL-001 — Prospecting Call Tools Suite (7)
+
+**Slug:** `pkt-call-001-prospecting-call-tools`
+**Execution Class:** REVIEW-FIRST
+**Status:** REVIEW — Wave 1 implemented; Waves 2–3 deliberately deferred
+**Priority:** 80
+**Classification:** Standard (suite) · sequential waves inside one packet
+**SKILLS:** orchestrator · executor · mac-keepr · people-keepr (consumer contract)
+**PROJECT:** The Bridge (platform tools) · related ops: KUP Solutions prospecting
+**Agent Type:** Implementation (Bridge MCP tools)
+
+**Orchestrator source:** `focus-keepr/orchestrator` v7.1.x (packet architect protocol)
+**Origin session:** 2026-07-16 — Prospect Execute + CallHistory recon
+
+---
+
+## Goal Contract
+
+**Outcome:** Seven Bridge MCP tools ship so an agent can read Mac call history, log prospecting call touches into PROSPECTS/OUTREACH, run a Prospect Execute loop, join call+Messages timelines, prep dials, follow up after VM, and recommend next best actions — without inventing CONTACTS or auto-sending.
+
+**Scope (in):**
+1. `calls_recent` — read CallHistoryDB
+2. `log_call_touch` — write OUTREACH + update PROSPECT from a call or operator claim
+3. `prospect_execute_loop` — boot / tick / close for a Prospect block
+4. `handle_timeline` — calls + Messages (+ optional mail later) for one handle
+5. `dial_prep` — brief + talk track + open `tel:` via Phone
+6. `vm_followup` — draft SMS/email after VM; wrong-number fork
+7. `next_best_action` — call vs text vs pause vs warm intro for one prospect or queue
+
+**Scope (out):**
+- Call recording / live transcription
+- Auto-dial spam or unattended mass dialing
+- Auto-send SMS/email without operator confirm
+- Auto-create CONTACT / CLIENT (conversion remains create+dispose with human or explicit GO)
+- Treating CallHistory “answered” as full Phone Verified identity
+- AppleScript Phone recents (dead end — use CallHistoryDB)
+- iOS-only private APIs
+
+**Constraints:**
+- Local-first: CallHistory path `~/Library/Application Support/CallHistoryDB/CallHistory.storedata`
+- TCC: Full Disk Access for The Bridge if required on some macOS versions
+- Governance: read tools open/notify; write/log notify; send paths request + confirm
+- Conversion law (ops): never move DS rows; create downstream + Status=Converted on source
+- Tool count / floor gate: bump `staticFeatureModuleToolCount` + `make test-floor`
+- Prefer shared primitives over one-off VoiceMemo-style triple round trips
+
+**Success Criteria:**
+1. All seven tools registered in ToolAnnotationCatalog with governance tiers
+2. `calls_recent` returns Jeff-class rows (e.g. outbound unanswered ~74s to 6128403028 when present in history)
+3. `log_call_touch` creates OUTREACH linked to PROSPECT and updates Last Touched / Next Action
+4. `prospect_execute_loop` boot returns Top queue + unlogged dials since `since`
+5. `handle_timeline` merges call + messages for a known number without inventing contacts
+6. `dial_prep` opens Phone with `tel:` (system default Phone.app)
+7. `vm_followup` returns draft text only (no send) unless confirm path used
+8. `next_best_action` returns ranked options with reasons grounded in history
+9. Unit/integration tests for parse/normalize/match; floor green
+10. Operator brief documents how Prospect Execute uses the suite
+
+**Verification:**
+- `make test` / `make test-floor` green
+- Live MCP smoke: `calls_recent` limit 10; match Jeff if in DB
+- Live smoke: `log_call_touch` dryRun then real against a test PROSPECT
+- Manual: dial_prep opens Phone; no Google Voice handler required
+- Docs: AGENTS.md or operator packet note updated
+
+**Execution Class:** REVIEW-FIRST
+Ship to reviewable PR stack + smoke evidence; operator GO before merge to main / release.
+
+**Review Requirement:**
+- Reviewer: Isaiah (or Bridge code owner)
+- Artifact: PR(s) + smoke transcript + tool catalog entries
+- Decisions: Approve merge · Request changes · Park
+
+**Failure / Stop Conditions:**
+- CallHistory unreadable after FDA granted → BLOCKED with exact TCC steps
+- Schema drift in ZCALLRECORD without adapter → REVIEW with mapping gap
+- Any path that would auto-send or auto-convert CONTACT → stop, fix design
+- Ambiguous multi-match prospect for a number → no silent write; return ambiguous
+
+**Output / Brief Contract:**
+- PR description with tool list + tiers
+- Operator one-pager: Prospect Execute with tools
+- Packet Runner Output sections filled on completion
+
+## GOAL_CONDITION
+
+Ship seven Bridge MCP tools (`calls_recent`, `log_call_touch`, `prospect_execute_loop`, `handle_timeline`, `dial_prep`, `vm_followup`, `next_best_action`) so Prospect Execute can read Mac CallHistory, log touches to PROSPECTS/OUTREACH, and recommend next actions within scope, proven by test-floor green and live MCP smoke on CallHistory + a PROSPECT row; REVIEW-FIRST before release; stop if FDA/schema blocks or auto-send/auto-convert would be required.
+
+---
+
+## Current System State & Context
+
+**Proven on operator Mac (2026-07-16):**
+- CallHistory SQLite readable at `CallHistoryDB/CallHistory.storedata`
+- Columns usable: ZDATE, ZDURATION, ZORIGINATED, ZANSWERED, ZADDRESS, ZNAME, ZSERVICE_PROVIDER, ZORIGINATINGDEVICENAME
+- Jeff O’Neill (6128403028): outbound, unanswered, ~74s VM-class duration logged same day
+- PROSPECTS registry entity `prospect` bound to DS `97a4ae02-…`
+- OUTREACH has PROSPECT relation; Status/Outcome include Voicemail
+- Messages tools exist (`messages_chat`, `messages_recent`, …)
+- Phone.app opens via `open -a Phone tel:…`; system `tel:` should be Phone (not Google Voice)
+- No Bridge `calls_*` tools today
+
+**Ops doctrine:**
+- Invent PROSPECTS only after verification gate
+- Contact = quality relationship; Client = paid
+- Convert = create + dispose (Status=Converted), never move/delete
+- Prospect Execute Top 5 from trades Excel + open PROSPECTS
+
+**Context relevance list:**
+- This packet + Bridge repo `Sources/` Mac/Registry modules
+- `docs/operator/packets/PKT-MEM-135-…` as pattern for new tools
+- Prospect aura invent/convert law
+- Sales strategy pipeline / conversion law
+
+---
+
+## Material decisions (recommended defaults — operator may override)
+
+| ID | Decision | Recommended | Impact if otherwise |
+|---|---|---|---|
+| D1 | Module home | New **Calls** feature surface under Mac tooling (or MacModule extension), not Notion-only | Wrong module → messy ownership |
+| D2 | Packet shape | **One suite packet**, sequential waves W1→W3 (not 7 micro-packets) | More packets → more runner overhead |
+| D3 | FDA | Document FDA requirement; fail with actionable error if DB unreadable | Silent empty lists mislead agents |
+| D4 | Number match | Normalize to digits; match last-10 US; multi-prospect → ambiguous error | Wrong person logged |
+| D5 | Auto Phone Verified | **Never** set true from unanswered/VM; optional suggest after answered + duration ≥ threshold | False identity claims |
+| D6 | Sends | `vm_followup` drafts only unless existing messages_send confirm path | Accidental customer SMS |
+
+**Assumed GO on D1–D6 unless operator objects before QUEUE.**
+
+---
+
+## Decomposition / Waves (sequential)
+
+### Wave 1 — Call truth (unblocks all)
+**Tools:** `calls_recent`
+**Deliverables:** Reader for CallHistory.storedata; filters limit/since/number/direction; ToolAnnotationCatalog; tests with fixture DB or mocked rows; FDA error path.
+
+### Wave 2 — Log + block loop
+**Tools:** `log_call_touch`, `prospect_execute_loop`
+**Depends on:** Wave 1
+**Deliverables:**
+- `log_call_touch`: input call id or {number, at, outcome claim}; resolve PROSPECT; create OUTREACH; update Last Touched / Next Action; dryRun
+- `prospect_execute_loop`: mode boot|tick|close; boot = queue + recent calls; tick = unlogged dials since; close = digest + scoreboard
+
+### Wave 3 — Context, prep, recovery, judgment
+**Tools:** `handle_timeline`, `dial_prep`, `vm_followup`, `next_best_action`
+**Depends on:** Wave 1–2
+**Deliverables:**
+- Timeline merge calls + messages_chat/recent
+- dial_prep: registry prospect brief + open tel
+- vm_followup: draft only
+- next_best_action: ranked options with evidence fields
+
+**Merge points:** shared phone normalize + CallHistory reader + prospect match helper (extract once in W1, reuse W2–W3).
+
+---
+
+## Definition of Done (checklist)
+
+### Wave 1
+- [x] `calls_recent` implemented and registered
+- [x] Returns newest-first rows with stable field names
+- [x] Filters: limit, since, number (normalized), direction
+- [x] Unreadable DB → structured error with FDA hint
+- [x] Tests + floor bump
+
+### Wave 2
+- [ ] `log_call_touch` dryRun + write paths
+- [ ] OUTREACH linked to PROSPECT when relation exists
+- [ ] Does not set Phone Verified on VM/unanswered
+- [ ] `prospect_execute_loop` boot/tick/close
+- [ ] Tick lists unlogged outbound calls matched to prospects
+- [ ] Tests + floor bump
+
+### Wave 3
+- [ ] `handle_timeline` for a handle
+- [ ] `dial_prep` returns brief + opens Phone (or returns tel URL if open fails)
+- [ ] `vm_followup` draft body + optional Ready OUTREACH without send
+- [ ] `next_best_action` returns ≥1 ranked option with reason
+- [ ] Operator brief markdown in repo
+- [ ] Tests + floor bump
+- [ ] REVIEW artifact ready for merge GO
+
+---
+
+## Required Capabilities
+
+- `repo:the-bridge` — Swift MCP tool modules, tests, annotations, version/floor
+- Local filesystem read: CallHistoryDB (operator machine)
+- Bridge registry: `prospect` read/write; Notion OUTREACH create via existing paths
+- messages_* read for timeline (existing)
+
+## Prohibited Actions
+
+- No merge to main without REVIEW GO
+- No production deploy from this packet
+- No messages_send / mail_send without operator confirm:'SEND'
+- No bulk invent CONTACTS from call history
+- No deletion of CallHistory or prospect rows
+- No secret values in packet or logs
+
+---
+
+## Replay and Recovery
+
+1. **Detect prior work:** tools exist in catalog + tests green + Version/floor comments dated PKT-CALL-001
+2. **Stable keys:** tool names exact as listed; CallHistory reader module path documented
+3. **Safe resume:** land waves in order; if W2 mid-flight, do not start W3 tools depending on missing APIs
+4. **Unsafe:** partial catalog registration without tests → REVIEW before more tools
+
+---
+
+## Review Contract
+
+| Item | Value |
+|---|---|
+| Who | Isaiah / Bridge owner |
+| Artifact | PR stack + smoke notes + this packet Output section |
+| Approve | Merge + optional release notes |
+| Request changes | List gaps; keep branch |
+| Park | Leave Draft/REVIEW with reason |
+
+---
+
+## Brief Contract (operator-facing after ship)
+
+1. How to run Prospect Execute with the suite
+2. What CallHistory can/can’t prove (identity)
+3. FDA one-liner if empty results
+4. Continuity note: Mac vs iPhone call chooser is OS UX, not tool failure
+
+---
+
+## Dependencies
+
+| Depends on | State |
+|---|---|
+| CallHistoryDB present on operator Mac | Available (verified 2026-07-16) |
+| PROSPECTS + OUTREACH live | Available |
+| Messages tools | Available |
+| tel: → Phone.app | Operator preference (fixed once; re-check if Chrome steals handler) |
+
+**Blocked by:** none hard. Soft: FDA if tool returns empty erroneously.
+
+---
+
+## Tool contracts (authoritative for implementers)
+
+### 1. `calls_recent`
+```
+in:  { limit?: number, since?: ISO8601, number?: string, direction?: "inbound"|"outbound"|"all" }
+out: { calls: [{ id, at, number, name?, originated, answered, durationSec, service?, device? }], source: "CallHistoryDB" }
+tier: open | notify
+```
+
+### 2. `log_call_touch`
+```
+in:  { callId?: string, number?: string, at?: ISO8601, outcome: "Connected"|"Voicemail"|"No answer"|"Wrong number"|"Booked", prospectId?: string, dryRun?: bool, nextAction?: string }
+out: { outreachId?, prospectId?, updated: string[], suggestions?: string[] }
+tier: notify (write)
+```
+
+### 3. `prospect_execute_loop`
+```
+in:  { mode: "boot"|"tick"|"close", since?: ISO8601, brand?: string }
+out: boot → { queue, recentCalls, openProspects }; tick → { unloggedCalls, suggestions }; close → { scoreboard, digest }
+tier: open/notify
+```
+
+### 4. `handle_timeline`
+```
+in:  { number: string, limit?: number }
+out: { events: [{ at, channel: "call"|"message", summary, ref }] }
+tier: open
+```
+
+### 5. `dial_prep`
+```
+in:  { prospectId: string, openPhone?: bool }
+out: { brief, talkTrack, telUrl, opened?: bool }
+tier: notify if opens Phone
+```
+
+### 6. `vm_followup`
+```
+in:  { prospectId: string, channel?: "Text"|"Email", createOutreachDraft?: bool }
+out: { draftBody, subject?, outreachId? }
+tier: notify if writes draft row; never send
+```
+
+### 7. `next_best_action`
+```
+in:  { prospectId?: string, queue?: bool }
+out: { actions: [{ rank, action, reason, evidence[] }] }
+tier: open
+```
+
+---
+
+## Packet Runner Output
+
+### Current Canonical Result
+
+Wave 1 is implemented on `codex/calls-recent` for review. `calls_recent` reads
+CallHistoryDB through a read-only SQLite connection, supports the four locked
+filters, returns newest-first structured records, and explicitly reports that
+no contact identity was resolved. It does not select or expose CallHistory's
+name column.
+
+Verification on 2026-07-17:
+
+- Operator DB preflight: read-only open, required schema, and sample SELECT all
+  succeeded under The Bridge's installed FDA identity.
+- Hermetic suite: 3221 passed, 0 failed; floor 3207 → 3221.
+- Structured error tests: FDA denial and unsupported schema both fail visibly;
+  neither degrades to an empty-success result.
+- Live installed MCP smoke remains the final review-integration gate because
+  the currently installed app predates this branch.
+
+Waves 2–3 are not part of the approved stabilization scope and remain unchecked.
+Recommended next step after Wave 1 review: extract the normalized-number helper
+into a shared Calls primitive, then implement `log_call_touch` with dry-run and
+ambiguous-prospect fail-closed behavior before adding any higher-level loop.
+
+### Artifact Manifest
+
+- **Canonical mission surface:** [PACKETS · PKT-CALL-001](https://app.notion.com/p/PKT-CALL-001-Prospecting-Call-Tools-Suite-7-39fcbb58889e81cb9c9cca1dfee73cc6)
+- DOCS dual `pkt-call-001` **deleted** 2026-07-16 (standing order: Packet Mission Surface)
+- Repo mirror only (not a second SSOT)
+
+- This file: `docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md`
+- Notion packet page: https://app.notion.com/p/PKT-CALL-001-Prospecting-Call-Tools-Suite-7-39fcbb58889e81cb9c9cca1dfee73cc6
+
+### Exceptional History
+
+- 2026-07-16: Scoped via orchestrator protocol from seven-tool consolidation; CallHistory recon confirmed readable; Jeff VM call present in DB.
+- 2026-07-17: Stabilization scope locked to Wave 1 only. Implemented and tested
+  `calls_recent`; retained Waves 2–3 as future review work rather than silently
+  expanding the branch.
+
+---
+
+## Fresh-Agent Test
+
+A fresh executor with this packet + Bridge repo can implement Wave 1 without asking material questions (path, schema columns, and tool names are specified). Waves 2–3 reuse Wave 1 helpers. Operator review required before merge (REVIEW-FIRST).
+
+## Autonomy Gate
+
+- Material decisions D1–D6 recommended and assumed
+- Execution Class set
+- Verification named
+- No customer auto-send
+- PROJECT relation: The Bridge (set on Notion row)
+- Ready for QUEUE after operator confirms D1–D6 (or silence = accept defaults)

--- a/docs/operator/v4-release-gate.md
+++ b/docs/operator/v4-release-gate.md
@@ -1,29 +1,35 @@
 # The Bridge v4 — Release-Gate Runbook (the path to first sale)
 
-**Status:** everything *code-side* for v4 is merged to `main` (PRs #43/#44/#45 · floor 2250/0 · security audit clean — `docs/audits/v4-security-audit-2026-06-23.md`). What remains is **operator-only**: set secrets, prove the durable identity on-device, publish legal + submit the connector, then cut the release. **No code changes are required below.**
+**Status:** code-side v4 is consolidated in integration PR #110 (floor
+3355/0; security audit clean — `docs/audits/v4-security-audit-2026-06-23.md`).
+The Apple agreement and `ServerManager` gates are resolved. What remains is
+**operator-owned**: production license-key custody, live payment fulfillment,
+durable identity proof without the env agent, legal/submission, and the release.
 
 The committed defaults are all **fail-closed** (empty license key → no activation; empty OAuth identity → placeholder AS that now *fails loud*), so nothing ships insecure if a step is skipped — it just won't activate/connect until configured.
 
 ## At a glance (ordered; **0 blocks everything**, 1–3 gate the release build, 7 triggers it)
-0. **Apple Developer legal agreement signed** — notarization (and the published build) fails until then
+0. **Apple Developer legal agreement signed** — RESOLVED; notary history is healthy
 1. Licensing keypair + CI secret
 2. Stripe live price + Payment Link + fulfillment + `STRIPE_PAYMENT_LINK`
 3. Remote-Access: 5 OAuth/WorkOS CI secrets → on-device PRM proof → retire env agent
 4. Connector: privacy/ToS published + Anthropic Directory submission
 5. Legal sign-off (TERMS / refund)
-6. Decide the `ServerManager.swift` one-liner
+6. Decide the `ServerManager.swift` one-liner — RESOLVED; committed on both startup paths
 7. Version bump → push the `v4.0.0` tag (the release trigger)
 
 ---
 
 ## 0 · Apple Developer legal agreement — notarization prerequisite ⚠️ (blocks the release)
-**Discovered 2026-06-24** running `make install`: code-signing succeeds, but the Apple notary service rejects the upload —
+**Discovered 2026-06-24** running `make install`: code-signing succeeded, but the Apple notary service rejected the upload —
 > HTTP 403 — "A required agreement is missing or has expired. … Ensure your team has signed the necessary legal agreements and that they are not expired."
 
 Notarization is REQUIRED for the published DMG (gate 7 · `release.yml` → `notarize`), so this blocks the v4 release **ahead of everything below**. It is an Apple-account action, not a code change.
-- [ ] As the **Account Holder**, sign in at [developer.apple.com/account](https://developer.apple.com/account) **and** App Store Connect; accept any pending agreements (updated **Apple Developer Program License Agreement**, **Paid Apps Agreement**, etc.).
-- [ ] Confirm a clean notarize: re-run `make install` (or `xcrun notarytool submit … --keychain-profile "notarytool-profile" --wait`) → no 403.
-- [ ] Until then, `make install-copy` (signed, no notarize) deploys to *this* Mac for local use — but the build is **not distributable / auto-updatable** without notarization.
+- [x] Agreement issue resolved. On 2026-07-18, `xcrun notarytool history
+  --keychain-profile notarytool-profile` succeeded; the most recent v3.9.9 app
+  archive and DMG entries are both `Accepted` (2026-07-09).
+- [ ] The v4 release still needs its own notarized artifact and clean-install /
+  Sparkle proof; prior accepted submissions prove account access, not v4.
 
 ## 1 · Licensing (Packet B) — first-sale activation
 - [ ] Generate the **prod Ed25519 keypair** under your custody: `swift run license-cli keygen` (details: `docs/operator/license-ops-runbook.md`). **The private key NEVER enters the repo** — store it in your password manager / secure store.
@@ -61,7 +67,8 @@ Set these 5 `release.yml` secrets so `make inject-remote-access` bakes the IdP i
 - [ ] Sign off on the **TERMS / refund policy** (refund window 7→14d is already in the copy).
 
 ## 6 · `ServerManager.swift` one-liner
-- [ ] Decide the uncommitted `_ = await manager.enable()` line in `TheBridge/Server/ServerManager.swift` (cloud-enabled block): **include** (commit it), **revert**, or **leave**. Not authored this sprint — your call before the release build.
+- [x] Included and committed on both server startup paths. Verified in source on
+  2026-07-18; no uncommitted decision remains.
 
 ## 7 · Cut the release (the trigger)
 - [ ] Bump `TheBridge/Config/Version.swift` (marketing → **4.0.0**) **and** root `Info.plist` (`CFBundleShortVersionString` / `CFBundleVersion`) in sync; +1 build number.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2293,3 +2293,9 @@ set -euo pipefail
 
 # 2026-07-15 Notion views list/get + comment discussionId reply. FLOOR 3207→3213 (+6 greens; hermetic body/schema tests). staticFeatureModuleToolCount 205→207.
 # 2026-07-15 Voice Memo Reliability (list filters/pagination/health + commit receipts + FieldsFilter identity keys). FLOOR 3207→3214 (+7).
+# PKT-CALL-001 Wave 1 (2026-07-17): +14 hermetic CallHistory tests cover
+# calls_recent registration/tier/schema/annotations, phone normalization,
+# limit/since/number/direction filters, newest-first ordering, identity-free
+# output, actionable Full Disk Access failure, explicit schema-drift failure,
+# and an incompatible SQLite fixture. Measured 3221 passed, 0 failed on the
+# origin/main-based calls worktree. FLOOR 3207 -> 3221.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2338,3 +2338,8 @@ set -euo pipefail
 
 # Review-integration replay: authority and uniqueness hardening adds 11 greens
 # to the combined candidate floor. FLOOR 3288 -> 3299.
+
+- Calendar–Registry vNext forward-only pairing (2026-07-18): replaced the procedural recovery path with stage-directed forward-only continuation; added a durable Calendar Create Invocation ID that permanently closes automatic recreation after uncertainty, strict production Notion authority/state/revision decoding, synchronization writer tokens and monotonic Sync Revision readback, EventKit metadata v2, bounded owned-identity search receipts, and Operator Review terminal semantics. Hardened a dedicated local coordinator across lock, SQLite, WAL, and SHM files with symlink, owner, mode, link-count, stable device/inode, partial-write, and directory-fsync checks. Expanded the hermetic and production-adapter recovery matrix from 61 to 80 scenarios, including ledger-loss no-recreate, late-stage crash resumption, zero EventKit access before registry authorization, malformed revision refusal, writer-token loss, bounded-search truth, and coordinator attack cases. Measured 3297 passed, 0 failed. FLOOR 3278 -> 3297.
+
+# Review-integration replay: forward-only pairing adds 19 greens to the
+# combined candidate floor. FLOOR 3299 -> 3318.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2323,3 +2323,8 @@ set -euo pipefail
 
 # Review-integration replay: recovery hardening adds 6 greens to the combined
 # candidate floor. FLOOR 3254 -> 3260.
+
+- Calendar–Registry single-writer fencing (2026-07-17): upgraded the SQLite recovery ledger into a single-machine transaction coordinator with expiring leases, fencing tokens, monotonic revisions, compare-and-swap saves, stage/identity regression guards, and cancellation-aware ownership. Added typed raw Notion identity reads, strict page/create/update/query row decoding, identity-first EventKit recovery across unsupported shapes, canonical manifest semantics, final Sync Hash/Last Synced At readback, and ledger-corruption refusal. The synchronization matrix now contains 40 scenarios, including same-key independent-engine races, stale fences, lease expiry, ledger-known malformed/missing identity, uncertain create recovery, unsupported existing event shapes, unrelated malformed metadata isolation, final evidence loss, and pre/post-effect cancellation. Measured 3257 passed, 0 failed. FLOOR 3239 -> 3257.
+
+# Review-integration replay: single-writer fencing adds 18 greens to the
+# combined candidate floor. FLOOR 3260 -> 3278.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2328,3 +2328,8 @@ set -euo pipefail
 
 # Review-integration replay: single-writer fencing adds 18 greens to the
 # combined candidate floor. FLOOR 3260 -> 3278.
+
+- Calendar–Registry fail-closed smoke narrowing (2026-07-17): replaced lease-expiry-based external-effect ownership with a per-idempotency-key OS advisory lock held across the complete registry/EventKit transaction. Narrowed the smoke path to one pre-existing canonical Notion EVENT; automatic Notion creation and partial repair are no longer reachable. Added durable EventKit create-intent / calendar-effect-unknown recovery-only stages, immutable established pair identifiers, final-read Sync Hash recomputation, exact delimited metadata attribution, optional provider modification timestamps, local-filesystem composition enforcement, and schema-v3 stage migration. The hermetic recovery matrix now contains 50 scenarios, including real child-process contention with a provider call held beyond SQLite lease duration, unknown-effect no-recreate behavior, production Notion adapter no-create proof, final identity/evidence mutation, and state-specific recovery receipts. Measured 3267 passed, 0 failed. FLOOR 3257 -> 3267.
+
+# Review-integration replay: fail-closed smoke narrowing adds 10 greens to the
+# combined candidate floor. FLOOR 3278 -> 3288.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2343,3 +2343,11 @@ set -euo pipefail
 
 # Review-integration replay: forward-only pairing adds 19 greens to the
 # combined candidate floor. FLOOR 3299 -> 3318.
+
+# Calendar–Registry literal crash matrix (2026-07-18): +16 tests. CR81–CR95
+# terminate a real child process after each material durable-write or EventKit
+# effect boundary, then run two fresh-process recoveries. All paths prove at
+# most one automatic create: 13 recover to Complete with exactly one item; the
+# two Create Invocation registry/ledger gaps stop at Operator Review with zero
+# creates. CR96 locks removal of the unreachable legacy procedural recovery
+# helpers. FLOOR 3318 -> 3334.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2292,3 +2292,4 @@ set -euo pipefail
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
 
 # 2026-07-15 Notion views list/get + comment discussionId reply. FLOOR 3207→3213 (+6 greens; hermetic body/schema tests). staticFeatureModuleToolCount 205→207.
+# 2026-07-15 Voice Memo Reliability (list filters/pagination/health + commit receipts + FieldsFilter identity keys). FLOOR 3207→3214 (+7).

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2299,3 +2299,11 @@ set -euo pipefail
 # output, actionable Full Disk Access failure, explicit schema-drift failure,
 # and an incompatible SQLite fixture. Measured 3221 passed, 0 failed on the
 # origin/main-based calls worktree. FLOOR 3207 -> 3221.
+# Agent-feedback reconciliation (2026-07-17): +11 net-new tests cover job
+# previous-result paths and fail-closed misses, Messages attribution provenance,
+# bounded skill/Notion section misses, skill metadata drift, block/page cache
+# eviction, cross-entity registry cache eviction, packet/session compatibility,
+# and actionable Notion 401 guidance. Measured 3218 passed, 0 failed on the
+# origin/main-based feedback worktree. FLOOR 3207 -> 3218. A deliberately
+# failing precursor also proved complete-log retention to the stable evidence
+# directory before its assertion was corrected.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2333,3 +2333,8 @@ set -euo pipefail
 
 # Review-integration replay: fail-closed smoke narrowing adds 10 greens to the
 # combined candidate floor. FLOOR 3278 -> 3288.
+
+- Calendar–Registry authority and uniqueness hardening (2026-07-17): final verification now re-proves exactly one live Notion EVENT and one EventKit identity; registry-first execution requires Registry authority and an admissible clean-or-complete pairing state before calendar access; Notion writes are revision-checked and limited to pairing-owned fields so concurrent semantic edits are preserved; production uses one canonical local coordinator with hardened lock-root/file validation; receipts separate stable transaction ID from attempt ID and report coordinator namespace, final registry revision, and uniqueness counts. The hermetic recovery matrix now contains 61 scenarios. Measured 3278 passed, 0 failed. FLOOR 3267 -> 3278.
+
+# Review-integration replay: authority and uniqueness hardening adds 11 greens
+# to the combined candidate floor. FLOOR 3288 -> 3299.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2312,3 +2312,9 @@ set -euo pipefail
 # PR #107 Voice Memo reliability, PKT-CALL-001 Wave 1, and the agent-feedback
 # reconciliation coexist on one origin/main-based worktree. Measured 3249 passed,
 # 0 failed. FLOOR 3221 -> 3249 for the review integration candidate.
+
+# Calendar–Registry hardening (2026-07-17): +26 net-new hermetic tests across two independently reviewable units. The skill-mutation unit covers parent/specialist resolution, specialist body eviction, metadata convergence, and separate routing-refresh evidence. The reduced sync unit covers atomic transaction-journal restart, sequential and concurrent idempotency, calendar-create and post-calendar-write recovery, false-Synced prevention, fresh EventKit-provider recovery, ambiguous identity conflict, degraded lookup refusal, full date-range/timezone round-trip, authoritative filtered Notion lookup, explicit nullable clears, recoverable partial Notion creation, disabled composition, and route ownership. Measured 3232 before the final cache-evidence test; expected final floor 3233. FLOOR 3228 -> 3233.
+
+# Calendar–Registry review-integration replay (2026-07-18): the reduced sync
+# unit adds 5 greens to the 3249 review-integration floor while the unrelated
+# skill-mutation commit remains excluded. FLOOR 3249 -> 3254.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2351,3 +2351,8 @@ set -euo pipefail
 # two Create Invocation registry/ledger gaps stop at Operator Review with zero
 # creates. CR96 locks removal of the unreachable legacy procedural recovery
 # helpers. FLOOR 3318 -> 3334.
+
+# Bridge v4 integration (2026-07-18): replayed the unique specialist-metadata
+# mutation fix after the review-integration + Calendar candidate. Adds 8 greens
+# covering parent/specialist mutation targeting, specialist body-cache eviction,
+# and shared cache refresh. Measured 3355 passed, 0 failed. FLOOR 3334 -> 3342.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2356,3 +2356,7 @@ set -euo pipefail
 # mutation fix after the review-integration + Calendar candidate. Adds 8 greens
 # covering parent/specialist mutation targeting, specialist body-cache eviction,
 # and shared cache refresh. Measured 3355 passed, 0 failed. FLOOR 3334 -> 3342.
+
+# CI portability hardening (2026-07-18): resolve TheBridgeTests through
+# SwiftPM's architecture-aware `swift build --show-bin-path -c debug` output
+# instead of assuming the convenience `.build/debug` symlink exists. Floor unchanged.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2307,3 +2307,8 @@ set -euo pipefail
 # origin/main-based feedback worktree. FLOOR 3207 -> 3218. A deliberately
 # failing precursor also proved complete-log retention to the stable evidence
 # directory before its assertion was corrected.
+
+# Review integration proof (2026-07-17): PR #106 Notion views/comment replies,
+# PR #107 Voice Memo reliability, PKT-CALL-001 Wave 1, and the agent-feedback
+# reconciliation coexist on one origin/main-based worktree. Measured 3249 passed,
+# 0 failed. FLOOR 3221 -> 3249 for the review integration candidate.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2359,4 +2359,6 @@ set -euo pipefail
 
 # CI portability hardening (2026-07-18): resolve TheBridgeTests through
 # SwiftPM's architecture-aware `swift build --show-bin-path -c debug` output
-# instead of assuming the convenience `.build/debug` symlink exists. Floor unchanged.
+# instead of assuming the convenience `.build/debug` symlink exists, and request
+# the `TheBridgeTests` executable product explicitly so a clean SwiftPM build
+# cannot stop after compiling target objects without linking the harness. Floor unchanged.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2290,3 +2290,5 @@ set -euo pipefail
 # mutation, rate-limited unknown-tool audit telemetry, secret-shaped miss
 # redaction, and client name/version attribution. Measured 3207 passed, 0
 # failed on the current origin/main-based worktree. FLOOR 3202 -> 3207.
+
+# 2026-07-15 Notion views list/get + comment discussionId reply. FLOOR 3207→3213 (+6 greens; hermetic body/schema tests). staticFeatureModuleToolCount 205→207.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2318,3 +2318,8 @@ set -euo pipefail
 # Calendar–Registry review-integration replay (2026-07-18): the reduced sync
 # unit adds 5 greens to the 3249 review-integration floor while the unrelated
 # skill-mutation commit remains excluded. FLOOR 3249 -> 3254.
+
+- Calendar–Registry recovery hardening (2026-07-17): replaced the process-local JSON correctness boundary with a SQLite recovery ledger and immutable operation fingerprint persisted on Notion and EventKit; added production gateway truth/strict decoding, identity-envelope repair, manifest-authority verification, timezone/event-shape/calendar-qualification gates, durable failure receipts, and migration-model validation. The recovery matrix now contains 22 scenarios, including independent SQLite handles, ledger-loss reconstruction/conflict, partial-page retry, drift refusal, invalid timezone/key, shape rejection, unqualified calendar refusal, and unpersisted recovery evidence. Measured 3239 passed, 0 failed. FLOOR 3233 -> 3239.
+
+# Review-integration replay: recovery hardening adds 6 greens to the combined
+# candidate floor. FLOOR 3254 -> 3260.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3249}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3254}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -11,8 +11,8 @@
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
 FLOOR="${BRIDGE_TEST_FLOOR:-3342}"
 
-echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."
-swift build -c debug
+echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
+swift build -c debug --product TheBridgeTests
 BIN="$(swift build --show-bin-path -c debug)/TheBridgeTests"
 if [ ! -x "$BIN" ]; then
   echo "::error::test-floor-gate: compiled test binary is missing or not executable at $BIN"

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3221}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3249}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -18,6 +18,21 @@ swift build -c debug
 LOG="$(mktemp -t bridge-test-floor.XXXXXX)"
 trap 'rm -f "$LOG"' EXIT
 
+# A failing run is evidence, not disposable noise. Copy the complete log to a
+# stable operator-visible directory before the temporary file is cleaned up,
+# then print both the path and every explicit failure row found anywhere in the
+# log (not merely the tail). Tests/CI may override this location.
+FAILURE_DIR="${BRIDGE_TEST_FAILURE_DIR:-${HOME}/Library/Logs/TheBridge/test-floor-failures}"
+retain_failure_log() {
+  mkdir -p "$FAILURE_DIR"
+  RETAINED_LOG="${FAILURE_DIR}/test-floor-$(date -u +%Y%m%dT%H%M%SZ)-$$.log"
+  cp "$LOG" "$RETAINED_LOG"
+  echo "::notice::test-floor-gate: complete failure log retained at $RETAINED_LOG"
+  echo "--- failure rows from complete test output ---"
+  grep -aE '(^|[[:space:]])❌|::error::|error:' "$RETAINED_LOG" || echo "(no explicit failure row found; inspect the retained complete log)"
+  echo "--- end failure rows ---"
+}
+
 # Watchdog: cap the test binary at DEADLINE seconds (default 1500 = 25 min;
 # local run is ~5 min, CI macos-26 is ~3x slower). Override with
 # TEST_WATCHDOG_SECONDS — a short value (e.g. 5) makes the watchdog testable.
@@ -72,6 +87,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # kept as a defensive fallback in case a future change reintroduces an alarm.)
   if [ "$RC" -eq 137 ] || [ "$RC" -eq 142 ] || [ "$RC" -eq 14 ]; then
     echo "::error::test-floor-gate: test binary exceeded ${DEADLINE}s watchdog and was killed"
+    retain_failure_log
     echo "--- last 60 lines of test output (so you can see which test hung) ---"
     tail -60 "$LOG" || true
     echo "--- end of test output tail ---"
@@ -79,6 +95,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   fi
   if [ "$RC" -ne 0 ]; then
     echo "::error::test-floor-gate: test binary exited with code $RC (non-zero, non-timeout)"
+    retain_failure_log
     echo "--- last 60 lines of test output ---"
     tail -60 "$LOG" || true
     echo "--- end of test output tail ---"
@@ -95,6 +112,7 @@ done
 LINE="$(tr -d '\000-\010\013\014\016-\037' < "$LOG" | grep -aE 'Results: [0-9]+ passed, [0-9]+ failed, [0-9]+ total' | tail -1 || true)"
 if [ -z "$LINE" ]; then
   echo "::error::test-floor-gate: no 'Results:' summary line after ${ATTEMPTS} attempts"
+  retain_failure_log
   exit 2
 fi
 
@@ -103,11 +121,13 @@ FAILED="$(printf '%s\n' "$LINE" | sed -E 's/^Results: [0-9]+ passed, ([0-9]+) fa
 
 if [ "$FAILED" -ne 0 ]; then
   echo "::error::test-floor-gate: ${FAILED} failing test(s) — green bar broken"
+  retain_failure_log
   exit 1
 fi
 
 if [ "$PASSED" -lt "$FLOOR" ]; then
   echo "::error::test-floor-gate: passed=${PASSED} is BELOW floor=${FLOOR} — tests were removed or disabled. If this drop is intentional, lower the floor in scripts/test-floor-gate.sh in the same change and record why."
+  retain_failure_log
   exit 1
 fi
 

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3288}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3299}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3260}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3278}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3254}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3260}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -2,7 +2,7 @@
 # test-floor-gate.sh — WS-C (v2.3, PKT-798)
 #
 # Locks the green test baseline as a CI gate. The custom harness
-# (.build/debug/TheBridgeTests) already exits non-zero on any failing
+# (`swift build --show-bin-path -c debug`/TheBridgeTests) already exits non-zero on any failing
 # test, but that does NOT catch tests being silently deleted or disabled —
 # a suite that shrinks from 710 → 600 with 0 failures would otherwise pass
 # CI unnoticed. This gate fails the build if the passing count drops below
@@ -10,10 +10,14 @@
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
 FLOOR="${BRIDGE_TEST_FLOOR:-3342}"
-BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."
 swift build -c debug
+BIN="$(swift build --show-bin-path -c debug)/TheBridgeTests"
+if [ ! -x "$BIN" ]; then
+  echo "::error::test-floor-gate: compiled test binary is missing or not executable at $BIN"
+  exit 127
+fi
 
 LOG="$(mktemp -t bridge-test-floor.XXXXXX)"
 trap 'rm -f "$LOG"' EXIT

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,11 +9,9 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-# 2026-07-15: Notion views list/get + comment discussionId reply body tests.
-# Measured green count 3213 (4 pre-existing WorkOS fail-closed tests still red
-# when OAuth/WorkOS credentials are present in the process environment / baked
-# config — not regressions from this slice). Floor raised to net greens.
-FLOOR="${BRIDGE_TEST_FLOOR:-3213}"
+# 2026-07-15 Voice Memo Reliability: list filters + commit receipts + FieldsFilter
+# identity retention. Measured 3214 passed / 0 failed. FLOOR 3207→3214.
+FLOOR="${BRIDGE_TEST_FLOOR:-3214}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,11 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3207}"
+# 2026-07-15: Notion views list/get + comment discussionId reply body tests.
+# Measured green count 3213 (4 pre-existing WorkOS fail-closed tests still red
+# when OAuth/WorkOS credentials are present in the process environment / baked
+# config — not regressions from this slice). Floor raised to net greens.
+FLOOR="${BRIDGE_TEST_FLOOR:-3213}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,9 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-# 2026-07-15 Voice Memo Reliability: list filters + commit receipts + FieldsFilter
-# identity retention. Measured 3214 passed / 0 failed. FLOOR 3207→3214.
-FLOOR="${BRIDGE_TEST_FLOOR:-3214}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3221}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3278}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3288}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3318}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3334}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3299}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3318}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3334}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3342}"
 BIN=".build/debug/TheBridgeTests"
 
 echo "🧪 test-floor-gate: building debug + running suite (floor=${FLOOR})..."


### PR DESCRIPTION
## What changed

- consolidates the Notion views, voice memo reliability, calls_recent, audited feedback, and review-integration lines
- adds the complete Calendar–Registry single-machine authority-and-uniqueness candidate, including literal crash recovery
- carries forward the unique specialist metadata mutation and cache-refresh fix
- makes the test-floor harness resolve SwiftPM's architecture-aware binary path on CI
- records the live five-field Schedule migration and reconciles current v4 release gates

## Why

The installed runtime was ahead of `main`, Calendar work existed on a separate candidate lineage, and the skills fix was unique on a parallel branch. This PR creates one clean integration line before any truthful v4.0.0 promotion.

## Impact

- one canonical source lineage for the next installed Bridge runtime
- live Schedule schema is 41/41 bound with zero drift
- Calendar–Registry remains internally disabled until a disposable installed smoke is separately verified
- standalone PRs #106–#109 are closed as superseded
- public v4.0.0 remains operator-gated by production licensing/payment/legal proof

## Validation

- `make test-floor`: 3,355 passed, 0 failed; floor 3,342
- `swift build -c release -Xswiftc -strict-concurrency=complete`: passed
- `git diff --check`: passed
- integration head: `8c30e778284b2bd863a3e778e24fb4f4333f36bb`


