### PR TITLE
Assign build 85 for C0 installed pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.0.2 (build 85) — C0 installed-pilot candidate — 2026-07-30
+
+- **Pilot identity** — Build-only local candidate identity for the merged-main
+  C0 Runtime Worktree Ownership integration; marketing remains **4.0.2**.
+- **Scope** — No behavior changes beyond the already-reviewed C0 merge. This
+  commit synchronizes `Version.swift`, root `Info.plist`, and this changelog.
+- **Promotion boundary** — No tag, DMG, appcast, Sparkle publication, or
+  customer-facing release. Installation still requires candidate smoke and a
+  separate explicit Ship Gate.
+
 ## v4.0.2 (build 84) — THREAD Messages C1 containment — 2026-07-26
 
 - **Containment** — Any THREAD-shaped `messages_send` request returns

--- a/Info.plist
+++ b/Info.plist
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>84</string>
+	<string>85</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -308,7 +308,9 @@ public enum AppVersion {
     ///   Sale-ready V4 cut: W5B bundle-id cutover + continuity, Notion Views
     ///   write tools, Wave A Settings UI-ITER polish, license public-key +
     ///   WorkOS OAuth bake secrets present for release.yml inject. Floor 3391.
-    public static let build = "84"
+    /// v4.0.2 C0 installed-pilot candidate: 84 -> 85 -- local-only build identity
+    /// for merged-main worktree-ownership acceptance; no tag, appcast, or release.
+    public static let build = "85"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## Scope

Identity-only integration for the approved C0 installed-pilot contract.

- marketing remains `4.0.2`
- build `84 → 85`
- synchronized `Version.swift`, root `Info.plist`, and `CHANGELOG.md` only
- no source behavior, tag, DMG, appcast, Sparkle publication, or customer release

## Evidence

- parent main: `23d53d85e66290b5e3915bd721e512c77622429b`
- identity commit: `ed1f55b437f902841df2914aafc4766791e14d2b`
- reviewed patch SHA-256: `2bda5db74ea0ac0737da0fd06331aae57a80e3faff072c9db9b531d9ff73f520`
- independent read-only review: APPROVE, zero findings
- `git diff --check`: passed

Installation remains blocked behind candidate build, genuine smoke, and a separate explicit Ship Gate.