### PR TITLE
chore(pilot): assign C0 installed build 86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.0.2 (build 86) — C0 fail-closed enforcement pilot — 2026-07-30
+
+- **Pilot identity** — Build-only local candidate identity for the exact merged
+  `main` C0 enforcement source; marketing remains **4.0.2**.
+- **Scope** — This commit synchronizes `Version.swift`, root `Info.plist`, and
+  this changelog. No tag, DMG, appcast, Sparkle publication, or customer-facing
+  release is created.
+- **Promotion boundary** — Candidate smoke and an explicit installation Ship
+  Gate remain required before `/Applications` changes.
+
 ## v4.0.2 (build 85) — C0 installed-pilot candidate — 2026-07-30
 
 - **Pilot identity** — Build-only local candidate identity for the merged-main

--- a/Info.plist
+++ b/Info.plist
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>85</string>
+	<string>86</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -308,9 +308,9 @@ public enum AppVersion {
     ///   Sale-ready V4 cut: W5B bundle-id cutover + continuity, Notion Views
     ///   write tools, Wave A Settings UI-ITER polish, license public-key +
     ///   WorkOS OAuth bake secrets present for release.yml inject. Floor 3391.
-    /// v4.0.2 C0 installed-pilot candidate: 84 -> 85 -- local-only build identity
-    /// for merged-main worktree-ownership acceptance; no tag, appcast, or release.
-    public static let build = "85"
+    /// v4.0.2 C0 installed-pilot candidate: 85 -> 86 -- local-only build identity
+    /// after the fail-closed enforcement merge; no tag, appcast, or release.
+    public static let build = "86"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## What changed

Assigns the local C0 installed-pilot identity to **4.0.2 (86)**.

- Updates `TheBridge/Config/Version.swift` and root `Info.plist` together.
- Adds the matching local-pilot changelog entry.

## Why

The existing build-85 candidate was built before the fail-closed C0 enforcement merge. Build 86 gives the exact merged enforcement source a unique, monotonic local-pilot identity while retaining marketing version 4.0.2.

## Impact and boundaries

This is identity-only. It does not tag, publish an appcast, create a DMG, enable a customer release, or replace `/Applications/The Bridge.app`. Candidate smoke and a separate installation Ship Gate remain required.

## Validation

- `make test` — 3556 passed, 0 failed
- `make test-floor` — 3556 passed, 0 failed; floor 3556
- `git diff --check` — passed
