### PR TITLE
W5B cutover continuity: prefs migration + ACL heal storm fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — W5B cutover continuity (defaults + ACL heal) — 2026-07-21
+
+- **Fix** — One-shot `BundleIDDefaultsMigration` copies UserDefaults from prior
+  `kup.solutions.notion-bridge` suite so credentials/tunnel/flags survive the id flip.
+- **Fix** — Keychain ACL heal sets its sentinel *before* walking items; cutover
+  launch suppresses the automatic heal storm (on-demand Settings path remains).
+- **Tests** — +10 hermetic (defaults migration + access-group allowlist + ACL sentinel).
+  Floor 3381 → 3391.
+
 ## Unreleased — W5B bundle-id cutover — 2026-07-21
 
 - **Cutover** — `CFBundleIdentifier` → `kup.solutions.the-bridge` (extension

--- a/TheBridge/App/AppDelegate.swift
+++ b/TheBridge/App/AppDelegate.swift
@@ -323,6 +323,20 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             print("[PathMigration] WARNING: migration failed: \(error)")
         }
 
+        // W5B: CFBundleIdentifier cutover → new UserDefaults suite. Copy missing
+        // keys from the prior id BEFORE CredentialsFeature / other flag readers
+        // apply first-launch defaults on an empty suite.
+        let bundleDefaultsReport = BundleIDDefaultsMigration.runOnce()
+        if !bundleDefaultsReport.alreadyComplete && !bundleDefaultsReport.skipped {
+            print("[BundleIDDefaultsMigration] keysCopied:\(bundleDefaultsReport.keysCopied)")
+            // Suppress the launch-time Keychain ACL heal storm. The new codesign
+            // identity no longer matches ACLs minted under
+            // `kup.solutions.notion-bridge`, so walking every mirrored item
+            // (canonical + 2 legacy services) would queue dozens of
+            // "enter your password" dialogs. Heal stays available on demand.
+            KeychainManager.suppressACLHeal()
+        }
+
         // PKT-MEM-115 Wave 3: fresh installs seed per-client Cursor inject ON.
         MemoryAutoInjectClientStore.seedWave3DefaultsIfNeeded()
 

--- a/TheBridge/Core/BundleIDDefaultsMigration.swift
+++ b/TheBridge/Core/BundleIDDefaultsMigration.swift
@@ -1,0 +1,75 @@
+// BundleIDDefaultsMigration.swift — W5B: copy UserDefaults from prior CFBundleIdentifier
+//
+// Changing CFBundleIdentifier gives the process a fresh `UserDefaults.standard`
+// suite. Without a one-time copy, feature flags (credentials, tunnel URL,
+// module grants, onboarding) reset to first-launch defaults and look like data
+// loss even though Keychain + Application Support are intact.
+//
+// Properties:
+//   • Idempotent — sentinel key in the *current* suite; second launch no-ops.
+//   • One-shot prefer-prior — on the cutover launch, prior-suite values win for
+//     every key present there (the new suite is otherwise a false fresh install).
+//   • Scoped — only runs when current id is `kup.solutions.the-bridge`.
+
+import Foundation
+
+public enum BundleIDDefaultsMigration: Sendable {
+
+    public static let priorBundleID = "kup.solutions.notion-bridge"
+    public static let canonicalBundleID = "kup.solutions.the-bridge"
+    public static let sentinelKey = "com.notionbridge.bundleIdDefaultsMigration.w5b"
+
+    public struct Report: Equatable, Sendable {
+        public let keysCopied: Int
+        public let alreadyComplete: Bool
+        public let skipped: Bool
+
+        public static let noopComplete = Report(keysCopied: 0, alreadyComplete: true, skipped: false)
+        public static let noopSkipped = Report(keysCopied: 0, alreadyComplete: false, skipped: true)
+    }
+
+    /// Read the prior app's persistent domain (production default).
+    public static func loadPriorPersistentDomain(
+        suiteName: String = priorBundleID
+    ) -> [String: Any]? {
+        UserDefaults(suiteName: suiteName)?.persistentDomain(forName: suiteName)
+    }
+
+    /// Copy keys from the prior bundle-id suite into `current` (one shot).
+    /// Safe to call every launch.
+    @discardableResult
+    public static func runOnce(
+        currentBundleID: String? = Bundle.main.bundleIdentifier,
+        current: UserDefaults = .standard,
+        priorDomain: [String: Any]? = nil,
+        log: (String) -> Void = { print("[BundleIDDefaultsMigration] \($0)") }
+    ) -> Report {
+        guard let currentID = currentBundleID else {
+            return .noopSkipped
+        }
+        guard currentID == canonicalBundleID else {
+            return .noopSkipped
+        }
+        if current.bool(forKey: sentinelKey) {
+            return .noopComplete
+        }
+
+        let domain = priorDomain ?? loadPriorPersistentDomain()
+        guard let domain, !domain.isEmpty else {
+            current.set(true, forKey: sentinelKey)
+            log("no prior suite content; sentinel set")
+            return Report(keysCopied: 0, alreadyComplete: false, skipped: false)
+        }
+
+        var copied = 0
+        for key in domain.keys.sorted() where key != sentinelKey {
+            current.set(domain[key], forKey: key)
+            copied += 1
+        }
+
+        current.set(true, forKey: sentinelKey)
+        current.synchronize()
+        log("copied \(copied) key(s) from \(priorBundleID)")
+        return Report(keysCopied: copied, alreadyComplete: false, skipped: false)
+    }
+}

--- a/TheBridge/Security/CredentialManager.swift
+++ b/TheBridge/Security/CredentialManager.swift
@@ -158,22 +158,23 @@ public final class CredentialManager: Sendable {
     /// Access groups that still count as "ours" after the W5B bundle-id cutover.
     /// Items written under `kup.solutions.notion-bridge` keep that implicit group
     /// forever; new writes use `kup.solutions.the-bridge`.
+    /// Pure helper — testable without a real app bundle.
+    public static func accessGroupsOwned(prefix: String, currentBundleID: String?) -> [String] {
+        var ids: [String] = []
+        if let current = currentBundleID {
+            ids.append(current)
+        }
+        for id in ["kup.solutions.notion-bridge", "kup.solutions.the-bridge"] where !ids.contains(id) {
+            ids.append(id)
+        }
+        return ids.map { "\(prefix)\($0)" }
+    }
+
     private static func keychainAccessGroupsOwnedByThisApp() -> [String] {
         guard let prefix = Bundle.main.object(forInfoDictionaryKey: "AppIdentifierPrefix") as? String else {
             return []
         }
-        var ids: [String] = []
-        if let current = Bundle.main.bundleIdentifier {
-            ids.append(current)
-        }
-        // Prior CFBundleIdentifier — keep readable after cutover.
-        if !ids.contains("kup.solutions.notion-bridge") {
-            ids.append("kup.solutions.notion-bridge")
-        }
-        if !ids.contains("kup.solutions.the-bridge") {
-            ids.append("kup.solutions.the-bridge")
-        }
-        return ids.map { "\(prefix)\($0)" }
+        return accessGroupsOwned(prefix: prefix, currentBundleID: Bundle.main.bundleIdentifier)
     }
 
     /// `true` when the keychain item belongs to this app's default access group.

--- a/TheBridge/Security/KeychainManager.swift
+++ b/TheBridge/Security/KeychainManager.swift
@@ -317,8 +317,27 @@ public final class KeychainManager: @unchecked Sendable {
 
     // MARK: - One-time ACL re-authorization (prompt heal)
 
-    /// UserDefaults flag marking that the one-time ACL heal has run.
-    private static let aclHealedKey = "kup.solutions.the-bridge.keychainACLHealedV1"
+    /// UserDefaults flag marking that the one-time ACL heal has run (or was
+    /// suppressed after W5B cutover). Public so launch / migration / tests share
+    /// one key.
+    public static let aclHealedKey = "kup.solutions.the-bridge.keychainACLHealedV1"
+
+    /// Returns `true` when the caller should perform the heal walk.
+    /// Sets the sentinel **before** returning true so a force-quit mid-walk
+    /// cannot restart the full password-prompt storm on next launch.
+    @discardableResult
+    public static func beginACLHealIfNeeded(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.bool(forKey: aclHealedKey) { return false }
+        defaults.set(true, forKey: aclHealedKey)
+        defaults.synchronize()
+        return true
+    }
+
+    /// Mark heal complete/suppressed without walking items (W5B cutover path).
+    public static func suppressACLHeal(defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: aclHealedKey)
+        defaults.synchronize()
+    }
 
     /// One-time heal for the recurring access-prompt issue. Items created by
     /// older builds carry a default ACL that macOS re-confirms on each read;
@@ -326,11 +345,16 @@ public final class KeychainManager: @unchecked Sendable {
     /// `makeSelfTrustAccess`). Reading each stale item surfaces ONE prompt
     /// (unavoidable — the value must be read to be re-written), after which all
     /// future reads are silent. Idempotent, UserDefaults-guarded → runs once.
+    ///
+    /// W5B: the sentinel is set **before** the walk. A force-quit mid-heal used
+    /// to leave the flag clear, so the next launch restarted the full prompt
+    /// storm (canonical + legacy services × every account). Partial heal is
+    /// recoverable via the Settings "Re-authorize" affordance; a relaunch storm
+    /// is not.
     public func reauthorizeIfNeeded() {
         guard keychainEnabled else { return }
-        guard !UserDefaults.standard.bool(forKey: Self.aclHealedKey) else { return }
+        guard Self.beginACLHealIfNeeded() else { return }
         reauthorizeAllItems()
-        UserDefaults.standard.set(true, forKey: Self.aclHealedKey)
     }
 
     /// Re-save every stored item under the clean always-allow-self ACL. Public +

--- a/TheBridgeTests/BundleIDDefaultsMigrationTests.swift
+++ b/TheBridgeTests/BundleIDDefaultsMigrationTests.swift
@@ -1,0 +1,96 @@
+// BundleIDDefaultsMigrationTests.swift — W5B UserDefaults suite cutover
+
+import Foundation
+import TheBridgeLib
+
+func runBundleIDDefaultsMigrationTests() async {
+    print("\n📦 BundleIDDefaultsMigration Tests (W5B)")
+
+    await test("W5B: skips when current bundle id is not the-bridge") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.skip.\(UUID().uuidString)"
+        let current = UserDefaults(suiteName: suite)!
+        defer { current.removePersistentDomain(forName: suite) }
+        let report = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: "kup.solutions.notion-bridge",
+            current: current,
+            priorDomain: ["com.notionbridge.credentialsEnabled": true],
+            log: { _ in }
+        )
+        try expect(report.skipped)
+        try expect(current.object(forKey: BundleIDDefaultsMigration.sentinelKey) == nil)
+    }
+
+    await test("W5B: skips when bundle id is nil") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.nil.\(UUID().uuidString)"
+        let current = UserDefaults(suiteName: suite)!
+        defer { current.removePersistentDomain(forName: suite) }
+        let report = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: nil,
+            current: current,
+            priorDomain: ["k": "v"],
+            log: { _ in }
+        )
+        try expect(report.skipped)
+    }
+
+    await test("W5B: empty prior domain still sets sentinel (no thrash)") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.empty.\(UUID().uuidString)"
+        let current = UserDefaults(suiteName: suite)!
+        defer { current.removePersistentDomain(forName: suite) }
+        let report = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: BundleIDDefaultsMigration.canonicalBundleID,
+            current: current,
+            priorDomain: [:],
+            log: { _ in }
+        )
+        try expect(!report.alreadyComplete)
+        try expect(report.keysCopied == 0)
+        try expect(current.bool(forKey: BundleIDDefaultsMigration.sentinelKey) == true)
+        let second = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: BundleIDDefaultsMigration.canonicalBundleID,
+            current: current,
+            priorDomain: ["com.notionbridge.credentialsEnabled": true],
+            log: { _ in }
+        )
+        try expect(second.alreadyComplete)
+        try expect(current.object(forKey: "com.notionbridge.credentialsEnabled") == nil)
+    }
+
+    await test("W5B: copies prior suite keys once, then no-ops") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.cur.\(UUID().uuidString)"
+        let current = UserDefaults(suiteName: suite)!
+        defer { current.removePersistentDomain(forName: suite) }
+
+        let prior: [String: Any] = [
+            "com.notionbridge.credentialsEnabled": true,
+            "tunnelURL": "https://example.test/mcp",
+        ]
+        current.set("keep-me", forKey: "alreadyOnNew")
+
+        let first = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: BundleIDDefaultsMigration.canonicalBundleID,
+            current: current,
+            priorDomain: prior,
+            log: { _ in }
+        )
+        try expect(!first.alreadyComplete)
+        try expect(first.keysCopied == 2)
+        try expect(current.bool(forKey: "com.notionbridge.credentialsEnabled") == true)
+        try expect(current.string(forKey: "tunnelURL") == "https://example.test/mcp")
+        try expect(current.string(forKey: "alreadyOnNew") == "keep-me")
+        try expect(current.bool(forKey: BundleIDDefaultsMigration.sentinelKey) == true)
+
+        let second = BundleIDDefaultsMigration.runOnce(
+            currentBundleID: BundleIDDefaultsMigration.canonicalBundleID,
+            current: current,
+            priorDomain: [
+                "com.notionbridge.credentialsEnabled": false,
+                "tunnelURL": "https://should-not-apply.test/mcp",
+            ],
+            log: { _ in }
+        )
+        try expect(second.alreadyComplete)
+        try expect(current.bool(forKey: "com.notionbridge.credentialsEnabled") == true)
+        try expect(current.string(forKey: "tunnelURL") == "https://example.test/mcp")
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -830,6 +830,12 @@ await runPKT1010OnboardingTests()
 // v3.6.0 D1: Credentials scope filter regression guard.
 await runCredentialsScopeFilterTests()
 
+// W5B: UserDefaults suite migration after CFBundleIdentifier cutover.
+await runBundleIDDefaultsMigrationTests()
+
+// W5B: ACL heal sentinel-first + credential access-group continuity.
+await runW5BCutoverContinuityTests()
+
 // v3.6.0 D6: ModuleGroupCard expand-state persistence contract.
 await runModuleGroupExpandPersistenceTests()
 

--- a/TheBridgeTests/W5BCutoverContinuityTests.swift
+++ b/TheBridgeTests/W5BCutoverContinuityTests.swift
@@ -1,0 +1,83 @@
+// W5BCutoverContinuityTests.swift — ACL heal sentinel-first + access-group allowlist
+
+import Foundation
+import Security
+import TheBridgeLib
+
+func runW5BCutoverContinuityTests() async {
+    print("\n🔐 W5B Cutover Continuity Tests (ACL heal + access groups)")
+
+    await test("W5B: ACL heal begin sets sentinel before any walk would run") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.acl.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        try expect(defaults.bool(forKey: KeychainManager.aclHealedKey) == false)
+        let shouldWalk = KeychainManager.beginACLHealIfNeeded(defaults: defaults)
+        try expect(shouldWalk == true)
+        try expect(defaults.bool(forKey: KeychainManager.aclHealedKey) == true)
+
+        // Second call must refuse the walk even if a prior force-quit interrupted it.
+        let again = KeychainManager.beginACLHealIfNeeded(defaults: defaults)
+        try expect(again == false)
+        try expect(defaults.bool(forKey: KeychainManager.aclHealedKey) == true)
+    }
+
+    await test("W5B: suppressACLHeal marks sentinel without requiring a walk") {
+        let suite = "kup.solutions.the-bridge.tests.w5b.acl.suppress.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        KeychainManager.suppressACLHeal(defaults: defaults)
+        try expect(defaults.bool(forKey: KeychainManager.aclHealedKey) == true)
+        try expect(KeychainManager.beginACLHealIfNeeded(defaults: defaults) == false)
+    }
+
+    await test("W5B: accessGroupsOwned includes prior + canonical bundle ids") {
+        let groups = CredentialManager.accessGroupsOwned(
+            prefix: "TEAMID.",
+            currentBundleID: "kup.solutions.the-bridge"
+        )
+        try expect(groups.contains("TEAMID.kup.solutions.the-bridge"))
+        try expect(groups.contains("TEAMID.kup.solutions.notion-bridge"))
+        try expect(groups.count == 2)
+    }
+
+    await test("W5B: accessGroupsOwned still lists both when current is prior id") {
+        let groups = CredentialManager.accessGroupsOwned(
+            prefix: "ABC.",
+            currentBundleID: "kup.solutions.notion-bridge"
+        )
+        try expect(groups == [
+            "ABC.kup.solutions.notion-bridge",
+            "ABC.kup.solutions.the-bridge",
+        ])
+    }
+
+    await test("W5B: matchesAccessGroup accepts prior-id group after cutover") {
+        let priorGroup = "VP24Z9CS22.kup.solutions.notion-bridge"
+        let item: [String: Any] = [
+            kSecAttrAccessGroup as String: priorGroup,
+            kSecAttrService as String: "license-ed25519",
+            kSecAttrAccount as String: "private",
+        ]
+        try expect(CredentialManager.matchesAccessGroup(item: item, expected: priorGroup) == true)
+        try expect(
+            CredentialManager.matchesAccessGroup(
+                item: item,
+                expected: "VP24Z9CS22.kup.solutions.the-bridge"
+            ) == false
+        )
+        // Owned-list semantics: either group counts as ours.
+        let owned = CredentialManager.accessGroupsOwned(
+            prefix: "VP24Z9CS22.",
+            currentBundleID: "kup.solutions.the-bridge"
+        )
+        try expect(owned.contains { CredentialManager.matchesAccessGroup(item: item, expected: $0) })
+    }
+
+    await test("W5B: KeychainManager legacyServices still include prior id") {
+        try expect(KeychainManager.legacyServices.contains("kup.solutions.notion-bridge"))
+        try expect(KeychainManager.service == "kup.solutions.the-bridge")
+    }
+}

--- a/docs/operator/w5b-bundle-id-cutover-runbook.md
+++ b/docs/operator/w5b-bundle-id-cutover-runbook.md
@@ -1,6 +1,6 @@
 # W5B — Bundle ID cutover runbook (`notion-bridge` → `the-bridge`)
 
-**Status (2026-07-21):** MANUAL cutover **IN PROGRESS** on `feat/w5b-bundle-id-cutover` after D1 dry_run green ([run 29795964814](https://github.com/KUP-IP/the-bridge/actions/runs/29795964814)). Do **not** tag `v4.0.0` (Sale Gate locked).
+**Status (2026-07-21):** Bundle-id cutover **merged** ([PR #115](https://github.com/KUP-IP/the-bridge/pull/115)). Continuity follow-on (UserDefaults migration + ACL-heal storm fix) on `feat/w5b-cutover-continuity`. Do **not** tag `v4.0.0` (Sale Gate locked).
 
 ## Target
 

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2399,3 +2399,7 @@ set -euo pipefail
 # PASS for width/visible/wrap/frozen; capability matrix + W5B prep runbook.
 # Rebased onto Voice Memo #113. Measured 3381 passed, 0 failed.
 # FLOOR 3374 -> 3381.
+
+# W5B cutover continuity (2026-07-21): BundleIDDefaultsMigration (+4) +
+# ACL heal sentinel-first / access-group allowlist (+6). Measured 3391
+# passed, 0 failed. FLOOR 3381 -> 3391.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3381}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3391}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- One-shot `BundleIDDefaultsMigration` copies UserDefaults from prior `kup.solutions.notion-bridge` suite after CFBundleIdentifier cutover.
- Keychain ACL heal sets sentinel *before* walking items; cutover launch suppresses automatic heal (on-demand Settings path remains).
- Credential access-group allowlist accepts prior + canonical bundle ids. Floor 3381 → 3391 (+10 tests).

## Test plan
- [x] Hermetic 3391 / 0
- [ ] `make install-copy` + relaunch on continuity SHA
- [ ] W5B feature smoke script (no Keychain prompt storm)
- [ ] Views create/update Demo Gate with operator PASS/FAIL


Made with [Cursor](https://cursor.com)