### PR TITLE
chore(pilot): assign C0 installed build 87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v4.0.2 (build 87) — C0 denial-diagnostics installed pilot — 2026-07-31
+
+- **Pilot identity** — Build-only local candidate identity for exact merged
+  `main` after PR #136 denial-diagnostics remediation; marketing remains **4.0.2**.
+- **Scope** — This commit synchronizes `Version.swift`, root `Info.plist`, and
+  this changelog. No tag, DMG, appcast, Sparkle publication, or customer-facing
+  release is created.
+- **Promotion boundary** — Candidate smoke and an explicit installation Ship
+  Gate remain required before `/Applications` changes. Retained b86 archives
+  embed pre-fix SHA `14694765…` and must not be installed.
+
 ## v4.0.2 (build 86) — C0 fail-closed enforcement pilot — 2026-07-30
 
 - **Pilot identity** — Build-only local candidate identity for the exact merged

--- a/Info.plist
+++ b/Info.plist
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>86</string>
+	<string>87</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -308,9 +308,9 @@ public enum AppVersion {
     ///   Sale-ready V4 cut: W5B bundle-id cutover + continuity, Notion Views
     ///   write tools, Wave A Settings UI-ITER polish, license public-key +
     ///   WorkOS OAuth bake secrets present for release.yml inject. Floor 3391.
-    /// v4.0.2 C0 installed-pilot candidate: 85 -> 86 -- local-only build identity
-    /// after the fail-closed enforcement merge; no tag, appcast, or release.
-    public static let build = "86"
+    /// v4.0.2 C0 installed-pilot candidate: 86 -> 87 -- local-only build identity
+    /// after the denial-diagnostics remediation merge; no tag, appcast, or release.
+    public static let build = "87"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## Summary
- Identity-only bump to **4.0.2 (87)** for the C0 denial-diagnostics installed pilot on exact post-#136 `main`.
- Syncs `Version.swift`, root `Info.plist`, and `CHANGELOG.md` only.
- No tag, DMG, appcast, Sparkle, or customer release. Retained b86 archives must not be installed (pre-fix SHA).

## Test plan
- [ ] CI `build-and-test` green
- [ ] Confirm only identity files changed
- [ ] After merge: FF primary, `make test` + `make test-floor` on exact identity SHA
- [ ] Fresh signed candidate + isolated smoke before any `/Applications` GO


Made with [Cursor](https://cursor.com)