### PR TITLE
W5B: cut over bundle id to kup.solutions.the-bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **3.9.9** (build **81**). It registers **205 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **31 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
 
-Bundle ID: `kup.solutions.notion-bridge` (legacy: `solutions.kup.keepr`)
+Bundle ID: `kup.solutions.the-bridge` (legacy: `kup.solutions.notion-bridge`, `solutions.kup.keepr`)
 
 > **Agents:** see [`docs/AGENT_PLAYBOOK.md`](docs/AGENT_PLAYBOOK.md) for a task → tool
 > map (builds/tests → `bg_process_*`, surgical edits → `file_edit`, filesystem grounding
@@ -206,7 +206,7 @@ The project enforces Swift 6 strict concurrency (`-strict-concurrency=complete`)
 
 ### TCC Permissions
 
-The app requires Full Disk Access, Automation, and optionally Screen Recording and Accessibility. During development, after frequent rebuilds that change the code signature, run `make clean-tcc` to clear stale TCC grants for both the current (`kup.solutions.notion-bridge`) and legacy (`solutions.kup.keepr`) bundle IDs.
+The app requires Full Disk Access, Automation, and optionally Screen Recording and Accessibility. During development, after frequent rebuilds that change the code signature, run `make clean-tcc` to clear stale TCC grants for the current (`kup.solutions.the-bridge`), prior (`kup.solutions.notion-bridge`), and legacy (`solutions.kup.keepr`) bundle IDs.
 
 ## Jobs (scheduler module) — v1.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased — W5B bundle-id cutover — 2026-07-21
+
+- **Cutover** — `CFBundleIdentifier` → `kup.solutions.the-bridge` (extension
+  `…notification-content`; URL names updated). Makefile `BUNDLE_ID` / `clean-tcc`
+  and TCC client queries accept the new id plus prior `kup.solutions.notion-bridge`.
+- **Continuity** — Keychain service legacy list unchanged; credential access-group
+  filter accepts both prior and new `TEAMID.<bundle-id>` groups so stored secrets
+  remain visible after the id flip.
+- **Docs** — AGENTS / CLAUDE / standing-orders / runbook / TCC + Sparkle operator
+  notes updated. No marketing/build bump; Sale Gate still locks `v4.0.0`.
+
 ## Unreleased — Notion Views write (create/update) — 2026-07-20
 
 - **Feature** — `notion_view_create` / `notion_view_update` wrap `POST`/`PATCH`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Overview
 A macOS menu-bar app that exposes the Mac + a Notion workspace to AI agents over MCP
 (stdio + Streamable-HTTP `/mcp` + legacy SSE `/sse`). Ships as "The Bridge.app"
-(bundle id `kup.solutions.notion-bridge`), updated via Sparkle. SwiftPM, no Xcode project.
+(bundle id `kup.solutions.the-bridge`), updated via Sparkle. SwiftPM, no Xcode project.
 
 ## Architecture
 - **Library target `TheBridgeLib`** holds everything testable; thin `TheBridge`

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -4,7 +4,7 @@
 
 **Effective date:** _(to be set on publish)_
 **Licensor:** KUP Solutions (Isaiah Peters), Texas, USA — `isaiah@kup.solutions`
-**Product:** The Bridge (Swift target `The Bridge`, bundle ID `kup.solutions.notion-bridge`)
+**Product:** The Bridge (Swift target `The Bridge`, bundle ID `kup.solutions.the-bridge`)
 
 This Commercial Use License (the "**CUL**") governs Your commercial use of **The Bridge** ("**Software**") when You have purchased a license through KUP Solutions. The CUL is layered **on top of** the [KUP Solutions Source-Available License](./LICENSE) (the "**Source-Available License**"): the Source-Available License continues to govern Your access to the source code, and this CUL grants the additional rights needed to run the Software in a commercial capacity on a single machine.
 

--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleIconFile</key>
 	<string>TheBridge</string>
 	<key>CFBundleIdentifier</key>
-	<string>kup.solutions.notion-bridge</string>
+	<string>kup.solutions.the-bridge</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -30,7 +30,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>CFBundleURLName</key>
-			<string>kup.solutions.notion-bridge.cloud-auth</string>
+			<string>kup.solutions.the-bridge.cloud-auth</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>bridge-auth</string>
@@ -40,7 +40,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>CFBundleURLName</key>
-			<string>kup.solutions.notion-bridge.settings-deeplink</string>
+			<string>kup.solutions.the-bridge.settings-deeplink</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>bridge</string>

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 APP_NAME        = The Bridge
 DMG_VOLUME_NAME = The Bridge
-BUNDLE_ID       = kup.solutions.notion-bridge
+BUNDLE_ID       = kup.solutions.the-bridge
 BINARY_NAME     = TheBridge
 BUILD_DIR       = .build
 RELEASE_DIR     = $(BUILD_DIR)/release
@@ -358,8 +358,10 @@ install-agent-safe: install-copy
 clean-tcc:
 	@echo "🧹 Resetting TCC for legacy bundle ID (solutions.kup.keepr)..."
 	-tccutil reset All solutions.kup.keepr
-	@echo "🧹 Resetting TCC for current bundle ID (kup.solutions.notion-bridge)..."
+	@echo "🧹 Resetting TCC for prior bundle ID (kup.solutions.notion-bridge)..."
 	-tccutil reset All kup.solutions.notion-bridge
+	@echo "🧹 Resetting TCC for current bundle ID (kup.solutions.the-bridge)..."
+	-tccutil reset All kup.solutions.the-bridge
 	@echo "✅ TCC reset complete — permissions will be re-requested on next launch"
 
 # ── Appcast ───────────────────────────────────────────────────

--- a/NotificationContentExtension/Info.plist
+++ b/NotificationContentExtension/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>NotificationContentExtension</string>
 	<key>CFBundleIdentifier</key>
-	<string>kup.solutions.notion-bridge.notification-content</string>
+	<string>kup.solutions.the-bridge.notification-content</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -24,10 +24,6 @@
 	<string>14.0</string>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.usernotifications.content-extension</string>
-		<key>NSExtensionPrincipalClass</key>
-		<string>NotificationViewController</string>
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>UNNotificationExtensionCategory</key>
@@ -41,11 +37,15 @@
 				<string>CURSOR_AGENT_STALLED</string>
 				<string>CURSOR_AGENT_NEEDS_APPROVAL</string>
 			</array>
-			<key>UNNotificationExtensionInitialContentSizeRatio</key>
-			<real>0.5</real>
 			<key>UNNotificationExtensionDefaultContentHidden</key>
 			<true/>
+			<key>UNNotificationExtensionInitialContentSizeRatio</key>
+			<real>0.5</real>
 		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.content-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>NotificationViewController</string>
 	</dict>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Bridge exposes your local Mac and connected services as Model Context Protoc
 
 **Product page:** https://kup.solutions/notion-bridge
 
-> **Naming history:** "TheBridge" was the product's original name; the user-facing brand is **The Bridge**. The Swift target and bundle identifier (`kup.solutions.notion-bridge`) are intentionally preserved for data continuity. The Keychain service was renamed `com.notionbridge` → `kup.solutions.the-bridge` (v3.7.8), and all prior services are still read so existing secrets migrate with zero loss.
+> **Naming history:** "TheBridge" was the product's original name; the user-facing brand is **The Bridge**. The Swift target names are preserved for continuity. The bundle identifier cut over to `kup.solutions.the-bridge` (W5B); prior id `kup.solutions.notion-bridge` remains a TCC/Keychain legacy. The Keychain service was renamed `com.notionbridge` → `kup.solutions.the-bridge` (v3.7.8), and all prior services are still read so existing secrets migrate with zero loss.
 
 ---
 

--- a/TheBridge/App/AppDelegate.swift
+++ b/TheBridge/App/AppDelegate.swift
@@ -797,7 +797,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Uses NSRunningApplication to check by bundle identifier.
     /// Returns true if this is the only instance, false if a duplicate exists.
     private func ensureSingleInstance() -> Bool {
-        let bundleID = Bundle.main.bundleIdentifier ?? "kup.solutions.notion-bridge"
+        let bundleID = Bundle.main.bundleIdentifier ?? "kup.solutions.the-bridge"
         let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
         let myPID = ProcessInfo.processInfo.processIdentifier
 

--- a/TheBridge/Modules/FilesystemSkillIndex.swift
+++ b/TheBridge/Modules/FilesystemSkillIndex.swift
@@ -5,7 +5,7 @@
 //   • Bundled defaults: Bundle.module, subdir `skills/<name>/SKILL.md`
 //     (or `STUB.md` for source-available linked-only skills).
 //   • User-installable: ~/Library/Application Support/The Bridge/skills/
-//     (or `kup.solutions.notion-bridge`'s appSupport dir derived from the
+//     (or `kup.solutions.the-bridge`'s appSupport dir derived from the
 //     main bundle id).
 //
 // Parses each file's YAML frontmatter via `FrontmatterParser` (zero deps)
@@ -71,11 +71,12 @@ public actor FilesystemSkillIndex {
     /// Watcher-driven invalidation should normally beat this floor.
     public static let cacheTTL: TimeInterval = 60.0
 
-    /// Default app-support bundle id (matches `kup.solutions.notion-bridge`
+    /// Default app-support bundle id (matches `kup.solutions.the-bridge`
     /// from `Info.plist` — kept as a fallback so the index works in
     /// headless test harnesses where `Bundle.main.bundleIdentifier` is
-    /// the test executable id, not the production app).
-    public static let defaultBundleId = "kup.solutions.notion-bridge"
+    /// the test executable id, not the production app). Production skills
+    /// live under `BridgePaths` (`The Bridge/skills/`), not this id path.
+    public static let defaultBundleId = "kup.solutions.the-bridge"
 
     /// Shared default-configured instance — production code path.
     public static let shared = FilesystemSkillIndex()

--- a/TheBridge/Modules/PermissionsModule.swift
+++ b/TheBridge/Modules/PermissionsModule.swift
@@ -329,7 +329,7 @@ public enum PermissionsModule {
             SELECT indirect_object_identifier, auth_value
             FROM access
             WHERE service = 'kTCCServiceAppleEvents'
-            AND client = 'kup.solutions.notion-bridge'
+            AND client IN ('kup.solutions.the-bridge', 'kup.solutions.notion-bridge')
             """
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")

--- a/TheBridge/Modules/ScreenRecording.swift
+++ b/TheBridge/Modules/ScreenRecording.swift
@@ -13,7 +13,10 @@ import CoreMedia
 import AVFoundation
 import os.log
 
-private let recLog = Logger(subsystem: "kup.solutions.notion-bridge", category: "ScreenRecording")
+private let recLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "kup.solutions.the-bridge",
+    category: "ScreenRecording"
+)
 
 // MARK: - ScreenModule Recording Extension
 

--- a/TheBridge/Resources/standing-orders/orders.md
+++ b/TheBridge/Resources/standing-orders/orders.md
@@ -225,6 +225,6 @@ You are connecting to **The Bridge** — a local MCP server on the operator's ma
 - **One surface, every client.** Tools, skills, and commands appear identically to any MCP client (Claude Code, Claude.ai, ChatGPT Dev Mode, Cursor, Raycast). Behavior should be consistent regardless of how you arrived.
 - **Confirm-before-destructive.** Tools that delete, send, rename, or pay route through a confirmation gate. Surface what will happen and what cannot be undone before requesting approval.
 - **Sensitive paths.** The Bridge enforces a Sensitive Paths list (e.g. `~/.ssh`, `~/.aws`, `~/Library/Keychains`). File tools refuse to read or write inside these. Do not attempt to work around it; surface the protection to the operator.
-- **Bridge version:** query `bridge_status` at session start for the running version — do not rely on a static number in this file. **Bundle ID:** `kup.solutions.notion-bridge` (unchanged from the historical name "Notion Bridge").
+- **Bridge version:** query `bridge_status` at session start for the running version — do not rely on a static number in this file. **Bundle ID:** `kup.solutions.the-bridge` (prior: `kup.solutions.notion-bridge`).
 
 If any of the above conflicts with the SSOT page in Notion, the SSOT wins. Re-fetch when in doubt.

--- a/TheBridge/Security/CredentialManager.swift
+++ b/TheBridge/Security/CredentialManager.swift
@@ -155,6 +155,27 @@ public final class CredentialManager: Sendable {
         return "\(prefix)\(bundleID)"
     }
 
+    /// Access groups that still count as "ours" after the W5B bundle-id cutover.
+    /// Items written under `kup.solutions.notion-bridge` keep that implicit group
+    /// forever; new writes use `kup.solutions.the-bridge`.
+    private static func keychainAccessGroupsOwnedByThisApp() -> [String] {
+        guard let prefix = Bundle.main.object(forInfoDictionaryKey: "AppIdentifierPrefix") as? String else {
+            return []
+        }
+        var ids: [String] = []
+        if let current = Bundle.main.bundleIdentifier {
+            ids.append(current)
+        }
+        // Prior CFBundleIdentifier — keep readable after cutover.
+        if !ids.contains("kup.solutions.notion-bridge") {
+            ids.append("kup.solutions.notion-bridge")
+        }
+        if !ids.contains("kup.solutions.the-bridge") {
+            ids.append("kup.solutions.the-bridge")
+        }
+        return ids.map { "\(prefix)\($0)" }
+    }
+
     /// `true` when the keychain item belongs to this app's default access group.
     /// v3.6 fix: missing-access-group no longer counts as "ours" — that defaulted-true
     /// path surfaced every system keychain item (Apple system services, Chrome, Spark,
@@ -162,7 +183,8 @@ public final class CredentialManager: Sendable {
     /// fallback paths in `shouldSurfaceCredentialFromKeychainItem` (metadata flag or
     /// `com.notionbridge` infrastructure service).
     public static func isKeychainItemManagedByThisApp(_ item: [String: Any]) -> Bool {
-        guard let expected = defaultKeychainAccessGroupForThisApp() else {
+        let owned = keychainAccessGroupsOwnedByThisApp()
+        guard !owned.isEmpty else {
             // v3.7 hotfix: if we cannot resolve OUR keychain access group
             // (e.g. AppIdentifierPrefix missing from Info.plist or the
             // keychain-access-groups entitlement isn't declared), default
@@ -184,7 +206,7 @@ public final class CredentialManager: Sendable {
             // service == "com.notionbridge" path).
             return false
         }
-        return matchesAccessGroup(item: item, expected: expected)
+        return owned.contains { matchesAccessGroup(item: item, expected: $0) }
     }
 
     /// Pure helper for `isKeychainItemManagedByThisApp` — testable without an
@@ -229,7 +251,7 @@ public final class CredentialManager: Sendable {
         let probe: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccessGroup as String: group,
-            kSecAttrService as String: "kup.solutions.notion-bridge.entitlement-probe",
+            kSecAttrService as String: "kup.solutions.the-bridge.entitlement-probe",
             kSecAttrAccount as String: "__probe__",
             kSecMatchLimit as String: kSecMatchLimitOne
         ]

--- a/TheBridge/Security/PermissionManager.swift
+++ b/TheBridge/Security/PermissionManager.swift
@@ -653,7 +653,7 @@ public final class PermissionManager {
             SELECT indirect_object_identifier, auth_value
             FROM access
             WHERE service = 'kTCCServiceAppleEvents'
-            AND client = 'kup.solutions.notion-bridge'
+            AND client IN ('kup.solutions.the-bridge', 'kup.solutions.notion-bridge')
             """
 
         let process = Process()

--- a/TheBridge/UI/PermissionView.swift
+++ b/TheBridge/UI/PermissionView.swift
@@ -18,7 +18,10 @@ import SwiftUI
 import AppKit
 import os.log
 
-private let permLog = Logger(subsystem: "kup.solutions.notion-bridge", category: "PermissionView")
+private let permLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "kup.solutions.the-bridge",
+    category: "PermissionView"
+)
 
 /// Displays the V1 TCC permission status grid.
 /// PKT-362 D1: Clean rows — name + status icon only, no DisclosureGroup.

--- a/TheBridge/UI/Sections/CredentialsSection.swift
+++ b/TheBridge/UI/Sections/CredentialsSection.swift
@@ -104,7 +104,7 @@ public struct CredentialsSection: View {
         BridgeBanner(
             signal: .info,
             message:
-                "Secrets live in your macOS Keychain under kup.solutions.notion-bridge. "
+                "Secrets live in your macOS Keychain under kup.solutions.the-bridge. "
                 + "Touch ID to reveal — Bridge never writes plaintext to disk.",
             systemImage: "key.fill"
         )

--- a/TheBridge/UI/SettingsWindow+Sections.swift
+++ b/TheBridge/UI/SettingsWindow+Sections.swift
@@ -289,7 +289,11 @@ extension SettingsView {
     // MARK: - Permissions Helpers
 
     func resetTCCPermissions() async -> (message: String, didFail: Bool) {
-        let ids = ["kup.solutions.notion-bridge", "solutions.kup.keepr"]
+        let ids = [
+            "kup.solutions.the-bridge",
+            "kup.solutions.notion-bridge",
+            "solutions.kup.keepr",
+        ]
         var failures: [String] = []
 
         for id in ids {

--- a/docs/operator/live-os-gates-tcc.md
+++ b/docs/operator/live-os-gates-tcc.md
@@ -6,7 +6,7 @@ place and verified (Info.plist usage strings, module registration, and
 `requestFullAccess*` consent calls) — this runbook covers the on-device grant +
 verification that only the operator can perform.
 
-- App: **The Bridge** (`kup.solutions.notion-bridge`), menu-bar agent (`LSUIElement`).
+- App: **The Bridge** (`kup.solutions.the-bridge`), menu-bar agent (`LSUIElement`).
 - Version audited: 3.7.6 (build 51), branch `integration/v3.7.6`.
 - macOS: target is `LSMinimumSystemVersion 26.0`; consent uses the macOS-14+
   full-access APIs (`requestFullAccessToReminders` / `requestFullAccessToEvents`).
@@ -117,8 +117,11 @@ granted and operational.
 
 To force the `.notDetermined` state again so Step 1's dialogs reappear:
 ```bash
-tccutil reset Reminders kup.solutions.notion-bridge
-tccutil reset Calendar kup.solutions.notion-bridge
+tccutil reset Reminders kup.solutions.the-bridge
+tccutil reset Calendar kup.solutions.the-bridge
+# Prior id (pre-W5B) — reset if an old grant is stuck:
+# tccutil reset Reminders kup.solutions.notion-bridge
+# tccutil reset Calendar kup.solutions.notion-bridge
 ```
 Then relaunch The Bridge and re-run Step 1. (`tccutil reset` requires confirming
 any consequent prompts; it clears the recorded decision for this bundle id only.)

--- a/docs/operator/w5b-bundle-id-cutover-runbook.md
+++ b/docs/operator/w5b-bundle-id-cutover-runbook.md
@@ -1,16 +1,17 @@
 # W5B — Bundle ID cutover runbook (`notion-bridge` → `the-bridge`)
 
-**Status (Closeout-A 2026-07-20):** MANUAL cutover **blocked on D1** (`LICENSE_PUBLIC_KEY_BASE64URL` + release dry_run). Prep here is documentation only — **do not** flip `CFBundleIdentifier` in this sprint.
+**Status (2026-07-21):** MANUAL cutover **IN PROGRESS** on `feat/w5b-bundle-id-cutover` after D1 dry_run green ([run 29795964814](https://github.com/KUP-IP/the-bridge/actions/runs/29795964814)). Do **not** tag `v4.0.0` (Sale Gate locked).
 
 ## Target
 
-| Surface | Current | After cutover |
-|---------|---------|---------------|
+| Surface | Current (pre-cutover) | After cutover |
+|---------|----------------------|---------------|
 | `CFBundleIdentifier` | `kup.solutions.notion-bridge` | `kup.solutions.the-bridge` |
 | Keychain canonical | already `kup.solutions.the-bridge` (W5A) | unchanged |
 | Keychain legacy read | includes `kup.solutions.notion-bridge` | keep forever for migration |
+| Keychain access group | `TEAM.kup.solutions.notion-bridge` | accept both prior + new groups |
 
-## Prep that is safe before D1 (no Info.plist flip)
+## Prep that was safe before D1 (no Info.plist flip)
 
 - Derive TCC / logger subsystem strings from `Bundle.main.bundleIdentifier` with constant fallback.
 - Keep `KeychainManager.legacyServices` containing `kup.solutions.notion-bridge`.
@@ -19,17 +20,18 @@
 
 ## MANUAL cutover (after D1 dry_run green)
 
-1. Branch off current `main`; bump marketing/build per release rules if shipping.
-2. Flip root `Info.plist` `CFBundleIdentifier` (+ any extension ids if present).
-3. `make test-floor` → `make install` (notarized) or operator-approved install path.
-4. Relaunch via `open -a "The Bridge"` so launchd env agent applies.
-5. Live TCC: Full Disk Access, Automation, Screen Recording, Accessibility — re-grant for the **new** id.
-6. Sparkle: prove old install → new update path (or clean reinstall if Sparkle channel breaks across id change — document which).
-7. Evidence: `/health`, `bridge_status`, Keychain credential read still works via legacy fallback.
-8. Only then mark W5B packet Done.
+1. Branch off current `main`; bump marketing/build per release rules **only if shipping** (Sale Gate still locked → no `v4.0.0` tag).
+2. Flip root `Info.plist` `CFBundleIdentifier` (+ extension ids).
+3. Update Makefile `BUNDLE_ID` / `clean-tcc`, TCC SQL clients, Settings reset ids, credential access-group allowlist for prior id.
+4. `make test-floor` → `make install-copy` (or notarized `make install` when shipping).
+5. Relaunch via `open -a "The Bridge"` so launchd env agent applies.
+6. Live TCC: Full Disk Access, Automation, Screen Recording, Accessibility — re-grant for the **new** id.
+7. Sparkle: prove old install → new update path (or clean reinstall if Sparkle channel breaks across id change — document which).
+8. Evidence: `/health`, `bridge_status`, Keychain credential read still works via legacy fallback.
+9. Only then mark W5B packet Done.
 
-## Explicitly out of Closeout-A
+## Explicitly out of scope until Sale Gate
 
 - Claiming cutover Done without runtime id `kup.solutions.the-bridge`.
 - EdDSA key rotate bundled with id change.
-- Tagging `v4.0.0` (Sale Gate / Fork1 unlock only).
+- Tagging `v4.0.0`.

--- a/docs/release/sparkle-troubleshooting.md
+++ b/docs/release/sparkle-troubleshooting.md
@@ -157,8 +157,11 @@ osascript -e 'tell application "The Bridge" to quit' 2>/dev/null || true
 pkill -f "The Bridge.app/Contents/MacOS/TheBridge" 2>/dev/null || true
 
 # 2. Clear pending Sparkle staged update (the corrupt swap source)
-rm -rf "$HOME/Library/Caches/kup.solutions.notion-bridge/org.sparkle-project.Sparkle/Installation/"*
-rm -rf "$HOME/Library/Caches/kup.solutions.notion-bridge/org.sparkle-project.Sparkle/PersistentDownloads/"*
+rm -rf "$HOME/Library/Caches/kup.solutions.the-bridge/org.sparkle-project.Sparkle/Installation/"*
+rm -rf "$HOME/Library/Caches/kup.solutions.the-bridge/org.sparkle-project.Sparkle/PersistentDownloads/"*
+# Prior id (pre-W5B installs):
+# rm -rf "$HOME/Library/Caches/kup.solutions.notion-bridge/org.sparkle-project.Sparkle/Installation/"*
+# rm -rf "$HOME/Library/Caches/kup.solutions.notion-bridge/org.sparkle-project.Sparkle/PersistentDownloads/"*
 
 # 3. Reinstall a known-good build (clears + re-copies the SPM resource bundle)
 make install-copy


### PR DESCRIPTION
## Summary
- Flip `CFBundleIdentifier` (app + notification extension + URL names) to `kup.solutions.the-bridge` after D1 dry_run green.
- Keep prior `kup.solutions.notion-bridge` in TCC reset/SQL clients and credential access-group allowlist so Keychain/TCC continuity holds.
- Update Makefile `BUNDLE_ID` / `clean-tcc`, operator docs, standing-orders, AGENTS/CLAUDE. No marketing/build bump; Sale Gate still locks `v4.0.0`.

## Test plan
- [x] Suite: 3381 passed / 0 failed (floor 3381)
- [ ] `make install-copy` + `open -a "The Bridge"`
- [ ] Confirm runtime bundle id `kup.solutions.the-bridge`
- [ ] Re-grant TCC for new id; credential_list still shows license-ed25519 + prior vault items
- [ ] Note Sparkle path: clean reinstall vs old→new update (document in runbook evidence)


Made with [Cursor](https://cursor.com)