### PR TITLE
Closeout-A: Voice Memo Reliability slice-2 (SC2/4/5/6/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@
   `data_source` only (not `database`) under Notion-Version 2026-03-11.
 - **Counts** — static feature tools 205 → 207; test floor 3207 → 3213.
 
+## Unreleased — Voice Memo Reliability slice-2 (SC2/4/5/6/8) — 2026-07-20
+
+- **Fix (SC2)** — `memory_keep` preflights unbound required fields (esp. `summary` /
+  title) before any Notion create; surfaces candidate Notion names for rebind.
+- **Feature (SC4)** — registry row resolve: after exact `registry_find` miss, unique
+  first-name / first-token match via `registry_list` resolves; ≥2 candidates throw
+  `registryAmbiguous` with `{id|title}` pairs (never auto-pick).
+- **Feature (SC5)** — LLM/timeout degraded summarize/understand paths emit a
+  sectioned preview (`Topics` / `Decisions` / `Actions`) instead of an opening fragment.
+- **Feature (SC6)** — reminder titles pass a mid-clause gate; rejected titles use a
+  stable transcript-derived fallback before `reminders_create`.
+- **Feature (SC8)** — Notion Memory failure routes through explicit policy
+  (`off` | `review` | `agentMemory`); default absent key = `review` (never silent
+  agent-memory substitute).
+
 ## Unreleased — Voice Memo Reliability (list + receipts + identity projection) — 2026-07-15
 
 - **Fix** — `FieldsFilter` retains `id` / `entity` / `title` on projected registry

--- a/TheBridge/Core/BridgeDefaults.swift
+++ b/TheBridge/Core/BridgeDefaults.swift
@@ -219,6 +219,27 @@ public enum BridgeDefaults {
     /// Voice memo curator Understand routing: auto | heuristics | local | agent | cloud.
     public static let voiceMemoCuratorMode = "com.notionbridge.voiceMemo.curatorMode"
 
+    /// When Notion Memory `memory_keep` fails: `off` | `review` | `agentMemory`.
+    /// Default (absent) = `review` — never silently substitute agent memory (SC8).
+    public static let voiceMemoMemoryFallbackPolicy = "com.notionbridge.voiceMemo.memoryFallbackPolicy"
+
+    public enum VoiceMemoMemoryFallbackPolicy: String, Sendable {
+        case off
+        case review
+        case agentMemory
+    }
+
+    public static var voiceMemoMemoryFallbackPolicyEffective: VoiceMemoMemoryFallbackPolicy {
+        let raw = UserDefaults.standard.string(forKey: voiceMemoMemoryFallbackPolicy)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        switch raw {
+        case "off", "none", "fail": return .off
+        case "agentmemory", "agent_memory", "agent-memory": return .agentMemory
+        default: return .review
+        }
+    }
+
     /// Default operational model for routing, tool-oriented classification, and structured output.
     public static let ollamaRoutingModelDefault = "qwen3.5:9b"
 

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoDegradedPreviewBuilder.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoDegradedPreviewBuilder.swift
@@ -1,0 +1,84 @@
+// VoiceMemoDegradedPreviewBuilder.swift — SC5 structured preview when LLM is degraded
+
+import Foundation
+
+public enum VoiceMemoDegradedPreviewBuilder {
+
+    public struct Preview: Equatable, Sendable {
+        public var summary: String
+        public var actions: [String]
+        public var decisions: [String]
+
+        public init(summary: String, actions: [String], decisions: [String]) {
+            self.summary = summary
+            self.actions = actions
+            self.decisions = decisions
+        }
+    }
+
+    /// Build a usable sectioned preview from raw transcript without an LLM.
+    public static func build(from transcript: String, maxSummaryLen: Int = 400) -> Preview {
+        let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            return Preview(summary: "", actions: [], decisions: [])
+        }
+
+        let sentences = splitSentences(text)
+        var actions: [String] = []
+        var decisions: [String] = []
+        var topicBits: [String] = []
+
+        let actionHints = ["remind", "follow up", "call ", "email", "text ", "schedule", "need to", "have to", "should "]
+        let decisionHints = ["decided", "going to", "will ", "won't", "instead", "chose", "picking"]
+
+        for sentence in sentences {
+            let lower = sentence.lowercased()
+            let clipped = String(sentence.prefix(160)).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard clipped.count >= 8 else { continue }
+            if actionHints.contains(where: { lower.contains($0) }) {
+                actions.append(clipped)
+            } else if decisionHints.contains(where: { lower.contains($0) }) {
+                decisions.append(clipped)
+            } else if topicBits.count < 4 {
+                topicBits.append(clipped)
+            }
+        }
+
+        if actions.isEmpty {
+            actions = Array(VoiceMemoParser.extractActionBulletsPublic(from: text).prefix(5))
+        }
+
+        var summaryParts: [String] = []
+        if !topicBits.isEmpty {
+            summaryParts.append("Topics: " + topicBits.prefix(3).joined(separator: " · "))
+        }
+        if !decisions.isEmpty {
+            summaryParts.append("Decisions: " + decisions.prefix(2).joined(separator: " · "))
+        }
+        if !actions.isEmpty {
+            summaryParts.append("Actions: " + actions.prefix(3).joined(separator: " · "))
+        }
+        if summaryParts.isEmpty {
+            summaryParts.append(VoiceMemoParser.firstSentencePublic(in: text, maxLen: maxSummaryLen))
+        }
+
+        var summary = summaryParts.joined(separator: "\n")
+        if summary.count > maxSummaryLen {
+            summary = String(summary.prefix(maxSummaryLen - 1)) + "…"
+        }
+
+        return Preview(
+            summary: summary,
+            actions: Array(actions.prefix(8)),
+            decisions: Array(decisions.prefix(6))
+        )
+    }
+
+    private static func splitSentences(_ text: String) -> [String] {
+        text
+            .replacingOccurrences(of: "\n", with: ". ")
+            .components(separatedBy: CharacterSet(charactersIn: ".!?"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -353,9 +353,11 @@ public enum VoiceMemoProcessor {
     public static func execute(intent: VoiceMemoIntent, plan: VoiceMemoPlan, transcript: String, memoId: String = "", router: ToolRouter) async throws -> String {
         switch intent.kind {
         case .reminder:
-            return try await executeReminder(intent, router: router)
+            return try await executeReminder(intent, router: router, transcript: transcript)
         case .memoryKeep:
-            return try await executeMemoryKeep(intent, plan: plan, transcript: transcript, router: router)
+            return try await executeMemoryKeepWithFallbackPolicy(
+                intent, plan: plan, transcript: transcript, router: router
+            )
         case .agentMemory:
             return try await executeAgentMemory(intent, plan: plan, transcript: transcript, router: router)
         case .registryUpdate:
@@ -367,15 +369,49 @@ public enum VoiceMemoProcessor {
         }
     }
 
-    static func executeReminder(_ intent: VoiceMemoIntent, router: ToolRouter) async throws -> String {
-        guard let title = intent.title, !title.isEmpty else {
+    /// SC8 — Notion Memory failure routes through an explicit policy (default: review).
+    static func executeMemoryKeepWithFallbackPolicy(
+        _ intent: VoiceMemoIntent,
+        plan: VoiceMemoPlan,
+        transcript: String,
+        router: ToolRouter
+    ) async throws -> String {
+        do {
+            return try await executeMemoryKeep(intent, plan: plan, transcript: transcript, router: router)
+        } catch {
+            switch BridgeDefaults.voiceMemoMemoryFallbackPolicyEffective {
+            case .off:
+                throw error
+            case .review:
+                throw VoiceMemoError.memoryFallbackReview(
+                    intent.entityKey ?? "memory",
+                    BridgeDefaults.VoiceMemoMemoryFallbackPolicy.review.rawValue,
+                    error.localizedDescription
+                )
+            case .agentMemory:
+                let detail = try await executeAgentMemory(intent, plan: plan, transcript: transcript, router: router)
+                return "\(detail) [fallback=agent_memory policy=agentMemory reason=\(error.localizedDescription)]"
+            }
+        }
+    }
+
+    static func executeReminder(_ intent: VoiceMemoIntent, router: ToolRouter, transcript: String = "") async throws -> String {
+        let rawTitle = intent.title ?? ""
+        let resolvedTitle: String
+        switch VoiceMemoReminderTitleGate.evaluate(rawTitle, transcript: transcript) {
+        case .ok(let title):
+            resolvedTitle = title
+        case .rejected(_, let fallback):
+            resolvedTitle = fallback
+        }
+        guard !resolvedTitle.isEmpty else {
             throw VoiceMemoError.invalidIntent("reminder missing title")
         }
-        var args: [String: Value] = ["title": .string(title)]
+        var args: [String: Value] = ["title": .string(resolvedTitle)]
         if let notes = intent.body { args["notes"] = .string(notes) }
         if let due = intent.dueISO8601 { args["due"] = .string(due) }
         _ = try await router.dispatch(toolName: "reminders_create", arguments: .object(args))
-        return "reminders_create: \(title)"
+        return "reminders_create: \(resolvedTitle)"
     }
 
     public static func executeAgentMemory(_ intent: VoiceMemoIntent, plan: VoiceMemoPlan, transcript: String, router: ToolRouter) async throws -> String {
@@ -444,6 +480,13 @@ public enum VoiceMemoProcessor {
         // never a silent write of the raw transcript into Notion.
         if let rejected = VoiceMemoTranscriptOverlapGuard.firstRejectedField(in: fields, transcript: transcript) {
             throw VoiceMemoError.transcriptOverlapRejected(entityKey, rejected.key, rejected.runLength)
+        }
+
+        // SC2 — fail closed when required write fields (esp. summary/title) are
+        // unbound BEFORE any Notion create. Surfaces candidate Notion names for
+        // rebind via registry_introspect.
+        if let entity {
+            try Self.preflightMemoryKeepBindings(entity: entity, fields: fields)
         }
 
         // PKT-1064 — attach the ORIGINATING Player relation to the new Memory
@@ -714,9 +757,9 @@ public enum VoiceMemoProcessor {
     /// non-Skills entities) — so a not-yet-configured entity (first run) still
     /// dispatches a well-formed call instead of guessing a wrong key.
     ///
-    /// Ambiguity semantics are unchanged from the caller's perspective: a single
-    /// match returns that row id, ≥2 matches throw `registryAmbiguous` (never an
-    /// auto-picked write), and no match throws `registryMatchFailed`.
+    /// SC4: when exact match fails, a unique first-name / first-token title match
+    /// resolves deterministically; ≥2 first-name matches throw `registryAmbiguous`
+    /// with candidate `{id,title}` pairs (never an auto-picked write).
     public static func resolveRegistryRowId(entityKey: String, hint: String?, router: ToolRouter) async throws -> String {
         let normalizedHint = hint?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let normalizedHint, !normalizedHint.isEmpty else {
@@ -728,20 +771,108 @@ public enum VoiceMemoProcessor {
             "entity": .string(entityKey),
             "where": .object([titleKey: .string(normalizedHint)]),
         ]))
-        guard case .object(let envelope) = found,
-              case .array(let rows)? = envelope["rows"] else {
+        if case .object(let envelope) = found, case .array(let rows)? = envelope["rows"] {
+            let ids: [String] = rows.compactMap { row in
+                guard case .object(let rowObj) = row, case .string(let id)? = rowObj["id"] else { return nil }
+                return id
+            }
+            let distinct = Set(ids)
+            if distinct.count == 1, let only = ids.first { return only }
+            if distinct.count >= 2 {
+                let candidates = Self.candidatePairs(from: rows)
+                throw VoiceMemoError.registryAmbiguous(entityKey, hint, distinct.count, candidates)
+            }
+        }
+
+        // SC4 — exact miss: first-name / first-token uniqueness scan via list.
+        let listed = try await router.dispatch(toolName: "registry_list", arguments: .object([
+            "entity": .string(entityKey),
+            "limit": .int(200),
+            "fields": .array([.string("title"), .string("id")]),
+        ]))
+        let firstName = normalizedHint
+            .split(whereSeparator: { $0.isWhitespace || $0 == "," })
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .punctuationCharacters)
+            .lowercased() ?? ""
+        guard !firstName.isEmpty else {
             throw VoiceMemoError.registryMatchFailed(entityKey, hint)
         }
-        let ids: [String] = rows.compactMap { row in
-            guard case .object(let rowObj) = row, case .string(let id)? = rowObj["id"] else { return nil }
-            return id
+        var firstNameHits: [(id: String, title: String)] = []
+        if case .object(let listEnv) = listed, case .array(let listRows)? = listEnv["rows"] {
+            for row in listRows {
+                guard case .object(let rowObj) = row,
+                      case .string(let id)? = rowObj["id"] else { continue }
+                let title = Self.rowTitle(from: rowObj) ?? ""
+                let titleFirst = title
+                    .split(whereSeparator: { $0.isWhitespace || $0 == "," })
+                    .first
+                    .map(String.init)?
+                    .trimmingCharacters(in: .punctuationCharacters)
+                    .lowercased() ?? ""
+                if titleFirst == firstName || title.lowercased().hasPrefix(firstName + " ") {
+                    firstNameHits.append((id, title.isEmpty ? id : title))
+                }
+            }
         }
-        let distinct = Set(ids)
-        // PKT-MEM-106 0a: do not silently auto-pick the first of several matches; an
-        // ambiguous hint must route to a manual / picker decision, never a wrong-row write.
-        if distinct.count == 1, let only = ids.first { return only }
-        if distinct.count >= 2 { throw VoiceMemoError.registryAmbiguous(entityKey, hint, distinct.count) }
+        let distinctFirst = Dictionary(grouping: firstNameHits, by: \.id)
+        if distinctFirst.count == 1, let only = firstNameHits.first {
+            return only.id
+        }
+        if distinctFirst.count >= 2 {
+            let candidates = firstNameHits.map { "\($0.id)|\($0.title)" }
+            throw VoiceMemoError.registryAmbiguous(entityKey, hint, distinctFirst.count, candidates)
+        }
         throw VoiceMemoError.registryMatchFailed(entityKey, hint)
+    }
+
+    /// SC2 — required Notion-bound fields must be bound before any write.
+    public static func preflightMemoryKeepBindings(entity: RegistryEntity, fields: [String: String]) throws {
+        let input = fields.mapValues { Value.string($0) }
+        let resolved = RegistryWriter.resolve(input, entity: entity)
+        var unbound = resolved.unbound
+        // Ensure the entity's summary + title slots exist and are bound even when
+        // the caller omitted a key (drift: Relevant: unbound while summary key set).
+        for key in ["summary", "title"] {
+            if let prop = entity.property(key), !prop.isBound, !unbound.contains(key) {
+                unbound.append(key)
+            }
+        }
+        if let titleProp = entity.titleProperty, !titleProp.isBound,
+           !unbound.contains(titleProp.key) {
+            unbound.append(titleProp.key)
+        }
+        guard !unbound.isEmpty else { return }
+        let candidates = unbound.compactMap { key -> String? in
+            guard let prop = entity.property(key) else { return key }
+            let alts = entity.properties
+                .filter { $0.key != key && !$0.isBound }
+                .prefix(3)
+                .map(\.notionName)
+            if alts.isEmpty { return "\(key) (Notion: \(prop.notionName))" }
+            return "\(key) (Notion: \(prop.notionName); nearby unbound: \(alts.joined(separator: ", ")))"
+        }
+        throw VoiceMemoError.requiredFieldsUnbound(entity.key, unbound.sorted(), candidates)
+    }
+
+    private static func candidatePairs(from rows: [Value]) -> [String] {
+        rows.compactMap { row -> String? in
+            guard case .object(let rowObj) = row,
+                  case .string(let id)? = rowObj["id"] else { return nil }
+            let title = rowTitle(from: rowObj) ?? id
+            return "\(id)|\(title)"
+        }
+    }
+
+    private static func rowTitle(from rowObj: [String: Value]) -> String? {
+        if case .string(let t)? = rowObj["title"], !t.isEmpty { return t }
+        if case .object(let props)? = rowObj["properties"] {
+            for key in ["title", "name"] {
+                if case .string(let t)? = props[key], !t.isEmpty { return t }
+            }
+        }
+        return nil
     }
 
     static func resolvedMemoryKeepFields(intent: VoiceMemoIntent, plan: VoiceMemoPlan) -> [String: String] {
@@ -1264,6 +1395,9 @@ public enum VoiceMemoProcessor {
                 fallbackTitle: fallbackTitle, recordingPath: recordingPath
             )
             plan.degraded = true
+            let preview = VoiceMemoDegradedPreviewBuilder.build(from: transcript)
+            if !preview.summary.isEmpty { plan.summary = preview.summary }
+            if !preview.actions.isEmpty { plan.actions = preview.actions }
             return plan
         }
     }
@@ -1282,15 +1416,17 @@ public enum VoiceMemoProcessor {
                 await VoiceMemoSummarizer.structuredSummary(transcript: transcript, fallbackTitle: fallbackTitle)
             }
         } catch {
-            // Timed out — same heuristic fallback structuredSummary itself would have
-            // used for an unhealthy/unreachable Ollama daemon.
+            // SC5 — timed out / LLM degraded: sectioned preview, not opening fragment only.
             let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else {
                 return VoiceMemoStructuredSummary(paragraph: fallbackTitle, actions: [])
             }
+            let preview = VoiceMemoDegradedPreviewBuilder.build(from: trimmed)
             return VoiceMemoStructuredSummary(
-                paragraph: VoiceMemoParser.firstSentencePublic(in: trimmed, maxLen: 280),
-                actions: VoiceMemoParser.extractActionBulletsPublic(from: trimmed)
+                paragraph: preview.summary.isEmpty ? fallbackTitle : preview.summary,
+                actions: preview.actions.isEmpty
+                    ? VoiceMemoParser.extractActionBulletsPublic(from: trimmed)
+                    : preview.actions
             )
         }
     }
@@ -1511,7 +1647,7 @@ public enum VoiceMemoProcessor {
             }
             return receipt
         } catch let error as VoiceMemoError {
-            if case .registryAmbiguous = error {
+            if case .registryAmbiguous(_, _, _, let candidates) = error {
                 var receipt = commitReceipt(
                     ok: false,
                     memoId: recording.id,
@@ -1522,16 +1658,21 @@ public enum VoiceMemoProcessor {
                 )
                 if case .object(var obj) = receipt {
                     obj["needsManual"] = .bool(true)
+                    if !candidates.isEmpty {
+                        obj["candidates"] = .array(candidates.map { .string($0) })
+                    }
                     receipt = .object(obj)
                 }
                 return receipt
             }
-            if case .contentQualityRejected = error {
-                // GH #81 — the commit-time counterpart of processOne's queueReview: an
-                // agent-driven commit() that fails the quality gate must land in the SAME
-                // review queue a batch run would use (packet requirement), not just fail
-                // the tool call with no durable trace. Best-effort enqueue (never blocks
-                // the graceful response on a store-write failure).
+            let reviewProvenance: String?
+            switch error {
+            case .contentQualityRejected: reviewProvenance = "content-quality-gate"
+            case .requiredFieldsUnbound: reviewProvenance = "required-fields-unbound"
+            case .memoryFallbackReview: reviewProvenance = "memory-fallback-review"
+            default: reviewProvenance = nil
+            }
+            if let reviewProvenance {
                 let intentId = VoiceMemoIntentIdentity.intentId(memoId: recording.id, intent: intent)
                 try? VoiceMemoReviewStore.enqueue(VoiceMemoReviewEntry(
                     memoId: recording.id,
@@ -1544,7 +1685,7 @@ public enum VoiceMemoProcessor {
                     intentId: intentId,
                     entityKey: intent.entityKey,
                     entityHint: intent.entityHint,
-                    provenance: "content-quality-gate"
+                    provenance: reviewProvenance
                 ))
                 var receipt = commitReceipt(
                     ok: false,
@@ -1592,7 +1733,7 @@ public enum VoiceMemoProcessor {
 
     /// Structured commit receipt (Voice Memo Reliability packet SC #7 / proposed receipt).
     /// Additive fields — existing clients still read ok/memoId/intentKind/detail/markedProcessed.
-    static func commitReceipt(
+    public static func commitReceipt(
         ok: Bool,
         memoId: String,
         intentKind: String,
@@ -1714,7 +1855,12 @@ public enum VoiceMemoProcessor {
 public enum VoiceMemoError: Error, LocalizedError {
     case invalidIntent(String)
     case registryMatchFailed(String, String?)
-    case registryAmbiguous(String, String?, Int)
+    /// Ambiguous registry target. `candidates` are `"id|title"` strings (SC4).
+    case registryAmbiguous(String, String?, Int, [String])
+    /// SC2 — required write fields unbound before any Notion call.
+    case requiredFieldsUnbound(String, [String], [String])
+    /// SC8 — memory_keep failed; policy=review (explicit, not silent fallback).
+    case memoryFallbackReview(String, String, String)
     /// The Memory entity has no BOUND PLAYERS relation property, so the
     /// originating Player cannot be attached — a graceful BLOCKED → REVIEW,
     /// never a silent successful processed receipt (PKT-1064).
@@ -1751,8 +1897,15 @@ public enum VoiceMemoError: Error, LocalizedError {
         case .invalidIntent(let msg): return msg
         case .registryMatchFailed(let entity, let hint):
             return "no registry row matched entity=\(entity) hint=\(hint ?? "nil")"
-        case .registryAmbiguous(let entity, let hint, let count):
-            return "ambiguous registry target entity=\(entity) hint=\(hint ?? "nil") matched \(count) rows — select a rowId"
+        case .registryAmbiguous(let entity, let hint, let count, let candidates):
+            let list = candidates.prefix(8).joined(separator: "; ")
+            let suffix = list.isEmpty ? "select a rowId" : "candidates: \(list)"
+            return "ambiguous registry target entity=\(entity) hint=\(hint ?? "nil") matched \(count) rows — \(suffix)"
+        case .requiredFieldsUnbound(let entity, let unbound, let candidates):
+            let detail = candidates.isEmpty ? unbound.joined(separator: ", ") : candidates.joined(separator: "; ")
+            return "entity ‘\(entity)’ required fields unbound before write: \(detail) — rebind via registry_introspect (BLOCKED, queued for review)"
+        case .memoryFallbackReview(let entity, let policy, let reason):
+            return "entity=\(entity) memory_keep failed; fallback policy=\(policy) → REVIEW (\(reason))"
         case .playerRelationUnbound(let entity):
             return "entity ‘\(entity)’ has no bound PLAYERS relation property — cannot attach the originating Player; bind PLAYERS via registry_introspect, then reprocess (BLOCKED, queued for review)"
         case .playerRelationVerifyFailed(let entity, let pageId, let player):

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoReminderTitleGate.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoReminderTitleGate.swift
@@ -1,0 +1,84 @@
+// VoiceMemoReminderTitleGate.swift — SC6 reminder title quality (Voice Memo Reliability)
+// Rejects sentence-middle / conjunction-led fragments; supplies a stable fallback.
+
+import Foundation
+
+public enum VoiceMemoReminderTitleGate {
+
+    public enum Verdict: Equatable, Sendable {
+        case ok(String)
+        case rejected(reason: String, fallback: String)
+    }
+
+    /// Leading tokens that usually mean the title was sliced from mid-clause.
+    public static let midClauseOpeners: Set<String> = [
+        "too", "but", "and", "or", "so", "because", "anyway", "well",
+        "also", "then", "just", "like", "uh", "um", "okay", "ok",
+    ]
+
+    public static func evaluate(_ title: String, transcript: String) -> Verdict {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = stableFallbackTitle(transcript: transcript)
+        guard !trimmed.isEmpty else {
+            return .rejected(reason: "reminder title is empty", fallback: fallback)
+        }
+
+        let words = trimmed
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        guard words.count >= 2 else {
+            return .rejected(reason: "reminder title is only \(words.count) word(s)", fallback: fallback)
+        }
+
+        let first = words[0]
+            .trimmingCharacters(in: .punctuationCharacters)
+            .lowercased()
+        if midClauseOpeners.contains(first) {
+            return .rejected(
+                reason: "reminder title opens with mid-clause fragment ‘\(words[0])’",
+                fallback: fallback
+            )
+        }
+
+        // Leading lowercase letter + comma shortly after → classic mid-sentence cut.
+        if let firstScalar = trimmed.unicodeScalars.first,
+           CharacterSet.lowercaseLetters.contains(firstScalar),
+           trimmed.contains(",") {
+            return .rejected(
+                reason: "reminder title looks like a sentence-middle fragment",
+                fallback: fallback
+            )
+        }
+
+        return .ok(trimmed)
+    }
+
+    /// Prefer an imperative “Remind …” / block-phrase style line; else first clean sentence.
+    public static func stableFallbackTitle(transcript: String) -> String {
+        let text = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty { return "Follow up from voice memo" }
+
+        let lower = text.lowercased()
+        if let range = lower.range(of: #"remind(?:\s+me)?\s+to\s+"#, options: .regularExpression) {
+            let after = text[range.upperBound...]
+            let snippet = String(after.prefix(80))
+                .components(separatedBy: CharacterSet(charactersIn: ".!?\n"))
+                .first?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if snippet.count >= 4 {
+                return VoiceMemoParser.sanitizeTitle("Remind me to \(snippet)", fallback: "Follow up from voice memo")
+            }
+        }
+
+        let sentence = VoiceMemoParser.firstSentencePublic(in: text, maxLen: 72)
+        let cleaned = VoiceMemoParser.sanitizeTitle(sentence, fallback: "Follow up from voice memo")
+        let words = cleaned.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }
+        if let first = words.first?
+            .trimmingCharacters(in: .punctuationCharacters)
+            .lowercased(),
+           midClauseOpeners.contains(first) {
+            return "Follow up from voice memo"
+        }
+        return cleaned.isEmpty ? "Follow up from voice memo" : cleaned
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -723,6 +723,7 @@ await runVoiceMemoMCPRoutingTests() // PKT-MEM-120: Auto+MCP Execute defer, pres
 await runVoiceMemoPlayerAttachTests() // PKT-1064: memo→Memory attaches + verifies the originating Player relation; absent/unbound PLAYERS → graceful BLOCKED
 await runVoiceMemoCommentTests() // PKT-MEM-136: comment intent (idea|reflow purpose) resolves via registry_resolve_and_update (PKT-MEM-135), posts via notion_comment_create, idea-purpose logs to VoiceMemoIdeaThreadStore ledger, reflow never logs; resolution/post failure → graceful BLOCKED (no crash)
 await runVoiceMemoContentQualityGateTests() // GH #81: minimum-information quality gate blocks markedProcessed:true on filler/short memory_keep summaries (routes to review instead), first-class voice_memo_commit `summary` schema param; GH #73: per-stage timeouts (VoiceMemoStageTimeout) guarantee process(args:)/commit(args:) always terminate in {done, error, review-queue}, never hang
+await runVoiceMemoReliabilitySlice2Tests() // Closeout-A Voice Memo SC2/4/5/6/8 + SC1 hermetic: unbound preflight, first-name resolve, degraded preview, reminder title gate, fallback policy default=review
 // PKT-MEM-106 0a + 0b run early in runAllTests() (flake-avoidance) — not duplicated here.
 await runMemorySettingsTests()         // PKT-MEM-102: Memory Settings section + Inbox UI
 await runOllamaModuleTests()           // Local Ollama client + module (Wave 2a)

--- a/TheBridgeTests/VoiceMemoReliabilitySlice2Tests.swift
+++ b/TheBridgeTests/VoiceMemoReliabilitySlice2Tests.swift
@@ -1,0 +1,175 @@
+// VoiceMemoReliabilitySlice2Tests.swift — Closeout-A SC2/4/5/6/8 + SC1 hermetic
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runVoiceMemoReliabilitySlice2Tests() async {
+    print("\n🎙 Voice Memo Reliability Slice-2 (SC2/4/5/6/8/1)")
+
+    await test("SC6_reminderTitleGate_rejectsMidClause_usesStableFallback") {
+        let transcript = "I need you to remind me to call Greg about the proposal tomorrow morning."
+        let bad = "too, but anyway, I'm trying to remediate this issue, issue"
+        guard case .rejected(_, let fallback) = VoiceMemoReminderTitleGate.evaluate(bad, transcript: transcript) else {
+            try expect(false, "SC6 mid-clause title must reject")
+            return
+        }
+        try expect(!fallback.isEmpty, "SC6 fallback non-empty")
+        try expect(!fallback.lowercased().hasPrefix("too"), "SC6 fallback not mid-clause")
+
+        guard case .ok(let t) = VoiceMemoReminderTitleGate.evaluate("Call Greg about proposal", transcript: transcript) else {
+            try expect(false, "SC6 clean title should pass")
+            return
+        }
+        try expect(t.contains("Greg") || t.lowercased().contains("call"), "SC6 good title ok")
+    }
+
+    await test("SC5_degradedPreview_isSectioned") {
+        let long = """
+        Today I decided we will ship the bridge closeout first. I need to follow up with Greg Flicek.
+        Also remind me to email the proposal. The topics include registry reliability and voice memos.
+        """
+        let preview = VoiceMemoDegradedPreviewBuilder.build(from: long)
+        try expect(!preview.summary.isEmpty, "SC5 summary non-empty")
+        try expect(
+            preview.summary.contains("Topics:") || preview.summary.contains("Actions:") || preview.summary.contains("Decisions:"),
+            "SC5 summary sectioned"
+        )
+        try expect(!preview.actions.isEmpty || preview.summary.contains("Actions:"), "SC5 has actions signal")
+    }
+
+    await test("SC2_memoryKeep_unboundSummary_preflightFailsClosed") {
+        let unboundEntity = RegistryEntity(
+            key: "memory",
+            displayName: "Memory",
+            dataSourceId: "ds-test",
+            properties: [
+                RegistryProperty(key: "title", notionName: "Memory", notionPropertyId: "title", type: "title", role: .title),
+                RegistryProperty(key: "summary", notionName: "Relevant:", notionPropertyId: nil, type: "rich_text"),
+                RegistryProperty(key: "players", notionName: "PLAYERS", notionPropertyId: "rel1", type: "relation", role: .relation),
+            ],
+            cacheTTLSeconds: 3600,
+            hasBody: true
+        )
+        var threw = false
+        do {
+            try VoiceMemoProcessor.preflightMemoryKeepBindings(
+                entity: unboundEntity,
+                fields: ["title": "Memo", "summary": "A real eight word summary about the topic here"]
+            )
+        } catch let error as VoiceMemoError {
+            if case .requiredFieldsUnbound(_, let unbound, _) = error {
+                threw = unbound.contains("summary")
+            }
+        }
+        try expect(threw, "SC2 unbound summary → requiredFieldsUnbound")
+
+        let boundEntity = RegistryEntity(
+            key: "memory",
+            displayName: "Memory",
+            dataSourceId: "ds-test",
+            properties: [
+                RegistryProperty(key: "title", notionName: "Memory", notionPropertyId: "title", type: "title", role: .title),
+                RegistryProperty(key: "summary", notionName: "Relevant", notionPropertyId: "sum1", type: "rich_text"),
+            ],
+            cacheTTLSeconds: 3600,
+            hasBody: true
+        )
+        try VoiceMemoProcessor.preflightMemoryKeepBindings(
+            entity: boundEntity,
+            fields: ["title": "Memo", "summary": "A real eight word summary about the topic here"]
+        )
+    }
+
+    await test("SC8_memoryFallbackPolicy_defaultsToReview") {
+        let prior = UserDefaults.standard.string(forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+        defer {
+            if let prior {
+                UserDefaults.standard.set(prior, forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+            } else {
+                UserDefaults.standard.removeObject(forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+            }
+        }
+        UserDefaults.standard.removeObject(forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+        try expect(
+            BridgeDefaults.voiceMemoMemoryFallbackPolicyEffective == .review,
+            "SC8 default policy=review"
+        )
+        UserDefaults.standard.set("agentMemory", forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+        try expect(
+            BridgeDefaults.voiceMemoMemoryFallbackPolicyEffective == .agentMemory,
+            "SC8 agentMemory parse"
+        )
+        UserDefaults.standard.set("off", forKey: BridgeDefaults.voiceMemoMemoryFallbackPolicy)
+        try expect(
+            BridgeDefaults.voiceMemoMemoryFallbackPolicyEffective == .off,
+            "SC8 off parse"
+        )
+    }
+
+    await test("SC4_firstNameUnique_resolvesViaListAfterExactMiss") {
+        let router = ToolRouter(securityGate: SecurityGate(), auditLog: AuditLog())
+        let schema: Value = .object(["type": .string("object")])
+        await router.register(ToolRegistration(
+            name: "registry_find",
+            module: "registry",
+            tier: .open,
+            description: "stub",
+            inputSchema: schema,
+            handler: { _ in .object(["rows": .array([])]) }
+        ))
+        await router.register(ToolRegistration(
+            name: "registry_list",
+            module: "registry",
+            tier: .open,
+            description: "stub",
+            inputSchema: schema,
+            handler: { _ in
+                .object([
+                    "rows": .array([
+                        .object([
+                            "id": .string("contact-greg"),
+                            "title": .string("Greg Flicek"),
+                        ]),
+                    ]),
+                ])
+            }
+        ))
+        let id = try await VoiceMemoProcessor.resolveRegistryRowId(
+            entityKey: "contact", hint: "Greg", router: router
+        )
+        try expect(id == "contact-greg", "SC4 unique first-name → id, got \(id)")
+    }
+
+    await test("SC1_commitReceipt_exposesMemoStateAndCompletedIntents") {
+        let receipt = VoiceMemoProcessor.commitReceipt(
+            ok: true,
+            memoId: "memo-sc1-unique-\(UUID().uuidString)",
+            intentKind: "reminder",
+            intentState: "committed",
+            detail: "reminders_create: x",
+            markedProcessed: false
+        )
+        guard case .object(let obj) = receipt else {
+            try expect(false, "SC1 receipt object")
+            return
+        }
+        guard case .string(let state)? = obj["memoState"] else {
+            try expect(false, "SC1 memoState present")
+            return
+        }
+        try expect(
+            state == "partially_committed" || state == "committed",
+            "SC1 memoState present (\(state))"
+        )
+        guard case .bool(let marked)? = obj["markedProcessed"] else {
+            try expect(false, "SC1 markedProcessed present")
+            return
+        }
+        try expect(marked == false, "SC1 not fully processed")
+        guard case .array(let completed)? = obj["completedIntents"] else {
+            try expect(false, "SC1 completedIntents present")
+            return
+        }
+        try expect(!completed.isEmpty, "SC1 completedIntents non-empty on ok")
+    }
+}

--- a/docs/operator/calendar-registry-live-smoke.md
+++ b/docs/operator/calendar-registry-live-smoke.md
@@ -49,10 +49,10 @@ Pre-seed required by engine: Sync Key = idempotency key, Operation Fingerprint =
 
 ## EventKit / EVENT leftover policy
 
-- **Keep Notion EVENT** `3a3cbb58889e8166ba5fc30451086e14` with sync identity for evidence (do not strip Sync Key / fingerprint / calendar ids unless intentionally retiring the receipt).
-- **Delete disposable EventKit item** when convenient via `calendar_delete` (Request-tier approval) or Calendar.app:
-  - `305A17D8-38F0-4A51-B0CF-B44DB346A65A:C8F7C880-B051-4ECB-A468-AD52E4E9775E` (Aug 2 success)
-- Earlier abort fixture left a separate EventKit item from conflicted key `smoke-2026-07-20-pair-2` on EVENT `3a3cbb58889e8137a5fac7d1885d06cf` (“Bridge Registry Smoke Disposable”, Aug 1) — also safe to delete; that ledger key remains conflict and must not be retried.
+- **Keep Notion EVENT** `3a3cbb58889e8166ba5fc30451086e14` (and conflicted sibling `3a3cbb58889e8137a5fac7d1885d06cf`) with sync identity for evidence (do not strip Sync Key / fingerprint / calendar ids unless intentionally retiring the receipt).
+- **EventKit cleanup done (2026-07-20 closeout):** both disposable items deleted via `calendar_delete`; FOCUS calendar Aug 1–2 query returned 0 events.
+  - Deleted success pair: `305A17D8-38F0-4A51-B0CF-B44DB346A65A:C8F7C880-B051-4ECB-A468-AD52E4E9775E`
+  - Conflicted key `smoke-2026-07-20-pair-2` must not be retried (ledger remains conflict).
 
 ## Live learnings folded into tip
 

--- a/docs/operator/v4-release-gate.md
+++ b/docs/operator/v4-release-gate.md
@@ -34,6 +34,7 @@ Notarization is REQUIRED for the published DMG (gate 7 · `release.yml` → `not
 ## 1 · Licensing (Packet B) — first-sale activation
 - [ ] Generate the **prod Ed25519 keypair** under your custody: `swift run license-cli keygen` (details: `docs/operator/license-ops-runbook.md`). **The private key NEVER enters the repo** — store it in your password manager / secure store.
 - [ ] Set GitHub repo secret **`LICENSE_PUBLIC_KEY_BASE64URL`** = the public key (base64url). `release.yml`'s `make inject-license-key` bakes it into the build so a minted token verifies against the bundled key. (Committed default is EMPTY = fail-closed → an unconfigured build accepts no license.)
+  - **2026-07-20 Closeout-A:** secret still **ABSENT** (`gh secret list` names-only). Track B = Engineering-ready STOP — not Ship-Gate-ready; dry_run fails secret preflight until set.
 - [ ] Mint customer tokens with `swift run license-cli mint …` (operator custody).
 - [ ] **Verify:** baked build + a freshly-minted token → activates end-to-end.
 

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2387,3 +2387,9 @@ set -euo pipefail
 # lastVerifiedAt to Notion read-back after sync-evidence write so minute-
 # truncated date properties do not false-conflict (CR98). Measured 3368
 # passed, 0 failed. FLOOR 3367 -> 3368.
+
+# Closeout-A Voice Memo Reliability slice-2 (2026-07-20): SC2 unbound summary
+# preflight, SC4 unique first-name resolve after exact miss, SC5 degraded
+# sectioned preview, SC6 reminder mid-clause title gate, SC8 memory fallback
+# policy default=review, SC1 commit receipt shape (+6 hermetic). Measured
+# 3374 passed, 0 failed. FLOOR 3368 -> 3374.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3368}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3374}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Fail closed on unbound `memory_keep` summary/title bindings before Notion write (SC2); unique first-name resolve after exact miss with ambiguous candidate list (SC4).
- Degraded summarize/understand paths emit sectioned Topics/Decisions/Actions previews (SC5); reminder titles pass a mid-clause gate with stable fallback (SC6).
- Explicit Memory fallback policy (`off` | `review` | `agentMemory`), default **review** (SC8); +6 hermetic tests; floor **3368 → 3374**.

## Test plan
- [x] `make test-floor` green (3374 passed, floor 3374)
- [ ] `make install-copy` + relaunch; spot-check reminder title / memory unbound / Greg first-name resolve (or waive live July 7 / Greg checks in packet Output)
- [ ] Merge → update Voice Memo packet Output/status for slice-2 Closeout-A


Made with [Cursor](https://cursor.com)