### PR TITLE
Wave A: Settings UI-ITER polish (Skills/Jobs/Security)

### DIFF
--- a/TheBridge/UI/JobsView.swift
+++ b/TheBridge/UI/JobsView.swift
@@ -457,11 +457,12 @@ struct JobGlassRow: View {
         return cadence ?? "no actions"
     }
 
-    /// Compact next-run hint. Paused → "paused"; failing → "retrying…";
-    /// active → the ACTUAL next fire time (relative for near, clock for far),
-    /// falling back to the humanized cadence if the schedule can't be resolved.
+    /// Compact next-run hint. Paused → em dash (badge already says Paused);
+    /// failing → "retrying…"; active → the ACTUAL next fire time (relative for
+    /// near, clock for far), falling back to the humanized cadence if the
+    /// schedule can't be resolved.
     private var nextRunText: String {
-        if job.status == .paused { return "paused" }
+        if job.status == .paused { return "—" }
         if isFailing { return "retrying…" }
         if let next = JobScheduleClock.nextFireDate(for: job.schedule) {
             return JobScheduleClock.relativeNextRun(next)

--- a/TheBridge/UI/Sections/ToolDepLinks.swift
+++ b/TheBridge/UI/Sections/ToolDepLinks.swift
@@ -93,9 +93,9 @@ public struct DepLinkChip: Identifiable, Sendable {
 public enum ToolDepLinks {
     /// Build "used by" chips for a credential row from the live ToolInfo
     /// list. The chip count is exact — equal to the number of tools in
-    /// the dependent modules. Variant is `.bad` if no live tools match
-    /// (credential is orphaned — wasted secret) so the user sees they
-    /// can safely remove it.
+    /// the dependent modules. Variant is `.info` if no live tools match
+    /// (credential is unused by tools — informational orphan, not an error)
+    /// so the row stays calm while still surfacing that nothing consumes it.
     @MainActor
     public static func usedByChips(
         forCredentialService service: String,
@@ -112,7 +112,7 @@ public enum ToolDepLinks {
                 DepLinkChip(
                     id: "cred-orphan-\(normalizedName)",
                     label: "no tools registered",
-                    variant: .bad,
+                    variant: .info,
                     section: .tools,
                     anchor: normalizedName
                 )

--- a/TheBridge/UI/SkillsView.swift
+++ b/TheBridge/UI/SkillsView.swift
@@ -533,14 +533,21 @@ struct SkillsView: View {
     }
 
     /// `.sk-group-cap` — an uppercase kind caption + count + a trailing rule.
+    /// SK-1: keep caption single-line (long labels like "Routing & orchestrators"
+    /// used to wrap a stray letter under the count). Count is fixedSize; the
+    /// rule absorbs leftover width.
     private func groupHeader(_ label: String, count: Int) -> some View {
         HStack(spacing: 8) {
             Text(label).bridgeCap()
                 .foregroundStyle(BridgeTokens.fg4)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
             Text("\(count)")
                 .font(BridgeTokens.Typeface.micro)
                 .monospacedDigit()
                 .foregroundStyle(BridgeTokens.fg5)
+                .fixedSize(horizontal: true, vertical: false)
             Rectangle().fill(BridgeTokens.hairlineFaint).frame(height: 0.5)
         }
         .padding(.horizontal, 7)

--- a/TheBridgeTests/SettingsSectionsLGTests.swift
+++ b/TheBridgeTests/SettingsSectionsLGTests.swift
@@ -20,8 +20,8 @@
 //      a future Grant added without dep mapping fails the test.
 //   6. ToolDepLinks.usedByChips collapses N tools per module into one
 //      chip with the correct plural form ("28 notion tools" vs "1 ...").
-//   7. ToolDepLinks.usedByChips returns a single `.bad` orphan chip when
-//      no live tools match (credential is wasted).
+//   7. ToolDepLinks.usedByChips returns a single `.info` orphan chip when
+//      no live tools match (credential unused by tools — informational).
 //   8. ToolDepLinks.requiredByChips returns `.bad` chips when permission
 //      not granted but tools depend on it ("9 file tools — disabled").
 //   9. BridgeSectionIcon.systemImage(for:) returns the locked SF Symbol
@@ -143,8 +143,8 @@ func runSettingsSectionsLGTests() async {
                    "singular pluralization wrong: \(chips[0].label)")
     }
 
-    // 8. Orphan credential → single .bad chip.
-    await test("PKT-876: ToolDepLinks.usedByChips returns .bad orphan chip when no tools match") {
+    // 8. Orphan credential → single .info chip (informational, not error-red).
+    await test("PKT-876: ToolDepLinks.usedByChips returns .info orphan chip when no tools match") {
         let chips = await MainActor.run { () -> [DepLinkChip] in
             ToolDepLinks.usedByChips(
                 forCredentialService: "openai",
@@ -154,8 +154,8 @@ func runSettingsSectionsLGTests() async {
             )
         }
         try expect(chips.count == 1)
-        if case .bad = chips[0].variant { } else {
-            throw TestError.assertion("expected .bad variant for orphan, got .info")
+        if case .info = chips[0].variant { } else {
+            throw TestError.assertion("expected .info variant for orphan, got .bad")
         }
         try expect(chips[0].label == "no tools registered")
     }

--- a/docs/operator/uiiter/bridge-settings-uiiter-log.md
+++ b/docs/operator/uiiter/bridge-settings-uiiter-log.md
@@ -1,42 +1,58 @@
 # Bridge Settings UI-ITER — Wave A
 
-**SHA base:** `7a13c67` · **Branch:** `feat/ui-iter` · **Installed at audit:** 3.9.9 / 81  
-**Evidence:** `docs/operator/uiiter/captures/*.png` · A.0 PASS (Security)
+**SHA:** `aff3592` · **Branch:** `feat/ui-iter` · **Installed:** 3.9.9 / 81 (`ALLOW_NON_MAIN_INSTALL=1 make install-copy`)  
+**Evidence:** `docs/operator/uiiter/captures/` (baseline) · `captures/pass1/` (post-fix)
 
 ## A.0 Capture smoke
 - Triad: `bridge_open_settings` → `bridge_settings_navigate(Security)` → `bridge_focus_settings` → `screen_capture` window `kup.solutions.the-bridge`
-- Result: Settings Security visible (sidebar + Vault). **PASS**
+- Result: Settings Security visible. **PASS**
 
-## Master critique board (Light, first pass)
+## Master critique board
 
 | ID | Surface | P | Finding | Visual evidence | Status |
 |----|---------|---|---------|-----------------|--------|
-| SK-1 | Skills | P1 | Group caption wraps; stray letter under count (`ROUTING & ORCHESTRATORS` + `8`) | skills.png — caption line break | fixed (lineLimit+truncation+layoutPriority) — pending F.0 re-verify |
-| JOB-1 | Jobs | P2 | Duplicate pause signal: mono `paused` + badge `Paused` | jobs.png — trailing grid | fixed (paused → `—`; badge keeps status) — pending F.0 re-verify |
-| SEC-1 | Security | P2 | `USED BY no tools registered` in error-red for every vault row (reads as failure) | security.png — credential cards | fixed (orphan chip `.bad`→`.info`) — pending F.0 re-verify |
-| SEC-2 | Security | P3 | GATES cluster digits unlabeled | security.png — hero | defer |
-| CMD-1 | Commands | P3 | Stats `12 commands · 10 favorites` repeated (hero + list footer) | commands.png | defer |
-| SK-2 | Skills | P3 | Tall palette empty-state banner competes with index | skills.png — top banner | defer |
-| CON-1 | Connection | P3 | Live count 47 vs sessions 48 (data, not chrome) | connection.png | defer (data) |
-| CON-2 | Connection | P3 | Runtime meta line micro-contrast | connection.png — runtime card footer | defer |
-| MEM-1 | Memory | P3 | Empty preview pane sparse (acceptable empty state) | memory.png | defer |
-| DS-1 | Data Sources | P3 | Last card clipped at window bottom (scroll expected) | data-sources.png | defer |
-| ADV-1 | Advanced | P3 | Network Save vs field height micro-mismatch | advanced.png | defer |
-| TOOLS-1 | Tools | — | No P0/P1; family list readable | tools.png | clean |
+| SK-1 | Skills | P1 | Group caption wraps; stray letter under count | skills.png (baseline) | **fixed + F.0 re-verified** pass1/skills.png — single-line `ROUTING & ORCHESTRATORS 8` |
+| JOB-1 | Jobs | P2 | Duplicate pause: mono `paused` + badge `Paused` | jobs.png (baseline) | **fixed + F.0 re-verified** pass1/jobs.png — badge only; next-run column clean |
+| SEC-1 | Security | P2 | Orphan used-by chip error-red | security.png (baseline) | **fixed + F.0 re-verified** pass1/security.png — `no tools registered` no longer failure-red (`.info`) |
+| SEC-2 | Security | P3 | GATES cluster digits unlabeled | security.png | deferred — density, not ship-blocking |
+| CMD-1 | Commands | P3 | Stats repeated (hero + footer) | commands.png | deferred |
+| SK-2 | Skills | P3 | Tall palette empty-state banner | skills.png / pass1 | deferred |
+| CON-1 | Connection | P3 | Live vs sessions count skew | connection.png | deferred (data) |
+| CON-2 | Connection | P3 | Runtime meta micro-contrast | connection.png | deferred |
+| MEM-1 | Memory | P3 | Empty preview pane sparse | memory.png | deferred (acceptable empty) |
+| DS-1 | Data Sources | P3 | Last card clipped at bottom | data-sources.png | deferred (scroll) |
+| ADV-1 | Advanced | P3 | Network Save vs field height | advanced.png | deferred |
+| TOOLS-1 | Tools | — | No P0/P1 | tools.png | clean |
 
 **P0:** none.
 
 ## Visual DoD checklist (Wave A)
-- [ ] Section headers consistent
-- [ ] Empty states present when empty
-- [ ] No clipped primary CTAs
-- [ ] Hairline/token grammar OK
-- [ ] Light+Dark on Security / Connection / Memory (Dark TBD this wave if time)
+- [x] Section headers consistent (Settings chrome)
+- [x] Empty states present when empty (Skills detail, Memory preview, Jobs recent runs)
+- [x] No clipped primary CTAs on audited surfaces
+- [x] Hairline/token grammar OK on fixed surfaces
+- [x] Light captured for Security / Connection / Memory (`pass1/`)
+- [ ] Dark for Security / Connection / Memory — **deferred**: system appearance is operator-owned; Light Demo Gate evidence is the Wave A bar
+
+## Demo Gate (polish-2)
+Agent visual Demo Gate on installed 3.9.9 / `aff3592` — ask operator to confirm if desired.
+
+| Surface | Evidence | Verdict | Notes |
+|---------|----------|---------|-------|
+| Security | pass1/security.png | **PASS** | Vault readable; orphan chips calm; license banner OK |
+| Connection | pass1/connection.png | **PASS** | Endpoint / handshake / clients / loopback coherent |
+| Memory | pass1/memory.png | **PASS** | Memos list + empty preview; no chrome breakage |
+
+≥2 of {Security, Connection, Memory} PASS — DoD met.
 
 ## Pass notes
-- Pass 1 (structure): SK-1, JOB-1, SEC-1 code landed in worktree (`feat/ui-iter`) — not yet installed / re-captured.
-- Pass 2: blocked until Agent mode (install-copy → triad re-capture → Demo Gate → `make test-floor`).
-- SEC-1 chose `.info` (not new `.warn` variant) — compiles without `BridgeThemeV2` change; softer than red, still not amber. Acceptable Wave A; optional `.warn` deferred.
+- Pass 1: SK-1 / JOB-1 / SEC-1 landed + installed + re-captured.
+- Pass 2: Demo Gate PASS ×3 (Light); Dark deferred with reason; P3s deferred.
+- SEC-1 used `.info` (BridgeDepLink has no `.warn`) — intentional.
 
-## Checkpoint (Execute interrupted)
-Parent still in **Plan mode** after mode-switch reject — cannot `make install-copy` / re-capture / test from this session until Agent is approved.
+## Version
+Marketing **3.9.9** unchanged (Wave A — no Sale Gate / no `v4.0.0` tag).
+
+## Housekeeping
+- Smoke-receipt `docs/operator/views-write-smoke-2026-07-21-w5b-install.md` (primary checkout untracked incomplete) — **leave untracked**; out of Wave A Settings scope.
+- Captures are large PNGs — keep local under `docs/operator/uiiter/captures/`; log is the committed SSOT.

--- a/docs/operator/uiiter/bridge-settings-uiiter-log.md
+++ b/docs/operator/uiiter/bridge-settings-uiiter-log.md
@@ -1,0 +1,42 @@
+# Bridge Settings UI-ITER — Wave A
+
+**SHA base:** `7a13c67` · **Branch:** `feat/ui-iter` · **Installed at audit:** 3.9.9 / 81  
+**Evidence:** `docs/operator/uiiter/captures/*.png` · A.0 PASS (Security)
+
+## A.0 Capture smoke
+- Triad: `bridge_open_settings` → `bridge_settings_navigate(Security)` → `bridge_focus_settings` → `screen_capture` window `kup.solutions.the-bridge`
+- Result: Settings Security visible (sidebar + Vault). **PASS**
+
+## Master critique board (Light, first pass)
+
+| ID | Surface | P | Finding | Visual evidence | Status |
+|----|---------|---|---------|-----------------|--------|
+| SK-1 | Skills | P1 | Group caption wraps; stray letter under count (`ROUTING & ORCHESTRATORS` + `8`) | skills.png — caption line break | fixed (lineLimit+truncation+layoutPriority) — pending F.0 re-verify |
+| JOB-1 | Jobs | P2 | Duplicate pause signal: mono `paused` + badge `Paused` | jobs.png — trailing grid | fixed (paused → `—`; badge keeps status) — pending F.0 re-verify |
+| SEC-1 | Security | P2 | `USED BY no tools registered` in error-red for every vault row (reads as failure) | security.png — credential cards | fixed (orphan chip `.bad`→`.info`) — pending F.0 re-verify |
+| SEC-2 | Security | P3 | GATES cluster digits unlabeled | security.png — hero | defer |
+| CMD-1 | Commands | P3 | Stats `12 commands · 10 favorites` repeated (hero + list footer) | commands.png | defer |
+| SK-2 | Skills | P3 | Tall palette empty-state banner competes with index | skills.png — top banner | defer |
+| CON-1 | Connection | P3 | Live count 47 vs sessions 48 (data, not chrome) | connection.png | defer (data) |
+| CON-2 | Connection | P3 | Runtime meta line micro-contrast | connection.png — runtime card footer | defer |
+| MEM-1 | Memory | P3 | Empty preview pane sparse (acceptable empty state) | memory.png | defer |
+| DS-1 | Data Sources | P3 | Last card clipped at window bottom (scroll expected) | data-sources.png | defer |
+| ADV-1 | Advanced | P3 | Network Save vs field height micro-mismatch | advanced.png | defer |
+| TOOLS-1 | Tools | — | No P0/P1; family list readable | tools.png | clean |
+
+**P0:** none.
+
+## Visual DoD checklist (Wave A)
+- [ ] Section headers consistent
+- [ ] Empty states present when empty
+- [ ] No clipped primary CTAs
+- [ ] Hairline/token grammar OK
+- [ ] Light+Dark on Security / Connection / Memory (Dark TBD this wave if time)
+
+## Pass notes
+- Pass 1 (structure): SK-1, JOB-1, SEC-1 code landed in worktree (`feat/ui-iter`) — not yet installed / re-captured.
+- Pass 2: blocked until Agent mode (install-copy → triad re-capture → Demo Gate → `make test-floor`).
+- SEC-1 chose `.info` (not new `.warn` variant) — compiles without `BridgeThemeV2` change; softer than red, still not amber. Acceptable Wave A; optional `.warn` deferred.
+
+## Checkpoint (Execute interrupted)
+Parent still in **Plan mode** after mode-switch reject — cannot `make install-copy` / re-capture / test from this session until Agent is approved.


### PR DESCRIPTION
## Summary
- Skills group captions stay single-line (no stray wrap under count).
- Paused jobs show `—` in next-run column; badge remains the status signal.
- Orphan credential “used by” chips use `.info` instead of error-red `.bad`.
- Operator log: `docs/operator/uiiter/bridge-settings-uiiter-log.md` (Demo Gate Light PASS on Security / Connection / Memory; Dark deferred).

## Test plan
- [x] `make test-floor` → 3391 passed, floor 3391
- [x] `ALLOW_NON_MAIN_INSTALL=1 make install-copy` → 3.9.9 / 81
- [x] F.0 re-capture Skills / Jobs / Security / Connection / Memory
- [ ] Operator Demo Gate confirm PASS on ≥2 of {Security, Connection, Memory} (agent PASS recorded; silence ≠ PASS per smoke receipt)

## Out of scope (Wave A)
- Sale Gate / `v4.0.0` tag / Sparkle
- Shell surfaces (Dashboard / Command Bridge / Onboarding)


Made with [Cursor](https://cursor.com)