### PR TITLE
fix(remote): kickstart cloudflared LaunchAgent on Mac wake

### DIFF
--- a/TheBridge/App/AppDelegate.swift
+++ b/TheBridge/App/AppDelegate.swift
@@ -577,6 +577,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             Task.detached {
                 await VoiceMemoReviewLifecycle.sweepIfNeeded(router: await JobsManager.shared.router_())
             }
+            // Sleep drops Cloudflare edge sockets for LaunchAgent cloudflared while
+            // local /mcp often stays fine. Kickstart the tunnel agent after a short
+            // delay (throttled). Residual: ChatGPT may still need one plugin reconnect.
+            Task.detached {
+                try? await Task.sleep(nanoseconds: TunnelLaunchAgentHealer.defaultPostWakeDelayNanoseconds)
+                _ = TunnelLaunchAgentHealer.handleWake()
+            }
         }
     }
 

--- a/TheBridge/Core/BridgeDefaults.swift
+++ b/TheBridge/Core/BridgeDefaults.swift
@@ -193,6 +193,48 @@ public enum BridgeDefaults {
     /// first transition to `.online`. ABSENT ⇒ not yet seen (modal shows once).
     public static let hasSeenCloudAccessFirstRun = "com.notionbridge.hasSeenCloudAccessFirstRun"
 
+    // MARK: - Wake tunnel heal (LaunchAgent cloudflared)
+
+    /// When true, `NSWorkspace.didWake` may kickstart the cloudflared LaunchAgent
+    /// so remote connectors recover after lid sleep. ABSENT ⇒ ON.
+    public static let tunnelWakeHealEnabled = "com.notionbridge.tunnelWakeHeal.enabled"
+
+    public static var tunnelWakeHealEnabledValue: Bool {
+        if UserDefaults.standard.object(forKey: tunnelWakeHealEnabled) == nil { return true }
+        return UserDefaults.standard.bool(forKey: tunnelWakeHealEnabled)
+    }
+
+    /// LaunchAgent label for `launchctl kickstart -k gui/<uid>/<label>`.
+    /// ABSENT ⇒ `TunnelLaunchAgentHealer.defaultLabel` (`com.kup.cloudflared-bridge`).
+    public static let tunnelLaunchAgentLabel = "com.notionbridge.tunnelWakeHeal.launchAgentLabel"
+
+    public static var tunnelLaunchAgentLabelValue: String {
+        let raw = UserDefaults.standard.string(forKey: tunnelLaunchAgentLabel)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return raw.isEmpty ? TunnelLaunchAgentHealer.defaultLabel : raw
+    }
+
+    /// Minimum seconds between wake kickstarts. ABSENT or ≤0 ⇒ 90.
+    public static let tunnelWakeHealThrottleSeconds = "com.notionbridge.tunnelWakeHeal.throttleSeconds"
+
+    public static var tunnelWakeHealThrottleSecondsValue: TimeInterval {
+        let stored = UserDefaults.standard.double(forKey: tunnelWakeHealThrottleSeconds)
+        return stored > 0 ? stored : TunnelLaunchAgentHealer.defaultThrottleSeconds
+    }
+
+    /// Last successful kickstart time (TimeInterval since reference date).
+    public static let tunnelWakeHealLastKickAtKey = "com.notionbridge.tunnelWakeHeal.lastKickAt"
+
+    public static var tunnelWakeHealLastKickAt: Date? {
+        let raw = UserDefaults.standard.double(forKey: tunnelWakeHealLastKickAtKey)
+        guard raw > 0 else { return nil }
+        return Date(timeIntervalSinceReferenceDate: raw)
+    }
+
+    public static func recordTunnelWakeHealKick(at date: Date = Date()) {
+        UserDefaults.standard.set(date.timeIntervalSinceReferenceDate, forKey: tunnelWakeHealLastKickAtKey)
+    }
+
     // MARK: - Local Models (Ollama · Wave 2a)
 
     /// Base URL for the local Ollama HTTP API. String. Default `http://127.0.0.1:11434`.

--- a/TheBridge/Modules/Cloud/TunnelLaunchAgentHealer.swift
+++ b/TheBridge/Modules/Cloud/TunnelLaunchAgentHealer.swift
@@ -1,0 +1,166 @@
+// TunnelLaunchAgentHealer.swift — sleep/wake remote-tunnel self-heal
+// TheBridge · Modules · Cloud
+//
+// Laptop sleep drops Cloudflare edge sockets for the operator's LaunchAgent
+// `cloudflared` (`com.kup.cloudflared-bridge`). Local Bridge `/health` can
+// stay fine while ChatGPT connectors fail until the tunnel re-registers and
+// the client reconnects. Bridge's wake path historically only healed jobs /
+// credentials — not the tunnel agent.
+//
+// v1 policy (Red Team hardened):
+// - ALWAYS one kickstart attempt per eligible wake (do NOT treat launchctl
+//   "state=running" as healthy — process can be up with dead edge sockets).
+// - Throttle so lid thrash cannot storm kickstart.
+// - Skip when heal is disabled, or when the network is clearly unavailable.
+// - Target the LaunchAgent label (configurable); do not use FakeTunnelProcess.
+// - Residual: ChatGPT may still need one plugin reconnect after the edge is up.
+//
+// Production kick: `/bin/launchctl kickstart -k gui/<uid>/<label>`.
+
+import Foundation
+import SystemConfiguration
+
+public enum TunnelLaunchAgentHealer: Sendable {
+
+    /// Default LaunchAgent label for Isaiah's install (and docs).
+    public static let defaultLabel = "com.kup.cloudflared-bridge"
+
+    /// Minimum seconds between kickstarts (lid open/close thrash).
+    public static let defaultThrottleSeconds: TimeInterval = 90
+
+    /// Delay after `didWake` before kick — let networking stack come up.
+    public static let defaultPostWakeDelayNanoseconds: UInt64 = 3_000_000_000
+
+    public enum Decision: String, Equatable, Sendable {
+        case kick
+        case skippedDisabled
+        case skippedThrottled
+        case skippedNoNetwork
+    }
+
+    public enum Outcome: Equatable, Sendable {
+        case kicked
+        case skippedDisabled
+        case skippedThrottled
+        case skippedNoNetwork
+        case failed(String)
+    }
+
+    public enum HealError: Error, Equatable, Sendable {
+        case kickstartFailed(status: Int32, domain: String)
+    }
+
+    // MARK: - Pure decision (hermetic)
+
+    /// Pure policy — no launchd, no network, fully unit-testable.
+    ///
+    /// - enabled: operator master for wake heal (default ON).
+    /// - networkAvailable: false ⇒ skip (airplane / offline wake).
+    /// - lastKickAt + throttleSeconds: prevent kick storms.
+    ///
+    /// When eligible, always returns `.kick` (Red Team: no "agent running ⇒ healthy").
+    public static func decide(
+        enabled: Bool,
+        networkAvailable: Bool,
+        now: Date,
+        lastKickAt: Date?,
+        throttleSeconds: TimeInterval
+    ) -> Decision {
+        guard enabled else { return .skippedDisabled }
+        guard networkAvailable else { return .skippedNoNetwork }
+        if let lastKickAt, now.timeIntervalSince(lastKickAt) < throttleSeconds {
+            return .skippedThrottled
+        }
+        return .kick
+    }
+
+    public static func launchctlDomain(uid: uid_t = getuid(), label: String) -> String {
+        "gui/\(uid)/\(label)"
+    }
+
+    // MARK: - Side-effecting heal (injectable)
+
+    /// Run wake heal. Defaults read BridgeDefaults; all effects injectable for tests.
+    @discardableResult
+    public static func handleWake(
+        enabled: Bool = BridgeDefaults.tunnelWakeHealEnabledValue,
+        networkAvailable: Bool = liveNetworkAvailable(),
+        now: Date = Date(),
+        lastKickAt: Date? = BridgeDefaults.tunnelWakeHealLastKickAt,
+        throttleSeconds: TimeInterval = BridgeDefaults.tunnelWakeHealThrottleSecondsValue,
+        label: String = BridgeDefaults.tunnelLaunchAgentLabelValue,
+        recordKick: (Date) -> Void = { BridgeDefaults.recordTunnelWakeHealKick(at: $0) },
+        kickstart: (String) throws -> Void = { try liveKickstart(label: $0) },
+        log: (String) -> Void = { print($0) }
+    ) -> Outcome {
+        let decision = decide(
+            enabled: enabled,
+            networkAvailable: networkAvailable,
+            now: now,
+            lastKickAt: lastKickAt,
+            throttleSeconds: throttleSeconds
+        )
+        switch decision {
+        case .skippedDisabled:
+            log("[TunnelLaunchAgentHealer] wake tunnel heal: skipped_disabled")
+            return .skippedDisabled
+        case .skippedThrottled:
+            log("[TunnelLaunchAgentHealer] wake tunnel heal: skipped_throttled")
+            return .skippedThrottled
+        case .skippedNoNetwork:
+            log("[TunnelLaunchAgentHealer] wake tunnel heal: skipped_no_network")
+            return .skippedNoNetwork
+        case .kick:
+            do {
+                try kickstart(label)
+                recordKick(now)
+                log("[TunnelLaunchAgentHealer] wake tunnel heal: kicked label=\(label)")
+                return .kicked
+            } catch {
+                let message = (error as? HealError).map { String(describing: $0) }
+                    ?? error.localizedDescription
+                log("[TunnelLaunchAgentHealer] wake tunnel heal: failed \(message)")
+                return .failed(message)
+            }
+        }
+    }
+
+    /// Production launchctl kickstart. Throws if process cannot start or exits non-zero.
+    public static func liveKickstart(label: String) throws {
+        let domain = launchctlDomain(label: label)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["kickstart", "-k", domain]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            throw HealError.kickstartFailed(status: -1, domain: domain)
+        }
+        guard process.terminationStatus == 0 else {
+            throw HealError.kickstartFailed(status: process.terminationStatus, domain: domain)
+        }
+    }
+
+    /// Best-effort IPv4 default-route reachability. On failure to query, returns
+    /// `true` so throttle (not a stuck "always offline") governs offline loops.
+    public static func liveNetworkAvailable() -> Bool {
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        guard let reachability = withUnsafePointer(to: &address, { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                SCNetworkReachabilityCreateWithAddress(nil, sockPtr)
+            }
+        }) else {
+            return true
+        }
+        var flags = SCNetworkReachabilityFlags()
+        guard SCNetworkReachabilityGetFlags(reachability, &flags) else {
+            return true
+        }
+        let reachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        return reachable && !needsConnection
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -1000,6 +1000,10 @@ await runMemoryHubLiveProcessingTests()
 // connector token. Pure decision logic + injected-seam repair action.
 await runCloudEnvSelfHealTests()
 
+// Sleep/wake: kickstart LaunchAgent cloudflared so remote connectors recover
+// without quitting The Bridge. Pure decide + injectable kick (no real sleep).
+await runTunnelLaunchAgentHealerTests()
+
 // ============================================================
 // MARK: - Summary
 // ============================================================

--- a/TheBridgeTests/TunnelLaunchAgentHealerTests.swift
+++ b/TheBridgeTests/TunnelLaunchAgentHealerTests.swift
@@ -1,0 +1,177 @@
+// TunnelLaunchAgentHealerTests.swift — sleep/wake LaunchAgent tunnel heal
+// Pure decision + injectable kickstart. No real launchd / sleep.
+
+import Foundation
+import TheBridgeLib
+
+func runTunnelLaunchAgentHealerTests() async {
+    print("\n🔌 TunnelLaunchAgentHealer (wake cloudflared LaunchAgent)")
+
+    let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    await test("decide: disabled never kicks") {
+        let d = TunnelLaunchAgentHealer.decide(
+            enabled: false,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90
+        )
+        try expect(d == .skippedDisabled)
+    }
+
+    await test("decide: no network skips without kick") {
+        let d = TunnelLaunchAgentHealer.decide(
+            enabled: true,
+            networkAvailable: false,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90
+        )
+        try expect(d == .skippedNoNetwork)
+    }
+
+    await test("decide: within throttle window skips") {
+        let last = now.addingTimeInterval(-30)
+        let d = TunnelLaunchAgentHealer.decide(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: last,
+            throttleSeconds: 90
+        )
+        try expect(d == .skippedThrottled)
+    }
+
+    await test("decide: past throttle or never kicked → kick (not 'agent running' probe)") {
+        let d1 = TunnelLaunchAgentHealer.decide(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90
+        )
+        try expect(d1 == .kick, "first wake must kick — process-running is not health")
+        let d2 = TunnelLaunchAgentHealer.decide(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: now.addingTimeInterval(-120),
+            throttleSeconds: 90
+        )
+        try expect(d2 == .kick, "after throttle elapses must kick again")
+    }
+
+    await test("launchctlDomain builds gui/uid/label") {
+        let domain = TunnelLaunchAgentHealer.launchctlDomain(uid: 501, label: "com.kup.cloudflared-bridge")
+        try expect(domain == "gui/501/com.kup.cloudflared-bridge")
+    }
+
+    await test("handleWake: kick path records kick and returns kicked") {
+        var kickLabels: [String] = []
+        var recorded: Date?
+        let outcome = TunnelLaunchAgentHealer.handleWake(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90,
+            label: "com.example.tunnel",
+            recordKick: { recorded = $0 },
+            kickstart: { label in kickLabels.append(label) },
+            log: { _ in }
+        )
+        try expect(outcome == .kicked)
+        try expect(kickLabels == ["com.example.tunnel"])
+        try expect(recorded == now)
+    }
+
+    await test("handleWake: throttle path does not call kickstart") {
+        var kicks = 0
+        let outcome = TunnelLaunchAgentHealer.handleWake(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: now.addingTimeInterval(-10),
+            throttleSeconds: 90,
+            label: "com.example.tunnel",
+            recordKick: { _ in },
+            kickstart: { _ in kicks += 1 },
+            log: { _ in }
+        )
+        try expect(outcome == .skippedThrottled)
+        try expect(kicks == 0)
+    }
+
+    await test("handleWake: kickstart failure does not record kick") {
+        var recorded = false
+        let outcome = TunnelLaunchAgentHealer.handleWake(
+            enabled: true,
+            networkAvailable: true,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90,
+            label: "com.example.tunnel",
+            recordKick: { _ in recorded = true },
+            kickstart: { _ in
+                throw TunnelLaunchAgentHealer.HealError.kickstartFailed(status: 5, domain: "gui/501/x")
+            },
+            log: { _ in }
+        )
+        guard case .failed(let message) = outcome else {
+            throw TestError.assertion("expected .failed, got \(outcome)")
+        }
+        try expect(message.contains("kickstartFailed") || message.contains("5"),
+                   "failure message should mention kickstart error: \(message)")
+        try expect(recorded == false, "failed kick must not advance throttle clock")
+    }
+
+    await test("handleWake: no network does not kick") {
+        var kicks = 0
+        let outcome = TunnelLaunchAgentHealer.handleWake(
+            enabled: true,
+            networkAvailable: false,
+            now: now,
+            lastKickAt: nil,
+            throttleSeconds: 90,
+            kickstart: { _ in kicks += 1 },
+            log: { _ in }
+        )
+        try expect(outcome == .skippedNoNetwork)
+        try expect(kicks == 0)
+    }
+
+    await test("BridgeDefaults: label falls back to default when empty") {
+        let key = BridgeDefaults.tunnelLaunchAgentLabel
+        let previous = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        UserDefaults.standard.removeObject(forKey: key)
+        try expect(BridgeDefaults.tunnelLaunchAgentLabelValue == TunnelLaunchAgentHealer.defaultLabel)
+        UserDefaults.standard.set("  ", forKey: key)
+        try expect(BridgeDefaults.tunnelLaunchAgentLabelValue == TunnelLaunchAgentHealer.defaultLabel)
+        UserDefaults.standard.set("com.custom.tunnel", forKey: key)
+        try expect(BridgeDefaults.tunnelLaunchAgentLabelValue == "com.custom.tunnel")
+    }
+
+    await test("BridgeDefaults: heal enabled defaults ON") {
+        let key = BridgeDefaults.tunnelWakeHealEnabled
+        let previous = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        UserDefaults.standard.removeObject(forKey: key)
+        try expect(BridgeDefaults.tunnelWakeHealEnabledValue == true)
+        UserDefaults.standard.set(false, forKey: key)
+        try expect(BridgeDefaults.tunnelWakeHealEnabledValue == false)
+    }
+}

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2408,3 +2408,7 @@ set -euo pipefail
 # governance + routing-manifest markers survive Mcp-Session-Id churn; empty
 # sub refused; clientInfo alone still fail-closed (PKT-1124). +6 hermetic.
 # Measured 3397 passed, 0 failed. FLOOR 3391 -> 3397.
+
+# Wake tunnel LaunchAgent heal (2026-07-23): didWake kickstarts
+# com.kup.cloudflared-bridge (throttled; no "running=healthy" probe). +11 hermetic.
+# Measured 3408 passed, 0 failed. FLOOR 3397 -> 3408.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3397}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3408}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- After lid sleep, Cloudflare edge sockets die while local Bridge often stays healthy; ChatGPT connectors then fail until the tunnel re-registers.
- On `didWake`, throttle-kickstart LaunchAgent `com.kup.cloudflared-bridge` (configurable label; default ON; 90s throttle; skip offline). Never treat launchctl "running" as healthy.
- Residual: ChatGPT may still need one plugin reconnect after the edge is up. Does not quit Bridge.

## Test plan
- [x] Hermetic suite 3408 passed / 0 failed; floor 3397 → 3408
- [x] Live `launchctl kickstart -k gui/$UID/com.kup.cloudflared-bridge` exit 0 on operator Mac
- [ ] After install-copy: lid sleep ≥2 min → wake → log `wake tunnel heal: kicked` and tunnel re-register without quitting Bridge
- [ ] Confirm ChatGPT residual (may need one reconnect) is acceptable