### PR TITLE
fix(registry): make find scans complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — Registry find/list completeness — 2026-07-25
+
+- **Fix** — `registry_find` now paginates the source independently of its return
+  cap, so completeness-critical predicates can match rows beyond the first
+  list window (including the F2 `Ship KeepUp MVP` project fixture).
+- **Honesty** — `registry_list` preserves its bounded result window and adds
+  `has_more` when additional rows exist; existing response keys are unchanged.
+- **Tests** — Golden F2/F5 membership regression plus list truncation coverage.
+
 ## Unreleased — Command Bridge visual pass (Spotlight-rhyme) — 2026-07-23
 
 - **UI** — Smaller bar (560×52), content-hug host (no 360pt plate), shared glass

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -357,7 +357,7 @@ public enum RegistryModule {
     public static func makeList() -> ToolRegistration {
         ToolRegistration(
             name: "registry_list", module: moduleName, tier: .open,
-            description: "List rows of a registry entity (cache-backed, offline-tolerant). Returns projected rows keyed by the entity's canonical field keys." + fieldsParamDescriptionSuffix,
+            description: "List rows of a registry entity (cache-backed, offline-tolerant). Returns projected rows keyed by the entity's canonical field keys. The additive `has_more` flag is true when the requested window is truncated." + fieldsParamDescriptionSuffix,
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -377,10 +377,15 @@ public enum RegistryModule {
                 var limit = 50
                 if case .int(let n)? = a["limit"] { limit = max(1, min(500, n)) }
                 let reader = RegistryReader(gateway: gateway())
-                let rows = try await reader.list(entity: entity, limit: limit)
+                // Read one sentinel row beyond the requested window so callers
+                // can distinguish an exhausted source from a truncated list.
+                let scanned = try await reader.list(entity: entity, limit: limit + 1)
+                let hasMore = scanned.count > limit
+                let rows = Array(scanned.prefix(limit))
                 return .object([
                     "entity": .string(key),
                     "count": .int(rows.count),
+                    "has_more": .bool(hasMore),
                     "rows": .array(rows.map { FieldsFilter.project(rowValue($0, stale: $0.isExpired()), fields: requestedFields) }),
                 ])
             })
@@ -405,7 +410,7 @@ public enum RegistryModule {
                 "properties": .object([
                     "entity": .object(["type": .string("string"), "description": .string("Entity key.")]),
                     "where": .object(["type": .string("object"), "description": .string("Map of canonical field key → value to match (e.g. {\"name\":\"Alpha\"} or {\"status\":\"Active\",\"slug\":\"x\"}). ALL predicates must match.")]),
-                    "limit": .object(["type": .string("integer"), "description": .string("Max rows scanned/returned (default 100, max 500; paginates internally).")]),
+                    "limit": .object(["type": .string("integer"), "description": .string("Max matching rows returned (default 100, max 500). The source scan paginates independently to exhaustion.")]),
                     "fields": fieldsParamSchema(),
                 ]),
                 "required": .array([.string("entity"), .string("where")]),

--- a/TheBridge/Modules/Registry/RegistryReader.swift
+++ b/TheBridge/Modules/Registry/RegistryReader.swift
@@ -143,8 +143,11 @@ public struct RegistryReader: Sendable {
     /// Read-only: matches `predicates` (canonical KEY → value) against the
     /// entity's projected rows, which are keyed rename-safe by BOUND PROPERTY
     /// ID (projection resolves each cell via `cell(for:)`, id-first), so a
-    /// Notion rename never breaks the match. Reuses `list` verbatim, so it
-    /// inherits the same read-through cache + offline fallback contract.
+    /// Notion rename never breaks the match. Unlike `list`, the caller's
+    /// `limit` is only a RETURN cap: the live source is paginated to exhaustion
+    /// before matching, so rows beyond the first list window remain findable.
+    /// The scan preserves the same read-through cache + offline fallback
+    /// contract as `list`.
     ///
     /// Semantics: ALL predicates must match (AND). A row matches a predicate
     /// when the projected value for that key equals the predicate value —
@@ -153,14 +156,44 @@ public struct RegistryReader: Sendable {
     /// absent key never matches. Zero matches is a valid, non-error result
     /// (empty array). Ambiguous input naturally yields multiple rows.
     public func find(entity: RegistryEntity, predicates: [String: Value], limit: Int = 100) async throws -> [CachedRow] {
-        let rows = try await list(entity: entity, limit: limit)
-        guard !predicates.isEmpty else { return rows }
-        return rows.filter { row in
+        let returnCap = max(1, limit)
+        let rows = try await scanAll(entity: entity)
+        guard !predicates.isEmpty else { return Array(rows.prefix(returnCap)) }
+        return Array(rows.filter { row in
             guard case .object(let props) = row.properties else { return false }
             return predicates.allSatisfy { key, wanted in
                 guard let have = props[key] else { return false }
                 return Self.valueMatches(have, wanted)
             }
+        }.prefix(returnCap))
+    }
+
+    /// Exhaustively page the live source for completeness-critical lookups.
+    /// A repeated cursor is treated as an invalid gateway response rather than
+    /// looping forever. On any live failure, fall back to the entity cache —
+    /// identical to `list`'s offline-tolerant contract.
+    private func scanAll(entity: RegistryEntity) async throws -> [CachedRow] {
+        do {
+            var out: [CachedRow] = []
+            var cursor: String? = nil
+            var seenCursors = Set<String>()
+            repeat {
+                if let cursor, !seenCursors.insert(cursor).inserted {
+                    throw RegistryGatewayError.invalidResponse("Notion query repeated cursor \(cursor)")
+                }
+                let result = try await gateway.query(
+                    dataSourceId: entity.dataSourceId, workspace: entity.workspace,
+                    pageSize: 100, startCursor: cursor)
+                for row in result.rows {
+                    out.append(await Self.store(row, entity: entity, into: cache))
+                }
+                cursor = result.nextCursor
+            } while cursor != nil
+            return out
+        } catch {
+            let cached = await cache.readAll(entity: entity.key)
+            if cached.isEmpty { throw error }
+            return cached
         }
     }
 

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -18,11 +18,18 @@ private actor ModFakeGateway: RegistryNotionGateway {
     private(set) var updated: [(String, [BoundField])] = []
     private(set) var archived: [String] = []
     private(set) var markdownWrites: [(pageId: String, markdown: String)] = []
+    private(set) var queryCalls = 0
     init(schema: DataSourceSchema, queryRows: [NotionRow] = [], pages: [String: NotionRow] = [:]) {
         self.schemaToReturn = schema; self.queryRows = queryRows; self.pages = pages
     }
     func schema(dataSourceId: String, workspace: String?) async throws -> DataSourceSchema { schemaToReturn }
-    func query(dataSourceId: String, workspace: String?, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) { (queryRows, nil) }
+    func query(dataSourceId: String, workspace: String?, pageSize: Int, startCursor: String?) async throws -> (rows: [NotionRow], nextCursor: String?) {
+        queryCalls += 1
+        let start = Int(startCursor ?? "0") ?? 0
+        let end = min(start + max(1, pageSize), queryRows.count)
+        let page = start < end ? Array(queryRows[start..<end]) : []
+        return (page, end < queryRows.count ? String(end) : nil)
+    }
     func page(pageId: String, workspace: String?) async throws -> NotionRow {
         guard let r = pages[CachedRow.normalize(pageId)] ?? pages[pageId] else { throw NSError(domain: "fake", code: 404) }
         return r
@@ -69,11 +76,25 @@ private func packetSchema() -> DataSourceSchema {
     ])
 }
 
+private func projectSchema() -> DataSourceSchema {
+    DataSourceSchema(columnsByName: [
+        "VENTURE > PROJECT": .init(id: "id_project_title", type: "title"),
+        "Status": .init(id: "id_project_status", type: "status"),
+    ])
+}
+
 private func skillRow(id: String, name: String) -> NotionRow {
     NotionRow(id: CachedRow.normalize(id), url: "https://n/\(id)", lastEditedTime: "2026-06-17T10:00:00.000Z", cells: [
         "Skill Name": NotionCell(id: "id_title", type: "title", value: .string(name)),
         "Description": NotionCell(id: "id_desc", type: "rich_text", value: .string("desc of \(name)")),
         "Status": NotionCell(id: "id_status", type: "status", value: .string("Stable")),
+    ])
+}
+
+private func projectRow(id: String, name: String, status: String) -> NotionRow {
+    NotionRow(id: CachedRow.normalize(id), url: "https://n/\(id)", lastEditedTime: "2026-07-25T10:00:00.000Z", cells: [
+        "VENTURE > PROJECT": NotionCell(id: "id_project_title", type: "title", value: .string(name)),
+        "Status": NotionCell(id: "id_project_status", type: "status", value: .string(status)),
     ])
 }
 
@@ -177,6 +198,29 @@ func runRegistryModuleTests() async {
         }
     }
 
+    await test("registry_list reports has_more without changing existing row keys") {
+        let fake = ModFakeGateway(schema: skillsSchema(), queryRows: (0..<75).map {
+            skillRow(id: String(format: "%032x", $0 + 1), name: "Skill \($0)")
+        })
+        try await withRegistryModuleEnv(fake) {
+            let first = try await RegistryModule.makeList().handler(.object([
+                "entity": .string("skill"),
+                "limit": .int(50),
+            ]))
+            try expect(obj(first)["count"] == .int(50), "requested window preserved")
+            try expect(obj(first)["has_more"] == .bool(true), "truncation is explicit")
+            try expect(obj(first)["entity"] == .string("skill") && obj(first)["rows"] != nil,
+                       "existing response keys preserved")
+
+            let all = try await RegistryModule.makeList().handler(.object([
+                "entity": .string("skill"),
+                "limit": .int(100),
+            ]))
+            try expect(obj(all)["count"] == .int(75), "all rows returned when window is large enough")
+            try expect(obj(all)["has_more"] == .bool(false), "exhausted source is honest")
+        }
+    }
+
     await test("registry_get returns one projected row by id") {
         let fake = ModFakeGateway(schema: skillsSchema(), pages: [
             "bbbb0000000000000000000000000001": skillRow(id: "bbbb0000000000000000000000000001", name: "Gamma"),
@@ -203,6 +247,51 @@ func runRegistryModuleTests() async {
             guard case .array(let rows)? = obj(out)["rows"], let r0 = rows.first else { throw TestError.assertion("no rows") }
             try expect(obj(r0)["id"] == .string("ffff0000000000000000000000000001"), "the correct row id")
             try expect(obj(r0)["title"] == .string("Alpha"), "and its title")
+        }
+    }
+
+    await test("registry_find F2 completeness: default return cap does not cap source scan") {
+        let f2 = "5de3190f0a394c13b7f8163e75301e24"
+        let f5 = "389cbb58889e81829ad9d4e6dc45543e"
+        var rows = (0..<390).map { index in
+            projectRow(
+                id: String(format: "%032x", index + 10_000),
+                name: "Project \(index)",
+                status: "BACKLOG"
+            )
+        }
+        rows[25] = projectRow(id: f5, name: "KeepUp Beta Launch", status: "FOCUS")
+        rows[320] = projectRow(id: f2, name: "Ship KeepUp MVP", status: "FOCUS")
+
+        let fake = ModFakeGateway(schema: projectSchema(), queryRows: rows)
+        try await withRegistryModuleEnv(fake) {
+            _ = try await RegistryModule.makeAddEntity().handler(.object([
+                "key": .string("project"),
+                "displayName": .string("Projects"),
+                "dataSourceId": .string("project_ds"),
+                "hasBody": .bool(false),
+                "properties": .array([
+                    .object(["key": .string("title"), "notionName": .string("VENTURE > PROJECT"), "type": .string("title"), "role": .string("title")]),
+                    .object(["key": .string("status"), "notionName": .string("Status"), "type": .string("status"), "role": .string("status")]),
+                ]),
+            ]))
+            _ = try await RegistryModule.makeIntrospect().handler(.object(["entity": .string("project")]))
+
+            let out = try await RegistryModule.makeFind().handler(.object([
+                "entity": .string("project"),
+                "where": .object(["status": .string("FOCUS")]),
+            ]))
+            guard case .array(let matches)? = obj(out)["rows"] else {
+                throw TestError.assertion("rows missing")
+            }
+            let ids = Set(matches.compactMap { row -> String? in
+                if case .string(let id)? = obj(row)["id"] { return id }
+                return nil
+            })
+            try expect(ids.contains(f2), "F2 Ship KeepUp MVP must be findable beyond the first 100 rows")
+            try expect(ids.contains(f5), "F5 control must remain findable")
+            let calls = await fake.queryCalls
+            try expect(calls == 4, "390 rows should be scanned across four pages, got \(calls)")
         }
     }
 

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2419,3 +2419,7 @@ set -euo pipefail
 
 # Command Bridge visual-pass 2026-07-23: chrome metrics + open/close duration
 # family (+1 net). Measured 3412 passed, 0 failed. FLOOR 3411 -> 3412.
+
+# Registry find/list completeness F2 (2026-07-25): exhaustive find scan
+# beyond the return cap + additive list has_more (+2 hermetic). Measured 3414
+# passed, 0 failed. FLOOR 3412 -> 3414.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3412}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3414}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- decouple `registry_find` source scanning from its return cap
- paginate RegistryReader find scans to exhaustion with repeated-cursor protection
- add additive `has_more` honesty to bounded `registry_list` responses
- add F2/F5 golden regression coverage and raise the test floor

## Verification
- `make test`: 3414 passed, 0 failed
- `make test-floor`: 3414 passed, 0 failed; floor 3414
- sequential local MCP protocol smoke:
  - F2 get status = FOCUS
  - FOCUS find count = 9 and contains F2 + F5
  - list(250) = 250, `has_more: true`
  - list(500) = 390, `has_more: false`, contains F2 + F5

## Scope
No tunnel/OAuth, workspaceRoot, 14-entity audit, or release-version changes.
