### PR TITLE
Close PKT-CALL-001 Wave 1R call-truth review

### DIFF
--- a/TheBridge/Modules/CallHistoryModule.swift
+++ b/TheBridge/Modules/CallHistoryModule.swift
@@ -65,6 +65,9 @@ public struct CallHistoryRawRecord: Sendable, Equatable {
 }
 
 public enum CallHistoryReadError: Error, Sendable, Equatable {
+    /// Path does not exist on disk (distinguish from FDA / open denial).
+    case missing(String)
+    /// Database exists but cannot be opened (typically Full Disk Access).
     case unavailable(String)
     case unsupportedSchema(missingColumns: [String])
     case queryFailed(String)
@@ -94,6 +97,15 @@ public enum CallHistoryModule {
 
     public static func normalizePhoneNumber(_ value: String) -> String {
         String(value.unicodeScalars.filter { CharacterSet.decimalDigits.contains($0) })
+    }
+
+    /// Durable call identity for idempotent follow-on tools.
+    /// Prefer `ZUNIQUE_ID` when present; fall back to `Z_PK` as a string.
+    public static func stableCallID(uniqueID: String?, primaryKey: Int64) -> String {
+        if let uniqueID, !uniqueID.isEmpty {
+            return uniqueID
+        }
+        return String(primaryKey)
     }
 
     public static func parseQuery(_ arguments: Value) throws -> CallHistoryQuery {
@@ -214,7 +226,7 @@ public enum CallHistoryModule {
             let records = filteredRecords(try reader(databasePath), query: query)
             let iso = makeISO8601()
             let calls: [Value] = records.map { record in
-                let identifier = record.uniqueID.flatMap { $0.isEmpty ? nil : $0 } ?? String(record.primaryKey)
+                let identifier = stableCallID(uniqueID: record.uniqueID, primaryKey: record.primaryKey)
                 return .object([
                     "id": .string(identifier),
                     "startedAt": .string(iso.string(from: record.date)),
@@ -243,6 +255,13 @@ public enum CallHistoryModule {
                 "count": .int(calls.count),
                 "calls": .array(calls)
             ])
+        } catch CallHistoryReadError.missing(let detail) {
+            return errorResponse(
+                code: "database_missing",
+                message: "The local CallHistory database was not found.",
+                remediation: "Confirm macOS Call History exists for this user, then retry. If the path is unexpected, report it to The Bridge developer.",
+                details: detail
+            )
         } catch CallHistoryReadError.unavailable(let detail) {
             return errorResponse(
                 code: "full_disk_access_required",
@@ -293,6 +312,10 @@ public enum CallHistoryModule {
     }
 
     public static func readDatabase(at path: String) throws -> [CallHistoryRawRecord] {
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw CallHistoryReadError.missing("CallHistory database not found at \(path)")
+        }
+
         var database: OpaquePointer?
         let openResult = sqlite3_open_v2(path, &database, SQLITE_OPEN_READONLY, nil)
         guard openResult == SQLITE_OK, let database else {

--- a/TheBridgeTests/CallHistoryModuleTests.swift
+++ b/TheBridgeTests/CallHistoryModuleTests.swift
@@ -219,4 +219,126 @@ func runCallHistoryModuleTests() async {
             try expect(missing.contains("ZADDRESS"))
         }
     }
+
+    await test("missing database is distinguishable from Full Disk Access denial") {
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calls-recent-missing-\(UUID().uuidString)/CallHistory.storedata")
+            .path
+        let missing = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: missingPath
+        )
+        let missingResult = try object(missing)
+        try expect(missingResult["success"] == .bool(false))
+        guard case .object(let missingError) = missingResult["error"] else {
+            throw TestError.assertion("Missing database_missing error")
+        }
+        try expect(missingError["code"] == .string("database_missing"))
+
+        let denied = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/denied",
+            reader: { _ in throw CallHistoryReadError.unavailable("authorization denied") }
+        )
+        let deniedResult = try object(denied)
+        guard case .object(let deniedError) = deniedResult["error"] else {
+            throw TestError.assertion("Missing full_disk_access_required error")
+        }
+        try expect(deniedError["code"] == .string("full_disk_access_required"))
+        try expect(missingError["code"] != deniedError["code"])
+    }
+
+    await test("query failure returns a distinct structured error code") {
+        let value = try CallHistoryModule.response(
+            arguments: .object([:]),
+            databasePath: "/fixture",
+            reader: { _ in throw CallHistoryReadError.queryFailed("sqlite prepare failed") }
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(false))
+        try expect(result["calls"] == nil)
+        guard case .object(let error) = result["error"] else {
+            throw TestError.assertion("Missing query failed error")
+        }
+        try expect(error["code"] == .string("call_history_query_failed"))
+    }
+
+    await test("stable call ID prefers uniqueID and falls back to primary key") {
+        try expect(CallHistoryModule.stableCallID(uniqueID: "754D6E7D-3764-49FC-823E-8710CFD8AA76", primaryKey: 42)
+            == "754D6E7D-3764-49FC-823E-8710CFD8AA76")
+        try expect(CallHistoryModule.stableCallID(uniqueID: "", primaryKey: 42) == "42")
+        try expect(CallHistoryModule.stableCallID(uniqueID: nil, primaryKey: 7) == "7")
+    }
+
+    await test("compatible SQLite fixture exercises adapter date decoding and durable ids") {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calls-recent-compatible-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("CallHistory.storedata").path
+
+        var database: OpaquePointer?
+        try expect(sqlite3_open(path, &database) == SQLITE_OK)
+        guard let database else { throw TestError.assertion("Failed to open fixture DB") }
+        defer { sqlite3_close(database) }
+
+        let createSQL = """
+            CREATE TABLE ZCALLRECORD (
+                Z_PK INTEGER PRIMARY KEY,
+                ZUNIQUE_ID TEXT,
+                ZDATE REAL,
+                ZDURATION REAL,
+                ZADDRESS TEXT,
+                ZORIGINATED INTEGER,
+                ZANSWERED INTEGER,
+                ZCALLTYPE INTEGER,
+                ZSERVICE_PROVIDER TEXT
+            );
+            """
+        try expect(sqlite3_exec(database, createSQL, nil, nil, nil) == SQLITE_OK)
+
+        let startedAt = ISO8601DateFormatter().date(from: "2026-07-17T12:00:00Z")!
+        let zDate = startedAt.timeIntervalSinceReferenceDate
+        let insertWithID = """
+            INSERT INTO ZCALLRECORD
+            (Z_PK, ZUNIQUE_ID, ZDATE, ZDURATION, ZADDRESS, ZORIGINATED, ZANSWERED, ZCALLTYPE, ZSERVICE_PROVIDER)
+            VALUES (1, 'AAAA1111-BBBB-CCCC-DDDD-EEEEEEEEEEEE', \(zDate), 12.5, '+16055550123', 1, 1, 1, 'com.apple.Telephony');
+            """
+        let insertFallback = """
+            INSERT INTO ZCALLRECORD
+            (Z_PK, ZUNIQUE_ID, ZDATE, ZDURATION, ZADDRESS, ZORIGINATED, ZANSWERED, ZCALLTYPE, ZSERVICE_PROVIDER)
+            VALUES (2, NULL, \(zDate - 60), 0, '6055550199', 0, 0, 1, 'com.apple.Telephony');
+            """
+        try expect(sqlite3_exec(database, insertWithID, nil, nil, nil) == SQLITE_OK)
+        try expect(sqlite3_exec(database, insertFallback, nil, nil, nil) == SQLITE_OK)
+
+        let firstRead = try CallHistoryModule.readDatabase(at: path)
+        try expect(firstRead.count == 2)
+        try expect(firstRead[0].uniqueID == "AAAA1111-BBBB-CCCC-DDDD-EEEEEEEEEEEE")
+        try expect(abs(firstRead[0].date.timeIntervalSince(startedAt)) < 0.001)
+
+        let secondRead = try CallHistoryModule.readDatabase(at: path)
+        try expect(firstRead.map(\.uniqueID) == secondRead.map(\.uniqueID))
+        try expect(firstRead.map(\.primaryKey) == secondRead.map(\.primaryKey))
+
+        let value = try CallHistoryModule.response(
+            arguments: .object(["limit": .int(10)]),
+            databasePath: path
+        )
+        let result = try object(value)
+        try expect(result["success"] == .bool(true))
+        guard case .array(let calls) = result["calls"],
+              case .object(let newest) = calls.first,
+              case .object(let oldest) = calls.last else {
+            throw TestError.assertion("Expected two structured calls from fixture")
+        }
+        try expect(newest["id"] == .string("AAAA1111-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        try expect(oldest["id"] == .string("2"))
+        try expect(newest["normalizedNumber"] == .string("16055550123"))
+        try expect(newest["direction"] == .string("outbound"))
+        guard case .string(let startedAtString) = newest["startedAt"] else {
+            throw TestError.assertion("Missing startedAt")
+        }
+        try expect(startedAtString.hasPrefix("2026-07-17T12:00:00"))
+    }
 }

--- a/docs/operator/calls-recent.md
+++ b/docs/operator/calls-recent.md
@@ -20,23 +20,59 @@ Every field is optional. `limit` defaults to 20 and is capped at 100.
 non-decimal characters and then requires an exact normalized match. Results are
 newest-first.
 
-The response includes `identityResolved: false`. Call direction, answered
-state, duration, and service-provider metadata are call facts only; none proves
-who owns the number.
+Successful response shape (field names are authoritative):
 
-## Full Disk Access
+```json
+{
+  "success": true,
+  "source": "CallHistoryDB",
+  "identityResolved": false,
+  "count": 1,
+  "calls": [
+    {
+      "id": "754D6E7D-3764-49FC-823E-8710CFD8AA76",
+      "startedAt": "2026-07-19T04:37:51.072Z",
+      "durationSeconds": 0,
+      "number": "+15073847875",
+      "normalizedNumber": "15073847875",
+      "direction": "inbound",
+      "answered": false,
+      "callType": 1,
+      "serviceProvider": "com.apple.Telephony"
+    }
+  ]
+}
+```
 
-If the database cannot be opened, the tool returns
-`full_disk_access_required` with remediation instead of an empty list. Grant
-Full Disk Access to The Bridge in **System Settings > Privacy & Security > Full
-Disk Access**, relaunch The Bridge, reconnect MCP clients, and retry.
+Call direction, answered state, duration, and service-provider metadata are call
+facts only; none proves who owns the number.
 
-An incompatible database returns `unsupported_call_history_schema` with the
-missing columns. Do not treat that response as evidence that there were no
-calls.
+## Durable call `id`
+
+- Prefer CallHistory `ZUNIQUE_ID` when present (UUID string observed on macOS).
+- If `ZUNIQUE_ID` is null/empty, fall back to `Z_PK` as a decimal string.
+- The same source row yields the same `id` across repeated reads on an unchanged
+  database. Follow-on tools (e.g. future `log_call_touch`) must treat `id` as
+  the idempotency key and must not invent a second identity scheme.
+
+## Error taxonomy
+
+Failures never degrade to an empty-success list. Codes are distinguishable:
+
+| Code | When |
+|---|---|
+| `database_missing` | Path does not exist on disk |
+| `full_disk_access_required` | DB exists but open is denied (typically FDA) |
+| `unsupported_call_history_schema` | Required `ZCALLRECORD` columns missing |
+| `call_history_query_failed` | Open succeeded; prepare/step failed |
+
+Grant Full Disk Access to The Bridge in **System Settings > Privacy & Security >
+Full Disk Access**, relaunch The Bridge, reconnect MCP clients, and retry when
+you see `full_disk_access_required`.
 
 ## Scope boundary
 
-Wave 1 intentionally stops at read-only call truth. Prospect matching, outreach
+Wave 1 / Wave 1R stop at read-only call truth. Prospect matching, outreach
 writes, dialing, message drafts, and next-action recommendations belong to later
-reviewed waves in `PKT-CALL-001`; they are not implied by this tool.
+reviewed waves in `PKT-CALL-001`; they are not implied by this tool. W1R success
+does not authorize Wave 2 schema or `log_call_touch`.

--- a/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
+++ b/docs/operator/packets/PKT-CALL-001-prospecting-call-tools-suite.md
@@ -2,7 +2,7 @@
 
 **Slug:** `pkt-call-001-prospecting-call-tools`
 **Execution Class:** REVIEW-FIRST
-**Status:** REVIEW — Wave 1 implemented; Waves 2–3 deliberately deferred
+**Status:** REVIEW — Wave 1 + W1R hardening on `fix/pkt-call-001-w1r`; Waves 2–3 deliberately deferred; W1R success ≠ W2 authorized
 **Priority:** 80
 **Classification:** Standard (suite) · sequential waves inside one packet
 **SKILLS:** orchestrator · executor · mac-keepr · people-keepr (consumer contract)
@@ -164,6 +164,14 @@ Ship seven Bridge MCP tools (`calls_recent`, `log_call_touch`, `prospect_execute
 - [x] Unreadable DB → structured error with FDA hint
 - [x] Tests + floor bump
 
+### Wave 1R
+- [x] Compatible SQLite fixture exercises adapter/date decoding
+- [x] Permission, missing, corrupt/schema, and query errors are distinguishable
+- [x] Stable call ID is proven and documented, including fallback
+- [x] Canonical contract, tip evidence, and smoke evidence agree (PR #109 retired; tip via #110 + W1R branch)
+- [x] Test suite + floor + live read-only smoke are green (3359 passed, floor 3359; live MCP UUID ids)
+- [ ] Reviewer decision recorded *(Approve / Request changes / Park — operator only; merge OUT)*
+
 ### Wave 2
 - [ ] `log_call_touch` dryRun + write paths
 - [ ] OUTREACH linked to PROSPECT when relation exists
@@ -249,7 +257,9 @@ Ship seven Bridge MCP tools (`calls_recent`, `log_call_touch`, `prospect_execute
 ### 1. `calls_recent`
 ```
 in:  { limit?: number, since?: ISO8601, number?: string, direction?: "inbound"|"outbound"|"all" }
-out: { calls: [{ id, at, number, name?, originated, answered, durationSec, service?, device? }], source: "CallHistoryDB" }
+out: { success, source: "CallHistoryDB", identityResolved: false, count, calls: [{ id, startedAt, durationSeconds, number, normalizedNumber, direction, answered, callType, serviceProvider }], filters }
+errors: database_missing | full_disk_access_required | unsupported_call_history_schema | call_history_query_failed
+id: ZUNIQUE_ID preferred; fallback String(Z_PK)
 tier: open | notify
 ```
 
@@ -301,26 +311,24 @@ tier: open
 
 ### Current Canonical Result
 
-Wave 1 is implemented on `codex/calls-recent` for review. `calls_recent` reads
-CallHistoryDB through a read-only SQLite connection, supports the four locked
-filters, returns newest-first structured records, and explicitly reports that
-no contact identity was resolved. It does not select or expose CallHistory's
-name column.
+`calls_recent` is on `origin/main` via PR **#110** (merged 2026-07-18; tip
+`4fb9b03`). Draft PR **#109** is CLOSED and is not live evidence.
 
-Verification on 2026-07-17:
+Wave 1R hardening lands on branch `fix/pkt-call-001-w1r` (2026-07-19):
 
-- Operator DB preflight: read-only open, required schema, and sample SELECT all
-  succeeded under The Bridge's installed FDA identity.
-- Hermetic suite: 3221 passed, 0 failed; floor 3207 → 3221.
-- Structured error tests: FDA denial and unsupported schema both fail visibly;
-  neither degrades to an empty-success result.
-- Live installed MCP smoke remains the final review-integration gate because
-  the currently installed app predates this branch.
+- Compatible SQLite fixture exercises real `readDatabase` + Apple reference-date
+  decoding and durable `id` (uniqueID preferred; `Z_PK` string fallback).
+- Distinguishable errors: `database_missing`, `full_disk_access_required`,
+  `unsupported_call_history_schema`, `call_history_query_failed`.
+- Operator guide `docs/operator/calls-recent.md` documents `id` + error taxonomy.
+- Live MCP smoke on installed Bridge (still 3.9.9/81): `calls_recent` returns
+  UUID `id` values with `identityResolved: false`.
 
-Waves 2–3 are not part of the approved stabilization scope and remain unchecked.
-Recommended next step after Wave 1 review: extract the normalized-number helper
-into a shared Calls primitive, then implement `log_call_touch` with dry-run and
-ambiguous-prospect fail-closed behavior before adding any higher-level loop.
+**W1R complete ≠ W2 authorized.** Schema mutation / `log_call_touch` remain
+blocked pending separate GO + registry reconcile.
+
+Merge to main, tag, and release are OUT of Execute — reviewer decides
+Approve / Request changes / Park.
 
 ### Artifact Manifest
 

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2362,3 +2362,8 @@ set -euo pipefail
 # instead of assuming the convenience `.build/debug` symlink exists, and request
 # the `TheBridgeTests` executable product explicitly so a clean SwiftPM build
 # cannot stop after compiling target objects without linking the harness. Floor unchanged.
+
+# PKT-CALL-001 Wave 1R (2026-07-19): compatible CallHistory SQLite fixture +
+# Apple reference-date decoding; distinguishable database_missing vs FDA vs
+# schema vs query errors; durable call-id helper (ZUNIQUE_ID / Z_PK fallback)
+# with docs sync. Measured 3359 passed, 0 failed. FLOOR 3342 -> 3359.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3342}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3359}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Harden `calls_recent` for Wave 1R: distinguishable `database_missing` vs FDA vs schema vs query errors, durable call `id` (`ZUNIQUE_ID` → `Z_PK` fallback), and a compatible SQLite fixture that exercises real adapter/date decoding.
- Sync operator guide + packet mirror evidence (retire draft PR #109; tip evidence is #110 + this branch). Notion PACKETS SSOT already updated in session.
- Raise test floor 3342 → 3359 (3359 green locally). Stay REVIEW — merge requires separate operator Approve; W1R ≠ W2 authorization.

## Test plan
- [x] `make test-floor` → 3359 passed, 0 failed, floor 3359
- [x] Live MCP `calls_recent` smoke (pre-install tip binary) returned UUID ids with `identityResolved: false`
- [ ] After `make install-copy` + `open -a "The Bridge"`: re-smoke `calls_recent` on installed binary
- [ ] Reviewer records Approve / Request changes / Park on PKT-CALL-001 (no merge until GO)

