### PR TITLE
release: prepare v4.0.1 build 83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## Unreleased — Registry find/list completeness — 2026-07-25
+## v4.0.1 (build 83) — Post-v4 reliability and UX — 2026-07-25
+
+- **Release** — Marketing **4.0.0 → 4.0.1**, build **82 → 83**.
+- **Remote governance** — OAuth principals retain governed routing state across
+  `Mcp-Session-Id` churn; empty subjects remain fail-closed.
+- **Wake reliability** — The app can throttle and kickstart the cloudflared
+  LaunchAgent after Mac wake instead of leaving remote access silently stale.
+- **Registry correctness** — `registry_find` scans the complete source before
+  filtering/capping, and `registry_list` reports exact additive `has_more`.
+- **Command Bridge** — Spotlight-rhyme sizing, glass, favorite tiles, and motion
+  refinements ship with the post-v4 reliability batch.
+- **Runtime hardening** — Build inject templates restore cleanly, `git_status`
+  separates worktree cleanliness from upstream synchronization, and skill-body
+  section selection supports unique heading prefixes.
+- **Tests** — Floor **3391 → 3416**, with **3416 passed, 0 failed** on the
+  release candidate.
+
+### Registry find/list completeness — 2026-07-25
 
 - **Fix** — `registry_find` now paginates the source independently of its return
   cap, so completeness-critical predicates can match rows beyond the first
@@ -11,7 +28,7 @@
   coverage, exact `has_more` boundaries, repeated-cursor termination, and
   later-page cache fallback. Test floor **3414 → 3416**.
 
-## Unreleased — Command Bridge visual pass (Spotlight-rhyme) — 2026-07-23
+### Command Bridge visual pass (Spotlight-rhyme) — 2026-07-23
 
 - **UI** — Smaller bar (560×52), content-hug host (no 360pt plate), shared glass
   recipe for bar + favorite tiles + results (regular+ultraThin, soft shadow).
@@ -22,7 +39,7 @@
 - **Settings** — Commands tray preview matches live tile chrome.
 - **Evidence** — `docs/operator/command-bridge-visual-pass-2026-07-23.md` (F.0 gate).
 
-## Unreleased — Calibrate APPLY (agent feedback) — 2026-07-23
+### Calibrate APPLY (agent feedback) — 2026-07-23
 
 - **Fix** — `make build` restores committed fail-closed inject templates
   (`RemoteAccessIdentity`, `LicensePublicKeyInjected`) after compile so local

--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>82</string>
+	<string>83</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "4.0.0"
+    public static let marketing = "4.0.1"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -302,7 +302,11 @@ public enum AppVersion {
     ///   Sale-ready V4 cut: W5B bundle-id cutover + continuity, Notion Views
     ///   write tools, Wave A Settings UI-ITER polish, license public-key +
     ///   WorkOS OAuth bake secrets present for release.yml inject. Floor 3391.
-    public static let build = "82"
+    /// v4.0.1: 82 -> 83 -- post-v4 reliability and UX batch: principal-keyed
+    ///   remote governance across MCP session churn, wake-time cloudflared
+    ///   LaunchAgent healing, Calibrate runtime fixes, Command Bridge visual
+    ///   refinement, and registry find/list completeness. Floor 3416.
+    public static let build = "83"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## Objective
Prepare the next Bridge release identity and signed local candidate without installing, tagging, notarizing, publishing, or updating the Sparkle feed.

## Release identity
- Marketing version: `4.0.1`
- Build number: `83`
- Candidate SHA: `6c51694040ac96f7b0367358ba519b1d1e5fd321`

## Scope
- Atomic version update in `Version.swift` and root `Info.plist`
- Consolidated post-v4.0.0 release notes in `CHANGELOG.md`
- No appcast change, tag, install, notarization, DMG, or public release

## Evidence
- Canonical local gate: 3416 passed, 0 failed; floor 3416
- Packaged `.build/TheBridge.app`: version 4.0.1 / build 83
- Embedded provenance: candidate SHA, dirty=false
- Developer ID signature: deep/strict verification passed
- Existing installed 4.0.0 / 82 app preserved and backed up before any future install

## Ship boundary
Merge, local installation, tag creation, notarization, appcast publication, and customer-facing release remain behind a separate Ship Gate and explicit operator GO.
