### PR TITLE
test(screen): hermetic handlers with bounded live OCR verification

### DIFF
--- a/TheBridge/Modules/BridgeAutomationModule.swift
+++ b/TheBridge/Modules/BridgeAutomationModule.swift
@@ -200,7 +200,7 @@ public enum BridgeSettingsAutomation {
     /// way. PKT-1005: the bare cast alone is the bug — it can miss under the
     /// adaptor and strand the open path.
     static func liveAppDelegate() -> AppDelegate? {
-        AppDelegate.shared ?? (NSApp.delegate as? AppDelegate)
+        AppDelegate.shared ?? (NSApp?.delegate as? AppDelegate)
     }
 
     /// Open the Settings window from a COLD / closed state and deep-link it to
@@ -219,7 +219,11 @@ public enum BridgeSettingsAutomation {
             SettingsNavigation.shared.go(section, anchor: anchor)
         }
 
-        let alreadyOpen = NSApp.windows.contains { isSettingsWindow($0) }
+        guard let app = NSApp else {
+            return (opened: false, section: section)
+        }
+
+        let alreadyOpen = app.windows.contains { isSettingsWindow($0) }
         if !alreadyOpen, let delegate = liveAppDelegate() {
             delegate.openSettings(section: section)
         } else if alreadyOpen, let section {
@@ -227,7 +231,7 @@ public enum BridgeSettingsAutomation {
             SettingsNavigation.shared.go(section, anchor: anchor)
         }
 
-        let opened = NSApp.windows.contains { isSettingsWindow($0) }
+        let opened = app.windows.contains { isSettingsWindow($0) }
         return (opened: opened, section: section)
     }
 
@@ -237,9 +241,13 @@ public enum BridgeSettingsAutomation {
     /// Settings window was found and ordered front.
     @discardableResult
     public static func focusSettings(openIfNeeded: Bool) -> (windowFound: Bool, activated: Bool) {
+        guard let app = NSApp else {
+            return (windowFound: false, activated: false)
+        }
+
         // Ensure the window exists if requested and none is open yet.
         if openIfNeeded {
-            let alreadyOpen = NSApp.windows.contains { $0.isVisible && isSettingsWindow($0) }
+            let alreadyOpen = app.windows.contains { $0.isVisible && isSettingsWindow($0) }
             if !alreadyOpen, let delegate = liveAppDelegate() {
                 delegate.openSettings(section: nil)
             }
@@ -248,12 +256,12 @@ public enum BridgeSettingsAutomation {
         // Accessory (LSUIElement) windows hide when the app deactivates; flip to
         // .regular so the window can come fully frontmost and stay visible to a
         // following screen_capture.
-        if NSApp.activationPolicy() != .regular {
-            NSApp.setActivationPolicy(.regular)
+        if app.activationPolicy() != .regular {
+            app.setActivationPolicy(.regular)
         }
-        NSApp.activate(ignoringOtherApps: true)
+        app.activate(ignoringOtherApps: true)
 
-        guard let window = NSApp.windows.first(where: { isSettingsWindow($0) }) else {
+        guard let window = app.windows.first(where: { isSettingsWindow($0) }) else {
             return (windowFound: false, activated: true)
         }
         if window.isMiniaturized {
@@ -472,9 +480,15 @@ public enum BridgeAutomationModule {
                     "activated": .bool(outcome.activated)
                 ]
                 if !outcome.windowFound {
-                    result["note"] = .string(openIfNeeded
-                        ? "App activated but no Settings window host present (headless/test context)."
-                        : "No Settings window found to focus.")
+                    let note: String
+                    if !outcome.activated {
+                        note = "No app window host present to activate (headless/test context)."
+                    } else if openIfNeeded {
+                        note = "App activated but no Settings window host present (headless/test context)."
+                    } else {
+                        note = "No Settings window found to focus."
+                    }
+                    result["note"] = .string(note)
                 }
                 return .object(result)
             }

--- a/TheBridge/Modules/BridgeAutomationModule.swift
+++ b/TheBridge/Modules/BridgeAutomationModule.swift
@@ -165,12 +165,20 @@ public enum BridgeSettingsAutomation {
     /// enumeration the sibling `focusSettings()` already uses), opening the host
     /// via the AppDelegate when one is reachable and none is open yet.
     public static func navigate(to section: SettingsSection, anchor: String?) -> Bool {
+        navigate(to: section, anchor: anchor, app: NSApp)
+    }
+
+    package static func navigate(
+        to section: SettingsSection,
+        anchor: String?,
+        app: NSApplication?
+    ) -> Bool {
         // Always update the shared selection model — this is the source of
         // truth the SettingsView binds to, and what makes navigation work even
         // when the window is already open.
         SettingsNavigation.shared.go(section, anchor: anchor)
 
-        guard let app = NSApp else {
+        guard let app else {
             return false
         }
 
@@ -180,7 +188,7 @@ public enum BridgeSettingsAutomation {
         // isn't published yet. This is what actually opens the window under the
         // adaptor — the bare cast could miss and leave it closed.
         let alreadyOpen = app.windows.contains { isSettingsWindow($0) }
-        if !alreadyOpen, let delegate = liveAppDelegate() {
+        if !alreadyOpen, let delegate = liveAppDelegate(app: app) {
             delegate.openSettings(section: section)
         }
 
@@ -199,8 +207,8 @@ public enum BridgeSettingsAutomation {
     /// the `NSApp.delegate` cast for any host that set the delegate the classic
     /// way. PKT-1005: the bare cast alone is the bug — it can miss under the
     /// adaptor and strand the open path.
-    static func liveAppDelegate() -> AppDelegate? {
-        AppDelegate.shared ?? (NSApp?.delegate as? AppDelegate)
+    static func liveAppDelegate(app: NSApplication?) -> AppDelegate? {
+        AppDelegate.shared ?? (app?.delegate as? AppDelegate)
     }
 
     /// Open the Settings window from a COLD / closed state and deep-link it to
@@ -215,16 +223,24 @@ public enum BridgeSettingsAutomation {
     /// to the requested section on its very first render (no post-open nav hop).
     @discardableResult
     public static func openSettings(section: SettingsSection?, anchor: String?) -> (opened: Bool, section: SettingsSection?) {
+        openSettings(section: section, anchor: anchor, app: NSApp)
+    }
+
+    package static func openSettings(
+        section: SettingsSection?,
+        anchor: String?,
+        app: NSApplication?
+    ) -> (opened: Bool, section: SettingsSection?) {
         if let section {
             SettingsNavigation.shared.go(section, anchor: anchor)
         }
 
-        guard let app = NSApp else {
+        guard let app else {
             return (opened: false, section: section)
         }
 
         let alreadyOpen = app.windows.contains { isSettingsWindow($0) }
-        if !alreadyOpen, let delegate = liveAppDelegate() {
+        if !alreadyOpen, let delegate = liveAppDelegate(app: app) {
             delegate.openSettings(section: section)
         } else if alreadyOpen, let section {
             // Already hosted — just (re)point it and bring it forward.
@@ -241,14 +257,21 @@ public enum BridgeSettingsAutomation {
     /// Settings window was found and ordered front.
     @discardableResult
     public static func focusSettings(openIfNeeded: Bool) -> (windowFound: Bool, activated: Bool) {
-        guard let app = NSApp else {
+        focusSettings(openIfNeeded: openIfNeeded, app: NSApp)
+    }
+
+    package static func focusSettings(
+        openIfNeeded: Bool,
+        app: NSApplication?
+    ) -> (windowFound: Bool, activated: Bool) {
+        guard let app else {
             return (windowFound: false, activated: false)
         }
 
         // Ensure the window exists if requested and none is open yet.
         if openIfNeeded {
             let alreadyOpen = app.windows.contains { $0.isVisible && isSettingsWindow($0) }
-            if !alreadyOpen, let delegate = liveAppDelegate() {
+            if !alreadyOpen, let delegate = liveAppDelegate(app: app) {
                 delegate.openSettings(section: nil)
             }
         }
@@ -320,6 +343,13 @@ public enum BridgeAutomationModule {
     }
 
     public static func register(on router: ToolRouter) async {
+        await register(on: router, applicationProvider: { NSApp })
+    }
+
+    package static func register(
+        on router: ToolRouter,
+        applicationProvider: @escaping @MainActor @Sendable () -> NSApplication?
+    ) async {
 
         // ── bridge_settings_navigate (open) ──────────────────────────────
         await router.register(ToolRegistration(
@@ -369,7 +399,12 @@ public enum BridgeAutomationModule {
                 // folded-in tab anchor (e.g. Credentials → security/vault).
                 let anchor = explicitAnchor ?? aliasAnchor
 
-                let windowDriven = await BridgeSettingsAutomation.navigate(to: section, anchor: anchor)
+                let application = await applicationProvider()
+                let windowDriven = await BridgeSettingsAutomation.navigate(
+                    to: section,
+                    anchor: anchor,
+                    app: application
+                )
                 var result: [String: Value] = [
                     "success": .bool(true),
                     "section": .string(section.rawValue),
@@ -385,7 +420,10 @@ public enum BridgeAutomationModule {
                 }
                 let shouldFocus = boolParam(params, "focus", default: true)
                 if shouldFocus {
-                    let focusOutcome = await BridgeSettingsAutomation.focusSettings(openIfNeeded: true)
+                    let focusOutcome = await BridgeSettingsAutomation.focusSettings(
+                        openIfNeeded: true,
+                        app: application
+                    )
                     result["focused"] = .bool(focusOutcome.windowFound)
                     result["activated"] = .bool(focusOutcome.activated)
                 }
@@ -441,7 +479,12 @@ public enum BridgeAutomationModule {
                     anchor = explicitAnchor ?? resolved.anchor
                 }
 
-                let outcome = await BridgeSettingsAutomation.openSettings(section: section, anchor: anchor)
+                let application = await applicationProvider()
+                let outcome = await BridgeSettingsAutomation.openSettings(
+                    section: section,
+                    anchor: anchor,
+                    app: application
+                )
                 var result: [String: Value] = [
                     "success": .bool(outcome.opened),
                     "opened": .bool(outcome.opened)
@@ -460,7 +503,7 @@ public enum BridgeAutomationModule {
             name: "bridge_focus_settings",
             module: moduleName,
             tier: .open,
-            description: "Bring The Bridge's Settings window frontmost and raise it so screen_capture or AX reads see it. The app is LSUIElement (accessory), so Settings can hide behind other apps after deactivation. Pair with bridge_settings_navigate or bridge_open_settings before capturing Settings.",
+            description: "Bring The Bridge's Settings window frontmost and raise it so screen_capture or AX reads see it. The app is LSUIElement (accessory), so Settings can hide behind other apps after deactivation. Pair with bridge_settings_navigate or bridge_open_settings before capturing Settings. success=true means a Settings window was found and raised; headless/no-host execution returns success=false.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -473,9 +516,13 @@ public enum BridgeAutomationModule {
             handler: { arguments in
                 let params = unwrap(arguments)
                 let openIfNeeded = boolParam(params, "openIfNeeded", default: true)
-                let outcome = await BridgeSettingsAutomation.focusSettings(openIfNeeded: openIfNeeded)
+                let application = await applicationProvider()
+                let outcome = await BridgeSettingsAutomation.focusSettings(
+                    openIfNeeded: openIfNeeded,
+                    app: application
+                )
                 var result: [String: Value] = [
-                    "success": .bool(true),
+                    "success": .bool(outcome.windowFound),
                     "focused": .bool(outcome.windowFound),
                     "activated": .bool(outcome.activated)
                 ]

--- a/TheBridge/Modules/ScreenModule.swift
+++ b/TheBridge/Modules/ScreenModule.swift
@@ -108,7 +108,7 @@ public enum ScreenModule {
     /// Register all ScreenModule tools with explicit runtime dependencies.
     package static func register(on router: ToolRouter, runtime: ScreenModuleRuntime) async {
 
-        // MARK: 1. screen_capture – Open (read-only)
+        // MARK: 1. screen_capture – Open (writes capture artifact)
         await router.register(ToolRegistration(
             name: "screen_capture",
             module: moduleName,
@@ -647,8 +647,9 @@ package struct ScreenModuleRuntime: Sendable {
 }
 
 extension ScreenModuleRuntime {
-    /// Production-only composition. `internal` intentionally keeps the live
-    /// framework implementation inaccessible to the separate test target.
+    /// Production-only composition. `internal` keeps the live factory hidden
+    /// from the separate test target; only the explicitly gated probe below can
+    /// route through it.
     internal static let live = ScreenModuleRuntime(
         frontmostBundleId: { ScreenModuleLive.frontmostBundleId() },
         cleanupCaptureFiles: { ScreenModuleLive.cleanupCaptureFiles() },
@@ -661,6 +662,19 @@ extension ScreenModuleRuntime {
             try ScreenModuleLive.recognizeText(image, language: language)
         }
     )
+}
+
+extension ScreenModule {
+    /// Explicit opt-in bridge for the non-canonical live OCR probe. Canonical
+    /// tests cannot accidentally register live dependencies because this path
+    /// refuses to run unless the dedicated environment switch is present.
+    package static func registerLiveProbe(on router: ToolRouter) async -> Bool {
+        guard ProcessInfo.processInfo.environment["BRIDGE_SCREEN_LIVE_PROBE"] == "1" else {
+            return false
+        }
+        await register(on: router, runtime: .live)
+        return true
+    }
 }
 
 /// Live macOS implementation. Handler registration and response assembly do

--- a/TheBridge/Modules/ScreenModule.swift
+++ b/TheBridge/Modules/ScreenModule.swift
@@ -1,10 +1,10 @@
 // ScreenModule.swift – V3-SCREEN-001 Screen Capture & OCR Tools
 // TheBridge · Modules
 //
-// Two read-only tools: screen_capture (Open), screen_ocr (Open).
-// Uses ScreenCaptureKit for capture, Vision framework for OCR.
-// Both classified as Open tier (read-only, zero side effects).
-// PKT-354: Pull-forward of Phase 4 ScreenModule — read tools only.
+// Two Open-tier tools: screen_capture and screen_ocr.
+// Uses ScreenCaptureKit for capture and Vision for OCR. screen_capture writes
+// one image artifact and performs best-effort cleanup of prior capture files.
+// PKT-354: Pull-forward of Phase 4 ScreenModule capture/OCR tools.
 //
 // Frameworks:
 //   - ScreenCaptureKit: SCScreenshotManager.captureImage for screenshots
@@ -15,12 +15,14 @@
 // Capture files: <configuredDir>/nb-screen-<timestamp>.<ext> (default ~/Desktop, fallback /tmp)
 // Cleanup: On each screen_capture call, delete files >1hr old, cap at 20.
 
-import MCP
 import AppKit
-import ScreenCaptureKit
-import Vision
+import CoreGraphics
+import Foundation
 import ImageIO
+import MCP
+import ScreenCaptureKit
 import UniformTypeIdentifiers
+import Vision
 
 // MARK: - ScreenModule
 
@@ -89,258 +91,22 @@ public enum ScreenModule {
         }
     }
 
-    // MARK: - Cleanup
+    // MARK: - Pure response helpers
 
-    /// Best-effort cleanup of old capture files.
-    /// Deletes nb-screen-* files older than 1 hour, then caps at 20 remaining.
-    /// Failures are logged but never block the capture operation.
-    private static func cleanupCaptureFiles() {
-        let resolved = ConfigManager.shared.resolvedScreenOutputDir()
-        let tmpDir = resolved.path
-        let prefix = "nb-screen-"
-        let oneHourAgo = Date().addingTimeInterval(-3600)
-        let fm = FileManager.default
-
-        do {
-            let allFiles = try fm.contentsOfDirectory(atPath: tmpDir)
-            let captureFiles = allFiles.filter { $0.hasPrefix(prefix) }
-
-            // Phase 1: Delete files older than 1 hour
-            for name in captureFiles {
-                let path = "\(tmpDir)/\(name)"
-                if let attrs = try? fm.attributesOfItem(atPath: path),
-                   let modified = attrs[.modificationDate] as? Date,
-                   modified < oneHourAgo {
-                    try? fm.removeItem(atPath: path)
-                }
-            }
-
-            // Phase 2: Cap at 20 files (delete oldest first)
-            let remaining = try fm.contentsOfDirectory(atPath: tmpDir)
-                .filter { $0.hasPrefix(prefix) }
-                .compactMap { name -> (path: String, date: Date)? in
-                    let path = "\(tmpDir)/\(name)"
-                    guard let attrs = try? fm.attributesOfItem(atPath: path),
-                          let modified = attrs[.modificationDate] as? Date else { return nil }
-                    return (path: path, date: modified)
-                }
-                .sorted { $0.date < $1.date }
-
-            if remaining.count > 20 {
-                for file in remaining.prefix(remaining.count - 20) {
-                    try? fm.removeItem(atPath: file.path)
-                }
-            }
-        } catch {
-            // Best-effort — never block capture
-        }
-    }
-
-    // MARK: - Frontmost Guard
-
-    /// The bundle identifier of the frontmost (active) application, if any.
-    /// Read on the main actor — `NSWorkspace.frontmostApplication` is
-    /// main-actor-isolated and stale reads off-main are unreliable.
-    @MainActor
-    private static func frontmostBundleId() -> String? {
-        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-    }
-
-    /// FB-AUTOMATION: optional guard for `screen_capture`. When the caller
-    /// passes `requireFrontmostBundleId`, the capture only proceeds if that
-    /// bundle id is currently frontmost. Lets an agent assert the expected app
-    /// (e.g. The Bridge after bridge_focus_settings) is actually in front before
-    /// spending a capture — and surface a clear error if focus was stolen.
-    /// Returns the structured-error `Value` to short-circuit with, or nil to
-    /// proceed.
-    @MainActor
-    private static func frontmostGuardFailure(required: String?) -> Value? {
-        guard let required, !required.isEmpty else { return nil }
-        let actual = frontmostBundleId()
+    private static func frontmostGuardFailure(required: String, actual: String?) -> Value? {
         if actual == required { return nil }
         return .object([
             "error": .string("frontmost_mismatch"),
             "message": .string("Required frontmost app '\(required)' is not active (frontmost: '\(actual ?? "unknown")'). Capture aborted. Bring the app forward (e.g. bridge_focus_settings) and retry."),
             "requiredBundleId": .string(required),
-            "frontmostBundleId": actual.map { Value.string($0) } ?? .null
+            "frontmostBundleId": actual.map(Value.string) ?? .null
         ])
-    }
-
-    // MARK: - Capture Helpers
-
-    /// Verify Screen Recording TCC grant and fetch shareable content.
-    /// Uses CGPreflightScreenCaptureAccess() only — never CGRequestScreenCaptureAccess()
-    /// (which opens a modal dialog, inappropriate at tool-call time).
-    private static func getShareableContent() async throws -> SCShareableContent {
-        guard CGPreflightScreenCaptureAccess() else {
-            throw ScreenModuleError.screenRecordingDenied
-        }
-        // SCK delivers its reply on the main run loop; calling it off the main
-        // actor leaks the continuation and hangs forever. Route through the
-        // main-actor boundary (see ScreenCaptureKitBoundary.swift). The
-        // preflight gate above keeps the denied path fast — we never reach the
-        // SCK call when access is not granted.
-        return try await SCKBoundary.fetchShareableContent()
-    }
-
-    /// Capture a CGImage based on target parameters.
-    ///
-    /// `@MainActor`: every ScreenCaptureKit async API used here
-    /// (`SCShareableContent.excludingDesktopWindows` via `getShareableContent`
-    /// and `SCScreenshotManager.captureImage`) delivers its reply on the main
-    /// run loop. Calling them off the main actor leaks the checked continuation
-    /// and hangs forever (it was masked only because GUI dispatch ran on main;
-    /// it surfaces as intermittent suite hangs from the nonisolated test
-    /// harness). Pinning the whole helper to the main actor makes every SCK
-    /// reply land on a serviced context. The fast denied-path short-circuit is
-    /// preserved: `getShareableContent` preflights TCC and throws before any
-    /// SCK call.
-    @MainActor
-    private static func captureImage(
-        target: String,
-        windowId: Int?,
-        bundleId: String?,
-        appName: String?,
-        region: (x: Int, y: Int, w: Int, h: Int)?,
-        displayIndex: Int? = nil
-    ) async throws -> CGImage {
-        let content = try await getShareableContent()
-
-        switch target {
-        case "window":
-            let candidates = content.windows.map { window in
-                WindowCandidate(
-                    windowId: Int(window.windowID),
-                    bundleId: window.owningApplication?.bundleIdentifier,
-                    appName: window.owningApplication?.applicationName)
-            }
-            let wid: Int
-            switch resolveWindowTarget(
-                windowId: windowId,
-                bundleId: bundleId,
-                appName: appName,
-                candidates: candidates
-            ) {
-            case .selected(let selected):
-                wid = selected
-            case .missingIdentity:
-                throw ScreenModuleError.missingParameter(
-                    "windowId, bundleId, or appName required for window target")
-            case .windowIdNotFound(let id):
-                throw ScreenModuleError.windowNotFound(id)
-            case .appNotFound(let query, let available):
-                throw ScreenModuleError.windowNotFoundForApp(query: query, available: available)
-            case .ambiguous(let query, let matches):
-                throw ScreenModuleError.ambiguousWindowsForApp(query: query, matches: matches)
-            }
-            guard let window = content.windows.first(where: { $0.windowID == CGWindowID(wid) }) else {
-                throw ScreenModuleError.windowNotFound(wid)
-            }
-            let filter = SCContentFilter(desktopIndependentWindow: window)
-            let config = SCStreamConfiguration()
-            config.width = Int(window.frame.width) * 2
-            config.height = Int(window.frame.height) * 2
-            config.scalesToFit = false
-            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-
-        case "region":
-            guard let r = region else {
-                throw ScreenModuleError.missingParameter("region {x,y,w,h} required for region target")
-            }
-            guard !content.displays.isEmpty else {
-                throw ScreenModuleError.noDisplays
-            }
-            let regionIdx = displayIndex ?? 0
-            guard regionIdx >= 0, regionIdx < content.displays.count else {
-                let available = content.displays.enumerated().map { "\($0.offset): \($0.element.width)x\($0.element.height)" }.joined(separator: ", ")
-                throw ScreenModuleError.missingParameter("displayIndex \(regionIdx) out of range. Available: [\(available)]")
-            }
-            let display = content.displays[regionIdx]
-            let filter = SCContentFilter(display: display, excludingWindows: [])
-            let config = SCStreamConfiguration()
-            config.sourceRect = CGRect(x: r.x, y: r.y, width: r.w, height: r.h)
-            config.width = r.w
-            config.height = r.h
-            config.scalesToFit = false
-            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-
-        case "all_displays":
-            guard content.displays.count > 1 else {
-                throw ScreenModuleError.missingParameter("all_displays requires 2+ displays; found \(content.displays.count)")
-            }
-            var images: [CGImage] = []
-            for disp in content.displays {
-                let f = SCContentFilter(display: disp, excludingWindows: [])
-                let c = SCStreamConfiguration()
-                c.width = disp.width * 2
-                c.height = disp.height * 2
-                c.scalesToFit = false
-                images.append(try await SCScreenshotManager.captureImage(contentFilter: f, configuration: c))
-            }
-            let totalWidth = images.reduce(0) { $0 + $1.width }
-            let maxHeight = images.map { $0.height }.max() ?? 0
-            guard let ctx = CGContext(
-                data: nil, width: totalWidth, height: maxHeight,
-                bitsPerComponent: 8, bytesPerRow: 0,
-                space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
-            ) else {
-                throw ScreenModuleError.captureFailed("Failed to create composite CGContext (\(totalWidth)x\(maxHeight))")
-            }
-            var xOffset = 0
-            for img in images {
-                ctx.draw(img, in: CGRect(x: xOffset, y: maxHeight - img.height, width: img.width, height: img.height))
-                xOffset += img.width
-            }
-            guard let composite = ctx.makeImage() else {
-                throw ScreenModuleError.captureFailed("Failed to finalize composite image")
-            }
-            return composite
-
-        default: // "display"
-            guard !content.displays.isEmpty else {
-                throw ScreenModuleError.noDisplays
-            }
-            let dispIdx = displayIndex ?? 0
-            guard dispIdx >= 0, dispIdx < content.displays.count else {
-                let available = content.displays.enumerated().map { "\($0.offset): \($0.element.width)x\($0.element.height)" }.joined(separator: ", ")
-                throw ScreenModuleError.missingParameter("displayIndex \(dispIdx) out of range. Available: [\(available)]")
-            }
-            let display = content.displays[dispIdx]
-            let filter = SCContentFilter(display: display, excludingWindows: [])
-            let config = SCStreamConfiguration()
-            config.width = display.width * 2
-            config.height = display.height * 2
-            config.scalesToFit = false
-            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-        }
-    }
-
-    /// Encode a CGImage to disk as PNG or JPEG using ImageIO (Sendable-safe, no AppKit).
-    private static func writeImage(_ cgImage: CGImage, format: String, to path: String) throws {
-        let url = URL(fileURLWithPath: path) as CFURL
-        let utType: CFString = format == "jpg"
-            ? UTType.jpeg.identifier as CFString
-            : UTType.png.identifier as CFString
-
-        guard let destination = CGImageDestinationCreateWithURL(url, utType, 1, nil) else {
-            throw ScreenModuleError.encodingFailed(format)
-        }
-
-        let options: [CFString: Any] = format == "jpg"
-            ? [kCGImageDestinationLossyCompressionQuality: 0.8]
-            : [:]
-        CGImageDestinationAddImage(destination, cgImage, options as CFDictionary)
-
-        guard CGImageDestinationFinalize(destination) else {
-            throw ScreenModuleError.encodingFailed(format)
-        }
     }
 
     // MARK: - Registration
 
-    /// Register all ScreenModule tools on the given router.
-    public static func register(on router: ToolRouter) async {
+    /// Register all ScreenModule tools with explicit runtime dependencies.
+    package static func register(on router: ToolRouter, runtime: ScreenModuleRuntime) async {
 
         // MARK: 1. screen_capture – Open (read-only)
         await router.register(ToolRegistration(
@@ -416,13 +182,13 @@ public enum ScreenModule {
                     if case .string(let value) = args["appName"] { return value }
                     return nil
                 }()
-                let region: (x: Int, y: Int, w: Int, h: Int)? = {
-                    if case .object(let r) = args["region"],
-                       case .int(let x) = r["x"],
-                       case .int(let y) = r["y"],
-                       case .int(let w) = r["w"],
-                       case .int(let h) = r["h"] {
-                        return (x: x, y: y, w: w, h: h)
+                let region: ScreenCaptureRegion? = {
+                    if case .object(let value) = args["region"],
+                       case .int(let x) = value["x"],
+                       case .int(let y) = value["y"],
+                       case .int(let width) = value["w"],
+                       case .int(let height) = value["h"] {
+                        return ScreenCaptureRegion(x: x, y: y, width: width, height: height)
                     }
                     return nil
                 }()
@@ -440,78 +206,70 @@ public enum ScreenModule {
                 }()
 
                 // FB-AUTOMATION: frontmost-app guard (opt-in). Short-circuit
-                // before any capture work if the required app is not in front.
-                if let guardFailure = await frontmostGuardFailure(required: requireFrontmost) {
-                    return guardFailure
-                }
-
-                // Cleanup old capture files (best-effort, never blocks)
-                cleanupCaptureFiles()
-
-                // Capture
-                let cgImage: CGImage
-                do {
-                    cgImage = try await captureImage(
-                        target: target,
-                        windowId: windowId,
-                        bundleId: bundleId,
-                        appName: appName,
-                        region: region,
-                        displayIndex: displayIndex)
-                } catch let error as ScreenModuleError {
-                    return error.toResponse()
-                } catch {
-                    return ScreenModuleError.captureFailed("Screen capture failed: \(error.localizedDescription)").toResponse()
-                }
-
-                // Encode to file
-                let ext = format == "jpg" ? "jpg" : "png"
-                let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-                let resolved = ConfigManager.shared.resolvedScreenOutputDir()
-                let filePath = "\(resolved.path)/nb-screen-\(timestamp).\(ext)"
-
-                do {
-                    try writeImage(cgImage, format: format, to: filePath)
-                } catch let error as ScreenModuleError {
-                    // PKT-373 P2-2: Clean up partial file on failure
-                    try? FileManager.default.removeItem(atPath: filePath)
-                    return error.toResponse()
-                } catch {
-                    // PKT-373 P2-2: Clean up partial file on failure
-                    try? FileManager.default.removeItem(atPath: filePath)
-                    return ScreenModuleError.captureFailed("Failed to write image to \(filePath): \(error.localizedDescription)").toResponse()
-                }
-
-                let fileSize = (try? FileManager.default.attributesOfItem(atPath: filePath)[.size] as? Int) ?? 0
-
-                // Fetch display info for response metadata. Route through the
-                // main-actor SCK boundary — an off-main call leaks its
-                // continuation and hangs. `try?` keeps metadata best-effort.
-                let displayInfoArray: [Value]
-                if let content = try? await SCKBoundary.fetchShareableContent() {
-                    displayInfoArray = content.displays.enumerated().map { idx, d in
-                        .object([
-                            "index": .int(idx),
-                            "width": .int(d.width),
-                            "height": .int(d.height),
-                            "isMain": .bool(idx == 0)
-                        ])
+                // before cleanup or capture if the required app is not in front.
+                if let required = requireFrontmost, !required.isEmpty {
+                    let actual = await runtime.frontmostBundleId()
+                    if let guardFailure = frontmostGuardFailure(required: required, actual: actual) {
+                        return guardFailure
                     }
-                } else {
-                    displayInfoArray = []
+                }
+
+                runtime.cleanupCaptureFiles()
+
+                let request = ScreenCaptureRequest(
+                    target: target,
+                    windowId: windowId,
+                    bundleId: bundleId,
+                    appName: appName,
+                    region: region,
+                    displayIndex: displayIndex
+                )
+
+                let image: CGImage
+                do {
+                    image = try await runtime.captureImage(request)
+                } catch let error as ScreenModuleError {
+                    return error.toResponse()
+                } catch {
+                    return ScreenModuleError.captureFailed(
+                        "Screen capture failed: \(error.localizedDescription)"
+                    ).toResponse()
+                }
+
+                let artifact: ScreenCaptureArtifact
+                do {
+                    artifact = try runtime.persistCaptureArtifact(image, format)
+                } catch let error as ScreenModuleError {
+                    return error.toResponse()
+                } catch {
+                    return ScreenModuleError.captureFailed(
+                        "Failed to persist capture artifact: \(error.localizedDescription)"
+                    ).toResponse()
+                }
+
+                let displayInfo = await runtime.displayMetadata()
+                let displayInfoArray: [Value] = displayInfo.map { display in
+                    .object([
+                        "index": .int(display.index),
+                        "width": .int(display.width),
+                        "height": .int(display.height),
+                        "isMain": .bool(display.isMain)
+                    ])
                 }
 
                 var response: [String: Value] = [
-                    "filePath": .string(filePath),
-                    "width": .int(cgImage.width),
-                    "height": .int(cgImage.height),
-                    "bytes": .int(fileSize),
-                    "format": .string(format),
+                    "filePath": .string(artifact.filePath),
+                    "width": .int(artifact.width),
+                    "height": .int(artifact.height),
+                    "bytes": .int(artifact.bytes),
+                    "format": .string(artifact.format),
                     "displayCount": .int(displayInfoArray.count),
                     "displays": .array(displayInfoArray)
                 ]
-                if resolved.isFallback {
-                    response["warning"] = .string("Configured output directory is invalid or not writable — fell back to /tmp")
+                if artifact.isFallback {
+                    response["warning"] = .string(
+                        "Configured output directory is invalid or not writable — fell back to /tmp"
+                    )
                 }
                 return .object(response)
             }
@@ -586,13 +344,13 @@ public enum ScreenModule {
                     if case .string(let value) = args["appName"] { return value }
                     return nil
                 }()
-                let region: (x: Int, y: Int, w: Int, h: Int)? = {
-                    if case .object(let r) = args["region"],
-                       case .int(let x) = r["x"],
-                       case .int(let y) = r["y"],
-                       case .int(let w) = r["w"],
-                       case .int(let h) = r["h"] {
-                        return (x: x, y: y, w: w, h: h)
+                let region: ScreenCaptureRegion? = {
+                    if case .object(let value) = args["region"],
+                       case .int(let x) = value["x"],
+                       case .int(let y) = value["y"],
+                       case .int(let width) = value["w"],
+                       case .int(let height) = value["h"] {
+                        return ScreenCaptureRegion(x: x, y: y, width: width, height: height)
                     }
                     return nil
                 }()
@@ -605,76 +363,78 @@ public enum ScreenModule {
                     return nil
                 }()
 
-                // Capture screen
-                let cgImage: CGImage
+                let request = ScreenCaptureRequest(
+                    target: target,
+                    windowId: windowId,
+                    bundleId: bundleId,
+                    appName: appName,
+                    region: region,
+                    displayIndex: displayIndex
+                )
+
+                let image: CGImage
                 do {
-                    cgImage = try await captureImage(
-                        target: target,
-                        windowId: windowId,
-                        bundleId: bundleId,
-                        appName: appName,
-                        region: region,
-                        displayIndex: displayIndex)
+                    image = try await runtime.captureImage(request)
                 } catch let error as ScreenModuleError {
                     return error.toResponse()
                 } catch {
-                    return ScreenModuleError.captureFailed("Screen capture failed: \(error.localizedDescription)").toResponse()
+                    return ScreenModuleError.captureFailed(
+                        "Screen capture failed: \(error.localizedDescription)"
+                    ).toResponse()
                 }
 
-                // Run Vision OCR
+                let observations: [ScreenOCRObservation]
                 do {
-                    let request = VNRecognizeTextRequest()
-                    request.recognitionLevel = .accurate
-                    request.recognitionLanguages = [language]
-                    request.usesLanguageCorrection = true
-
-                    let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-                    try handler.perform([request])
-
-                    guard let observations = request.results, !observations.isEmpty else {
-                        // Empty result is valid (blank screen, no visible text) — not an error
-                        return .object([
-                            "text": .string(""),
-                            "confidence": .double(0.0),
-                            "bounds": .array([])
-                        ])
-                    }
-
-                    var fullText = ""
-                    var totalConfidence: Float = 0
-                    var bounds: [Value] = []
-
-                    for observation in observations {
-                        guard let candidate = observation.topCandidates(1).first else { continue }
-                        fullText += candidate.string + "\n"
-                        totalConfidence += candidate.confidence
-
-                        let box = observation.boundingBox
-                        bounds.append(.object([
-                            "text": .string(candidate.string),
-                            "confidence": .double(Double(candidate.confidence)),
-                            "rect": .object([
-                                "x": .double(box.origin.x),
-                                "y": .double(box.origin.y),
-                                "width": .double(box.size.width),
-                                "height": .double(box.size.height)
-                            ])
-                        ]))
-                    }
-
-                    let avgConfidence = Double(totalConfidence) / Double(observations.count)
-
-                    return .object([
-                        "text": .string(fullText.trimmingCharacters(in: .whitespacesAndNewlines)),
-                        "confidence": .double((avgConfidence * 1000).rounded() / 1000),
-                        "bounds": .array(bounds)
-                    ])
+                    observations = try runtime.recognizeText(image, language)
                 } catch {
                     return .object([
                         "error": .string("ocr_failed"),
-                        "message": .string("Vision text recognition failed: \(error.localizedDescription)")
+                        "message": .string(
+                            "Vision text recognition failed: \(error.localizedDescription)"
+                        )
                     ])
                 }
+
+                guard !observations.isEmpty else {
+                    return .object([
+                        "text": .string(""),
+                        "confidence": .double(0.0),
+                        "bounds": .array([])
+                    ])
+                }
+
+                var fullText = ""
+                var totalConfidence: Float = 0
+                var bounds: [Value] = []
+
+                for observation in observations {
+                    guard let candidate = observation.candidate else { continue }
+                    fullText += candidate.text + "\n"
+                    totalConfidence += candidate.confidence
+
+                    let box = observation.boundingBox
+                    bounds.append(.object([
+                        "text": .string(candidate.text),
+                        "confidence": .double(Double(candidate.confidence)),
+                        "rect": .object([
+                            "x": .double(box.origin.x),
+                            "y": .double(box.origin.y),
+                            "width": .double(box.size.width),
+                            "height": .double(box.size.height)
+                        ])
+                    ]))
+                }
+
+                let averageConfidence = Double(totalConfidence) / Double(observations.count)
+                return .object([
+                    "text": .string(
+                        fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    ),
+                    "confidence": .double(
+                        (averageConfidence * 1000).rounded() / 1000
+                    ),
+                    "bounds": .array(bounds)
+                ])
             }
         ))
     }
@@ -683,7 +443,7 @@ public enum ScreenModule {
 // MARK: - Errors
 
 /// Structured error types for ScreenModule — all return JSON responses, never crash.
-private enum ScreenModuleError: Error {
+package enum ScreenModuleError: Error, Sendable, Equatable {
     case screenRecordingDenied
     case noDisplays
     case windowNotFound(Int)
@@ -753,5 +513,443 @@ private enum ScreenModuleError: Error {
         return candidates.map { candidate in
             "\(candidate.windowId):\(candidate.appName ?? "unknown") [\(candidate.bundleId ?? "unknown")]"
         }.joined(separator: ", ")
+    }
+}
+
+// MARK: - Screen Runtime Dependencies
+
+package struct ScreenCaptureRegion: Sendable, Equatable {
+    package let x: Int
+    package let y: Int
+    package let width: Int
+    package let height: Int
+
+    package init(x: Int, y: Int, width: Int, height: Int) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+package struct ScreenCaptureRequest: Sendable, Equatable {
+    package let target: String
+    package let windowId: Int?
+    package let bundleId: String?
+    package let appName: String?
+    package let region: ScreenCaptureRegion?
+    package let displayIndex: Int?
+
+    package init(
+        target: String,
+        windowId: Int?,
+        bundleId: String?,
+        appName: String?,
+        region: ScreenCaptureRegion?,
+        displayIndex: Int?
+    ) {
+        self.target = target
+        self.windowId = windowId
+        self.bundleId = bundleId
+        self.appName = appName
+        self.region = region
+        self.displayIndex = displayIndex
+    }
+}
+
+package struct ScreenCaptureArtifact: Sendable, Equatable {
+    package let filePath: String
+    package let width: Int
+    package let height: Int
+    package let bytes: Int
+    package let format: String
+    package let isFallback: Bool
+
+    package init(
+        filePath: String,
+        width: Int,
+        height: Int,
+        bytes: Int,
+        format: String,
+        isFallback: Bool
+    ) {
+        self.filePath = filePath
+        self.width = width
+        self.height = height
+        self.bytes = bytes
+        self.format = format
+        self.isFallback = isFallback
+    }
+}
+
+package struct ScreenDisplayInfo: Sendable, Equatable {
+    package let index: Int
+    package let width: Int
+    package let height: Int
+    package let isMain: Bool
+
+    package init(index: Int, width: Int, height: Int, isMain: Bool) {
+        self.index = index
+        self.width = width
+        self.height = height
+        self.isMain = isMain
+    }
+}
+
+package struct ScreenOCRCandidate: Sendable, Equatable {
+    package let text: String
+    package let confidence: Float
+
+    package init(text: String, confidence: Float) {
+        self.text = text
+        self.confidence = confidence
+    }
+}
+
+package struct ScreenOCRObservation: Sendable, Equatable {
+    package let candidate: ScreenOCRCandidate?
+    package let boundingBox: CGRect
+
+    package init(candidate: ScreenOCRCandidate?, boundingBox: CGRect) {
+        self.candidate = candidate
+        self.boundingBox = boundingBox
+    }
+}
+
+/// Explicit runtime dependencies for Screen handlers.
+///
+/// Production composition supplies the internal `.live` value. Tests must
+/// supply every dependency explicitly; there is no default-live registration
+/// path and no mutable global override.
+package struct ScreenModuleRuntime: Sendable {
+    package let frontmostBundleId: @MainActor @Sendable () -> String?
+    package let cleanupCaptureFiles: @Sendable () -> Void
+    package let captureImage: @MainActor @Sendable (ScreenCaptureRequest) async throws -> CGImage
+    package let persistCaptureArtifact: @Sendable (CGImage, String) throws -> ScreenCaptureArtifact
+    package let displayMetadata: @MainActor @Sendable () async -> [ScreenDisplayInfo]
+    package let recognizeText: @Sendable (CGImage, String) throws -> [ScreenOCRObservation]
+
+    package init(
+        frontmostBundleId: @escaping @MainActor @Sendable () -> String?,
+        cleanupCaptureFiles: @escaping @Sendable () -> Void,
+        captureImage: @escaping @MainActor @Sendable (ScreenCaptureRequest) async throws -> CGImage,
+        persistCaptureArtifact: @escaping @Sendable (CGImage, String) throws -> ScreenCaptureArtifact,
+        displayMetadata: @escaping @MainActor @Sendable () async -> [ScreenDisplayInfo],
+        recognizeText: @escaping @Sendable (CGImage, String) throws -> [ScreenOCRObservation]
+    ) {
+        self.frontmostBundleId = frontmostBundleId
+        self.cleanupCaptureFiles = cleanupCaptureFiles
+        self.captureImage = captureImage
+        self.persistCaptureArtifact = persistCaptureArtifact
+        self.displayMetadata = displayMetadata
+        self.recognizeText = recognizeText
+    }
+}
+
+extension ScreenModuleRuntime {
+    /// Production-only composition. `internal` intentionally keeps the live
+    /// framework implementation inaccessible to the separate test target.
+    internal static let live = ScreenModuleRuntime(
+        frontmostBundleId: { ScreenModuleLive.frontmostBundleId() },
+        cleanupCaptureFiles: { ScreenModuleLive.cleanupCaptureFiles() },
+        captureImage: { request in try await ScreenModuleLive.captureImage(request) },
+        persistCaptureArtifact: { image, format in
+            try ScreenModuleLive.persistCaptureArtifact(image, format: format)
+        },
+        displayMetadata: { await ScreenModuleLive.displayMetadata() },
+        recognizeText: { image, language in
+            try ScreenModuleLive.recognizeText(image, language: language)
+        }
+    )
+}
+
+/// Live macOS implementation. Handler registration and response assembly do
+/// not call these frameworks or side effects directly.
+private enum ScreenModuleLive {
+    @MainActor
+    static func frontmostBundleId() -> String? {
+        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    static func cleanupCaptureFiles() {
+        let resolved = ConfigManager.shared.resolvedScreenOutputDir()
+        let directory = resolved.path
+        let prefix = "nb-screen-"
+        let oneHourAgo = Date().addingTimeInterval(-3600)
+        let fileManager = FileManager.default
+
+        do {
+            let captureFiles = try fileManager.contentsOfDirectory(atPath: directory)
+                .filter { $0.hasPrefix(prefix) }
+
+            for name in captureFiles {
+                let path = "\(directory)/\(name)"
+                if let attributes = try? fileManager.attributesOfItem(atPath: path),
+                   let modified = attributes[.modificationDate] as? Date,
+                   modified < oneHourAgo {
+                    try? fileManager.removeItem(atPath: path)
+                }
+            }
+
+            let remaining = try fileManager.contentsOfDirectory(atPath: directory)
+                .filter { $0.hasPrefix(prefix) }
+                .compactMap { name -> (path: String, date: Date)? in
+                    let path = "\(directory)/\(name)"
+                    guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+                          let modified = attributes[.modificationDate] as? Date else {
+                        return nil
+                    }
+                    return (path, modified)
+                }
+                .sorted { $0.date < $1.date }
+
+            if remaining.count > 20 {
+                for file in remaining.prefix(remaining.count - 20) {
+                    try? fileManager.removeItem(atPath: file.path)
+                }
+            }
+        } catch {
+            // Best-effort cleanup must never block capture.
+        }
+    }
+
+    private static func getShareableContent() async throws -> SCShareableContent {
+        guard CGPreflightScreenCaptureAccess() else {
+            throw ScreenModuleError.screenRecordingDenied
+        }
+        return try await SCKBoundary.fetchShareableContent()
+    }
+
+    @MainActor
+    static func captureImage(_ request: ScreenCaptureRequest) async throws -> CGImage {
+        let content = try await getShareableContent()
+
+        switch request.target {
+        case "window":
+            let candidates = content.windows.map { window in
+                ScreenModule.WindowCandidate(
+                    windowId: Int(window.windowID),
+                    bundleId: window.owningApplication?.bundleIdentifier,
+                    appName: window.owningApplication?.applicationName
+                )
+            }
+            let windowId: Int
+            switch ScreenModule.resolveWindowTarget(
+                windowId: request.windowId,
+                bundleId: request.bundleId,
+                appName: request.appName,
+                candidates: candidates
+            ) {
+            case .selected(let selected):
+                windowId = selected
+            case .missingIdentity:
+                throw ScreenModuleError.missingParameter(
+                    "windowId, bundleId, or appName required for window target"
+                )
+            case .windowIdNotFound(let id):
+                throw ScreenModuleError.windowNotFound(id)
+            case .appNotFound(let query, let available):
+                throw ScreenModuleError.windowNotFoundForApp(query: query, available: available)
+            case .ambiguous(let query, let matches):
+                throw ScreenModuleError.ambiguousWindowsForApp(query: query, matches: matches)
+            }
+            guard let window = content.windows.first(where: { $0.windowID == CGWindowID(windowId) }) else {
+                throw ScreenModuleError.windowNotFound(windowId)
+            }
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+            let config = SCStreamConfiguration()
+            config.width = Int(window.frame.width) * 2
+            config.height = Int(window.frame.height) * 2
+            config.scalesToFit = false
+            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+
+        case "region":
+            guard let region = request.region else {
+                throw ScreenModuleError.missingParameter("region {x,y,w,h} required for region target")
+            }
+            guard !content.displays.isEmpty else {
+                throw ScreenModuleError.noDisplays
+            }
+            let index = request.displayIndex ?? 0
+            guard index >= 0, index < content.displays.count else {
+                let available = content.displays.enumerated()
+                    .map { "\($0.offset): \($0.element.width)x\($0.element.height)" }
+                    .joined(separator: ", ")
+                throw ScreenModuleError.missingParameter(
+                    "displayIndex \(index) out of range. Available: [\(available)]"
+                )
+            }
+            let display = content.displays[index]
+            let filter = SCContentFilter(display: display, excludingWindows: [])
+            let config = SCStreamConfiguration()
+            config.sourceRect = CGRect(
+                x: region.x,
+                y: region.y,
+                width: region.width,
+                height: region.height
+            )
+            config.width = region.width
+            config.height = region.height
+            config.scalesToFit = false
+            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+
+        case "all_displays":
+            guard content.displays.count > 1 else {
+                throw ScreenModuleError.missingParameter(
+                    "all_displays requires 2+ displays; found \(content.displays.count)"
+                )
+            }
+            var images: [CGImage] = []
+            for display in content.displays {
+                let filter = SCContentFilter(display: display, excludingWindows: [])
+                let config = SCStreamConfiguration()
+                config.width = display.width * 2
+                config.height = display.height * 2
+                config.scalesToFit = false
+                images.append(
+                    try await SCScreenshotManager.captureImage(
+                        contentFilter: filter,
+                        configuration: config
+                    )
+                )
+            }
+            let totalWidth = images.reduce(0) { $0 + $1.width }
+            let maxHeight = images.map(\.height).max() ?? 0
+            guard let context = CGContext(
+                data: nil,
+                width: totalWidth,
+                height: maxHeight,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+            ) else {
+                throw ScreenModuleError.captureFailed(
+                    "Failed to create composite CGContext (\(totalWidth)x\(maxHeight))"
+                )
+            }
+            var xOffset = 0
+            for image in images {
+                context.draw(
+                    image,
+                    in: CGRect(
+                        x: xOffset,
+                        y: maxHeight - image.height,
+                        width: image.width,
+                        height: image.height
+                    )
+                )
+                xOffset += image.width
+            }
+            guard let composite = context.makeImage() else {
+                throw ScreenModuleError.captureFailed("Failed to finalize composite image")
+            }
+            return composite
+
+        default:
+            guard !content.displays.isEmpty else {
+                throw ScreenModuleError.noDisplays
+            }
+            let index = request.displayIndex ?? 0
+            guard index >= 0, index < content.displays.count else {
+                let available = content.displays.enumerated()
+                    .map { "\($0.offset): \($0.element.width)x\($0.element.height)" }
+                    .joined(separator: ", ")
+                throw ScreenModuleError.missingParameter(
+                    "displayIndex \(index) out of range. Available: [\(available)]"
+                )
+            }
+            let display = content.displays[index]
+            let filter = SCContentFilter(display: display, excludingWindows: [])
+            let config = SCStreamConfiguration()
+            config.width = display.width * 2
+            config.height = display.height * 2
+            config.scalesToFit = false
+            return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+        }
+    }
+
+    static func persistCaptureArtifact(_ image: CGImage, format: String) throws -> ScreenCaptureArtifact {
+        let fileExtension = format == "jpg" ? "jpg" : "png"
+        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let resolved = ConfigManager.shared.resolvedScreenOutputDir()
+        let filePath = "\(resolved.path)/nb-screen-\(timestamp).\(fileExtension)"
+
+        do {
+            try writeImage(image, format: format, to: filePath)
+        } catch let error as ScreenModuleError {
+            try? FileManager.default.removeItem(atPath: filePath)
+            throw error
+        } catch {
+            try? FileManager.default.removeItem(atPath: filePath)
+            throw ScreenModuleError.captureFailed(
+                "Failed to write image to \(filePath): \(error.localizedDescription)"
+            )
+        }
+
+        let fileSize = (try? FileManager.default.attributesOfItem(atPath: filePath)[.size] as? Int) ?? 0
+        return ScreenCaptureArtifact(
+            filePath: filePath,
+            width: image.width,
+            height: image.height,
+            bytes: fileSize,
+            format: format,
+            isFallback: resolved.isFallback
+        )
+    }
+
+    @MainActor
+    static func displayMetadata() async -> [ScreenDisplayInfo] {
+        guard let content = try? await SCKBoundary.fetchShareableContent() else {
+            return []
+        }
+        return content.displays.enumerated().map { index, display in
+            ScreenDisplayInfo(
+                index: index,
+                width: display.width,
+                height: display.height,
+                isMain: index == 0
+            )
+        }
+    }
+
+    static func recognizeText(_ image: CGImage, language: String) throws -> [ScreenOCRObservation] {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.recognitionLanguages = [language]
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try handler.perform([request])
+
+        return (request.results ?? []).map { observation in
+            let candidate = observation.topCandidates(1).first.map {
+                ScreenOCRCandidate(text: $0.string, confidence: $0.confidence)
+            }
+            return ScreenOCRObservation(
+                candidate: candidate,
+                boundingBox: observation.boundingBox
+            )
+        }
+    }
+
+    private static func writeImage(_ image: CGImage, format: String, to path: String) throws {
+        let url = URL(fileURLWithPath: path) as CFURL
+        let utType: CFString = format == "jpg"
+            ? UTType.jpeg.identifier as CFString
+            : UTType.png.identifier as CFString
+
+        guard let destination = CGImageDestinationCreateWithURL(url, utType, 1, nil) else {
+            throw ScreenModuleError.encodingFailed(format)
+        }
+
+        let options: [CFString: Any] = format == "jpg"
+            ? [kCGImageDestinationLossyCompressionQuality: 0.8]
+            : [:]
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw ScreenModuleError.encodingFailed(format)
+        }
     }
 }

--- a/TheBridge/Server/BridgeModuleRegistry.swift
+++ b/TheBridge/Server/BridgeModuleRegistry.swift
@@ -49,7 +49,7 @@ public enum BridgeModuleRegistry {
         await CalendarModule.register(on: router)
         await CalendarRegistryModule.register(on: router) // env-filtered calendar_registry_pair (ListTools gated)
         await NotionModule.register(on: router)
-        await ScreenModule.register(on: router)
+        await ScreenModule.register(on: router, runtime: .live)
         await ScreenModule.registerRecording(on: router)
         await AccessibilityModule.register(on: router)
         await AppleScriptModule.register(on: router)

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -351,7 +351,7 @@ public enum ToolAnnotationCatalog {
         "reminders_lists": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "reminders_update": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "run_script": .init(readOnlyHint: false, destructiveHint: true, idempotentHint: false, requiresConfirmation: true, openWorld: true),
-        "screen_capture": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
+        "screen_capture": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "screen_ocr": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "screen_record_start": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),
         "screen_record_stop": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: true),

--- a/TheBridgeTests/BridgeAutomationModuleTests.swift
+++ b/TheBridgeTests/BridgeAutomationModuleTests.swift
@@ -77,7 +77,13 @@ func runBridgeAutomationModuleTests() async {
         } else {
             throw TestError.assertion("missing focused bool")
         }
-        try expect(dict["note"] != nil, "headless focus should surface a note")
+        if case .bool(let activated) = dict["activated"] {
+            try expect(activated == false, "headless test should report activated=false")
+        } else {
+            throw TestError.assertion("missing activated bool")
+        }
+        try expect(dict["note"] == .string("No app window host present to activate (headless/test context)."),
+                   "headless focus should surface the exact no-host note")
     }
 
     // MARK: - Section resolution

--- a/TheBridgeTests/BridgeAutomationModuleTests.swift
+++ b/TheBridgeTests/BridgeAutomationModuleTests.swift
@@ -22,7 +22,7 @@ func runBridgeAutomationModuleTests() async {
     let gate = SecurityGate(approvalProvider: TestSecurityApprovalProvider())
     let log  = AuditLog()
     let router = ToolRouter(securityGate: gate, auditLog: log)
-    await BridgeAutomationModule.register(on: router)
+    await BridgeAutomationModule.register(on: router, applicationProvider: { nil })
     await MouseClickModule.register(on: router)
 
     // MARK: - Registration + tiers
@@ -63,6 +63,13 @@ func runBridgeAutomationModuleTests() async {
         try expect(t.tier == .open, "expected .open, got \(t.tier.rawValue)")
     }
 
+    await test("bridge_focus_settings documents operational success semantics") {
+        let tools = await router.registrations(forModule: "automation")
+        let tool = tools.first { $0.name == "bridge_focus_settings" }!
+        try expect(tool.description.contains("success=true means a Settings window was found and raised"),
+                   "focus tool must define success as an achieved focus operation")
+    }
+
     await test("bridge_focus_settings returns focus outcome (headless: focused=false + note)") {
         let result = try await router.dispatch(
             toolName: "bridge_focus_settings",
@@ -71,7 +78,7 @@ func runBridgeAutomationModuleTests() async {
         guard case .object(let dict) = result else {
             throw TestError.assertion("expected object response")
         }
-        try expect(dict["success"] != nil, "missing success")
+        try expect(dict["success"] == .bool(false), "headless focus must report success=false")
         if case .bool(let focused) = dict["focused"] {
             try expect(focused == false, "headless test should report focused=false")
         } else {

--- a/TheBridgeTests/ScreenLiveProbeTests.swift
+++ b/TheBridgeTests/ScreenLiveProbeTests.swift
@@ -1,0 +1,58 @@
+// ScreenLiveProbeTests.swift — opt-in live Screen adapter verification
+// TheBridge · Tests
+//
+// Excluded from the canonical floor unless BRIDGE_SCREEN_LIVE_PROBE=1.
+// The process-level deadline lives in scripts/screen-live-probe.sh so a
+// synchronous Vision or framework stall cannot wedge verification forever.
+
+import Foundation
+import MCP
+import TheBridgeLib
+
+func runScreenLiveProbe() async {
+    print("\n📸 Screen live adapter probe")
+
+    await test("live screen_ocr returns a normal response on a granted host") {
+        guard ProcessInfo.processInfo.environment["BRIDGE_SCREEN_LIVE_PROBE"] == "1" else {
+            throw TestError.assertion("live Screen probe requires BRIDGE_SCREEN_LIVE_PROBE=1")
+        }
+
+        let gate = SecurityGate(approvalProvider: TestSecurityApprovalProvider())
+        let router = ToolRouter(securityGate: gate, auditLog: AuditLog())
+        let registered = await ScreenModule.registerLiveProbe(on: router)
+        try expect(registered, "live Screen runtime refused explicit probe registration")
+
+        let result = try await router.dispatch(
+            toolName: "screen_ocr",
+            arguments: .object(["target": .string("display"), "displayIndex": .int(0)])
+        )
+
+        guard case .object(let response) = result else {
+            throw TestError.assertion("live screen_ocr returned a non-object response: \(result)")
+        }
+        try expect(response["error"] == nil, "live screen_ocr returned an error envelope: \(result)")
+        guard case .string(let text)? = response["text"] else {
+            throw TestError.assertion("live screen_ocr response missing string text: \(result)")
+        }
+        guard case .double(let confidence)? = response["confidence"] else {
+            throw TestError.assertion("live screen_ocr response missing double confidence: \(result)")
+        }
+        guard case .array(let bounds)? = response["bounds"] else {
+            throw TestError.assertion("live screen_ocr response missing bounds array: \(result)")
+        }
+
+        let receipt: [String: Any] = [
+            "status": "passed",
+            "probe": "screen_ocr_live_granted",
+            "textLength": text.count,
+            "confidence": confidence,
+            "boundsCount": bounds.count,
+            "pid": ProcessInfo.processInfo.processIdentifier
+        ]
+        let data = try JSONSerialization.data(withJSONObject: receipt, options: [.sortedKeys])
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw TestError.assertion("failed to encode live probe receipt")
+        }
+        print("SCREEN_LIVE_PROBE_RECEIPT=\(json)")
+    }
+}

--- a/TheBridgeTests/ScreenModuleTests.swift
+++ b/TheBridgeTests/ScreenModuleTests.swift
@@ -12,12 +12,15 @@ import TheBridgeLib
 
 private enum ScreenFixtureError: Error, LocalizedError, Sendable {
     case unexpectedCall(String)
+    case persistenceFailure
     case ocrFailure
 
     var errorDescription: String? {
         switch self {
         case .unexpectedCall(let name):
             return "Unexpected Screen runtime call: \(name)"
+        case .persistenceFailure:
+            return "fixture persistence failure"
         case .ocrFailure:
             return "fixture OCR failure"
         }
@@ -32,7 +35,9 @@ private final class ScreenRuntimeSpy: @unchecked Sendable {
         let persistCalls: Int
         let metadataCalls: Int
         let ocrCalls: Int
+        let callOrder: [String]
         let lastCaptureRequest: ScreenCaptureRequest?
+        let lastPersistFormat: String?
         let lastOCRLanguage: String?
     }
 
@@ -43,7 +48,9 @@ private final class ScreenRuntimeSpy: @unchecked Sendable {
     private var persistCalls = 0
     private var metadataCalls = 0
     private var ocrCalls = 0
+    private var callOrder: [String] = []
     private var lastCaptureRequest: ScreenCaptureRequest?
+    private var lastPersistFormat: String?
     private var lastOCRLanguage: String?
 
     let frontmostValue: String?
@@ -77,30 +84,45 @@ private final class ScreenRuntimeSpy: @unchecked Sendable {
     func runtime() -> ScreenModuleRuntime {
         ScreenModuleRuntime(
             frontmostBundleId: { [self] in
-                lock.withLock { frontmostCalls += 1 }
+                lock.withLock {
+                    frontmostCalls += 1
+                    callOrder.append("frontmost")
+                }
                 return frontmostValue
             },
             cleanupCaptureFiles: { [self] in
-                lock.withLock { cleanupCalls += 1 }
+                lock.withLock {
+                    cleanupCalls += 1
+                    callOrder.append("cleanup")
+                }
             },
             captureImage: { [self] request in
                 lock.withLock {
                     captureCalls += 1
+                    callOrder.append("capture")
                     lastCaptureRequest = request
                 }
                 return try await capture(request)
             },
             persistCaptureArtifact: { [self] image, format in
-                lock.withLock { persistCalls += 1 }
+                lock.withLock {
+                    persistCalls += 1
+                    callOrder.append("persist")
+                    lastPersistFormat = format
+                }
                 return try persist(image, format)
             },
             displayMetadata: { [self] in
-                lock.withLock { metadataCalls += 1 }
+                lock.withLock {
+                    metadataCalls += 1
+                    callOrder.append("metadata")
+                }
                 return await metadata()
             },
             recognizeText: { [self] image, language in
                 lock.withLock {
                     ocrCalls += 1
+                    callOrder.append("ocr")
                     lastOCRLanguage = language
                 }
                 return try ocr(image, language)
@@ -117,7 +139,9 @@ private final class ScreenRuntimeSpy: @unchecked Sendable {
                 persistCalls: persistCalls,
                 metadataCalls: metadataCalls,
                 ocrCalls: ocrCalls,
+                callOrder: callOrder,
                 lastCaptureRequest: lastCaptureRequest,
+                lastPersistFormat: lastPersistFormat,
                 lastOCRLanguage: lastOCRLanguage
             )
         }
@@ -378,6 +402,93 @@ func runScreenModuleTests() async {
         ))
     }
 
+    await test("screen_capture success assembles exact artifact and display response in order") {
+        let image = try makeScreenTestImage()
+        let artifact = ScreenCaptureArtifact(
+            filePath: "/tmp/fixture-screen.jpg",
+            width: 640,
+            height: 480,
+            bytes: 12345,
+            format: "jpg",
+            isFallback: false
+        )
+        let displays = [
+            ScreenDisplayInfo(index: 0, width: 1728, height: 1117, isMain: true),
+            ScreenDisplayInfo(index: 1, width: 1920, height: 1080, isMain: false)
+        ]
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            persist: { _, _ in artifact },
+            metadata: { displays }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(
+            toolName: "screen_capture",
+            arguments: .object(["format": .string("jpg")])
+        )
+        let expected: Value = .object([
+            "filePath": .string("/tmp/fixture-screen.jpg"),
+            "width": .int(640),
+            "height": .int(480),
+            "bytes": .int(12345),
+            "format": .string("jpg"),
+            "displayCount": .int(2),
+            "displays": .array([
+                .object(["index": .int(0), "width": .int(1728), "height": .int(1117), "isMain": .bool(true)]),
+                .object(["index": .int(1), "width": .int(1920), "height": .int(1080), "isMain": .bool(false)])
+            ])
+        ])
+        try expect(result == expected, "unexpected successful capture response: \(result)")
+
+        let calls = spy.snapshot()
+        try expect(calls.callOrder == ["cleanup", "capture", "persist", "metadata"], "unexpected call order: \(calls.callOrder)")
+        try expect(calls.lastPersistFormat == "jpg")
+    }
+
+    await test("screen_capture fallback artifact emits exact warning") {
+        let image = try makeScreenTestImage()
+        let artifact = ScreenCaptureArtifact(
+            filePath: "/tmp/nb-screen-fixture.png",
+            width: 1,
+            height: 1,
+            bytes: 4,
+            format: "png",
+            isFallback: true
+        )
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            persist: { _, _ in artifact },
+            metadata: { [] }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_capture", arguments: .object([:]))
+        guard case .object(let response) = result else {
+            throw TestError.assertion("expected object response")
+        }
+        try expect(response["warning"] == .string("Configured output directory is invalid or not writable — fell back to /tmp"))
+        try expect(response["displayCount"] == .int(0))
+        try expect(spy.snapshot().callOrder == ["cleanup", "capture", "persist", "metadata"])
+    }
+
+    await test("screen_capture persistence failure skips display metadata") {
+        let image = try makeScreenTestImage()
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            persist: { _, _ in throw ScreenFixtureError.persistenceFailure }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_capture", arguments: .object([:]))
+        let expected: Value = .object([
+            "error": .string("capture_failed"),
+            "message": .string("Failed to persist capture artifact: fixture persistence failure")
+        ])
+        try expect(result == expected, "unexpected persistence failure response: \(result)")
+
+        let calls = spy.snapshot()
+        try expect(calls.callOrder == ["cleanup", "capture", "persist"])
+        try expect(calls.metadataCalls == 0)
+    }
+
     await test("screen_capture from detached task returns through fake capture without live SCK") {
         let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
         let testRouter = await makeScreenRouter(spy)
@@ -508,7 +619,7 @@ func runScreenModuleTests() async {
         try expect(!error.isEmpty)
     }
 
-    await test("Screen handler source is isolated from live framework and filesystem calls") {
+    await test("Screen registration has no known direct live-call tokens") {
         let repository = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -539,6 +650,26 @@ func runScreenModuleTests() async {
         try expect(!handlerSource.contains("public static func register(on router: ToolRouter) async"))
         try expect(liveSource.contains("internal static let live"))
         try expect(!liveSource.contains("package static let live"))
+        try expect(liveSource.contains("package static func registerLiveProbe"))
+
+        let testsDirectory = repository.appendingPathComponent("TheBridgeTests")
+        let probeURL = testsDirectory.appendingPathComponent("ScreenLiveProbeTests.swift")
+        let probeTests = try String(contentsOf: probeURL, encoding: .utf8)
+        let liveProbeCall = ["ScreenModule", ".registerLiveProbe(on:"].joined()
+        let canonicalSources = try FileManager.default.contentsOfDirectory(
+            at: testsDirectory,
+            includingPropertiesForKeys: nil
+        ).filter {
+            $0.pathExtension == "swift" && $0.lastPathComponent != probeURL.lastPathComponent
+        }
+        let offenders = try canonicalSources.compactMap { url -> String? in
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            return contents.contains(liveProbeCall) ? url.lastPathComponent : nil
+        }
+        try expect(offenders.isEmpty,
+                   "canonical tests must not invoke the live probe bridge: \(offenders)")
+        try expect(probeTests.contains(liveProbeCall),
+                   "dedicated live probe must be the only test route into live Screen dependencies")
     }
 
     await test("ScreenModule.moduleName is 'screen'") {

--- a/TheBridgeTests/ScreenModuleTests.swift
+++ b/TheBridgeTests/ScreenModuleTests.swift
@@ -1,29 +1,168 @@
-// ScreenModuleTests.swift – V1-TESTCOVERAGE
+// ScreenModuleTests.swift — deterministic Screen handler contracts
 // TheBridge · Tests
 //
-// Tests for ScreenModule (4 tools: screen_capture, screen_ocr,
-// screen_record_start, screen_record_stop).
-// Note: Screen tools require Screen Recording TCC grant. Tests focus on
-// registration, tier classification, and graceful error handling.
+// Canonical tests use explicit package-scoped runtime dependencies. They never
+// touch live TCC, ScreenCaptureKit, Vision, AppKit, capture directories, or
+// image persistence. Live integration and performance verification are separate.
 
+import CoreGraphics
 import Foundation
 import MCP
 import TheBridgeLib
+
+private enum ScreenFixtureError: Error, LocalizedError, Sendable {
+    case unexpectedCall(String)
+    case ocrFailure
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedCall(let name):
+            return "Unexpected Screen runtime call: \(name)"
+        case .ocrFailure:
+            return "fixture OCR failure"
+        }
+    }
+}
+
+private final class ScreenRuntimeSpy: @unchecked Sendable {
+    struct Snapshot: Sendable {
+        let frontmostCalls: Int
+        let cleanupCalls: Int
+        let captureCalls: Int
+        let persistCalls: Int
+        let metadataCalls: Int
+        let ocrCalls: Int
+        let lastCaptureRequest: ScreenCaptureRequest?
+        let lastOCRLanguage: String?
+    }
+
+    private let lock = NSLock()
+    private var frontmostCalls = 0
+    private var cleanupCalls = 0
+    private var captureCalls = 0
+    private var persistCalls = 0
+    private var metadataCalls = 0
+    private var ocrCalls = 0
+    private var lastCaptureRequest: ScreenCaptureRequest?
+    private var lastOCRLanguage: String?
+
+    let frontmostValue: String?
+    let capture: @MainActor @Sendable (ScreenCaptureRequest) async throws -> CGImage
+    let persist: @Sendable (CGImage, String) throws -> ScreenCaptureArtifact
+    let metadata: @MainActor @Sendable () async -> [ScreenDisplayInfo]
+    let ocr: @Sendable (CGImage, String) throws -> [ScreenOCRObservation]
+
+    init(
+        frontmostValue: String? = nil,
+        capture: @escaping @MainActor @Sendable (ScreenCaptureRequest) async throws -> CGImage = { _ in
+            throw ScreenFixtureError.unexpectedCall("captureImage")
+        },
+        persist: @escaping @Sendable (CGImage, String) throws -> ScreenCaptureArtifact = { _, _ in
+            throw ScreenFixtureError.unexpectedCall("persistCaptureArtifact")
+        },
+        metadata: @escaping @MainActor @Sendable () async -> [ScreenDisplayInfo] = {
+            []
+        },
+        ocr: @escaping @Sendable (CGImage, String) throws -> [ScreenOCRObservation] = { _, _ in
+            throw ScreenFixtureError.unexpectedCall("recognizeText")
+        }
+    ) {
+        self.frontmostValue = frontmostValue
+        self.capture = capture
+        self.persist = persist
+        self.metadata = metadata
+        self.ocr = ocr
+    }
+
+    func runtime() -> ScreenModuleRuntime {
+        ScreenModuleRuntime(
+            frontmostBundleId: { [self] in
+                lock.withLock { frontmostCalls += 1 }
+                return frontmostValue
+            },
+            cleanupCaptureFiles: { [self] in
+                lock.withLock { cleanupCalls += 1 }
+            },
+            captureImage: { [self] request in
+                lock.withLock {
+                    captureCalls += 1
+                    lastCaptureRequest = request
+                }
+                return try await capture(request)
+            },
+            persistCaptureArtifact: { [self] image, format in
+                lock.withLock { persistCalls += 1 }
+                return try persist(image, format)
+            },
+            displayMetadata: { [self] in
+                lock.withLock { metadataCalls += 1 }
+                return await metadata()
+            },
+            recognizeText: { [self] image, language in
+                lock.withLock {
+                    ocrCalls += 1
+                    lastOCRLanguage = language
+                }
+                return try ocr(image, language)
+            }
+        )
+    }
+
+    func snapshot() -> Snapshot {
+        lock.withLock {
+            Snapshot(
+                frontmostCalls: frontmostCalls,
+                cleanupCalls: cleanupCalls,
+                captureCalls: captureCalls,
+                persistCalls: persistCalls,
+                metadataCalls: metadataCalls,
+                ocrCalls: ocrCalls,
+                lastCaptureRequest: lastCaptureRequest,
+                lastOCRLanguage: lastOCRLanguage
+            )
+        }
+    }
+}
+
+private func makeScreenTestImage() throws -> CGImage {
+    guard let context = CGContext(
+        data: nil,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ), let image = context.makeImage() else {
+        throw TestError.assertion("failed to create deterministic 1x1 image")
+    }
+    return image
+}
+
+private func makeScreenRouter(_ spy: ScreenRuntimeSpy) async -> ToolRouter {
+    let gate = SecurityGate(approvalProvider: TestSecurityApprovalProvider())
+    let router = ToolRouter(securityGate: gate, auditLog: AuditLog())
+    await ScreenModule.register(on: router, runtime: spy.runtime())
+    await ScreenModule.registerRecording(on: router)
+    return router
+}
+
+private let screenRecordingDeniedResponse: Value = .object([
+    "error": .string("screen_recording_denied"),
+    "message": .string("Screen Recording permission not granted. Open System Settings > Privacy & Security > Screen Recording and enable The Bridge.")
+])
 
 // MARK: - ScreenModule Tests
 
 func runScreenModuleTests() async {
     print("\n📸 ScreenModule Tests")
 
-    let gate = SecurityGate(approvalProvider: TestSecurityApprovalProvider())
-    let log = AuditLog()
-    let router = ToolRouter(securityGate: gate, auditLog: log)
-    await ScreenModule.register(on: router)
-    await ScreenModule.registerRecording(on: router)
+    let registrationSpy = ScreenRuntimeSpy()
+    let router = await makeScreenRouter(registrationSpy)
 
     // --- Registration ---
 
-    await test("ScreenModule registers 4 tools") {
+    await test("ScreenModule registers 4 tools with explicit test runtime") {
         let tools = await router.registrations(forModule: "screen")
         try expect(tools.count == 4, "Expected 4 screen tools, got \(tools.count)")
     }
@@ -31,24 +170,31 @@ func runScreenModuleTests() async {
     await test("ScreenModule tool names are correct") {
         let tools = await router.registrations(forModule: "screen")
         let names = Set(tools.map(\.name))
-        try expect(names.contains("screen_capture"), "Missing screen_capture")
-        try expect(names.contains("screen_ocr"), "Missing screen_ocr")
-        try expect(names.contains("screen_record_start"), "Missing screen_record_start")
-        try expect(names.contains("screen_record_stop"), "Missing screen_record_stop")
+        try expect(names == ["screen_capture", "screen_ocr", "screen_record_start", "screen_record_stop"])
     }
 
-    // --- Tier classification ---
-
     await test("screen_capture is open tier") {
-        let tools = await router.registrations(forModule: "screen")
-        let tool = tools.first(where: { $0.name == "screen_capture" })!
+        let tool = await router.registrations(forModule: "screen")
+            .first(where: { $0.name == "screen_capture" })!
         try expect(tool.tier == .open, "Expected open, got \(tool.tier.rawValue)")
     }
 
     await test("screen_ocr is open tier") {
-        let tools = await router.registrations(forModule: "screen")
-        let tool = tools.first(where: { $0.name == "screen_ocr" })!
+        let tool = await router.registrations(forModule: "screen")
+            .first(where: { $0.name == "screen_ocr" })!
         try expect(tool.tier == .open, "Expected open, got \(tool.tier.rawValue)")
+    }
+
+    await test("screen_record_start is notify tier") {
+        let tool = await router.registrations(forModule: "screen")
+            .first(where: { $0.name == "screen_record_start" })!
+        try expect(tool.tier == .notify, "Expected notify, got \(tool.tier.rawValue)")
+    }
+
+    await test("screen_record_stop is notify tier") {
+        let tool = await router.registrations(forModule: "screen")
+            .first(where: { $0.name == "screen_record_stop" })!
+        try expect(tool.tier == .notify, "Expected notify, got \(tool.tier.rawValue)")
     }
 
     await test("screen window schemas expose bundleId and appName at both registration sites") {
@@ -65,6 +211,8 @@ func runScreenModuleTests() async {
         }
     }
 
+    // --- Pure window resolution ---
+
     let windows = [
         ScreenModule.WindowCandidate(windowId: 11, bundleId: "com.example.one", appName: "Example"),
         ScreenModule.WindowCandidate(windowId: 12, bundleId: "com.example.two", appName: "Example"),
@@ -76,7 +224,8 @@ func runScreenModuleTests() async {
             windowId: 13,
             bundleId: "com.example.one",
             appName: "Example",
-            candidates: windows)
+            candidates: windows
+        )
         try expect(result == .selected(13), "windowId must win: \(result)")
     }
 
@@ -85,7 +234,8 @@ func runScreenModuleTests() async {
             windowId: nil,
             bundleId: "com.example.unique",
             appName: nil,
-            candidates: windows)
+            candidates: windows
+        )
         try expect(result == .selected(13), "unique bundle match failed: \(result)")
     }
 
@@ -94,7 +244,8 @@ func runScreenModuleTests() async {
             windowId: nil,
             bundleId: nil,
             appName: "unique app",
-            candidates: windows)
+            candidates: windows
+        )
         try expect(result == .selected(13), "unique appName match failed: \(result)")
     }
 
@@ -103,12 +254,13 @@ func runScreenModuleTests() async {
             windowId: nil,
             bundleId: "com.example.missing",
             appName: nil,
-            candidates: windows)
+            candidates: windows
+        )
         guard case .appNotFound(let query, let available) = result else {
             throw TestError.assertion("expected appNotFound, got \(result)")
         }
-        try expect(query.contains("com.example.missing"), "query should identify bundle")
-        try expect(available == windows, "failure must list all capturable ids/names")
+        try expect(query.contains("com.example.missing"))
+        try expect(available == windows)
     }
 
     await test("screen window resolver errors instead of guessing across multiple matches") {
@@ -116,11 +268,12 @@ func runScreenModuleTests() async {
             windowId: nil,
             bundleId: nil,
             appName: "Example",
-            candidates: windows)
+            candidates: windows
+        )
         guard case .ambiguous(_, let matches) = result else {
             throw TestError.assertion("expected ambiguous result, got \(result)")
         }
-        try expect(matches.map(\.windowId) == [11, 12], "ambiguous ids should be explicit")
+        try expect(matches.map(\.windowId) == [11, 12])
     }
 
     await test("screen window resolver requires one identity") {
@@ -128,113 +281,267 @@ func runScreenModuleTests() async {
             windowId: nil,
             bundleId: nil,
             appName: nil,
-            candidates: windows)
-        try expect(result == .missingIdentity, "missing identity must not select a window")
-    }
-    await test("screen_record_start is notify tier") {
-        let tools = await router.registrations(forModule: "screen")
-        let tool = tools.first(where: { $0.name == "screen_record_start" })!
-        try expect(tool.tier == .notify, "Expected notify, got \(tool.tier.rawValue)")
+            candidates: windows
+        )
+        try expect(result == .missingIdentity)
     }
 
-    await test("screen_record_stop is notify tier") {
-        let tools = await router.registrations(forModule: "screen")
-        let tool = tools.first(where: { $0.name == "screen_record_stop" })!
-        try expect(tool.tier == .notify, "Expected notify, got \(tool.tier.rawValue)")
+    // --- Deterministic handler contracts ---
+
+    await test("screen_capture serializes exact Screen Recording denial and stops before persistence") {
+        let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_capture", arguments: .object([:]))
+        try expect(result == screenRecordingDeniedResponse, "unexpected denial response: \(result)")
+
+        let calls = spy.snapshot()
+        try expect(calls.cleanupCalls == 1)
+        try expect(calls.captureCalls == 1)
+        try expect(calls.persistCalls == 0)
+        try expect(calls.metadataCalls == 0)
+        try expect(calls.ocrCalls == 0)
     }
 
-    // --- Graceful error handling ---
+    await test("screen_ocr serializes exact Screen Recording denial and never invokes OCR") {
+        let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_ocr", arguments: .object([:]))
+        try expect(result == screenRecordingDeniedResponse, "unexpected denial response: \(result)")
 
-    await test("screen_capture returns error when Screen Recording denied") {
-        let result = try await router.dispatch(
+        let calls = spy.snapshot()
+        try expect(calls.cleanupCalls == 0)
+        try expect(calls.captureCalls == 1)
+        try expect(calls.persistCalls == 0)
+        try expect(calls.metadataCalls == 0)
+        try expect(calls.ocrCalls == 0)
+    }
+
+    await test("screen_capture frontmost mismatch short-circuits every downstream dependency") {
+        let spy = ScreenRuntimeSpy(frontmostValue: "com.example.other")
+        let testRouter = await makeScreenRouter(spy)
+        let required = "com.example.required"
+        let result = try await testRouter.dispatch(
             toolName: "screen_capture",
-            arguments: .object([:])
+            arguments: .object(["requireFrontmostBundleId": .string(required)])
         )
-        if case .object(let dict) = result {
-            if case .string(let err) = dict["error"] {
-                try expect(!err.isEmpty, "Error message should not be empty")
-            }
-        }
+        let expected: Value = .object([
+            "error": .string("frontmost_mismatch"),
+            "message": .string("Required frontmost app 'com.example.required' is not active (frontmost: 'com.example.other'). Capture aborted. Bring the app forward (e.g. bridge_focus_settings) and retry."),
+            "requiredBundleId": .string(required),
+            "frontmostBundleId": .string("com.example.other")
+        ])
+        try expect(result == expected, "unexpected mismatch response: \(result)")
+
+        let calls = spy.snapshot()
+        try expect(calls.frontmostCalls == 1)
+        try expect(calls.cleanupCalls == 0)
+        try expect(calls.captureCalls == 0)
+        try expect(calls.persistCalls == 0)
+        try expect(calls.metadataCalls == 0)
+        try expect(calls.ocrCalls == 0)
     }
 
-    await test("screen_ocr returns error when Screen Recording denied") {
-        let result = try await router.dispatch(
-            toolName: "screen_ocr",
-            arguments: .object([:])
+    await test("screen_capture empty frontmost requirement skips lookup and reaches capture") {
+        let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(
+            toolName: "screen_capture",
+            arguments: .object(["requireFrontmostBundleId": .string("")])
         )
-        if case .object(let dict) = result {
-            if case .string(let err) = dict["error"] {
-                try expect(!err.isEmpty, "Error message should not be empty")
-            }
-        }
+        try expect(result == screenRecordingDeniedResponse)
+
+        let calls = spy.snapshot()
+        try expect(calls.frontmostCalls == 0)
+        try expect(calls.cleanupCalls == 1)
+        try expect(calls.captureCalls == 1)
     }
+
+    await test("screen_capture forwards parsed target arguments to the capture dependency") {
+        let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
+        let testRouter = await makeScreenRouter(spy)
+        _ = try await testRouter.dispatch(
+            toolName: "screen_capture",
+            arguments: .object([
+                "target": .string("region"),
+                "region": .object(["x": .int(1), "y": .int(2), "w": .int(3), "h": .int(4)]),
+                "displayIndex": .int(2)
+            ])
+        )
+        let request = spy.snapshot().lastCaptureRequest
+        try expect(request == ScreenCaptureRequest(
+            target: "region",
+            windowId: nil,
+            bundleId: nil,
+            appName: nil,
+            region: ScreenCaptureRegion(x: 1, y: 2, width: 3, height: 4),
+            displayIndex: 2
+        ))
+    }
+
+    await test("screen_capture from detached task returns through fake capture without live SCK") {
+        let spy = ScreenRuntimeSpy(capture: { _ in throw ScreenModuleError.screenRecordingDenied })
+        let testRouter = await makeScreenRouter(spy)
+        let result = await Task.detached {
+            try? await testRouter.dispatch(toolName: "screen_capture", arguments: .object([:]))
+        }.value
+        try expect(result == screenRecordingDeniedResponse)
+        try expect(spy.snapshot().captureCalls == 1)
+    }
+
+    await test("screen_ocr empty observations return the exact blank-screen response") {
+        let image = try makeScreenTestImage()
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            ocr: { _, _ in [] }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_ocr", arguments: .object([:]))
+        let expected: Value = .object([
+            "text": .string(""),
+            "confidence": .double(0.0),
+            "bounds": .array([])
+        ])
+        try expect(result == expected, "unexpected blank OCR response: \(result)")
+    }
+
+    await test("screen_ocr maps OCR failure to exact ocr_failed response") {
+        let image = try makeScreenTestImage()
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            ocr: { _, _ in throw ScreenFixtureError.ocrFailure }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_ocr", arguments: .object([:]))
+        let expected: Value = .object([
+            "error": .string("ocr_failed"),
+            "message": .string("Vision text recognition failed: fixture OCR failure")
+        ])
+        try expect(result == expected, "unexpected OCR error response: \(result)")
+    }
+
+    await test("screen_ocr preserves observation order, bounds, language, and rounded average") {
+        let image = try makeScreenTestImage()
+        let firstConfidence = Float(0.9)
+        let secondConfidence = Float(0.3)
+        let observations = [
+            ScreenOCRObservation(
+                candidate: ScreenOCRCandidate(text: "First", confidence: firstConfidence),
+                boundingBox: CGRect(x: 0.1, y: 0.2, width: 0.3, height: 0.4)
+            ),
+            ScreenOCRObservation(
+                candidate: ScreenOCRCandidate(text: "Second", confidence: secondConfidence),
+                boundingBox: CGRect(x: 0.5, y: 0.6, width: 0.2, height: 0.1)
+            )
+        ]
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            ocr: { _, _ in observations }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(
+            toolName: "screen_ocr",
+            arguments: .object(["language": .string("fr")])
+        )
+        let expected: Value = .object([
+            "text": .string("First\nSecond"),
+            "confidence": .double(0.6),
+            "bounds": .array([
+                .object([
+                    "text": .string("First"),
+                    "confidence": .double(Double(firstConfidence)),
+                    "rect": .object([
+                        "x": .double(0.1), "y": .double(0.2),
+                        "width": .double(0.3), "height": .double(0.4)
+                    ])
+                ]),
+                .object([
+                    "text": .string("Second"),
+                    "confidence": .double(Double(secondConfidence)),
+                    "rect": .object([
+                        "x": .double(0.5), "y": .double(0.6),
+                        "width": .double(0.2), "height": .double(0.1)
+                    ])
+                ])
+            ])
+        ])
+        try expect(result == expected, "unexpected ordered OCR response: \(result)")
+        try expect(spy.snapshot().lastOCRLanguage == "fr")
+    }
+
+    await test("screen_ocr keeps candidate-less observations in confidence denominator") {
+        let image = try makeScreenTestImage()
+        let confidence = Float(0.9)
+        let spy = ScreenRuntimeSpy(
+            capture: { _ in image },
+            ocr: { _, _ in
+                [
+                    ScreenOCRObservation(
+                        candidate: ScreenOCRCandidate(text: "Only", confidence: confidence),
+                        boundingBox: .zero
+                    ),
+                    ScreenOCRObservation(candidate: nil, boundingBox: .zero)
+                ]
+            }
+        )
+        let testRouter = await makeScreenRouter(spy)
+        let result = try await testRouter.dispatch(toolName: "screen_ocr", arguments: .object([:]))
+        guard case .object(let response) = result else {
+            throw TestError.assertion("expected object response")
+        }
+        try expect(response["text"] == .string("Only"))
+        try expect(response["confidence"] == .double(0.45), "candidate-less observation must remain in denominator")
+        guard case .array(let bounds)? = response["bounds"] else {
+            throw TestError.assertion("expected bounds array")
+        }
+        try expect(bounds.count == 1, "candidate-less observation must not create a bounds row")
+    }
+
     await test("screen_record_stop handles no active recording") {
         let result = try await router.dispatch(
             toolName: "screen_record_stop",
             arguments: .object([:])
         )
-        if case .object(let dict) = result {
-            if case .string(let err) = dict["error"] {
-                try expect(!err.isEmpty, "Error message should not be empty")
-            }
+        guard case .object(let response) = result,
+              case .string(let error)? = response["error"] else {
+            throw TestError.assertion("expected nonempty recording error")
         }
+        try expect(!error.isEmpty)
     }
 
-    // --- Module name ---
+    await test("Screen handler source is isolated from live framework and filesystem calls") {
+        let repository = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repository.appendingPathComponent("TheBridge/Modules/ScreenModule.swift"),
+            encoding: .utf8
+        )
+        guard let runtimeMarker = source.range(of: "// MARK: - Screen Runtime Dependencies") else {
+            throw TestError.assertion("missing Screen runtime boundary marker")
+        }
+        let handlerSource = String(source[..<runtimeMarker.lowerBound])
+            .components(separatedBy: .newlines)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let liveSource = String(source[runtimeMarker.lowerBound...])
+        let forbidden = [
+            "CGPreflightScreenCaptureAccess(",
+            "SCScreenshotManager.captureImage",
+            "VNRecognizeTextRequest(",
+            "NSWorkspace.shared",
+            "CGImageDestinationCreateWithURL(",
+            "FileManager.default"
+        ]
+        for token in forbidden {
+            try expect(!handlerSource.contains(token), "handler source must not call live dependency: \(token)")
+        }
+        try expect(handlerSource.contains("package static func register(on router: ToolRouter, runtime: ScreenModuleRuntime)"))
+        try expect(!handlerSource.contains("public static func register(on router: ToolRouter) async"))
+        try expect(liveSource.contains("internal static let live"))
+        try expect(!liveSource.contains("package static let live"))
+    }
 
     await test("ScreenModule.moduleName is 'screen'") {
-        try expect(ScreenModule.moduleName == "screen",
-                   "Expected 'screen', got '\(ScreenModule.moduleName)'")
-    }
-
-    // --- SCK off-main-actor continuation-leak regression guard ---
-    // Before the SCKBoundary fix, dispatching an SCK-backed tool from a
-    // nonisolated / off-main-actor context (`Task.detached`) leaked the
-    // ScreenCaptureKit checked continuation and HUNG FOREVER ("SWIFT TASK
-    // CONTINUATION MISUSE"). The fix routes the SCK call onto the main actor
-    // and guards it with a libdispatch watchdog, so the call must now RETURN
-    // or THROW promptly. We only assert "did not hang" — content depends on
-    // live TCC/display/Chrome state, which we do not gate on here.
-    await test("screen_capture from a detached (off-main) task returns promptly, never hangs") {
-        let result = await Task.detached {
-            try? await router.dispatch(toolName: "screen_capture", arguments: .object([:]))
-        }.value
-        try expect(result != nil, "screen_capture dispatch should produce a value off-main, not hang")
-    }
-
-    // --- FB-AUTOMATION: requireFrontmostBundleId guard ---
-    // An impossible bundle id can never be frontmost, so the guard MUST short-
-    // circuit with error='frontmost_mismatch' and perform NO capture (no
-    // filePath in the response). This holds regardless of TCC/display state.
-    await test("screen_capture aborts with frontmost_mismatch when required app is not frontmost") {
-        let result = try await router.dispatch(
-            toolName: "screen_capture",
-            arguments: .object(["requireFrontmostBundleId": .string("com.example.never.frontmost.\(UUID().uuidString)")])
-        )
-        guard case .object(let dict) = result else {
-            throw TestError.assertion("expected object response")
-        }
-        guard case .string(let err) = dict["error"] else {
-            throw TestError.assertion("expected error key on mismatch, got keys: \(dict.keys)")
-        }
-        try expect(err == "frontmost_mismatch", "expected frontmost_mismatch, got \(err)")
-        try expect(dict["filePath"] == nil, "guard must abort BEFORE capture — no filePath expected")
-        try expect(dict["requiredBundleId"] != nil, "mismatch response should echo requiredBundleId")
-    }
-
-    // Empty / absent requireFrontmostBundleId must NOT engage the guard — the
-    // call proceeds exactly as before (returns promptly, content state-dependent).
-    await test("screen_capture with empty requireFrontmostBundleId does not engage the guard") {
-        let result = try await router.dispatch(
-            toolName: "screen_capture",
-            arguments: .object(["requireFrontmostBundleId": .string("")])
-        )
-        guard case .object(let dict) = result else {
-            throw TestError.assertion("expected object response")
-        }
-        // Must not be a frontmost_mismatch (guard skipped on empty string).
-        if case .string(let err) = dict["error"] {
-            try expect(err != "frontmost_mismatch", "empty guard string must not trigger frontmost_mismatch")
-        }
+        try expect(ScreenModule.moduleName == "screen")
     }
 }

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -286,6 +286,11 @@ struct TheBridgeTestRunner {
     // The full test sequence. `nonisolated` so it runs on whatever (non-main)
     // executor the detached task provides, NOT the main actor.
     nonisolated static func runAllTests() async {
+        if ProcessInfo.processInfo.environment["BRIDGE_SCREEN_LIVE_PROBE"] == "1" {
+            await runScreenLiveProbe()
+            return
+        }
+
         await runVoiceMemoHubTrustTests() // PKT-MEM-106 0a: trust + identity core (run early — flake-avoidance)
         await runMemoryHubCockpitTests()  // PKT-MEM-106 0b: run early alongside 0a (same flake-avoidance)
         await runMemoryHubGuardrailTests() // PKT-MEM-106 0c: preview + guardrails + tabs (run early)

--- a/TheBridgeTests/ToolAnnotationAuditTests.swift
+++ b/TheBridgeTests/ToolAnnotationAuditTests.swift
@@ -108,6 +108,20 @@ func runToolAnnotationAuditTests() async {
                    "job_resume must be idempotentHint:true — resuming a running job is a noop")
     }
 
+    await test("screen_capture is Open-tier but not read-only because it writes and cleans capture artifacts") {
+        guard let registration = regs.first(where: { $0.name == "screen_capture" }) else {
+            throw TestError.assertion("screen_capture must be registered")
+        }
+        let annotation = ToolAnnotationCatalog.annotations(for: "screen_capture")
+        try expect(registration.tier == .open, "screen_capture tier remains .open by explicit policy")
+        try expect(annotation?.readOnlyHint == false,
+                   "screen_capture writes one artifact and deletes old capture files")
+        try expect(annotation?.destructiveHint == false,
+                   "bounded capture cleanup remains non-destructive metadata")
+        try expect(annotation?.requiresConfirmation == false,
+                   "Open-tier screen_capture remains ungated in this slice")
+    }
+
     await test("requiresConfirmation mirrors the Bridge security model (request/neverAutoApprove)") {
         for reg in regs {
             guard let ann = ToolAnnotationCatalog.annotations(for: reg.name) else { continue }

--- a/scripts/screen-live-probe.sh
+++ b/scripts/screen-live-probe.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TIMEOUT_SECONDS="${SCREEN_LIVE_PROBE_TIMEOUT_SECONDS:-150}"
+LOG_PATH="${SCREEN_LIVE_PROBE_LOG:-$ROOT/.build/screen-live-probe.log}"
+
+cd "$ROOT"
+swift build --product TheBridgeTests
+
+BINARY="$ROOT/.build/debug/TheBridgeTests"
+if [[ ! -x "$BINARY" ]]; then
+  echo "screen-live-probe: missing executable $BINARY" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$LOG_PATH")"
+: > "$LOG_PATH"
+
+# Job control gives the probe its own process group. The deadline terminates
+# that entire group so a framework or descendant process cannot leak into
+# later verification runs.
+set -m
+BRIDGE_SCREEN_LIVE_PROBE=1 "$BINARY" >"$LOG_PATH" 2>&1 &
+PID=$!
+PGID="$(ps -o pgid= -p "$PID" | tr -d ' ')"
+DEADLINE=$((SECONDS + TIMEOUT_SECONDS))
+
+while kill -0 "$PID" 2>/dev/null; do
+  if (( SECONDS >= DEADLINE )); then
+    echo "screen-live-probe: deadline exceeded after ${TIMEOUT_SECONDS}s" >&2
+    kill -TERM -- "-$PGID" 2>/dev/null || kill -TERM "$PID" 2>/dev/null || true
+
+    GRACE_DEADLINE=$((SECONDS + 5))
+    while kill -0 "$PID" 2>/dev/null && (( SECONDS < GRACE_DEADLINE )); do
+      sleep 1
+    done
+    if kill -0 "$PID" 2>/dev/null; then
+      kill -KILL -- "-$PGID" 2>/dev/null || kill -KILL "$PID" 2>/dev/null || true
+    fi
+    wait "$PID" 2>/dev/null || true
+    set +m
+    cat "$LOG_PATH"
+    echo "SCREEN_LIVE_PROBE_STATUS=timeout"
+    echo "SCREEN_LIVE_PROBE_LOG=$LOG_PATH"
+    exit 124
+  fi
+  sleep 1
+done
+
+set +e
+wait "$PID"
+STATUS=$?
+set -e
+set +m
+
+cat "$LOG_PATH"
+if (( STATUS != 0 )); then
+  echo "SCREEN_LIVE_PROBE_STATUS=failed"
+  echo "SCREEN_LIVE_PROBE_EXIT=$STATUS"
+  echo "SCREEN_LIVE_PROBE_LOG=$LOG_PATH"
+  exit "$STATUS"
+fi
+
+RECEIPT="$(grep '^SCREEN_LIVE_PROBE_RECEIPT=' "$LOG_PATH" | tail -n 1 || true)"
+if [[ -z "$RECEIPT" ]]; then
+  echo "screen-live-probe: process exited successfully without a receipt" >&2
+  echo "SCREEN_LIVE_PROBE_STATUS=missing_receipt"
+  echo "SCREEN_LIVE_PROBE_LOG=$LOG_PATH"
+  exit 3
+fi
+
+echo "SCREEN_LIVE_PROBE_STATUS=passed"
+echo "SCREEN_LIVE_PROBE_LOG=$LOG_PATH"
+echo "$RECEIPT"


### PR DESCRIPTION
## Summary
- make canonical Screen handler tests hermetic through explicit runtime dependencies
- add exact successful `screen_capture` response and call-order coverage
- add a bounded, opt-in live `screen_ocr` probe outside the canonical floor
- make Settings automation headless behavior deterministic and correct `success` semantics
- mark `screen_capture` as non-read-only while retaining the existing `.open` tier

## Verification
- `make test-floor`: 3462 passed, 0 failed, floor 3416
- `swift build --product TheBridgeTests`: passed
- `bash -n scripts/screen-live-probe.sh`: passed
- `scripts/screen-live-probe.sh`: passed on granted host under 150s process deadline
  - textLength: 3656
  - boundsCount: 129
  - confidence: ~0.966
- `git diff --check`: passed

## Risk notes
- production Vision OCR remains synchronous and has no in-process timeout
- live probe is granted-host evidence, not a universal termination guarantee
- `bridge_focus_settings` now returns `success:false` when no Settings window is found
- `screen_capture` remains `.open` but now advertises `readOnlyHint:false`

## Deferred
- production OCR timeout/cancellation/performance work
- live permission-denied runner
- install, release, tag, appcast
