### PR TITLE
fix(skills): make exposure projection tests hermetic

### DIFF
--- a/TheBridge/Modules/Commands/RegistrySkillsCommandProvider.swift
+++ b/TheBridge/Modules/Commands/RegistrySkillsCommandProvider.swift
@@ -107,11 +107,14 @@ public struct RegistrySkillsCommandProvider: CommandDescriptorProviding {
     /// snapshot). Tests inject a closure over a private suite — zero
     /// process-global / network coupling.
     private let readBlob: @Sendable () -> Data?
+    private let readExposureGate: @Sendable () async -> SkillRuntimeExposureGate?
 
     /// Default: read the shared `BridgeDefaults.skills` from
-    /// `UserDefaults.standard` at every `descriptors()` call.
+    /// `UserDefaults.standard` and the active Runtime Exposure generation at
+    /// every `descriptors()` call.
     public init(storageKey: String = BridgeDefaults.skills) {
         self.readBlob = { UserDefaults.standard.data(forKey: storageKey) }
+        self.readExposureGate = { await SkillRuntimeGenerationStore.shared.gate() }
     }
 
     /// Test/diagnostic seam: read from a NAMED `UserDefaults` suite. Only
@@ -124,11 +127,38 @@ public struct RegistrySkillsCommandProvider: CommandDescriptorProviding {
         self.readBlob = {
             UserDefaults(suiteName: suiteName)?.data(forKey: storageKey)
         }
+        self.readExposureGate = { await SkillRuntimeGenerationStore.shared.gate() }
+    }
+
+    /// Hermetic projection seam. The registry fixture and resolved exposure
+    /// policy are explicit values, so tests never inherit machine-global
+    /// Runtime Exposure state.
+    @_spi(Testing)
+    public init(
+        suiteName: String,
+        storageKey: String = BridgeDefaults.skills,
+        exposureGate: SkillRuntimeExposureGate?
+    ) {
+        self.readBlob = {
+            UserDefaults(suiteName: suiteName)?.data(forKey: storageKey)
+        }
+        self.readExposureGate = { exposureGate }
     }
 
     /// Lowest-level seam: inject the blob reader directly.
     public init(readBlob: @escaping @Sendable () -> Data?) {
         self.readBlob = readBlob
+        self.readExposureGate = { await SkillRuntimeGenerationStore.shared.gate() }
+    }
+
+    /// Lowest-level hermetic seam for projection tests and diagnostics.
+    @_spi(Testing)
+    public init(
+        readBlob: @escaping @Sendable () -> Data?,
+        exposureGate: SkillRuntimeExposureGate?
+    ) {
+        self.readBlob = readBlob
+        self.readExposureGate = { exposureGate }
     }
 
     /// Decode the persisted registry and project the ENABLED entries onto
@@ -147,7 +177,7 @@ public struct RegistrySkillsCommandProvider: CommandDescriptorProviding {
         else {
             return []
         }
-        let exposureGate = await SkillRuntimeGenerationStore.shared.gate()
+        let exposureGate = await readExposureGate()
         return entries.compactMap { entry in
             // cmd-ux W4 (3.4.1): the palette shows skills with the
             // `inCommandPalette` flag set (and enabled). Routing-only

--- a/TheBridge/Modules/Skills/SkillsModuleFileSource.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleFileSource.swift
@@ -149,10 +149,19 @@ extension SkillsModule {
     /// per-path toggle when present, otherwise by frontmatter
     /// `visibility: routing`.
     public static func mergedRoutingSkills() async -> [Value] {
+        let exposureGate = await SkillRuntimeGenerationStore.shared.gate()
+        return await mergedRoutingSkills(exposureGate: exposureGate)
+    }
+
+    /// Hermetic projection seam. Production resolves the shared gate above;
+    /// tests supply the exact policy value they intend to exercise.
+    @_spi(Testing)
+    public static func mergedRoutingSkills(
+        exposureGate: SkillRuntimeExposureGate?
+    ) async -> [Value] {
         // Runtime Exposure v1: once a verified generation exists, it is the
         // final gate for Notion-backed routing. No generation means migration
         // has not cut over yet, so legacy installs remain byte-compatible.
-        let exposureGate = await SkillRuntimeGenerationStore.shared.gate()
         let notionSkills = readAllSkills().filter { s in
             let validLegacyRow = s.enabled && s.routingDiscoverable
                 && NotionPageRef.isValidStoredPageId(s.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/TheBridgeTests/CommandPaletteTests.swift
+++ b/TheBridgeTests/CommandPaletteTests.swift
@@ -494,7 +494,7 @@ func runCommandPaletteTests() async {
             (name: "Email Signature", pageId: pidSig, enabled: true),
             (name: "Mailing Address", pageId: pidAddr, enabled: true),
         ])
-        let provider = RegistrySkillsCommandProvider(
+        let provider = isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills)
         let got = await provider.descriptors()
         try expect(got.count == 2, "both enabled entries must map, got \(got.count)")
@@ -505,13 +505,46 @@ func runCommandPaletteTests() async {
                    "name is BOTH the descriptor name AND the abbreviation/trigger (registry has no short form)")
     }
 
+    await test("RegistryProvider explicit nil gate is hermetic from shared production exposure") {
+        let (d, suite) = makeIsolatedDefaults()
+        seedRegistry(d, key: BridgeDefaults.skills, [
+            (name: "Hermetic Command", pageId: pidSig, enabled: true),
+        ])
+        let got = await isolatedRegistryProvider(
+            suiteName: suite,
+            storageKey: BridgeDefaults.skills,
+            exposureGate: nil
+        ).descriptors()
+        try expect(got.map(\.id) == [pidSig],
+                   "an explicit nil gate must preserve legacy fixture projection regardless of machine state")
+    }
+
+    await test("RegistryProvider explicit gate enforces the command surface") {
+        let (d, suite) = makeIsolatedDefaults()
+        seedRegistry(d, key: BridgeDefaults.skills, [
+            (name: "Allowed Command", pageId: pidSig, enabled: true),
+            (name: "Routing Only", pageId: pidAddr, enabled: true),
+        ])
+        let gate = testExposureGate([
+            (pageID: pidSig, exposure: .command),
+            (pageID: pidAddr, exposure: .routing),
+        ])
+        let got = await isolatedRegistryProvider(
+            suiteName: suite,
+            storageKey: BridgeDefaults.skills,
+            exposureGate: gate
+        ).descriptors()
+        try expect(got.map(\.id) == [pidSig],
+                   "the command surface must include .command and exclude .routing entries, got \(got.map(\.id))")
+    }
+
     await test("RegistryProvider EXCLUDES disabled entries") {
         let (d, suite) = makeIsolatedDefaults()
         seedRegistry(d, key: BridgeDefaults.skills, [
             (name: "On Skill", pageId: pidSig, enabled: true),
             (name: "Off Skill", pageId: pidAddr, enabled: false),
         ])
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.count == 1, "only the enabled entry is selectable, got \(got.count)")
         try expect(got.first?.id == pidSig, "the disabled entry must be filtered out")
@@ -523,7 +556,7 @@ func runCommandPaletteTests() async {
             (name: "Has Page", pageId: pidSig, enabled: true),
             (name: "No Page", pageId: "   ", enabled: true),
         ])
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.count == 1 && got.first?.id == pidSig,
                    "a page-id-less row can never resolve a body — not a command, got \(got.map { $0.name })")
@@ -531,7 +564,7 @@ func runCommandPaletteTests() async {
 
     await test("RegistryProvider on a MISSING registry key → empty (no crash)") {
         let (_, suite) = makeIsolatedDefaults()  // nothing seeded
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.isEmpty, "an unset registry must yield an empty list, got \(got.count)")
     }
@@ -539,7 +572,7 @@ func runCommandPaletteTests() async {
     await test("RegistryProvider on MALFORMED registry data → empty (no crash)") {
         let (d, suite) = makeIsolatedDefaults()
         d.set(Data("not json".utf8), forKey: BridgeDefaults.skills)
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.isEmpty, "corrupt registry bytes must fail safe to empty, got \(got.count)")
     }
@@ -555,7 +588,7 @@ func runCommandPaletteTests() async {
             ["name": "Legacy", "notionPageId": pidSig, "visibility": "command"]
         ]
         d.set(try JSONSerialization.data(withJSONObject: legacy), forKey: BridgeDefaults.skills)
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.count == 1 && got.first?.name == "Legacy",
                    "a legacy row with no 'enabled' key must default to enabled, got \(got.map { $0.name })")
@@ -575,7 +608,7 @@ func runCommandPaletteTests() async {
         ])
         let mgr = CommandsManager(fetcher: { _ in mdJSON("body") })
         let coord = CommandPaletteCoordinator(
-            provider: RegistrySkillsCommandProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
+            provider: isolatedRegistryProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
             manager: mgr)
         let ranked = await coord.search("Email Signature")
         try expect(ranked.first?.descriptor.id == pidSig && ranked.first?.score == 1000,
@@ -606,7 +639,7 @@ func runCommandPaletteTests() async {
             (name: "Legacy AdminOnly", pageId: "eeee1111ffff222233334444aaaabbbb", enabled: true, visibility: "adminOnly"),
             (name: "Unknown Vis",  pageId: "ffff1111aaaa2222bbbb3333cccc4444", enabled: true, visibility: "totally-bogus"),
         ])
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         let names = Set(got.map { $0.name })
         try expect(got.count == 2,
@@ -628,7 +661,7 @@ func runCommandPaletteTests() async {
         seedRegistry(d, key: BridgeDefaults.skills, [
             (name: "Shared Key Skill", pageId: pidSig, enabled: true),
         ])
-        let got = await RegistrySkillsCommandProvider(suiteName: suite).descriptors()
+        let got = await isolatedRegistryProvider(suiteName: suite).descriptors()
         try expect(got.count == 1 && got.first?.name == "Shared Key Skill",
                    "the provider's default key must be com.notionbridge.skills, got \(got.map { $0.name })")
         try expect(BridgeDefaults.skills == "com.notionbridge.skills",
@@ -641,7 +674,7 @@ func runCommandPaletteTests() async {
             (name: "Zebra", pageId: pidSig, enabled: true),
             (name: "Apple", pageId: pidAddr, enabled: true),
         ])
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.map { $0.name } == ["Zebra", "Apple"],
                    "the provider must not re-order; ranking is CommandPaletteSearch's job, got \(got.map { $0.name })")
@@ -652,7 +685,7 @@ func runCommandPaletteTests() async {
         d.set(try JSONSerialization.data(withJSONObject: [[String: Any]]()), forKey: BridgeDefaults.skills)
         let mgr = CommandsManager(fetcher: { _ in mdJSON("x") })
         let coord = CommandPaletteCoordinator(
-            provider: RegistrySkillsCommandProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
+            provider: isolatedRegistryProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
             manager: mgr)
         let ranked = await coord.search("anything")
         try expect(ranked.isEmpty, "empty registry → no rows (and no crash), got \(ranked.count)")
@@ -762,7 +795,7 @@ func runCommandPaletteTests() async {
             return mdJSON("RESOLVED SIGNATURE BODY")
         })
         let coord = CommandPaletteCoordinator(
-            provider: RegistrySkillsCommandProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
+            provider: isolatedRegistryProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
             manager: mgr)
         let cb = InMemoryClipboard()
         let ctrl = await CommandBridgeController(clipboard: cb, coordinator: coord)

--- a/TheBridgeTests/CommandVisibilityTests.swift
+++ b/TheBridgeTests/CommandVisibilityTests.swift
@@ -87,7 +87,7 @@ func runCommandVisibilityTests() async {
             ("Disabled C", "eeee1111ffff222233334444aaaabbbb", false, "command"),
             ("Admin X",    "ffff1111aaaa2222bbbb3333cccc4444", true,  "adminOnly"),
         ])
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         let names = Set(got.map { $0.name })
         try expect(names == ["Command A", "Command B"],
@@ -103,7 +103,7 @@ func runCommandVisibilityTests() async {
         UserDefaults(suiteName: suite)!.set(
             try JSONSerialization.data(withJSONObject: legacy),
             forKey: BridgeDefaults.skills)
-        let got = await RegistrySkillsCommandProvider(
+        let got = await isolatedRegistryProvider(
             suiteName: suite, storageKey: BridgeDefaults.skills).descriptors()
         try expect(got.isEmpty,
                    "a visibility-less legacy row defaults to .standard ⇒ NOT a palette command, got \(got.map { $0.name })")

--- a/TheBridgeTests/FlagVisibilityMigrationTests.swift
+++ b/TheBridgeTests/FlagVisibilityMigrationTests.swift
@@ -172,7 +172,7 @@ func runFlagVisibilityMigrationTests() async {
         let data = try JSONSerialization.data(withJSONObject: rows)
         UserDefaults(suiteName: suite)!.set(data, forKey: BridgeDefaults.skills)
 
-        let provider = RegistrySkillsCommandProvider(suiteName: suite)
+        let provider = isolatedRegistryProvider(suiteName: suite)
         let descs = await provider.descriptors()
         let names = Set(descs.map(\.name))
         try expect(names == Set(["Legacy", "Flagged", "Combined"]),

--- a/TheBridgeTests/ListRoutingSkillsMergeTests.swift
+++ b/TheBridgeTests/ListRoutingSkillsMergeTests.swift
@@ -43,7 +43,7 @@ func runListRoutingSkillsMergeTests() async {
         // Note: this still reads the shared FilesystemSkillIndex, which
         // may or may not have bundled skills in a dev tree. We assert
         // shape, not strict emptiness — every row must have a `name`.
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         for r in rows {
             if case .object(let o) = r {
                 try expect(o["name"] != nil, "every row must have a name")
@@ -62,7 +62,7 @@ func runListRoutingSkillsMergeTests() async {
                 "visibility": "routing"
             ]
         ])
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         var foundNotion = false
         for r in rows {
             if case .object(let o) = r,
@@ -78,13 +78,35 @@ func runListRoutingSkillsMergeTests() async {
         try expect(foundNotion, "TestRouting should be in merged routing list")
     }
 
+    await test("mergedRoutingSkills: explicit gate enforces the routing surface") {
+        let routingID = "aaaa1111bbbb2222cccc3333dddd4444"
+        let commandID = "bbbb1111cccc2222dddd3333eeee4444"
+        seedNotionSkills([
+            ["name": "Allowed Routing", "notionPageId": routingID, "enabled": true, "visibility": "routing"],
+            ["name": "Command Only", "notionPageId": commandID, "enabled": true, "visibility": "routing"],
+        ])
+        let gate = testExposureGate([
+            (pageID: routingID, exposure: .routing),
+            (pageID: commandID, exposure: .command),
+        ])
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: gate)
+        let names = Set(rows.compactMap { row -> String? in
+            guard case .object(let object) = row, case .string(let name)? = object["name"] else { return nil }
+            return name
+        })
+        try expect(names.contains("Allowed Routing"),
+                   "the routing surface must include a .routing entry")
+        try expect(!names.contains("Command Only"),
+                   "the routing surface must exclude a .command entry")
+    }
+
     await test("mergedRoutingSkills: alphabetical ordering") {
         seedNotionSkills([
             ["name": "Zulu", "notionPageId": "aaaa1111bbbb2222cccc3333dddd4444", "enabled": true, "visibility": "routing"],
             ["name": "Alpha", "notionPageId": "bbbb1111cccc2222dddd3333eeee4444", "enabled": true, "visibility": "routing"],
             ["name": "Mike", "notionPageId": "cccc1111dddd2222eeee3333ffff4444", "enabled": true, "visibility": "routing"]
         ])
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         let names: [String] = rows.compactMap { r in
             guard case .object(let o) = r, case .string(let n)? = o["name"] else { return nil }
             return n
@@ -100,7 +122,7 @@ func runListRoutingSkillsMergeTests() async {
             ["name": "DisabledOne", "notionPageId": "aaaa1111bbbb2222cccc3333dddd4444",
              "enabled": false, "visibility": "routing"]
         ])
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         for r in rows {
             if case .object(let o) = r, case .string(let n)? = o["name"] {
                 try expect(n != "DisabledOne", "disabled skill leaked into merged list")
@@ -113,7 +135,7 @@ func runListRoutingSkillsMergeTests() async {
             ["name": "StdOnly", "notionPageId": "aaaa1111bbbb2222cccc3333dddd4444",
              "enabled": true, "visibility": "standard"]
         ])
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         for r in rows {
             if case .object(let o) = r, case .string(let n)? = o["name"] {
                 try expect(n != "StdOnly", "standard-visibility skill leaked into routing merge")
@@ -135,7 +157,7 @@ func runListRoutingSkillsMergeTests() async {
             return false
         }
 
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         let names: Set<String> = Set(rows.compactMap { r in
             guard case .object(let o) = r, case .string(let n)? = o["name"] else { return nil }
             return n
@@ -156,7 +178,7 @@ func runListRoutingSkillsMergeTests() async {
         UserDefaults.standard.removeObject(forKey: fileRoutingKey)
         UserDefaults.standard.removeObject(forKey: fileEnabledKey)
 
-        let rows = await SkillsModule.mergedRoutingSkills()
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: nil)
         let names: Set<String> = Set(rows.compactMap { r in
             guard case .object(let o) = r, case .string(let n)? = o["name"] else { return nil }
             return n

--- a/TheBridgeTests/SkillExposureProjectionTestSupport.swift
+++ b/TheBridgeTests/SkillExposureProjectionTestSupport.swift
@@ -1,0 +1,52 @@
+// SkillExposureProjectionTestSupport.swift — hermetic Runtime Exposure projection fixtures
+// TheBridge · Tests
+
+import Foundation
+import MCP
+@_spi(Testing) import TheBridgeLib
+
+@Sendable
+func isolatedRegistryProvider(
+    suiteName: String,
+    storageKey: String = BridgeDefaults.skills,
+    exposureGate: SkillRuntimeExposureGate? = nil
+) -> RegistrySkillsCommandProvider {
+    RegistrySkillsCommandProvider(
+        suiteName: suiteName,
+        storageKey: storageKey,
+        exposureGate: exposureGate
+    )
+}
+
+func mergedRoutingSkillsForTesting(
+    exposureGate: SkillRuntimeExposureGate?
+) async -> [Value] {
+    await SkillsModule.mergedRoutingSkills(exposureGate: exposureGate)
+}
+
+func testExposureGate(
+    _ entries: [(pageID: String, exposure: SkillRuntimeExposure)],
+    compiledAt: Date = Date()
+) -> SkillRuntimeExposureGate {
+    let manifest = entries.enumerated().map { index, item in
+        SkillPublishedManifestEntry(
+            notionPageUUID: item.pageID,
+            displayName: "Fixture \(index)",
+            slug: "fixture-\(index)-\(SkillExposureIdentity.normalize(item.pageID))",
+            desiredExposure: item.exposure,
+            publishedExposure: item.exposure,
+            lifecycleOverrideReason: nil,
+            approvalID: "test-fixture",
+            notionLastEditedTime: "test",
+            url: ""
+        )
+    }
+    return SkillRuntimeExposureGate(
+        generation: SkillRuntimeGeneration(
+            snapshotID: "test-fixture",
+            compilerVersion: "test",
+            compiledAt: compiledAt,
+            entries: manifest
+        )
+    )
+}

--- a/docs/evidence/runtime-exposure-test-seam-implementation-receipt.md
+++ b/docs/evidence/runtime-exposure-test-seam-implementation-receipt.md
@@ -1,0 +1,46 @@
+# Runtime Exposure Hermetic Test-Seam Implementation Receipt
+
+## Objective
+
+Make registry-projection tests independent of live machine Runtime Exposure state without changing default production enforcement.
+
+## Source tuple before commit
+
+- Worktree: `/Users/keepup/Developer/worktrees/the-bridge/runtime-exposure-test-seam`
+- Branch: `task/runtime-exposure-test-seam`
+- Base/HEAD/origin-main: `e0a49bc409c4f649d555556dd6883a814fe3d01e`
+
+## Implemented
+
+- `RegistrySkillsCommandProvider` now carries an asynchronous gate reader.
+  - Every existing production initializer retains its signature and dynamically resolves `SkillRuntimeGenerationStore.shared.gate()`.
+  - `@_spi(Testing)` overloads accept an explicit immutable `SkillRuntimeExposureGate?`.
+- `SkillsModule.mergedRoutingSkills()` retains its public zero-argument production behavior and delegates to an `@_spi(Testing)` explicit-gate helper.
+- A shared test support file constructs real Runtime Exposure generation/gate values.
+- Affected command and routing fixtures now state their exposure context explicitly.
+- New tests prove:
+  - explicit `nil` is hermetic from the host generation;
+  - command projection includes `.command` and excludes `.routing`;
+  - routing projection includes `.routing` and excludes `.command`.
+- Test floor reconciled from `3482` to `3504` with append-only provenance.
+
+## Boundaries preserved
+
+- No Runtime Exposure compiler, policy, storage, publication, rollback, expiry, or emergency-denylist change.
+- No exact-fetch, body-cache, specialist, or filesystem-skill behavior change.
+- No production exposure state was mutated by tests.
+- No C0 ownership source or evidence was included.
+- No merge, push, install, release, tag, reset, clean, stash, branch switch, or worktree deletion.
+
+## Verification before commit
+
+- Baseline job `20260729-191559249-2d470fb2`: `3488 passed, 13 failed, 3501 total`.
+- Candidate job `20260729-192626165-4e2127ed`: `3504 passed, 0 failed, 3504 total`.
+- Independent read-only review job `20260729-193029419-9840717c`: **APPROVE**, no Critical/High/Medium/Low findings.
+- Reconciled floor job `20260729-193357712-4180571f`: `3504 passed, 0 failed, 3504 total`; `passed=3504 >= floor=3504`.
+- Debug build passed.
+- `git diff --check` passed.
+
+## Exact-SHA evidence location
+
+The single source commit cannot contain its own Git SHA. The clean exact-SHA verification and final disposition are recorded in the external Execute/Ship Gate receipt after this immutable commit is created. No evidence-only follow-up commit is permitted.

--- a/docs/evidence/runtime-exposure-test-seam-review-prompt.md
+++ b/docs/evidence/runtime-exposure-test-seam-review-prompt.md
@@ -1,0 +1,93 @@
+# Independent Review — Runtime Exposure Hermetic Test Seam
+
+## Reviewer mandate
+
+Perform a read-only, diff-first review of the exact dirty candidate in:
+
+`/Users/keepup/Developer/worktrees/the-bridge/runtime-exposure-test-seam`
+
+Inspect tracked and untracked files. Do not modify the worktree, run formatters, create commits, change branches, or alter production Runtime Exposure state.
+
+Return exactly one verdict: `APPROVE` or `REJECT`.
+
+List findings by severity: Critical, High, Medium, Low. Approval requires no open Critical, High, or Medium findings.
+
+## Objective
+
+Restore a truthful zero-failure test floor by making Runtime Exposure filtering explicit and injectable at the two affected registry-projection boundaries, without changing default production behavior or the independently approved C0 ownership source.
+
+## Approved scope
+
+- `RegistrySkillsCommandProvider`: production initializers retain signatures and dynamically resolve `SkillRuntimeGenerationStore.shared.gate()`; SPI testing paths accept an explicit immutable `SkillRuntimeExposureGate?`.
+- `SkillsModule.mergedRoutingSkills()`: public production function resolves the shared gate and delegates to an SPI helper accepting an explicit gate value.
+- Affected registry projection fixtures explicitly supply `nil` or a constructed gate.
+- Tests prove nil isolation and command/routing allow-deny surface separation.
+- No production exposure policy, compiler, generation store, promotion, rollback, denylist, exact-fetch, body-cache, specialist, C0 ownership, or filesystem-skill behavior change.
+
+## Required checks
+
+1. Production defaults cannot accidentally disable Runtime Exposure enforcement.
+2. Explicit gate injection is limited to SPI/test surfaces and introduces no mutable global override.
+3. `nil` retains the intended pre-generation compatibility behavior; non-nil gates enforce the correct command/routing surfaces.
+4. Tests do not mutate the production active generation, generation files, or emergency denylist.
+5. Existing fixture semantics—disabled rows, blank IDs, legacy decoding, ordering, file-source routing, shadows, and sorting—remain intact.
+6. Swift concurrency and `Sendable` behavior are sound.
+7. No C0 ownership source or evidence is included.
+8. Scope is the smallest true fix; flag any unnecessary public API or broad refactor.
+
+## Evidence
+
+Baseline unmodified current-main run:
+- Job `20260729-191559249-2d470fb2`
+- `3488 passed, 13 failed, 3501 total`
+
+Candidate run with live production exposure state still present:
+- Job `20260729-192626165-4e2127ed`
+- `3504 passed, 0 failed, 3504 total`
+
+Additional checks:
+- Debug build passed.
+- `git diff --check` passed.
+- No C0 path appears in `git status`.
+- Base/HEAD before commit: `e0a49bc409c4f649d555556dd6883a814fe3d01e` (`origin/main`).
+
+## Changed files expected
+
+Production:
+- `TheBridge/Modules/Commands/RegistrySkillsCommandProvider.swift`
+- `TheBridge/Modules/Skills/SkillsModuleFileSource.swift`
+
+Tests:
+- `TheBridgeTests/SkillExposureProjectionTestSupport.swift`
+- `TheBridgeTests/CommandPaletteTests.swift`
+- `TheBridgeTests/CommandVisibilityTests.swift`
+- `TheBridgeTests/FlagVisibilityMigrationTests.swift`
+- `TheBridgeTests/ListRoutingSkillsMergeTests.swift`
+
+Evidence only:
+- `docs/evidence/runtime-exposure-test-seam-todo.md`
+- this review prompt
+
+## Output format
+
+```text
+VERDICT: APPROVE|REJECT
+
+Critical
+- ... or None
+
+High
+- ... or None
+
+Medium
+- ... or None
+
+Low
+- ... or None
+
+Scope assessment
+- ...
+
+Evidence assessment
+- ...
+```

--- a/docs/evidence/runtime-exposure-test-seam-review-result.md
+++ b/docs/evidence/runtime-exposure-test-seam-review-result.md
@@ -1,0 +1,24 @@
+# Runtime Exposure Test-Seam Independent Review Result
+
+- Reviewed worktree: `/Users/keepup/Developer/worktrees/the-bridge/runtime-exposure-test-seam`
+- Branch: `task/runtime-exposure-test-seam`
+- Base/HEAD before commit: `e0a49bc409c4f649d555556dd6883a814fe3d01e`
+- Review job: `20260729-193029419-9840717c`
+- Reviewer: Codex CLI 0.144.6, `-a never -s read-only --ephemeral`
+- Exit code: 0
+- Verdict: **APPROVE**
+
+## Findings
+
+- Critical: none
+- High: none
+- Medium: none
+- Low: none
+
+## Scope assessment
+
+The exact changed and untracked file set matches the approved scope. Production defaults continue to resolve `SkillRuntimeGenerationStore.shared.gate()` dynamically. Explicit gates are immutable and confined to `@_spi(Testing)` seams. No mutable global override or Runtime Exposure policy/state change is introduced.
+
+## Evidence assessment
+
+The reviewer independently confirmed the dirty diff was limited to the expected files and `git diff --check` passed. The supplied debug-build and `3504 passed, 0 failed, 3504 total` evidence was consistent with the implementation; the read-only reviewer did not rerun tests.

--- a/docs/evidence/runtime-exposure-test-seam-todo.md
+++ b/docs/evidence/runtime-exposure-test-seam-todo.md
@@ -1,0 +1,53 @@
+# Runtime Exposure Test-Seam Delivery Todo
+
+- [x] Resolve FOCUS and MAC route stack.
+- [x] Pass one-shot Mac capability gate.
+- [x] Create dedicated worktree from current `origin/main`.
+- [ ] Reproduce the 13 fixture failures with live production exposure state present.
+- [ ] Add focused failing tests for explicit nil, allow, deny, and surface separation.
+- [ ] Add immutable gate injection to `RegistrySkillsCommandProvider`.
+- [ ] Add explicit-gate helper to `SkillsModule.mergedRoutingSkills`.
+- [ ] Update affected fixtures without mutating production exposure state.
+- [ ] Run focused tests and Runtime Exposure authority tests.
+- [ ] Run debug build, full fresh-process suite, and `git diff --check`.
+- [ ] Run detached read-only independent review.
+- [ ] Reconcile floor only from a zero-failure run; run `make test-floor`.
+- [ ] Commit once and rerun clean exact-SHA verification.
+- [ ] Finalize receipt and stop at Ship Gate.
+
+## Boundaries
+
+No C0 ownership source changes. No production exposure policy changes. No mutation of the production active generation or emergency denylist. No merge, push, install, release, tag, reset, clean, stash, branch switch, or worktree deletion.
+
+## Baseline reproduction — 2026-07-29 14:20 CDT
+
+- Job: `20260729-191559249-2d470fb2`
+- Result: `3488 passed, 13 failed, 3501 total`
+- Branch/base: `task/runtime-exposure-test-seam` at `e0a49bc409c4f649d555556dd6883a814fe3d01e`
+- The 13 failures are the expected command-provider and merged-routing fixture failures caused by shared Runtime Exposure state.
+- [x] Reproduce the 13 fixture failures with live production exposure state present.
+
+## Implementation checkpoint — 2026-07-29
+
+- [x] Add focused failing tests for explicit nil, allow, deny, and surface separation.
+- [x] Add immutable gate injection to `RegistrySkillsCommandProvider` while preserving all production initializer signatures and shared-gate behavior.
+- [x] Add explicit-gate helper to `SkillsModule.mergedRoutingSkills` while preserving the public zero-argument production function.
+- [x] Update affected fixtures without mutating production exposure state.
+- [x] Run debug build.
+- [x] Run full fresh-process suite: job `20260729-192626165-4e2127ed`, `3504 passed, 0 failed, 3504 total`.
+- [x] Verify `git diff --check` passed.
+- [x] Verify no C0 ownership source or evidence path is present in this remediation.
+
+## Independent review and floor checkpoint
+
+- [x] Run detached read-only independent review: job `20260729-193029419-9840717c`, verdict `APPROVE`, no Critical/High/Medium/Low findings.
+- [x] Reconcile the test floor from `3482` to the measured green count `3504`.
+- [x] Append floor provenance describing 13 restored fixtures plus 3 new policy tests.
+- [ ] Run `make test-floor` with the reconciled floor.
+
+## Floor gate result
+
+- [x] Run `make test-floor`: job `20260729-193357712-4180571f`, `3504 passed, 0 failed, 3504 total`; `passed=3504 >= floor=3504`.
+- [ ] Create the single local commit.
+- [ ] Rerun debug build, full harness, `make test-floor`, and diff/status checks from the clean exact SHA.
+- [ ] Finalize the external Ship Gate receipt; do not merge, push, install, tag, or release.

--- a/scripts/test-floor-gate-history.md
+++ b/scripts/test-floor-gate-history.md
@@ -2431,3 +2431,5 @@ set -euo pipefail
 # Measured 3416 passed, 0 failed. FLOOR 3414 -> 3416.
 - 2026-07-27 · PKT-1212 B0 · `3416 → 3481` (+65): Stripe API-version/evidence transport, customer and invoice lifecycle, deterministic idempotency, indeterminate-effect recovery, and retained suite coverage.
 - 2026-07-28 · CI child-process harness hardening · `3481 → 3482` (+1): bounded calendar-registry child waits, executable forced-stall regression, and corrected CI watchdog ordering. Measured 3482 passed, 0 failed.
+
+- 2026-07-29 · Runtime Exposure hermetic projection seam · `3482 → 3504` (+22): restored 13 command/routing registry fixture tests that were incorrectly filtered by the live process-global exposure generation, and added 3 explicit nil/allow/deny surface tests. Measured 3504 passed, 0 failed with production exposure state present.

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -9,7 +9,7 @@
 # the floor OR any test fails.
 #
 # Full append-only FLOOR provenance: scripts/test-floor-gate-history.md
-FLOOR="${BRIDGE_TEST_FLOOR:-3482}"
+FLOOR="${BRIDGE_TEST_FLOOR:-3504}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Objective

Make Runtime Exposure filtering explicit and hermetic at the two registry-projection test boundaries, without changing default production behavior.

This is the prerequisite remediation for C0 runtime worktree ownership enforcement.

## Changes

- Preserve all production `RegistrySkillsCommandProvider` initializer signatures and dynamic `SkillRuntimeGenerationStore.shared.gate()` resolution.
- Add SPI-only explicit immutable `SkillRuntimeExposureGate?` injection for tests.
- Preserve public `SkillsModule.mergedRoutingSkills()` behavior and delegate to an SPI-only explicit-gate helper.
- Convert affected registry fixtures to explicit `nil`, allow, and deny exposure contexts.
- Add command/routing surface-separation coverage.
- Raise the test floor from `3482` to `3504` with append-only provenance.

## Scope exclusions

No change to Runtime Exposure policy, compiler, generation persistence, publication, promotion, rollback, expiry, emergency denylist, exact fetch, body cache, specialist exposure, filesystem-skill behavior, or C0 ownership source.

## Evidence

- Baseline on parent `e0a49bc409c4f649d555556dd6883a814fe3d01e`: `3488 passed, 13 failed, 3501 total`.
- Precommit full harness: `3504 passed, 0 failed, 3504 total`.
- Independent read-only review: **APPROVE**, no Critical/High/Medium/Low findings.
- Precommit `make test-floor`: passed at floor `3504`.
- Clean exact-SHA full harness at `30bf9a8c5ec3b825ce8e962c686cae9bb5618e04`: `3504 passed, 0 failed, 3504 total`.
- Clean exact-SHA `make test-floor`: `passed=3504 >= floor=3504`, zero failures.
- `git diff --check`: passed.

## Risk and rollback

The main residual risk is CI-environment sensitivity from the higher floor or an unintended future use of the testing SPI. Production entry points in this diff continue to resolve the live shared gate.

Rollback is a normal revert of this commit. A revert would restore the known 13 fixture failures and floor `3482`, so an alternative hermeticity fix would still be required.

## C0 continuation

Do not treat this merge as validation of C0. After this prerequisite reaches `main`, C0 must be refreshed onto the resulting exact base and rerun through its full harness and independent review.
