### PR TITLE
fix(broker): persist remote governance across session id churn

### DIFF
--- a/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
@@ -382,7 +382,8 @@ public enum BridgeInitializeService {
             transportSessionId: transportSessionId,
             client: context.client ?? dispatchContext?.client,
             mode: mode,
-            startedAt: context.now
+            startedAt: context.now,
+            principalKey: dispatchContext?.governancePrincipal
         )
         let constitution = includeConstitution
             ? (try? await constitutionStore.assemble(supplementalStore: store, commandStore: .shared))

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -737,7 +737,8 @@ public actor SSEServer {
     private func processStreamableHTTP(
         _ request: HTTPRequest,
         connectorAuthed: Bool = false,
-        origin: ToolDispatchOrigin = .local
+        origin: ToolDispatchOrigin = .local,
+        governancePrincipal: String? = nil
     ) async -> HTTPResponse {
         let sessionID = request.header(HTTPHeaderName.sessionID)
 
@@ -752,7 +753,8 @@ public actor SSEServer {
                     transportSessionId: sessionID,
                     origin: origin,
                     client: session.clientName,
-                    clientVersion: session.clientVersion
+                    clientVersion: session.clientVersion,
+                    governancePrincipal: governancePrincipal
                 )
             ) {
                 await session.transport.handleRequest(request)
@@ -769,7 +771,12 @@ public actor SSEServer {
            let body = request.body,
            isInitializeRequest(body)
         {
-            return await createSession(request, connectorAuthed: connectorAuthed, origin: origin)
+            return await createSession(
+                request,
+                connectorAuthed: connectorAuthed,
+                origin: origin,
+                governancePrincipal: governancePrincipal
+            )
         }
 
         if let sessionID {
@@ -952,10 +959,22 @@ public actor SSEServer {
         // connector clients compact JSON here, falling back to the SDK path for
         // anything processConnectorJSONRPC does not handle. The session pipeline
         // still skips the legacy static-bearer re-check (connectorAuthed).
-        if let connectorResponse = await processConnectorJSONRPC(request, token: token, auth: auth, origin: origin) {
+        let governancePrincipal = SessionRegistry.principalKey(subject: token.subject)
+        if let connectorResponse = await processConnectorJSONRPC(
+            request,
+            token: token,
+            auth: auth,
+            origin: origin,
+            governancePrincipal: governancePrincipal
+        ) {
             return connectorResponse
         }
-        return await processStreamableHTTP(request, connectorAuthed: true, origin: origin)
+        return await processStreamableHTTP(
+            request,
+            connectorAuthed: true,
+            origin: origin,
+            governancePrincipal: governancePrincipal
+        )
     }
 
     /// Compact JSON-RPC handler for OAuth connector clients (v3.7.10). ChatGPT's
@@ -971,7 +990,8 @@ public actor SSEServer {
         _ request: HTTPRequest,
         token: BridgeAccessToken,
         auth: ConnectorAuthContext,
-        origin: ToolDispatchOrigin
+        origin: ToolDispatchOrigin,
+        governancePrincipal: String? = nil
     ) async -> HTTPResponse? {
         guard request.method.uppercased() == "POST",
               let body = request.body,
@@ -983,6 +1003,7 @@ public actor SSEServer {
         let requestSessionID = request.header(HTTPHeaderName.sessionID)
         let sessionID = requestSessionID ?? UUID().uuidString
         let brokerSessionID = requestSessionID ?? (origin == .remote ? "remote-connector-json" : sessionID)
+        let principal = governancePrincipal ?? SessionRegistry.principalKey(subject: token.subject)
         let headers = Self.connectorJSONHeaders(sessionID: sessionID)
 
         switch method {
@@ -1069,7 +1090,8 @@ public actor SSEServer {
                 context: ToolDispatchContext(
                     transportSessionId: brokerSessionID,
                     origin: origin,
-                    client: origin == .remote ? "remote-connector" : nil
+                    client: origin == .remote ? "remote-connector" : nil,
+                    governancePrincipal: principal
                 )
             )
             if !isError { await MainActor.run { onToolCall() } }
@@ -1172,7 +1194,8 @@ public actor SSEServer {
     private func createSession(
         _ request: HTTPRequest,
         connectorAuthed: Bool = false,
-        origin: ToolDispatchOrigin = .local
+        origin: ToolDispatchOrigin = .local,
+        governancePrincipal: String? = nil
     ) async -> HTTPResponse {
         let sessionID = UUID().uuidString
 
@@ -1331,7 +1354,8 @@ public actor SSEServer {
                 transportSessionId: resourceSessionID,
                 origin: origin,
                 client: resourceClientName,
-                clientVersion: resourceClientVersion
+                clientVersion: resourceClientVersion,
+                governancePrincipal: governancePrincipal
             )
             let (text, isError) = await router.dispatchFormatted(
                 toolName: params.name,

--- a/TheBridge/Server/SessionRegistry.swift
+++ b/TheBridge/Server/SessionRegistry.swift
@@ -5,6 +5,10 @@
 // existing SessionPersistenceStore keeps Streamable HTTP session IDs alive
 // across app restarts; this registry records whether a caller has completed
 // bridge_initialize and is therefore governed.
+//
+// Remote OAuth connectors often rotate Mcp-Session-Id between tool calls.
+// Governance therefore also keys on a verified principal (`oauth-sub:<sub>`)
+// when present — never on spoofable clientInfo.
 
 import Foundation
 import SQLite3
@@ -22,6 +26,7 @@ public struct BrokerSessionRecord: Codable, Sendable, Equatable {
     public let sessionId: String
     public let transportSessionId: String
     public let client: String?
+    public let principalKey: String?
     public let mode: BrokerSessionMode
     public let startedAt: Date
     public let governed: Bool
@@ -31,6 +36,7 @@ public struct BrokerSessionRecord: Codable, Sendable, Equatable {
         sessionId: String = UUID().uuidString,
         transportSessionId: String,
         client: String?,
+        principalKey: String? = nil,
         mode: BrokerSessionMode,
         startedAt: Date = Date(),
         governed: Bool = true,
@@ -39,6 +45,7 @@ public struct BrokerSessionRecord: Codable, Sendable, Equatable {
         self.sessionId = sessionId
         self.transportSessionId = transportSessionId
         self.client = client
+        self.principalKey = principalKey
         self.mode = mode
         self.startedAt = startedAt
         self.governed = governed
@@ -58,24 +65,29 @@ public struct ToolDispatchContext: Sendable, Equatable {
     public let origin: ToolDispatchOrigin
     public let client: String?
     public let clientVersion: String?
+    /// Verified OAuth subject key (`oauth-sub:<sub>`). Never request-supplied.
+    public let governancePrincipal: String?
 
     public init(
         transportSessionId: String?,
         origin: ToolDispatchOrigin,
         client: String? = nil,
-        clientVersion: String? = nil
+        clientVersion: String? = nil,
+        governancePrincipal: String? = nil
     ) {
         self.transportSessionId = transportSessionId
         self.origin = origin
         self.client = client
         self.clientVersion = clientVersion
+        self.governancePrincipal = SessionRegistry.normalizedPrincipalKey(governancePrincipal)
     }
 
     public static let localDefault = ToolDispatchContext(
         transportSessionId: nil,
         origin: .local,
         client: nil,
-        clientVersion: nil
+        clientVersion: nil,
+        governancePrincipal: nil
     )
 }
 
@@ -95,32 +107,55 @@ public actor SessionRegistry {
             .appendingPathComponent("sessions.sqlite", isDirectory: false)
     }
 
+    /// Build a governance principal key from a verified OAuth subject.
+    /// Returns nil for empty/whitespace subjects so they cannot share a bucket.
+    public nonisolated static func principalKey(subject: String) -> String? {
+        let trimmed = subject.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return "oauth-sub:\(trimmed)"
+    }
+
+    public nonisolated static func normalizedPrincipalKey(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("oauth-sub:") {
+            let suffix = trimmed.dropFirst("oauth-sub:".count)
+            guard !suffix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return trimmed
+        }
+        return principalKey(subject: trimmed)
+    }
+
     @discardableResult
     public func open(
         transportSessionId: String,
         client: String?,
         mode: BrokerSessionMode,
-        startedAt: Date = Date()
+        startedAt: Date = Date(),
+        principalKey: String? = nil
     ) throws -> BrokerSessionRecord {
         try ensureOpen()
         let record = BrokerSessionRecord(
             transportSessionId: transportSessionId,
             client: client,
+            principalKey: Self.normalizedPrincipalKey(principalKey),
             mode: mode,
             startedAt: startedAt,
             governed: true
         )
         let sql = """
         INSERT INTO broker_sessions(
-            session_id, transport_session_id, client, mode, started_at, governed, closed_at
-        ) VALUES(?,?,?,?,?,?,NULL)
+            session_id, transport_session_id, client, mode, started_at, governed, closed_at, principal_key
+        ) VALUES(?,?,?,?,?,?,NULL,?)
         ON CONFLICT(transport_session_id) DO UPDATE SET
             session_id=excluded.session_id,
             client=excluded.client,
             mode=excluded.mode,
             started_at=excluded.started_at,
             governed=excluded.governed,
-            closed_at=NULL;
+            closed_at=NULL,
+            principal_key=excluded.principal_key;
         """
         try bindAndStep(sql) { stmt in
             sqlite3_bind_text(stmt, 1, record.sessionId, -1, SESSION_SQLITE_TRANSIENT)
@@ -133,6 +168,11 @@ public actor SessionRegistry {
             sqlite3_bind_text(stmt, 4, record.mode.rawValue, -1, SESSION_SQLITE_TRANSIENT)
             sqlite3_bind_text(stmt, 5, Self.iso(record.startedAt), -1, SESSION_SQLITE_TRANSIENT)
             sqlite3_bind_int(stmt, 6, record.governed ? 1 : 0)
+            if let principalKey = record.principalKey {
+                sqlite3_bind_text(stmt, 7, principalKey, -1, SESSION_SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(stmt, 7)
+            }
         }
         return record
     }
@@ -140,7 +180,7 @@ public actor SessionRegistry {
     public func current(transportSessionId: String) throws -> BrokerSessionRecord? {
         try ensureOpen()
         let rows = try query("""
-        SELECT session_id, transport_session_id, client, mode, started_at, governed, closed_at
+        SELECT session_id, transport_session_id, client, mode, started_at, governed, closed_at, principal_key
         FROM broker_sessions
         WHERE transport_session_id=? AND closed_at IS NULL
         LIMIT 1;
@@ -150,9 +190,27 @@ public actor SessionRegistry {
         return rows.compactMap(Self.record(from:)).first
     }
 
-    public func isGoverned(transportSessionId: String?) throws -> Bool {
-        guard let transportSessionId, !transportSessionId.isEmpty else { return false }
-        return try current(transportSessionId: transportSessionId)?.governed == true
+    public func isGoverned(
+        transportSessionId: String?,
+        principalKey: String? = nil
+    ) throws -> Bool {
+        try ensureOpen()
+        let principal = Self.normalizedPrincipalKey(principalKey)
+        if let transportSessionId, !transportSessionId.isEmpty {
+            if try current(transportSessionId: transportSessionId)?.governed == true {
+                return true
+            }
+        }
+        guard let principal, !principal.isEmpty else { return false }
+        let rows = try query("""
+        SELECT session_id, transport_session_id, client, mode, started_at, governed, closed_at, principal_key
+        FROM broker_sessions
+        WHERE principal_key=? AND closed_at IS NULL AND governed=1
+        LIMIT 1;
+        """) { stmt in
+            sqlite3_bind_text(stmt, 1, principal, -1, SESSION_SQLITE_TRANSIENT)
+        }
+        return rows.compactMap(Self.record(from:)).first != nil
     }
 
     public func close(transportSessionId: String, at date: Date = Date()) throws {
@@ -196,12 +254,19 @@ public actor SessionRegistry {
             mode TEXT NOT NULL,
             started_at TEXT NOT NULL,
             governed INTEGER NOT NULL,
-            closed_at TEXT
+            closed_at TEXT,
+            principal_key TEXT
         );
         """)
+        // Pre-existing DBs created before principal continuity lack the column.
+        try? exec("ALTER TABLE broker_sessions ADD COLUMN principal_key TEXT;")
         try exec("""
         CREATE INDEX IF NOT EXISTS idx_broker_sessions_transport
         ON broker_sessions(transport_session_id, closed_at);
+        """)
+        try exec("""
+        CREATE INDEX IF NOT EXISTS idx_broker_sessions_principal
+        ON broker_sessions(principal_key, closed_at, governed);
         """)
     }
 
@@ -267,10 +332,12 @@ public actor SessionRegistry {
               let started = isoDate(startedRaw),
               let governedRaw = row[5]
         else { return nil }
+        let principalKey = row.count >= 8 ? row[7] : nil
         return BrokerSessionRecord(
             sessionId: sessionId,
             transportSessionId: transportSessionId,
             client: row[2] ?? nil,
+            principalKey: principalKey ?? nil,
             mode: mode,
             startedAt: started,
             governed: governedRaw == "1",

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -284,12 +284,42 @@ public actor ToolRouter {
 
     /// Test/diagnostic seam for PKT-1094: a session is marked only after a
     /// successful bridge_initialize / fetch_skill / routing-skill manifest call.
+    /// Marks may be transport session ids or verified principal keys.
     public func hasRoutingManifestMarker(sessionID: String) -> Bool {
         routingManifestSessionIDs.contains(sessionID)
     }
 
     public func markRoutingManifestFetched(sessionID: String) {
         routingManifestSessionIDs.insert(sessionID)
+    }
+
+    private func isGoverned(_ context: ToolDispatchContext) async -> Bool? {
+        try? await sessionRegistry.isGoverned(
+            transportSessionId: context.transportSessionId,
+            principalKey: context.governancePrincipal
+        )
+    }
+
+    private func hasRoutingManifestMarker(context: ToolDispatchContext) -> Bool {
+        if let sessionID = context.transportSessionId,
+           !sessionID.isEmpty,
+           routingManifestSessionIDs.contains(sessionID) {
+            return true
+        }
+        if let principal = context.governancePrincipal,
+           routingManifestSessionIDs.contains(principal) {
+            return true
+        }
+        return false
+    }
+
+    private func markRoutingManifestFetched(context: ToolDispatchContext) {
+        if let sessionID = context.transportSessionId, !sessionID.isEmpty {
+            routingManifestSessionIDs.insert(sessionID)
+        }
+        if let principal = context.governancePrincipal {
+            routingManifestSessionIDs.insert(principal)
+        }
     }
 
     /// Surface for MCP `tools/list` — empty until startup registration completes (FB-4).
@@ -491,9 +521,7 @@ public actor ToolRouter {
            RemoteControlPlanePolicy.isAlwaysBlocked(tool: tool)
             || (BridgeDefaults.brokerRemoteControlPlaneBlockEnabled
                 && RemoteControlPlanePolicy.isBlocked(tool: tool)) {
-            let governed = try? await sessionRegistry.isGoverned(
-                transportSessionId: context.transportSessionId
-            )
+            let governed = await isGoverned(context)
             await auditLog.append(AuditEntry(
                 timestamp: Date(),
                 toolName: toolName,
@@ -519,9 +547,7 @@ public actor ToolRouter {
         if context.origin == .remote,
            BridgeDefaults.brokerRemoteGovernedSessionRequiredEnabled,
            RemoteControlPlanePolicy.requiresGovernedSession(tool: tool, effectiveTier: effectiveTier) {
-            let governed = try? await sessionRegistry.isGoverned(
-                transportSessionId: context.transportSessionId
-            )
+            let governed = await isGoverned(context)
             if governed != true {
                 await auditLog.append(AuditEntry(
                     timestamp: Date(),
@@ -553,9 +579,15 @@ public actor ToolRouter {
         // governing skill route" one — calling bridge_initialize satisfies both
         // at once (it is itself a manifest-marker tool), so there is no case
         // where reordering costs a legitimate caller an extra round trip.
-        if let sessionID = context.transportSessionId,
+        // Remote OAuth principals share the marker across Mcp-Session-Id churn.
+        // No correlatable identity (nil transport + nil principal) keeps the
+        // legacy skip — same as the prior `if let sessionID` gate.
+        let hasCorrelatableIdentity =
+            (context.transportSessionId?.isEmpty == false)
+            || (context.governancePrincipal != nil)
+        if hasCorrelatableIdentity,
            ToolSkillBindingRegistry.requiresManifestFetch(toolName),
-           !routingManifestSessionIDs.contains(sessionID) {
+           !hasRoutingManifestMarker(context: context) {
             let binding = ToolSkillBindingRegistry.binding(for: toolName)
             let governance = binding?.governanceSummary ?? "unregistered"
             let duration = ContinuousClock.now - start
@@ -569,7 +601,7 @@ public actor ToolRouter {
                 outputSummary: "REJECTED: routing manifest required (\(governance))",
                 durationMs: ms,
                 approvalStatus: .rejected,
-                transportSessionId: sessionID
+                transportSessionId: context.transportSessionId
             ))
             throw ToolRouterError.routingManifestRequired(
                 toolName: toolName,
@@ -633,9 +665,7 @@ public actor ToolRouter {
         // Execute handler
         do {
             let result = try await tool.handler(arguments)
-            let governed = try? await sessionRegistry.isGoverned(
-                transportSessionId: context.transportSessionId
-            )
+            let governed = await isGoverned(context)
             let governanceNote: String?
             let returnedResult: Value
             if Self.shouldAnnotateGovernance(
@@ -650,9 +680,8 @@ public actor ToolRouter {
                 returnedResult = result
             }
 
-            if let sessionID = context.transportSessionId,
-               ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) {
-                routingManifestSessionIDs.insert(sessionID)
+            if ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) {
+                markRoutingManifestFetched(context: context)
             }
 
             // F2 + PKT-552: Fire-and-forget Notify-tier notification with structured context.

--- a/TheBridgeTests/RemoteGovernanceContinuityTests.swift
+++ b/TheBridgeTests/RemoteGovernanceContinuityTests.swift
@@ -1,0 +1,305 @@
+// RemoteGovernanceContinuityTests.swift — principal-keyed remote governance +
+// routing-manifest continuity across Mcp-Session-Id churn (Red Team hardened).
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runRemoteGovernanceContinuityTests() async {
+    print("\n🔐 Remote Governance Continuity (principal key)")
+
+    await test("principalKey rejects empty/whitespace subjects") {
+        try expect(SessionRegistry.principalKey(subject: "") == nil)
+        try expect(SessionRegistry.principalKey(subject: "   ") == nil)
+        try expect(SessionRegistry.principalKey(subject: "user-123") == "oauth-sub:user-123")
+        try expect(SessionRegistry.normalizedPrincipalKey("oauth-sub:") == nil)
+        try expect(SessionRegistry.normalizedPrincipalKey("oauth-sub:user-123") == "oauth-sub:user-123")
+    }
+
+    await test("same OAuth principal governs notify across rotated transport sessions") {
+        try await withRemoteGovernanceHarness { harness in
+            let principal = SessionRegistry.principalKey(subject: "continuity-user")!
+            let sessionA = "sess-a-\(UUID().uuidString)"
+            let sessionB = "sess-b-\(UUID().uuidString)"
+
+            let initResult = await harness.router.dispatchFormatted(
+                toolName: BridgeInitializeModule.toolName,
+                arguments: .object(["client": .string("connectors-manager")]),
+                context: .init(
+                    transportSessionId: sessionA,
+                    origin: .remote,
+                    client: "connectors-manager",
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!initResult.isError, "bridge_initialize must succeed: \(initResult.text)")
+            try expect(try await harness.registry.isGoverned(
+                transportSessionId: sessionA,
+                principalKey: principal
+            ))
+            try expect(try await harness.registry.isGoverned(
+                transportSessionId: sessionB,
+                principalKey: principal
+            ), "principal continuity must cover a fresh transport session id")
+
+            let write = await harness.router.dispatchFormatted(
+                toolName: "governance_write_probe",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    client: "connectors-manager",
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!write.isError, "same-principal notify on session B must execute: \(write.text)")
+            try expect(write.text.contains("write-ok"), "unexpected write body: \(write.text)")
+            try expect(!write.text.contains("ungoverned_remote_session"))
+        }
+    }
+
+    await test("different OAuth principal stays fail-closed on notify") {
+        try await withRemoteGovernanceHarness { harness in
+            let principalA = SessionRegistry.principalKey(subject: "alice")!
+            let principalB = SessionRegistry.principalKey(subject: "bob")!
+            let sessionA = "sess-alice-\(UUID().uuidString)"
+            let sessionB = "sess-bob-\(UUID().uuidString)"
+
+            _ = await harness.router.dispatchFormatted(
+                toolName: BridgeInitializeModule.toolName,
+                arguments: .object(["client": .string("alice-client")]),
+                context: .init(
+                    transportSessionId: sessionA,
+                    origin: .remote,
+                    governancePrincipal: principalA
+                )
+            )
+
+            let rejected = await harness.router.dispatchFormatted(
+                toolName: "governance_write_probe",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principalB
+                )
+            )
+            try expect(rejected.isError)
+            try expect(rejected.text.contains("ungoverned_remote_session"),
+                       "cross-principal notify must fail closed: \(rejected.text)")
+        }
+    }
+
+    await test("empty principal never inherits another session's governance") {
+        try await withRemoteGovernanceHarness { harness in
+            let realPrincipal = SessionRegistry.principalKey(subject: "real-user")!
+            let sessionA = "sess-real-\(UUID().uuidString)"
+            let sessionEmpty = "sess-empty-\(UUID().uuidString)"
+
+            _ = await harness.router.dispatchFormatted(
+                toolName: BridgeInitializeModule.toolName,
+                arguments: .object(["client": .string("real")]),
+                context: .init(
+                    transportSessionId: sessionA,
+                    origin: .remote,
+                    governancePrincipal: realPrincipal
+                )
+            )
+
+            // Spoof / missing-sub path: governancePrincipal nil (empty subject → nil).
+            let rejected = await harness.router.dispatchFormatted(
+                toolName: "governance_write_probe",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionEmpty,
+                    origin: .remote,
+                    governancePrincipal: nil
+                )
+            )
+            try expect(rejected.isError)
+            try expect(rejected.text.contains("ungoverned_remote_session"))
+
+            // Explicit empty string must normalize away and not match.
+            let emptyNormalized = ToolDispatchContext(
+                transportSessionId: sessionEmpty,
+                origin: .remote,
+                governancePrincipal: ""
+            )
+            try expect(emptyNormalized.governancePrincipal == nil)
+            let rejectedEmpty = await harness.router.dispatchFormatted(
+                toolName: "governance_write_probe",
+                arguments: .object([:]),
+                context: emptyNormalized
+            )
+            try expect(rejectedEmpty.text.contains("ungoverned_remote_session"))
+        }
+    }
+
+    await test("routing-manifest marker follows principal across session rotation") {
+        try await withRemoteGovernanceHarness { harness in
+            let principal = SessionRegistry.principalKey(subject: "manifest-user")!
+            let sessionA = "manifest-a-\(UUID().uuidString)"
+            let sessionB = "manifest-b-\(UUID().uuidString)"
+
+            let initResult = await harness.router.dispatchFormatted(
+                toolName: BridgeInitializeModule.toolName,
+                arguments: .object(["client": .string("connectors-manager")]),
+                context: .init(
+                    transportSessionId: sessionA,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!initResult.isError)
+            try expect(await harness.router.hasRoutingManifestMarker(sessionID: sessionA))
+            try expect(await harness.router.hasRoutingManifestMarker(sessionID: principal),
+                       "bridge_initialize must mark the verified principal for churn continuity")
+
+            let bound = await harness.router.dispatchFormatted(
+                toolName: "notion_page_create",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!bound.isError, "manifest-bound notify on rotated session must pass: \(bound.text)")
+            try expect(bound.text.contains("notion-create-ok"), "unexpected body: \(bound.text)")
+            try expect(!bound.text.contains("routing manifest"),
+                       "must not re-demand routing manifest after principal-marked initialize: \(bound.text)")
+        }
+    }
+
+    await test("clientInfo alone still does not carry governance (PKT-1124 invariant)") {
+        try await withRemoteGovernanceHarness { harness in
+            let sessionA = "clientinfo-a-\(UUID().uuidString)"
+            let sessionB = "clientinfo-b-\(UUID().uuidString)"
+
+            _ = await harness.router.dispatchFormatted(
+                toolName: BridgeInitializeModule.toolName,
+                arguments: .object(["client": .string("spoofable-name")]),
+                context: .init(
+                    transportSessionId: sessionA,
+                    origin: .remote,
+                    client: "spoofable-name"
+                )
+            )
+
+            let rejected = await harness.router.dispatchFormatted(
+                toolName: "governance_write_probe",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    client: "spoofable-name"
+                )
+            )
+            try expect(rejected.text.contains("ungoverned_remote_session"),
+                       "matching clientInfo must never grant remote governance: \(rejected.text)")
+        }
+    }
+}
+
+private struct RemoteGovernanceHarness {
+    let root: URL
+    let registry: SessionRegistry
+    let router: ToolRouter
+}
+
+private func withRemoteGovernanceHarness(
+    _ body: (RemoteGovernanceHarness) async throws -> Void
+) async throws {
+    let fileManager = FileManager.default
+    let root = fileManager.temporaryDirectory
+        .appendingPathComponent("remote-gov-continuity-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(root)
+
+    let governedKey = BridgeDefaults.brokerRemoteGovernedSessionRequired
+    let advisoryKey = BridgeDefaults.brokerAdvisoryAnnotation
+    let previousGoverned = UserDefaults.standard.object(forKey: governedKey)
+    let previousAdvisory = UserDefaults.standard.object(forKey: advisoryKey)
+    UserDefaults.standard.set(true, forKey: governedKey)
+    UserDefaults.standard.set(true, forKey: advisoryKey)
+
+    defer {
+        if let previousGoverned {
+            UserDefaults.standard.set(previousGoverned, forKey: governedKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: governedKey)
+        }
+        if let previousAdvisory {
+            UserDefaults.standard.set(previousAdvisory, forKey: advisoryKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: advisoryKey)
+        }
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fileManager.removeItem(at: root)
+    }
+
+    try StandingOrdersStore.shared.resetForTesting()
+    _ = try StandingOrdersStore.shared.write(
+        "# Orders\n\n> **Amendment record:** v8.0.1\n\nRoot doctrine for remote governance continuity tests."
+    )
+
+    let registry = SessionRegistry(path: root.appendingPathComponent("broker-sessions.sqlite"))
+    try await registry.resetForTesting()
+    let router = ToolRouter(
+        securityGate: SecurityGate(),
+        auditLog: AuditLog(),
+        sessionRegistry: registry
+    )
+    let receiptStore = HandshakeReceiptStore(
+        baseDir: root.appendingPathComponent("handshakes", isDirectory: true)
+    )
+
+    await router.register(ToolRegistration(
+        name: BridgeInitializeModule.toolName,
+        module: BridgeInitializeModule.moduleName,
+        tier: .open,
+        description: "remote governance continuity bridge_initialize",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { arguments in
+            let client: String? = {
+                guard case .object(let object) = arguments,
+                      case .string(let value)? = object["client"] else { return nil }
+                return value
+            }()
+            let receipt = await BridgeInitializeService.run(
+                context: BridgeInitializeContext(
+                    client: client,
+                    connectionState: "remote",
+                    macToolsAvailable: true,
+                    bridgeState: "running",
+                    now: Date()
+                ),
+                mode: .execute,
+                includeConstitution: false,
+                sessionRegistry: registry,
+                receiptStore: receiptStore
+            )
+            return BridgeInitializeModule.receiptValue(receipt)
+        }
+    ))
+    await router.register(ToolRegistration(
+        name: "governance_write_probe",
+        module: "test",
+        tier: .notify,
+        description: "unbound notify probe",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in .object(["value": .string("write-ok")]) }
+    ))
+    // Manifest-bound notify tool — same name as a live binding so
+    // ToolSkillBindingRegistry.requiresManifestFetch is true.
+    await router.register(ToolRegistration(
+        name: "notion_page_create",
+        module: "notion",
+        tier: .notify,
+        description: "manifest-bound notify probe",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in .object(["value": .string("notion-create-ok")]) }
+    ))
+
+    try await body(.init(root: root, registry: registry, router: router))
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -736,6 +736,7 @@ await runStandingOrdersModuleTests() // PKT-931 (v3.7·B): standing_orders_* MCP
 await runBridgeInitializeTests()  // PKT-1065A: canonical bridge_initialize init-core + persisted handshake receipt
 await runWave1BrokerTests()       // Bridge Evolution Contract W1: session broker + constitution bundle + D9c remote block
 await runGovernancePropagationTests() // PKT-1124 W2C: real Streamable-HTTP governance session key propagation
+await runRemoteGovernanceContinuityTests() // principal-keyed remote governance + routing-manifest continuity across session churn
 await runCapabilityPreflightTests() // PKT-1065C: intent-sensitive capability preflight + Reminders adapter
 await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2403,3 +2403,8 @@ set -euo pipefail
 # W5B cutover continuity (2026-07-21): BundleIDDefaultsMigration (+4) +
 # ACL heal sentinel-first / access-group allowlist (+6). Measured 3391
 # passed, 0 failed. FLOOR 3381 -> 3391.
+
+# Remote governance continuity (2026-07-22): OAuth principal-keyed broker
+# governance + routing-manifest markers survive Mcp-Session-Id churn; empty
+# sub refused; clientInfo alone still fail-closed (PKT-1124). +6 hermetic.
+# Measured 3397 passed, 0 failed. FLOOR 3391 -> 3397.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3391}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3397}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Bind remote governed-session and routing-manifest state to the verified OAuth subject (`oauth-sub:<sub>`) so notify/request tools survive `Mcp-Session-Id` rotation after `bridge_initialize`.
- Keep fail-closed semantics for empty/`nil` subjects and for clientInfo-only spoofing (PKT-1124 invariant preserved).
- Raise the test floor 3391 → 3397 with `RemoteGovernanceContinuityTests`.

## Test plan
- [x] `make test-floor` (3397 passed, 0 failed)
- [ ] After merge/install: remote `bridge_initialize` then a notify-tier tool on a rotated session (ChatGPT / connectors-manager)
- [ ] Confirm a different OAuth subject still gets `ungoverned_remote_session`


Made with [Cursor](https://cursor.com)