### PR TITLE
feat: add claim-aware bounded worktree command runner

### DIFF
--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -467,7 +467,7 @@ public enum BridgeConstants {
     /// C0 runtime worktree ownership (2026-07-29): +2 tools
     ///   (worktree_claim + worktree_release; existing dev family). C0 is
     ///   default-ON only after opaque execution paths fail closed.
-    public static let staticFeatureModuleToolCount = 216
+    public static let staticFeatureModuleToolCount = 217
 
     /// Distinct `module` string families included in `staticFeatureModuleToolCount` (Stripe and `builtin` excluded).
     /// v2.2 · 0.1 (PKT-738): 15 + 1 (dev) = 16.

--- a/TheBridge/Modules/Auth/ConnectorScopeGate.swift
+++ b/TheBridge/Modules/Auth/ConnectorScopeGate.swift
@@ -99,7 +99,7 @@ public struct ConnectorScopeGate: ScopeGating {
     /// docs/operator/mcp-builder-audit-report.md but not currently
     /// registered anywhere in the codebase; add them here if/when they ship.
     private static let runnerExecTools: Set<String> = [
-        "shell_exec", "run_script",
+        "shell_exec", "run_script", "worktree_command_run",
         "bg_run", "bg_poll", "bg_kill",
         "job_create", "job_run", "job_update", "job_delete",
         "job_pause", "job_resume", "job_duplicate", "job_import",

--- a/TheBridge/Modules/WorktreeCommandModule.swift
+++ b/TheBridge/Modules/WorktreeCommandModule.swift
@@ -1,0 +1,528 @@
+// WorktreeCommandModule.swift — claim-aware, argv-only build/test execution.
+
+import CryptoKit
+import Darwin
+import Foundation
+import MCP
+
+public enum WorktreeCommandError: Error, LocalizedError, Sendable, Equatable {
+    case invalid(String)
+    case identityChanged(String)
+    case ownershipRequired(String)
+    case spawnFailed(String)
+
+    public var code: String {
+        switch self {
+        case .invalid: return "invalid_arguments"
+        case .identityChanged: return "worktree_identity_changed"
+        case .ownershipRequired: return "worktree_ownership_required"
+        case .spawnFailed: return "worktree_command_spawn_failed"
+        }
+    }
+
+    public var errorDescription: String? {
+        let detail: String
+        switch self {
+        case .invalid(let value), .identityChanged(let value),
+             .ownershipRequired(let value), .spawnFailed(let value):
+            detail = value
+        }
+        return "\(code): \(detail)"
+    }
+}
+
+public struct WorktreeCommandInvocation: Sendable, Equatable {
+    public let worktreePath: String
+    public let ownerSession: String
+    public let expectedBranch: String
+    public let expectedHead: String
+    public let executable: String
+    public let argv: [String]
+    public let declaredWriteRoots: [String]
+    public let timeoutSeconds: Int
+
+    public init(
+        worktreePath: String,
+        ownerSession: String,
+        expectedBranch: String,
+        expectedHead: String,
+        executable: String,
+        argv: [String],
+        declaredWriteRoots: [String],
+        timeoutSeconds: Int
+    ) {
+        self.worktreePath = worktreePath
+        self.ownerSession = ownerSession
+        self.expectedBranch = expectedBranch
+        self.expectedHead = expectedHead
+        self.executable = executable
+        self.argv = argv
+        self.declaredWriteRoots = declaredWriteRoots
+        self.timeoutSeconds = timeoutSeconds
+    }
+}
+
+private final class WorktreeCommandProcessBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didTimeOut = false
+
+    func markTimedOut() {
+        lock.lock()
+        didTimeOut = true
+        lock.unlock()
+    }
+
+    func timedOut() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didTimeOut
+    }
+}
+
+private final class WorktreeCommandDataBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = Data()
+
+    func set(_ data: Data) {
+        lock.lock()
+        storage = data
+        lock.unlock()
+    }
+
+    func get() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+private struct WorktreeCommandProcessResult: Sendable {
+    let exitCode: Int32
+    let stdout: Data
+    let stderr: Data
+    let timedOut: Bool
+    let durationMilliseconds: Int
+}
+
+private struct WorktreeCommandRepositorySnapshot: Sendable {
+    let statusSHA256: String
+    let contentSHA256: String
+    let fileSHA256: [String: String]
+}
+
+public enum WorktreeCommandContract {
+    private static let makeTargets: Set<String> = ["debug", "test", "test-floor", "build"]
+    private static let swiftArgv: Set<[String]> = [
+        ["build", "-c", "debug"],
+        ["build", "-c", "release", "-Xswiftc", "-strict-concurrency=complete"],
+    ]
+
+    public static func validate(_ invocation: WorktreeCommandInvocation) throws -> WorktreeCommandInvocation {
+        guard invocation.worktreePath.hasPrefix("/"),
+              !invocation.ownerSession.isEmpty,
+              !invocation.expectedBranch.isEmpty,
+              invocation.expectedHead.range(of: "^[0-9a-fA-F]{40}$", options: .regularExpression) != nil else {
+            throw WorktreeCommandError.invalid("worktreePath, ownerSession, expectedBranch, and a 40-character expectedHead are required")
+        }
+        guard (1...3600).contains(invocation.timeoutSeconds) else {
+            throw WorktreeCommandError.invalid("timeoutSeconds must be within 1...3600")
+        }
+        guard !invocation.declaredWriteRoots.isEmpty else {
+            throw WorktreeCommandError.invalid("declaredWriteRoots must contain at least one bounded path")
+        }
+        for value in [invocation.executable] + invocation.argv + invocation.declaredWriteRoots {
+            guard !value.isEmpty,
+                  !value.unicodeScalars.contains(where: { $0.value == 0 || $0.value == 10 || $0.value == 13 }) else {
+                throw WorktreeCommandError.invalid("executable, argv, and declaredWriteRoots must be non-empty and contain no control separators")
+            }
+        }
+
+        let worktree = try canonicalDirectory(invocation.worktreePath)
+        let executable = URL(fileURLWithPath: invocation.executable).standardizedFileURL.path
+        let allowed: Bool
+        switch executable {
+        case "/usr/bin/make":
+            allowed = invocation.argv.count == 1 && makeTargets.contains(invocation.argv[0])
+        case "/usr/bin/swift":
+            allowed = swiftArgv.contains(invocation.argv)
+        default:
+            let debugTests = worktree + "/.build/debug/TheBridgeTests"
+            allowed = executable == debugTests && invocation.argv.isEmpty
+        }
+        guard allowed else {
+            throw WorktreeCommandError.invalid(
+                "executable/argv is outside the reviewed build-test allowlist; shell strings, Git, install, push, merge, tag, release, and arbitrary scripts are not supported"
+            )
+        }
+        guard FileManager.default.isExecutableFile(atPath: executable) else {
+            throw WorktreeCommandError.invalid("approved executable is not available at the requested absolute path")
+        }
+
+        var roots: [String] = []
+        for rawRoot in invocation.declaredWriteRoots {
+            let root = try canonicalWriteRoot(rawRoot, worktree: worktree)
+            guard root != worktree, root != worktree + "/.git" else {
+                throw WorktreeCommandError.invalid("declaredWriteRoots may not grant the entire worktree or Git metadata")
+            }
+            if !roots.contains(root) { roots.append(root) }
+        }
+        return WorktreeCommandInvocation(
+            worktreePath: worktree,
+            ownerSession: invocation.ownerSession,
+            expectedBranch: invocation.expectedBranch,
+            expectedHead: invocation.expectedHead.lowercased(),
+            executable: executable,
+            argv: invocation.argv,
+            declaredWriteRoots: roots.sorted(),
+            timeoutSeconds: invocation.timeoutSeconds
+        )
+    }
+
+    private static func canonicalDirectory(_ raw: String) throws -> String {
+        let url = URL(fileURLWithPath: raw).standardizedFileURL.resolvingSymlinksInPath()
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw WorktreeCommandError.invalid("worktreePath must be an existing directory")
+        }
+        return url.path
+    }
+
+    private static func canonicalWriteRoot(_ raw: String, worktree: String) throws -> String {
+        let candidate = raw.hasPrefix("/")
+            ? URL(fileURLWithPath: raw)
+            : URL(fileURLWithPath: worktree).appendingPathComponent(raw)
+        let standardized = candidate.standardizedFileURL
+        let resolved: URL
+        if FileManager.default.fileExists(atPath: standardized.path) {
+            resolved = standardized.resolvingSymlinksInPath()
+        } else {
+            let parent = standardized.deletingLastPathComponent().resolvingSymlinksInPath()
+            resolved = parent.appendingPathComponent(standardized.lastPathComponent).standardizedFileURL
+        }
+        guard resolved.path.hasPrefix(worktree + "/") else {
+            throw WorktreeCommandError.invalid("declaredWriteRoots must remain inside the claimed worktree and may not escape through .. or symlinks")
+        }
+        return resolved.path
+    }
+}
+
+public enum WorktreeCommandModule {
+    public static let moduleName = "dev"
+    private static let maxReturnedBytes = 64 * 1024
+
+    public static func register(on router: ToolRouter) async {
+        await router.register(ToolRegistration(
+            name: "worktree_command_run",
+            module: moduleName,
+            tier: .request,
+            description: "Run one reviewed build or test command in an already-claimed Git worktree. Accepts an absolute executable plus argv (never a shell string), verifies owner/branch/HEAD before and after, bounds declared write roots to the worktree, and returns exact command/output/status digests. It cannot run Git, install, push, merge, tag, release, destructive commands, or arbitrary scripts.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "worktreePath": stringProperty("Canonical claimed worktree path."),
+                    "ownerSession": stringProperty("Owner session of the active worktree claim."),
+                    "expectedBranch": stringProperty("Exact branch expected before and after execution."),
+                    "expectedHead": stringProperty("Exact 40-character HEAD SHA expected before and after execution."),
+                    "executable": stringProperty("Absolute allow-listed executable path; no shell is used."),
+                    "argv": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                        "description": .string("Argument vector. Shell syntax, substitution, and glob expansion are never interpreted.")
+                    ]),
+                    "declaredWriteRoots": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                        "description": .string("Bounded absolute or worktree-relative paths expected to receive build/test writes.")
+                    ]),
+                    "timeoutSeconds": .object([
+                        "type": .string("integer"),
+                        "minimum": .int(1),
+                        "maximum": .int(3600),
+                        "description": .string("Foreground execution timeout.")
+                    ])
+                ]),
+                "required": .array([
+                    "worktreePath", "ownerSession", "expectedBranch", "expectedHead",
+                    "executable", "argv", "declaredWriteRoots", "timeoutSeconds"
+                ].map(Value.string)),
+                "additionalProperties": .bool(false)
+            ]),
+            handler: { arguments in
+                do {
+                    let invocation = try parse(arguments)
+                    return try await execute(invocation)
+                } catch let error as WorktreeCommandError {
+                    return errorValue(error)
+                } catch {
+                    return errorValue(.spawnFailed(error.localizedDescription))
+                }
+            }
+        ))
+    }
+
+    private static func parse(_ arguments: Value) throws -> WorktreeCommandInvocation {
+        guard case .object(let object) = arguments,
+              let worktreePath = string(object["worktreePath"]),
+              let ownerSession = string(object["ownerSession"]),
+              let expectedBranch = string(object["expectedBranch"]),
+              let expectedHead = string(object["expectedHead"]),
+              let executable = string(object["executable"]),
+              let argv = strings(object["argv"]),
+              let roots = strings(object["declaredWriteRoots"]),
+              case .int(let timeoutSeconds) = object["timeoutSeconds"] else {
+            throw WorktreeCommandError.invalid("required worktree command tuple is incomplete")
+        }
+        return try WorktreeCommandContract.validate(.init(
+            worktreePath: worktreePath,
+            ownerSession: ownerSession,
+            expectedBranch: expectedBranch,
+            expectedHead: expectedHead,
+            executable: executable,
+            argv: argv,
+            declaredWriteRoots: roots,
+            timeoutSeconds: timeoutSeconds
+        ))
+    }
+
+    private static func execute(_ invocation: WorktreeCommandInvocation) async throws -> Value {
+        let beforeIdentity = try WorktreeOwnershipGuard.liveIdentity(for: invocation.worktreePath)
+        try verifyIdentity(beforeIdentity, invocation: invocation, phase: "preflight")
+        guard let permit = WorktreeOwnershipGuard.currentPermit,
+              permit.ownerSession == invocation.ownerSession,
+              permit.stableIDs.contains(beforeIdentity.stableID) else {
+            throw WorktreeCommandError.ownershipRequired("an active task-local permit for this exact owner and worktree is required")
+        }
+
+        let beforeSnapshot = try await repositorySnapshot(invocation.worktreePath)
+        let startedAt = Date()
+        let process = try await runProcess(invocation)
+        let finishedAt = Date()
+        let afterIdentity = try WorktreeOwnershipGuard.liveIdentity(for: invocation.worktreePath)
+        try verifyIdentity(afterIdentity, invocation: invocation, phase: "readback")
+        let afterSnapshot = try await repositorySnapshot(invocation.worktreePath)
+        let outsideChanges = changedPaths(beforeSnapshot.fileSHA256, afterSnapshot.fileSHA256).filter {
+            !isInsideDeclaredRoots($0, invocation: invocation)
+        }
+        let commandDigest = digest(
+            Data(([invocation.executable] + invocation.argv).joined(separator: "\u{0}").utf8)
+        )
+        let stdoutDigest = digest(process.stdout)
+        let stderrDigest = digest(process.stderr)
+        let success = process.exitCode == 0 && !process.timedOut && outsideChanges.isEmpty
+        let status: String
+        if !outsideChanges.isEmpty { status = "write_scope_violation" }
+        else if process.timedOut { status = "timed_out" }
+        else if process.exitCode == 0 { status = "success" }
+        else { status = "failed" }
+
+        return .object([
+            "ok": .bool(success),
+            "status": .string(status),
+            "worktreePath": .string(invocation.worktreePath),
+            "ownerSession": .string(invocation.ownerSession),
+            "branch": .string(afterIdentity.branch),
+            "headSHA": .string(afterIdentity.headSHA),
+            "executable": .string(invocation.executable),
+            "argv": .array(invocation.argv.map(Value.string)),
+            "commandSHA256": .string(commandDigest),
+            "declaredWriteRoots": .array(invocation.declaredWriteRoots.map(Value.string)),
+            "outsideDeclaredWriteRoots": .array(outsideChanges.sorted().map(Value.string)),
+            "preGitStatusSHA256": .string(beforeSnapshot.statusSHA256),
+            "postGitStatusSHA256": .string(afterSnapshot.statusSHA256),
+            "preWorktreeContentSHA256": .string(beforeSnapshot.contentSHA256),
+            "postWorktreeContentSHA256": .string(afterSnapshot.contentSHA256),
+            "exitCode": .int(Int(process.exitCode)),
+            "timedOut": .bool(process.timedOut),
+            "terminationReason": .string(process.timedOut ? "timeout_killed" : (process.exitCode == 0 ? "exited" : "non_zero_exit")),
+            "timeoutSeconds": .int(invocation.timeoutSeconds),
+            "durationMilliseconds": .int(process.durationMilliseconds),
+            "startedAt": .string(ISO8601DateFormatter().string(from: startedAt)),
+            "finishedAt": .string(ISO8601DateFormatter().string(from: finishedAt)),
+            "stdout": .string(boundedText(process.stdout)),
+            "stderr": .string(boundedText(process.stderr)),
+            "stdoutSHA256": .string(stdoutDigest),
+            "stderrSHA256": .string(stderrDigest),
+            "stdoutBytes": .int(process.stdout.count),
+            "stderrBytes": .int(process.stderr.count),
+            "stdoutTruncated": .bool(process.stdout.count > maxReturnedBytes),
+            "stderrTruncated": .bool(process.stderr.count > maxReturnedBytes)
+        ])
+    }
+
+    private static func verifyIdentity(
+        _ identity: WorktreeOwnershipGuard.LiveIdentity,
+        invocation: WorktreeCommandInvocation,
+        phase: String
+    ) throws {
+        guard identity.worktreePath == invocation.worktreePath,
+              identity.branch == invocation.expectedBranch,
+              identity.headSHA.lowercased() == invocation.expectedHead else {
+            throw WorktreeCommandError.identityChanged(
+                "\(phase) expected {path=\(invocation.worktreePath), branch=\(invocation.expectedBranch), head=\(invocation.expectedHead)} but observed {path=\(identity.worktreePath), branch=\(identity.branch), head=\(identity.headSHA)}"
+            )
+        }
+    }
+
+    private static func runProcess(_ invocation: WorktreeCommandInvocation) async throws -> WorktreeCommandProcessResult {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: invocation.executable)
+                process.arguments = invocation.argv
+                process.currentDirectoryURL = URL(fileURLWithPath: invocation.worktreePath)
+                let inherited = ProcessInfo.processInfo.environment
+                var environment: [String: String] = [
+                    "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin",
+                    "LANG": inherited["LANG"] ?? "en_US.UTF-8",
+                    "LC_ALL": inherited["LC_ALL"] ?? "en_US.UTF-8"
+                ]
+                for key in ["HOME", "TMPDIR", "DEVELOPER_DIR", "SDKROOT"] {
+                    if let value = inherited[key] { environment[key] = value }
+                }
+                process.environment = environment
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
+                let state = WorktreeCommandProcessBox()
+                let outData = WorktreeCommandDataBox()
+                let errData = WorktreeCommandDataBox()
+                let ioGroup = DispatchGroup()
+                let started = Date()
+                do {
+                    try process.run()
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        outData.set(stdout.fileHandleForReading.readDataToEndOfFile())
+                        ioGroup.leave()
+                    }
+                    ioGroup.enter()
+                    DispatchQueue.global(qos: .utility).async {
+                        errData.set(stderr.fileHandleForReading.readDataToEndOfFile())
+                        ioGroup.leave()
+                    }
+                    let timeout = DispatchWorkItem {
+                        if process.isRunning {
+                            state.markTimedOut()
+                            process.terminate()
+                            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                                if process.isRunning { _ = Darwin.kill(process.processIdentifier, SIGKILL) }
+                            }
+                        }
+                    }
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .seconds(invocation.timeoutSeconds),
+                        execute: timeout
+                    )
+                    process.waitUntilExit()
+                    timeout.cancel()
+                    ioGroup.wait()
+                    continuation.resume(returning: WorktreeCommandProcessResult(
+                        exitCode: process.terminationStatus,
+                        stdout: outData.get(),
+                        stderr: errData.get(),
+                        timedOut: state.timedOut(),
+                        durationMilliseconds: Int(Date().timeIntervalSince(started) * 1000)
+                    ))
+                } catch {
+                    continuation.resume(throwing: WorktreeCommandError.spawnFailed(error.localizedDescription))
+                }
+            }
+        }
+    }
+
+    private static func repositorySnapshot(_ path: String) async throws -> WorktreeCommandRepositorySnapshot {
+        let status = try await GitRuntime.spawn(
+            executable: "/usr/bin/git",
+            args: ["status", "--porcelain=v1", "--untracked-files=all"],
+            cwd: path,
+            stdin: nil
+        )
+        guard status.exitCode == 0 else {
+            throw WorktreeCommandError.identityChanged("git status readback failed: \(status.stderr)")
+        }
+        let listing = try await GitRuntime.spawn(
+            executable: "/usr/bin/git",
+            args: ["ls-files", "-co", "--exclude-standard", "-z"],
+            cwd: path,
+            stdin: nil
+        )
+        guard listing.exitCode == 0 else {
+            throw WorktreeCommandError.identityChanged("git file inventory readback failed: \(listing.stderr)")
+        }
+        var files: [String: String] = [:]
+        for relative in listing.stdout.split(separator: "\0", omittingEmptySubsequences: true).map(String.init) {
+            let absolute = URL(fileURLWithPath: path).appendingPathComponent(relative).standardizedFileURL
+            guard absolute.path.hasPrefix(path + "/") else {
+                throw WorktreeCommandError.identityChanged("git inventory contained a path outside the worktree")
+            }
+            if let attributes = try? FileManager.default.attributesOfItem(atPath: absolute.path),
+               attributes[.type] as? FileAttributeType == .typeSymbolicLink {
+                let destination = (try? FileManager.default.destinationOfSymbolicLink(atPath: absolute.path)) ?? "<unreadable>"
+                files[relative] = digest(Data(("symlink\0" + destination).utf8))
+            } else if let data = try? Data(contentsOf: absolute, options: [.mappedIfSafe]) {
+                files[relative] = digest(data)
+            } else {
+                files[relative] = digest(Data("<missing-or-unreadable>".utf8))
+            }
+        }
+        let canonical = files.keys.sorted().map { "\($0)\0\(files[$0]!)" }.joined(separator: "\n")
+        return WorktreeCommandRepositorySnapshot(
+            statusSHA256: digest(Data(status.stdout.utf8)),
+            contentSHA256: digest(Data(canonical.utf8)),
+            fileSHA256: files
+        )
+    }
+
+    private static func changedPaths(
+        _ before: [String: String],
+        _ after: [String: String]
+    ) -> [String] {
+        Set(before.keys).union(after.keys).filter { before[$0] != after[$0] }
+    }
+
+    private static func isInsideDeclaredRoots(_ relativePath: String, invocation: WorktreeCommandInvocation) -> Bool {
+        let absolute = URL(fileURLWithPath: invocation.worktreePath)
+            .appendingPathComponent(relativePath)
+            .standardizedFileURL.path
+        return invocation.declaredWriteRoots.contains { absolute == $0 || absolute.hasPrefix($0 + "/") }
+    }
+
+    private static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func boundedText(_ data: Data) -> String {
+        let clipped = data.prefix(maxReturnedBytes)
+        return String(decoding: clipped, as: UTF8.self)
+    }
+
+    private static func string(_ value: Value?) -> String? {
+        guard case .string(let string) = value, !string.isEmpty else { return nil }
+        return string
+    }
+
+    private static func strings(_ value: Value?) -> [String]? {
+        guard case .array(let values) = value else { return nil }
+        var result: [String] = []
+        for value in values {
+            guard case .string(let string) = value else { return nil }
+            result.append(string)
+        }
+        return result
+    }
+
+    private static func stringProperty(_ description: String) -> Value {
+        .object(["type": .string("string"), "description": .string(description)])
+    }
+
+    private static func errorValue(_ error: WorktreeCommandError) -> Value {
+        .object([
+            "ok": .bool(false),
+            "status": .string(error.code),
+            "tool": .string("worktree_command_run"),
+            "error": .string(error.localizedDescription)
+        ])
+    }
+}

--- a/TheBridge/Modules/WorktreeOwnership.swift
+++ b/TheBridge/Modules/WorktreeOwnership.swift
@@ -1116,7 +1116,8 @@ public enum WorktreeOwnershipGuard {
     ) async throws -> WorktreeExecutionAuthorization? {
         guard directMutationTools.contains(toolName)
                 || toolName == "shell_exec"
-                || toolName == "bg_run" else { return nil }
+                || toolName == "bg_run"
+                || toolName == "worktree_command_run" else { return nil }
         guard case .object(let args) = arguments else { return nil }
 
         if toolName == "git_apply_patch",
@@ -1151,7 +1152,15 @@ public enum WorktreeOwnershipGuard {
         let paths: [String]
         let repositoryRequired: Bool
 
-        if toolName == "shell_exec" || toolName == "bg_run" {
+        if toolName == "worktree_command_run" {
+            guard let worktreePath = string(args["worktreePath"]) else {
+                throw WorktreeOwnershipError.targetUnresolved(
+                    "worktree_command_run requires an explicit worktreePath"
+                )
+            }
+            paths = [worktreePath]
+            repositoryRequired = true
+        } else if toolName == "shell_exec" || toolName == "bg_run" {
             guard let command = string(args["command"]) else { return nil }
             let workingDirectory = string(args["workingDir"])
                 ?? FileManager.default.currentDirectoryPath
@@ -1319,6 +1328,8 @@ public enum WorktreeOwnershipGuard {
         let rawTargets: [String]
         switch toolName {
         case "worktree_claim", "worktree_release":
+            rawTargets = compact([string(object["worktreePath"])])
+        case "worktree_command_run":
             rawTargets = compact([string(object["worktreePath"])])
         case "shell_exec", "bg_run":
             let workingDirectory = string(object["workingDir"])
@@ -3374,6 +3385,7 @@ public enum WorktreeOwnershipModule {
         on router: ToolRouter,
         store: WorktreeOwnershipStore = .shared
     ) async {
+        await WorktreeCommandModule.register(on: router)
         await router.register(ToolRegistration(
             name: "worktree_claim",
             module: moduleName,

--- a/TheBridge/Server/ToolAnnotations.swift
+++ b/TheBridge/Server/ToolAnnotations.swift
@@ -184,6 +184,7 @@ public enum ToolAnnotationCatalog {
         "git_status": .init(readOnlyHint: true, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "worktree_claim": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: true, requiresConfirmation: true, openWorld: false),
         "worktree_release": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
+        "worktree_command_run": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: false),
         // Sprint A · mcp-builder #6: git_worktree split into 3 primitives.
         "http_fetch": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: true, openWorld: true),
         "job_create": .init(readOnlyHint: false, destructiveHint: false, idempotentHint: false, requiresConfirmation: false, openWorld: false),

--- a/TheBridgeTests/DevSuiteAuditTests.swift
+++ b/TheBridgeTests/DevSuiteAuditTests.swift
@@ -58,7 +58,7 @@ func runDevSuiteAuditTests() async {
         // git_worktree split (alias kept):
         "git_worktree", "git_worktree_list", "git_worktree_add", "git_worktree_remove",
         "git_create_branch", 
-        "worktree_claim", "worktree_release",
+        "worktree_claim", "worktree_release", "worktree_command_run",
         "code_search",
         // file_edit merge:
         "file_edit",

--- a/TheBridgeTests/RemoteOAuthBearerTests.swift
+++ b/TheBridgeTests/RemoteOAuthBearerTests.swift
@@ -357,7 +357,7 @@ func runRemoteOAuthBearerTests() async {
     }
 
     await test("ScopeGate: runners.exec gates command/exec tools") {
-        for tool in ["shell_exec", "run_script", "bg_run", "job_run"] {
+        for tool in ["shell_exec", "run_script", "worktree_command_run", "bg_run", "job_run"] {
             let denied = await gate.evaluate(
                 toolName: tool, grantedScopes: [ConnectorScope(name: "snippets.read")]
             )

--- a/TheBridgeTests/WorktreeOwnershipTests.swift
+++ b/TheBridgeTests/WorktreeOwnershipTests.swift
@@ -2427,6 +2427,205 @@ func runWorktreeOwnershipTests() async {
         try expect(denied.text.contains("remedy=Use shell_exec with an explicit command and workingDir"))
     }
 
+    await test("WU0 command contract accepts only reviewed argv build/test families and bounded roots") {
+        let fixture = try C0GitFixture()
+        let accepted = try WorktreeCommandContract.validate(.init(
+            worktreePath: fixture.linked.path,
+            ownerSession: "owner",
+            expectedBranch: "packet/c0-linked",
+            expectedHead: fixture.baseSHA,
+            executable: "/usr/bin/make",
+            argv: ["test"],
+            declaredWriteRoots: [".build"],
+            timeoutSeconds: 60
+        ))
+        try expect(accepted.argv == ["test"])
+        try expect(accepted.declaredWriteRoots == [fixture.linked.appendingPathComponent(".build").path])
+
+        for (executable, argv) in [
+            ("/bin/bash", ["-c", "make test"]),
+            ("/usr/bin/git", ["push", "origin", "main"]),
+            ("/usr/bin/make", ["install-copy"]),
+            ("/usr/bin/make", ["release"]),
+        ] {
+            do {
+                _ = try WorktreeCommandContract.validate(.init(
+                    worktreePath: fixture.linked.path,
+                    ownerSession: "owner",
+                    expectedBranch: "packet/c0-linked",
+                    expectedHead: fixture.baseSHA,
+                    executable: executable,
+                    argv: argv,
+                    declaredWriteRoots: [".build"],
+                    timeoutSeconds: 60
+                ))
+                throw TestError.assertion("unexpectedly admitted \(executable) \(argv)")
+            } catch is WorktreeCommandError {
+                // expected
+            }
+        }
+
+        for root in [".", "../escaped"] {
+            do {
+                _ = try WorktreeCommandContract.validate(.init(
+                    worktreePath: fixture.linked.path,
+                    ownerSession: "owner",
+                    expectedBranch: "packet/c0-linked",
+                    expectedHead: fixture.baseSHA,
+                    executable: "/usr/bin/make",
+                    argv: ["debug"],
+                    declaredWriteRoots: [root],
+                    timeoutSeconds: 60
+                ))
+                throw TestError.assertion("unexpectedly admitted write root \(root)")
+            } catch is WorktreeCommandError {
+                // expected
+            }
+        }
+    }
+
+    await test("WU0 command runner requires the claimed owner before process launch") {
+        let fixture = try C0GitFixture()
+        let store = WorktreeOwnershipStore(databaseURL: fixture.databaseURL("wu0-owner"))
+        let missing = await c0ErrorCode {
+            _ = try await WorktreeOwnershipGuard.authorizeToolMutation(
+                toolName: "worktree_command_run",
+                arguments: .object([
+                    "worktreePath": .string(fixture.linked.path),
+                    "ownerSession": .string("owner")
+                ]),
+                store: store
+            )
+        }
+        try expect(missing == "worktree_ownership_required")
+        _ = try await c0Claim(
+            store,
+            fixture: fixture,
+            worktree: fixture.linked,
+            branch: "packet/c0-linked",
+            owner: "owner"
+        )
+        let authorization = try await WorktreeOwnershipGuard.authorizeToolMutation(
+            toolName: "worktree_command_run",
+            arguments: .object([
+                "worktreePath": .string(fixture.linked.path),
+                "ownerSession": .string("owner")
+            ]),
+            store: store
+        )
+        try expect(authorization != nil)
+        authorization?.release()
+    }
+
+    await test("WU0 command runner executes argv directly and returns branch, HEAD, and digest evidence") {
+        let fixture = try C0GitFixture()
+        let makefile = "debug:\n\t@mkdir -p .build\n\t@printf 'runner-ok\\n' > .build/wu0-marker\n\t@printf 'wu0-stdout\\n'\n"
+        try makefile.write(
+            to: fixture.linked.appendingPathComponent("Makefile"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try c0Run("/usr/bin/git", ["add", "Makefile"], cwd: fixture.linked)
+        try c0Run("/usr/bin/git", ["commit", "-m", "add runner fixture"], cwd: fixture.linked)
+        let expectedHead = try c0Run("/usr/bin/git", ["rev-parse", "HEAD"], cwd: fixture.linked).stdout
+        let store = WorktreeOwnershipStore(databaseURL: fixture.databaseURL("wu0-live"))
+        _ = try await store.claim(
+            repoRoot: fixture.repo.path,
+            worktreePath: fixture.linked.path,
+            branch: "packet/c0-linked",
+            baseSHA: expectedHead,
+            ownerSession: "wu0-live",
+            ttlSeconds: 300
+        )
+        let router = ToolRouter(
+            securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+            auditLog: AuditLog(),
+            worktreeOwnershipStore: store,
+            worktreeOwnershipEnabled: true,
+            licenseStatusProvider: { .grandfathered }
+        )
+        await WorktreeOwnershipModule.register(on: router, store: store)
+        let value = try await router.dispatch(
+            toolName: "worktree_command_run",
+            arguments: .object([
+                "worktreePath": .string(fixture.linked.path),
+                "ownerSession": .string("wu0-live"),
+                "expectedBranch": .string("packet/c0-linked"),
+                "expectedHead": .string(expectedHead),
+                "executable": .string("/usr/bin/make"),
+                "argv": .array([.string("debug")]),
+                "declaredWriteRoots": .array([.string(".build")]),
+                "timeoutSeconds": .int(30)
+            ])
+        )
+        guard case .object(let object) = value else {
+            throw TestError.assertion("expected worktree command object")
+        }
+        try expect(object["ok"] == .bool(true), "runner failed: \(value)")
+        try expect(object["headSHA"] == .string(expectedHead))
+        try expect(object["branch"] == .string("packet/c0-linked"))
+        try expect(object["stdout"] == .string("wu0-stdout\n"))
+        guard case .string(let commandDigest) = object["commandSHA256"] else {
+            throw TestError.assertion("missing command digest")
+        }
+        try expect(commandDigest.count == 64)
+        let marker = try String(
+            contentsOf: fixture.linked.appendingPathComponent(".build/wu0-marker"),
+            encoding: .utf8
+        )
+        try expect(marker == "runner-ok\n")
+    }
+
+    await test("WU0 command runner detects writes outside the declared roots") {
+        let fixture = try C0GitFixture()
+        let makefile = "debug:\n\t@printf 'outside\\n' > outside.txt\n"
+        try makefile.write(
+            to: fixture.linked.appendingPathComponent("Makefile"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try c0Run("/usr/bin/git", ["add", "Makefile"], cwd: fixture.linked)
+        try c0Run("/usr/bin/git", ["commit", "-m", "add scope fixture"], cwd: fixture.linked)
+        let expectedHead = try c0Run("/usr/bin/git", ["rev-parse", "HEAD"], cwd: fixture.linked).stdout
+        let store = WorktreeOwnershipStore(databaseURL: fixture.databaseURL("wu0-scope"))
+        _ = try await store.claim(
+            repoRoot: fixture.repo.path,
+            worktreePath: fixture.linked.path,
+            branch: "packet/c0-linked",
+            baseSHA: expectedHead,
+            ownerSession: "wu0-scope",
+            ttlSeconds: 300
+        )
+        let router = ToolRouter(
+            securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+            auditLog: AuditLog(),
+            worktreeOwnershipStore: store,
+            worktreeOwnershipEnabled: true,
+            licenseStatusProvider: { .grandfathered }
+        )
+        await WorktreeOwnershipModule.register(on: router, store: store)
+        let value = try await router.dispatch(
+            toolName: "worktree_command_run",
+            arguments: .object([
+                "worktreePath": .string(fixture.linked.path),
+                "ownerSession": .string("wu0-scope"),
+                "expectedBranch": .string("packet/c0-linked"),
+                "expectedHead": .string(expectedHead),
+                "executable": .string("/usr/bin/make"),
+                "argv": .array([.string("debug")]),
+                "declaredWriteRoots": .array([.string(".build")]),
+                "timeoutSeconds": .int(30)
+            ])
+        )
+        guard case .object(let object) = value else {
+            throw TestError.assertion("expected worktree command object")
+        }
+        try expect(object["ok"] == .bool(false))
+        try expect(object["status"] == .string("write_scope_violation"))
+        try expect(object["outsideDeclaredWriteRoots"] == .array([.string("outside.txt")]))
+        try expect(object["headSHA"] == .string(expectedHead))
+    }
+
     await test("C0 guarded public schemas expose ownerSession and tools are annotated") {
         let router = ToolRouter(
             securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
@@ -2444,7 +2643,7 @@ func runWorktreeOwnershipTests() async {
         await WorktreeOwnershipModule.register(on: router)
         let registrations = await router.allRegistrations()
         let guarded = Set([
-            "shell_exec", "run_script", "bg_run", "file_edit", "file_write", "file_append",
+            "shell_exec", "run_script", "bg_run", "worktree_command_run", "file_edit", "file_write", "file_append",
             "file_move", "file_rename", "file_copy", "dir_create", "file_zip",
             "file_unzip", "git_apply_patch", "git_create_branch"
         ])
@@ -2459,8 +2658,10 @@ func runWorktreeOwnershipTests() async {
         try expect(byName["worktree_release"] != nil)
         let claimAnnotation = ToolAnnotationCatalog.annotations(for: "worktree_claim")
         let releaseAnnotation = ToolAnnotationCatalog.annotations(for: "worktree_release")
+        let commandAnnotation = ToolAnnotationCatalog.annotations(for: "worktree_command_run")
         try expect(claimAnnotation?.idempotentHint == true)
         try expect(releaseAnnotation?.idempotentHint == false)
-        try expect(BridgeConstants.staticFeatureModuleToolCount == 216)
+        try expect(commandAnnotation?.requiresConfirmation == true)
+        try expect(BridgeConstants.staticFeatureModuleToolCount == 217)
     }
 }


### PR DESCRIPTION
## Stack

1 of 3. Base: `main`. The next draft PR targets this branch.

## What changed

Adds `worktree_command_run`, a bounded direct-argv runner for reviewed Swift and Make build/test families. It requires an existing worktree claim, verifies the expected branch and HEAD before and after execution, enforces declared write roots, records repository byte digests, applies a timeout and scrubbed environment, and returns structured execution evidence.

## Why

Normal Bridge mutation tools intentionally fail closed for opaque build and test commands. This provides a narrow, reviewable path for claimed worktrees without opening general shell execution.

## Impact

- Adds one static Bridge tool and updates the static tool count.
- Does not install or execute a production candidate.
- Does not permit shell strings, globs, substitutions, Git publication, installation, merge, tag, release, or destructive commands.

## Verification

Exact candidate `28b2a1189f0ef3cf638d3a99314b2dbb2f6ac818`:

- `make test-floor`: 3,574 passed, 0 failed.
- Tests cover contract validation, ownership denial, exact argv execution, branch/HEAD evidence, declared-root digests, and outside-root write detection.

## Review caution

Outside-declared-root detection is post-execution repository evidence, not an operating-system sandbox. This PR is intentionally draft and is not approved for installation, merge, tag, or release.