### PR TITLE
fix: unify runtime routing authority

### DIFF
--- a/TheBridge/Modules/Skills/SkillExposureAuthority.swift
+++ b/TheBridge/Modules/Skills/SkillExposureAuthority.swift
@@ -307,16 +307,27 @@ public struct SkillRuntimeExposureGate: Sendable {
     public static let degradedGraceInterval: TimeInterval = 24 * 3600
     public let generation: SkillRuntimeGeneration
     public let emergencyDenylist: Set<String>
+    public let freshnessRenewedAt: Date?
 
-    public init(generation: SkillRuntimeGeneration, emergencyDenylist: Set<String> = []) {
+    public init(generation: SkillRuntimeGeneration, emergencyDenylist: Set<String> = [],
+                freshnessRenewedAt: Date? = nil) {
         self.generation = generation
         self.emergencyDenylist = Set(emergencyDenylist.map(SkillExposureIdentity.normalize))
+        self.freshnessRenewedAt = freshnessRenewedAt
+    }
+
+    public var freshnessReferenceDate: Date {
+        max(generation.compiledAt, freshnessRenewedAt ?? generation.compiledAt)
+    }
+
+    public func isDegraded(now: Date = Date()) -> Bool {
+        now.timeIntervalSince(freshnessReferenceDate) > Self.degradedGraceInterval
     }
 
     public func allows(pageID: String, surface: SkillExposureSurface, now: Date = Date()) -> Bool {
         let id = SkillExposureIdentity.normalize(pageID)
         guard !emergencyDenylist.contains(id), let entry = generation.entry(pageID: id) else { return false }
-        if now.timeIntervalSince(generation.compiledAt) > Self.degradedGraceInterval {
+        if isDegraded(now: now) {
             switch surface {
             case .exactFetch, .bodyCache: return true
             case .routing, .command, .specialist: return false

--- a/TheBridge/Modules/Skills/SkillExposureRuntime.swift
+++ b/TheBridge/Modules/Skills/SkillExposureRuntime.swift
@@ -64,9 +64,35 @@ public actor SkillRuntimeGenerationStore {
         return try? decoder().decode(SkillRuntimeGeneration.self, from: data)
     }
 
+    public enum RoutingAuthority: Sendable {
+        case legacy
+        case active(SkillRuntimeExposureGate)
+        case corrupt(pointerID: String)
+    }
+
     public func gate() -> SkillRuntimeExposureGate? {
         guard let generation = activeGeneration() else { return nil }
-        return .init(generation: generation, emergencyDenylist: emergencyDenylist())
+        return .init(
+            generation: generation,
+            emergencyDenylist: emergencyDenylist(),
+            freshnessRenewedAt: unchangedShadowRenewal(for: generation)
+        )
+    }
+
+    public func routingAuthority() -> RoutingAuthority {
+        guard FileManager.default.fileExists(atPath: pointerURL.path) else { return .legacy }
+        guard let data = try? Data(contentsOf: pointerURL),
+              let pointer = try? decoder().decode(ActivePointer.self, from: data),
+              !pointer.generationID.isEmpty else {
+            return .corrupt(pointerID: "unreadable-active-pointer")
+        }
+        let pointerID = pointer.generationID
+        guard let generation = generation(id: pointerID) else { return .corrupt(pointerID: pointerID) }
+        return .active(.init(
+            generation: generation,
+            emergencyDenylist: emergencyDenylist(),
+            freshnessRenewedAt: unchangedShadowRenewal(for: generation)
+        ))
     }
 
     @discardableResult
@@ -103,6 +129,17 @@ public actor SkillRuntimeGenerationStore {
     public func latestReceipt() -> SkillExposureReconciliationReceipt? {
         guard let data = try? Data(contentsOf: root.appendingPathComponent("latest-receipt.json")) else { return nil }
         return try? decoder().decode(SkillExposureReconciliationReceipt.self, from: data)
+    }
+
+    private func unchangedShadowRenewal(for generation: SkillRuntimeGeneration) -> Date? {
+        guard let receipt = latestReceipt(),
+              receipt.mode == .shadow,
+              receipt.outcome == .shadowReady,
+              receipt.errors.isEmpty,
+              receipt.changes.isEmpty,
+              receipt.snapshotID == generation.snapshotID
+        else { return nil }
+        return receipt.attemptedAt
     }
 
     public func emergencyDenylist() -> Set<String> {

--- a/TheBridge/Modules/Skills/SkillRoutingSnapshot.swift
+++ b/TheBridge/Modules/Skills/SkillRoutingSnapshot.swift
@@ -1,0 +1,208 @@
+// SkillRoutingSnapshot.swift — authoritative Runtime Exposure routing projection
+
+import CryptoKit
+import Foundation
+import MCP
+
+public enum SkillRoutingSnapshotStatus: String, Codable, Sendable, Equatable {
+    case healthy
+    case degraded
+    case empty
+    case missing
+}
+
+public enum SkillRoutingSnapshotSource: String, Codable, Sendable, Equatable {
+    case runtimeExposureGeneration = "runtime_exposure_generation"
+    case legacyProjection = "legacy_projection"
+    case runtimeExposurePointer = "runtime_exposure_pointer"
+}
+
+public struct SkillRoutingSnapshotMetadata: Codable, Sendable, Equatable {
+    public let status: SkillRoutingSnapshotStatus
+    public let source: SkillRoutingSnapshotSource
+    public let snapshotID: String
+    public let count: Int
+    public let reason: String
+
+    public init(status: SkillRoutingSnapshotStatus, source: SkillRoutingSnapshotSource,
+                snapshotID: String, count: Int, reason: String) {
+        self.status = status
+        self.source = source
+        self.snapshotID = snapshotID
+        self.count = count
+        self.reason = reason
+    }
+}
+
+public struct SkillRoutingSnapshot: Sendable {
+    public let metadata: SkillRoutingSnapshotMetadata
+    public let skills: [Value]
+
+    public init(metadata: SkillRoutingSnapshotMetadata, skills: [Value]) {
+        self.metadata = metadata
+        self.skills = skills
+    }
+
+    public var value: Value {
+        .object([
+            "status": .string(metadata.status.rawValue),
+            "source": .string(metadata.source.rawValue),
+            "snapshot": .string(metadata.snapshotID),
+            "count": .int(metadata.count),
+            "reason": .string(metadata.reason),
+            "skills": .array(skills),
+        ])
+    }
+}
+
+extension SkillsModule {
+    /// The only production projection used by the routing tool, handshake
+    /// instructions, resources, and bridge_initialize evidence.
+    public static func routingSnapshot(now: Date = Date()) async -> SkillRoutingSnapshot {
+        let authority = await SkillRuntimeGenerationStore.shared.routingAuthority()
+        switch authority {
+        case .active(let gate):
+            let items = await mergedRoutingSkills(exposureGate: gate)
+            return runtimeRoutingSnapshot(items: items, gate: gate, now: now)
+        case .corrupt(let pointerID):
+            return .init(
+                metadata: .init(
+                    status: .missing,
+                    source: .runtimeExposurePointer,
+                    snapshotID: pointerID,
+                    count: 0,
+                    reason: "active_runtime_exposure_generation_is_missing_or_corrupt"
+                ),
+                skills: []
+            )
+        case .legacy:
+            return await legacyRoutingSnapshot()
+        }
+    }
+
+    /// Synchronous compatibility projection for callers that cannot suspend.
+    /// Production handshakes and resources use `routingSnapshot()` instead.
+    public static func legacyRoutingSnapshotSync() -> SkillRoutingSnapshot {
+        let items = legacyNotionRoutingRows()
+        return legacySnapshot(items: items)
+    }
+
+    @_spi(Testing)
+    public static func runtimeRoutingSnapshot(
+        items: [Value],
+        gate: SkillRuntimeExposureGate,
+        now: Date
+    ) -> SkillRoutingSnapshot {
+        let degraded = gate.isDegraded(now: now)
+        let status: SkillRoutingSnapshotStatus = degraded ? .degraded : (items.isEmpty ? .empty : .healthy)
+        let reason: String
+        if degraded {
+            reason = "runtime_exposure_freshness_expired"
+        } else if items.isEmpty {
+            reason = "verified_runtime_exposure_contains_no_routing_skills"
+        } else if gate.freshnessRenewedAt != nil {
+            reason = "verified_unchanged_shadow_renewed_freshness"
+        } else {
+            reason = "verified_active_runtime_exposure_generation"
+        }
+        return .init(
+            metadata: .init(
+                status: status,
+                source: .runtimeExposureGeneration,
+                snapshotID: gate.generation.generationID,
+                count: degraded ? 0 : items.count,
+                reason: reason
+            ),
+            skills: degraded ? [] : items
+        )
+    }
+
+    public static func renderRoutingInstructions(snapshot: SkillRoutingSnapshot) -> String {
+        let m = snapshot.metadata
+        let evidence = "Routing snapshot: status=\(m.status.rawValue) source=\(m.source.rawValue) snapshot=\(m.snapshotID) count=\(m.count) reason=\(m.reason)"
+        guard !snapshot.skills.isEmpty else {
+            return """
+            The Bridge MCP server. No routing skills are currently available.
+            \(evidence)
+            Call skills_routing_list to refresh the same authoritative snapshot.
+
+            \(dispatchContract)
+            """
+        }
+        let lines = snapshot.skills.compactMap(routingInstructionLine)
+        return """
+        The Bridge MCP server. \(snapshot.skills.count) routing skill(s) available:
+        \(lines.joined(separator: "\n"))
+        \(evidence)
+        Use fetch_skill to load full skill content by name. Call skills_routing_list to refresh this same snapshot.
+
+        \(dispatchContract)
+        """
+    }
+
+    private static func legacyRoutingSnapshot() async -> SkillRoutingSnapshot {
+        let items = await mergedRoutingSkills(exposureGate: nil)
+        return legacySnapshot(items: items)
+    }
+
+    private static func legacySnapshot(items: [Value]) -> SkillRoutingSnapshot {
+        let count = items.count
+        return .init(
+            metadata: .init(
+                status: count == 0 ? .empty : .healthy,
+                source: .legacyProjection,
+                snapshotID: legacySnapshotID(items),
+                count: count,
+                reason: count == 0
+                    ? "legacy_projection_contains_no_routing_skills"
+                    : "runtime_exposure_not_activated_legacy_projection_in_use"
+            ),
+            skills: items
+        )
+    }
+
+    private static func legacyNotionRoutingRows() -> [Value] {
+        readAllSkills().filter { skill in
+            guard skill.enabled, skill.routingDiscoverable else { return false }
+            switch skill.source {
+            case .notion(let pageID):
+                return NotionPageRef.isValidStoredPageId(pageID.trimmingCharacters(in: .whitespacesAndNewlines))
+            case .file:
+                return true
+            }
+        }.map { .object(skillRowFields($0).merging(["source": .string($0.source.isFile ? "file" : "notion")]) { old, _ in old }) }
+            .sorted { routingName($0).localizedCaseInsensitiveCompare(routingName($1)) == .orderedAscending }
+    }
+
+    private static func routingInstructionLine(_ value: Value) -> String? {
+        guard case .object(let row) = value,
+              case .string(let name)? = row["name"] else { return nil }
+        var line = name
+        if case .string(let summary)? = row["summary"], !summary.isEmpty { line += " — \(summary)" }
+        if case .array(let triggers)? = row["triggerPhrases"] {
+            let values = triggers.compactMap { if case .string(let value) = $0 { return value } else { return nil } }
+            if !values.isEmpty { line += " [triggers: \(values.joined(separator: ", "))]" }
+        }
+        if case .array(let antiTriggers)? = row["antiTriggerPhrases"] {
+            let values = antiTriggers.compactMap { if case .string(let value) = $0 { return value } else { return nil } }
+            if !values.isEmpty { line += " [avoid: \(values.joined(separator: ", "))]" }
+        }
+        return line
+    }
+
+    private static func routingName(_ value: Value) -> String {
+        guard case .object(let row) = value, case .string(let name)? = row["name"] else { return "" }
+        return name
+    }
+
+    private static func legacySnapshotID(_ items: [Value]) -> String {
+        let identity = items.map { value -> String in
+            guard case .object(let row) = value else { return "" }
+            let name = row["name"].flatMap { if case .string(let v) = $0 { return v } else { return nil } } ?? ""
+            let source = row["source"].flatMap { if case .string(let v) = $0 { return v } else { return nil } } ?? ""
+            return "\(name.lowercased())|\(source)"
+        }.joined(separator: "\n")
+        let digest = SHA256.hash(data: Data(identity.utf8)).map { String(format: "%02x", $0) }.joined()
+        return "legacy-\(String(digest.prefix(16)))"
+    }
+}

--- a/TheBridge/Modules/Skills/SkillsModuleExposureRegistration.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleExposureRegistration.swift
@@ -22,19 +22,24 @@ extension SkillsModule {
             handler: { _ in
                 let store = SkillRuntimeGenerationStore.shared
                 let active = await store.activeGeneration()
+                let gate = await store.gate()
                 let latest = await store.latestReceipt()
                 let denylist = await store.emergencyDenylist().sorted()
                 let baseline = await MainActor.run {
                     SkillExposureBaselineEntry.fromSkillsManager(SkillsManager())
                 }
                 let now = Date()
+                let routingSnapshot = await Self.routingSnapshot(now: now)
                 var result: [String: Value] = [
                     "active": .bool(active != nil),
                     "activeGenerationId": active.map { .string($0.generationID) } ?? .null,
                     "activeEntryCount": .int(active?.entries.count ?? 0),
                     "compiledAt": active.map { .string(Self.exposureISO8601($0.compiledAt)) } ?? .null,
                     "ageSeconds": active.map { .double(max(0, now.timeIntervalSince($0.compiledAt))) } ?? .null,
-                    "degraded": .bool(active.map { now.timeIntervalSince($0.compiledAt) > SkillRuntimeExposureGate.degradedGraceInterval } ?? false),
+                    "freshnessAt": gate.map { .string(Self.exposureISO8601($0.freshnessReferenceDate)) } ?? .null,
+                    "freshnessAgeSeconds": gate.map { .double(max(0, now.timeIntervalSince($0.freshnessReferenceDate))) } ?? .null,
+                    "degraded": .bool(routingSnapshot.metadata.status == .degraded),
+                    "routingSnapshot": routingSnapshot.value,
                     "enabledBaselineCount": .int(baseline.count),
                     "emergencyDenylist": .array(denylist.map(Value.string)),
                     "emergencyDenylistCount": .int(denylist.count),

--- a/TheBridge/Modules/Skills/SkillsModuleFileSource.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleFileSource.swift
@@ -168,13 +168,21 @@ extension SkillsModule {
             guard validLegacyRow else { return false }
             return exposureGate?.allows(pageID: s.notionPageId, surface: .routing) ?? true
         }
-        let fileSkills = await FilesystemSkillIndex.shared.allSkills().filter { fs in
-            // Honour per-path disable.
-            guard isFileSkillEnabled(path: fs.path) else { return false }
-            return isFileSkillRoutingDiscoverable(
-                path: fs.path,
-                frontmatter: fs.frontmatter
-            )
+        // After Runtime Exposure cutover, the verified generation is the sole
+        // authority for ambient routing. File-source skills remain exact-fetch
+        // capable but cannot silently join the routing roster outside that
+        // reviewed identity set. Legacy installations retain their prior merge.
+        let fileSkills: [ParsedSkill]
+        if exposureGate != nil {
+            fileSkills = []
+        } else {
+            fileSkills = await FilesystemSkillIndex.shared.allSkills().filter { fs in
+                guard isFileSkillEnabled(path: fs.path) else { return false }
+                return isFileSkillRoutingDiscoverable(
+                    path: fs.path,
+                    frontmatter: fs.frontmatter
+                )
+            }
         }
         let notionNames = Set(notionSkills.map { $0.name.lowercased() })
         var rows: [Value] = []

--- a/TheBridge/Modules/Skills/SkillsModuleRegistration.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleRegistration.swift
@@ -13,7 +13,7 @@ extension SkillsModule {
             name: "skills_routing_list",
             module: moduleName,
             tier: .open,
-            description: "Refresh the skill routing index (summaries + trigger phrases). Initial index is provided in server instructions at connection time — only call after a skill change.",
+            description: "Read the authoritative Runtime Exposure routing snapshot used by handshake instructions and bridge_initialize. Returns status, source, snapshot, count, reason, and the exact routable skill identities.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),
@@ -27,11 +27,7 @@ extension SkillsModule {
                 // Collisions annotate the Notion-source row with a
                 // `shadows: file:<path>` field for operator clarity;
                 // Notion wins on collision (D4).
-                let items = await Self.mergedRoutingSkills()
-                return .object([
-                    "skills": .array(items),
-                    "count": .int(items.count)
-                ])
+                return await Self.routingSnapshot().value
             }
         )
         await router.register(skillsRoutingList)

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -113,38 +113,7 @@ public enum SkillsModule {
     """
 
     public static func buildRoutingInstructions() -> String {
-        let skills = readAllSkills().filter { skill in
-            guard skill.enabled, skill.routingDiscoverable else { return false }
-            switch skill.source {
-            case .notion(let pid):
-                return NotionPageRef.isValidStoredPageId(pid.trimmingCharacters(in: .whitespacesAndNewlines))
-            case .file:
-                // W2 D6: file-source routing skills are merged in via
-                // `list_routing_skills` (see registerListRoutingSkills);
-                // the initial instructions block sticks to Notion skills
-                // to preserve the existing wire shape.
-                return true
-            }
-        }
-        guard !skills.isEmpty else {
-            return "The Bridge MCP server. Call skills_routing_list to discover available skill-based capabilities.\n\n\(dispatchContract)"
-        }
-        // Build compact JSON routing index
-        var lines: [String] = []
-        for s in skills {
-            var entry = "\(s.name)"
-            if !s.summary.isEmpty { entry += " — \(s.summary)" }
-            if !s.triggerPhrases.isEmpty { entry += " [triggers: \(s.triggerPhrases.joined(separator: ", "))]" }
-            if !s.antiTriggerPhrases.isEmpty { entry += " [avoid: \(s.antiTriggerPhrases.joined(separator: ", "))]" }
-            lines.append(entry)
-        }
-        return """
-        The Bridge MCP server. \(skills.count) routing skill(s) available:
-        \(lines.joined(separator: "\n"))
-        Use fetch_skill to load full skill content by name. Call skills_routing_list to refresh this index.
-
-        \(dispatchContract)
-        """
+        renderRoutingInstructions(snapshot: legacyRoutingSnapshotSync())
     }
 
     /// Register the `fetch_skill` tool on the given router.

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -23,6 +23,7 @@ public enum BridgeInitializeModule {
     /// handshake. Injectable so tests drive the Reminders adapter with the mock
     /// seam. Default binds the live EventKit-backed reminders store.
     public typealias PreflightProvider = @Sendable () -> CapabilityPreflightRegistry
+    public typealias RoutingSnapshotProvider = @Sendable (_ now: Date) async -> SkillRoutingSnapshot
 
     /// Default preflight: the Reminders adapter over the live EventKit store.
     /// The registry runs NO probe unless the opening intent requires it, so
@@ -31,6 +32,9 @@ public enum BridgeInitializeModule {
         CapabilityPreflightRegistry(probes: [
             RemindersCapabilityProbe(store: EventKitRemindersStore())
         ])
+    }
+    public static let defaultRoutingSnapshotProvider: RoutingSnapshotProvider = { now in
+        await SkillsModule.routingSnapshot(now: now)
     }
 
     /// Resolves the live runtime context (connection + capability + clock) for a
@@ -68,16 +72,19 @@ public enum BridgeInitializeModule {
     public static func register(
         on router: ToolRouter,
         contextProvider: @escaping ContextProvider = defaultContextProvider,
-        preflightProvider: @escaping PreflightProvider = defaultPreflightProvider
+        preflightProvider: @escaping PreflightProvider = defaultPreflightProvider,
+        routingSnapshotProvider: @escaping RoutingSnapshotProvider = defaultRoutingSnapshotProvider
     ) async {
         await router.register(makeTool(contextProvider: contextProvider,
-                                       preflightProvider: preflightProvider))
+                                       preflightProvider: preflightProvider,
+                                       routingSnapshotProvider: routingSnapshotProvider))
     }
 
     /// Factory for the `bridge_initialize` registration (exposed for tests).
     public static func makeTool(
         contextProvider: @escaping ContextProvider = defaultContextProvider,
-        preflightProvider: @escaping PreflightProvider = defaultPreflightProvider
+        preflightProvider: @escaping PreflightProvider = defaultPreflightProvider,
+        routingSnapshotProvider: @escaping RoutingSnapshotProvider = defaultRoutingSnapshotProvider
     ) -> ToolRegistration {
         ToolRegistration(
             name: toolName,
@@ -168,6 +175,7 @@ public enum BridgeInitializeModule {
                     return true
                 }()
                 let context = await contextProvider(client)
+                let routingSnapshot = await routingSnapshotProvider(context.now)
                 // Only build a preflight registry when an intent unlocks a probe
                 // — the universal, data-minimal path stays probe-free.
                 let preflight = intent == .none ? nil : preflightProvider()
@@ -176,7 +184,8 @@ public enum BridgeInitializeModule {
                     mode: mode,
                     includeConstitution: includeConstitution,
                     intent: intent,
-                    preflight: preflight
+                    preflight: preflight,
+                    routingSnapshot: routingSnapshot
                 )
                 return receiptValue(receipt)
             }
@@ -209,6 +218,15 @@ public enum BridgeInitializeModule {
             "connectionState": .string(r.connectionState),
             "telemetryEventRef": .string(r.telemetryEventRef),
             "routingRosterQuality": .string(r.routingRosterQuality.rawValue),
+            "routingSnapshot": r.routingSnapshot.map { snapshot in
+                .object([
+                    "status": .string(snapshot.status.rawValue),
+                    "source": .string(snapshot.source.rawValue),
+                    "snapshot": .string(snapshot.snapshotID),
+                    "count": .int(snapshot.count),
+                    "reason": .string(snapshot.reason),
+                ])
+            } ?? .null,
             "routingIntegrity": .object([
                 "registryVersion": .int(r.routingIntegrity.registryVersion),
                 "boundToolCount": .int(r.routingIntegrity.boundToolCount),

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
@@ -85,6 +85,9 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
     public let routingRosterState: String
     /// Richer routing-roster quality (HEALTHY / SPARSE / EMPTY) — PKT-1065C.
     public let routingRosterQuality: RoutingRosterQuality
+    /// Authoritative Runtime Exposure snapshot used by every routing surface.
+    /// Optional only so pre-WU1 persisted receipts remain decodable.
+    public let routingSnapshot: SkillRoutingSnapshotMetadata?
     public let routingWarnings: [String]
     public let supplementalOrderCounts: SupplementalOrderCounts
     public let connectionState: String
@@ -116,6 +119,7 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
         integrityResult: String,
         routingRosterState: String,
         routingRosterQuality: RoutingRosterQuality = .empty,
+        routingSnapshot: SkillRoutingSnapshotMetadata? = nil,
         routingWarnings: [String],
         supplementalOrderCounts: SupplementalOrderCounts,
         connectionState: String,
@@ -141,6 +145,7 @@ public struct HandshakeReceipt: Codable, Sendable, Equatable {
         self.integrityResult = integrityResult
         self.routingRosterState = routingRosterState
         self.routingRosterQuality = routingRosterQuality
+        self.routingSnapshot = routingSnapshot
         self.routingWarnings = routingWarnings
         self.supplementalOrderCounts = supplementalOrderCounts
         self.connectionState = connectionState
@@ -195,7 +200,7 @@ public struct BridgeInitializeContext: Sendable {
 public enum BridgeInitializeService {
 
     /// Current receipt schema contract version. Bump on any shape change.
-    public static let schemaVersion = 3
+    public static let schemaVersion = 4
 
     /// A supplemental order is deliberately inert ("ignored") when it is
     /// archived OR explicitly marked as a no-op / TEMP directive. The marker
@@ -237,7 +242,8 @@ public enum BridgeInitializeService {
         intent: PreflightIntent = .none,
         probeResults: [CapabilityProbeResult] = [],
         session: BrokerSessionRecord? = nil,
-        constitution: ConstitutionBundle? = nil
+        constitution: ConstitutionBundle? = nil,
+        routingSnapshot suppliedRoutingSnapshot: SkillRoutingSnapshot? = nil
     ) -> HandshakeReceipt {
         // 1–3: doctrine load + hash verify + integrity policy (init axis).
         try? StandingOrdersStore.shared.ensureInitializationContract()
@@ -253,15 +259,27 @@ public enum BridgeInitializeService {
         let expectedHash = StandingOrdersStore.shared.manifestDoctrineHash()
 
         // 4: routing roster state + quality + warnings (init axis — required source).
-        let routingIndex = SkillsModule.buildRoutingInstructions()
-        let routingLoaded = !routingIndex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let routingQuality = RoutingRosterQuality.assess(rendered: routingIndex)
+        let routingSnapshot = suppliedRoutingSnapshot ?? SkillsModule.legacyRoutingSnapshotSync()
+        let routingLoaded = routingSnapshot.metadata.count > 0
+        let routingQuality: RoutingRosterQuality = routingSnapshot.metadata.count == 0
+            ? .empty
+            : (routingSnapshot.metadata.count < 3 ? .sparse : .healthy)
         var routingWarnings: [String] = []
         var finalState = report.state
-        if !routingLoaded {
-            routingWarnings.append("Required routing roster is empty.")
+        switch routingSnapshot.metadata.status {
+        case .empty:
+            routingWarnings.append("Required routing roster is empty: \(routingSnapshot.metadata.reason).")
             finalState = .incomplete
-        } else if routingQuality == .sparse {
+        case .missing:
+            routingWarnings.append("Required routing snapshot is missing: \(routingSnapshot.metadata.reason).")
+            finalState = .incomplete
+        case .degraded:
+            routingWarnings.append("Routing snapshot is degraded: \(routingSnapshot.metadata.reason).")
+            if finalState == .complete { finalState = .degraded }
+        case .healthy:
+            break
+        }
+        if routingQuality == .sparse {
             routingWarnings.append("Routing roster is sparse — routing may be unreliable.")
         }
         if constitution?.doctrineFreshness == .stale && finalState == .complete {
@@ -338,6 +356,7 @@ public enum BridgeInitializeService {
             integrityResult: integrityResult,
             routingRosterState: routingLoaded ? "loaded" : "missing",
             routingRosterQuality: routingQuality,
+            routingSnapshot: routingSnapshot.metadata,
             routingWarnings: routingWarnings,
             supplementalOrderCounts: counts,
             connectionState: context.connectionState,
@@ -367,7 +386,8 @@ public enum BridgeInitializeService {
         intent: PreflightIntent = .none,
         preflight: CapabilityPreflightRegistry? = nil,
         constitutionStore: ConstitutionStore = ConstitutionStore(),
-        commandStore: CommandStore = .shared
+        commandStore: CommandStore = .shared,
+        routingSnapshot suppliedRoutingSnapshot: SkillRoutingSnapshot? = nil
     ) async -> HandshakeReceipt {
         let supplemental = await store.list(includeArchived: true)
         let handshakeId = UUID().uuidString
@@ -377,6 +397,12 @@ public enum BridgeInitializeService {
         // Intent-sensitive capability preflight — a domain probe runs ONLY when
         // the opening intent requires it. `.none` (universal init) runs NONE.
         let probeResults = await preflight?.run(intent: intent) ?? []
+        let routingSnapshot: SkillRoutingSnapshot
+        if let suppliedRoutingSnapshot {
+            routingSnapshot = suppliedRoutingSnapshot
+        } else {
+            routingSnapshot = await SkillsModule.routingSnapshot(now: context.now)
+        }
         let dispatchContext = ToolDispatchContext.current
         let transportSessionId = dispatchContext?.transportSessionId ?? ServerManager.stdioSessionID
         let brokerSession = try? await sessionRegistry.open(
@@ -389,7 +415,8 @@ public enum BridgeInitializeService {
         let constitution = includeConstitution
             ? (try? await constitutionStore.assemble(
                 supplementalStore: store,
-                commandStore: commandStore
+                commandStore: commandStore,
+                routingSnapshot: routingSnapshot
             ))
             : nil
         let receipt = buildReceipt(
@@ -400,7 +427,8 @@ public enum BridgeInitializeService {
             intent: intent,
             probeResults: probeResults,
             session: brokerSession,
-            constitution: constitution
+            constitution: constitution,
+            routingSnapshot: routingSnapshot
         )
         // Persist durably (best-effort; a write failure must not crash a
         // handshake — the receipt is still returned and telemetry still fires).

--- a/TheBridge/Modules/StandingOrders/CapabilityPreflight.swift
+++ b/TheBridge/Modules/StandingOrders/CapabilityPreflight.swift
@@ -347,6 +347,10 @@ public enum OperatorSummary {
 
         // Routing roster — state + quality + warnings.
         var routingLine = "Routing roster: \(r.routingRosterState) (\(r.routingRosterQuality.rawValue))"
+        if let snapshot = r.routingSnapshot {
+            routingLine += " · status=\(snapshot.status.rawValue) source=\(snapshot.source.rawValue)"
+                + " snapshot=\(snapshot.snapshotID) count=\(snapshot.count) reason=\(snapshot.reason)"
+        }
         if !r.routingWarnings.isEmpty {
             routingLine += " — " + r.routingWarnings.joined(separator: "; ")
         }

--- a/TheBridge/Modules/StandingOrders/ConstitutionStore.swift
+++ b/TheBridge/Modules/StandingOrders/ConstitutionStore.swift
@@ -89,7 +89,8 @@ public struct ConstitutionStore: Sendable {
 
     public func assemble(
         supplementalStore: StandingOrdersRecordStore = .shared,
-        commandStore: CommandStore = .shared
+        commandStore: CommandStore = .shared,
+        routingSnapshot suppliedRoutingSnapshot: SkillRoutingSnapshot? = nil
     ) async throws -> ConstitutionBundle {
         try StandingOrdersStore.shared.ensureInitializationContract()
         let report = StandingOrdersStore.shared.initializationReport()
@@ -126,6 +127,12 @@ public struct ConstitutionStore: Sendable {
             )
         }
 
+        let routingSnapshot: SkillRoutingSnapshot
+        if let suppliedRoutingSnapshot {
+            routingSnapshot = suppliedRoutingSnapshot
+        } else {
+            routingSnapshot = await SkillsModule.routingSnapshot()
+        }
         return ConstitutionBundle(
             tier0: tier0,
             doctrineCore: doctrineCoreResult.markdown,
@@ -133,7 +140,7 @@ public struct ConstitutionStore: Sendable {
             doctrineVersion: doctrineVersion,
             orders: orders,
             commandsIndex: commands,
-            routingRoster: SkillsModule.buildRoutingInstructions()
+            routingRoster: SkillsModule.renderRoutingInstructions(snapshot: routingSnapshot)
         )
     }
 

--- a/TheBridge/Modules/StandingOrders/StandingOrdersDelivery.swift
+++ b/TheBridge/Modules/StandingOrders/StandingOrdersDelivery.swift
@@ -119,9 +119,9 @@ public enum BridgeResources {
     public static func markdown(for uri: String, clientName: String? = nil) async throws -> String {
         switch uri {
         case standingOrdersURI:
-            return StandingOrdersDelivery.composition(clientName: clientName).instructionsMarkdown
+            return await StandingOrdersDelivery.asyncComposition(clientName: clientName).instructionsMarkdown
         case routingSkillsURI:
-            return StandingOrdersDelivery.composition(clientName: clientName).routingIndexMarkdown
+            return await StandingOrdersDelivery.asyncComposition(clientName: clientName).routingIndexMarkdown
         case memoryURI:
             return await memoryMarkdown()
         default:
@@ -160,6 +160,7 @@ public enum StandingOrdersDelivery {
         public let bridgeState: String
         public let doctrineVersion: String
         public let routingRosterState: String
+        public let routingSnapshot: SkillRoutingSnapshotMetadata
         public let supplementalOrderCount: Int
         public let initializationState: StandingOrdersStore.InitializationState
         public let issues: [String]
@@ -171,6 +172,7 @@ public enum StandingOrdersDelivery {
                 "- Bridge state: \(bridgeState)",
                 "- Doctrine version: \(doctrineVersion)",
                 "- Routing roster: \(routingRosterState)",
+                "- Routing snapshot: status=\(routingSnapshot.status.rawValue) source=\(routingSnapshot.source.rawValue) snapshot=\(routingSnapshot.snapshotID) count=\(routingSnapshot.count) reason=\(routingSnapshot.reason)",
                 "- Supplemental orders: \(supplementalOrderCount)",
                 "- Initialization: \(initializationState.rawValue)",
             ]
@@ -215,8 +217,12 @@ public enum StandingOrdersDelivery {
     /// receipt. Missing required doctrine never silently becomes “no standing
     /// orders”: the handshake remains available, but reports INCOMPLETE or
     /// DEGRADED with the exact failed assertion.
-    public static func composition(clientName: String? = nil) -> Composition {
-        let routingIndex = SkillsModule.buildRoutingInstructions()
+    public static func composition(
+        clientName: String? = nil,
+        routingSnapshot suppliedRoutingSnapshot: SkillRoutingSnapshot? = nil
+    ) -> Composition {
+        let routingSnapshot = suppliedRoutingSnapshot ?? SkillsModule.legacyRoutingSnapshotSync()
+        let routingIndex = SkillsModule.renderRoutingInstructions(snapshot: routingSnapshot)
 
         // Migrate legacy installations by creating only missing integrity files.
         // Existing mismatches are never overwritten; the report below surfaces them.
@@ -226,10 +232,19 @@ public enum StandingOrdersDelivery {
 
         var issues = report.issues
         var finalState = report.state
-        let routingRosterLoaded = !routingIndex.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        if !routingRosterLoaded {
-            issues.append("Required routing roster is empty.")
+        let routingRosterLoaded = routingSnapshot.metadata.count > 0
+        switch routingSnapshot.metadata.status {
+        case .empty:
+            issues.append("Required routing roster is empty: \(routingSnapshot.metadata.reason).")
             finalState = .incomplete
+        case .missing:
+            issues.append("Required routing snapshot is missing: \(routingSnapshot.metadata.reason).")
+            finalState = .incomplete
+        case .degraded:
+            issues.append("Routing snapshot is degraded: \(routingSnapshot.metadata.reason).")
+            if finalState == .complete { finalState = .degraded }
+        case .healthy:
+            break
         }
         if !supplemental.loaded {
             if let issue = supplemental.issue { issues.append(issue) }
@@ -240,6 +255,7 @@ public enum StandingOrdersDelivery {
             bridgeState: "running",
             doctrineVersion: report.doctrineVersion,
             routingRosterState: routingRosterLoaded ? "loaded" : "missing",
+            routingSnapshot: routingSnapshot.metadata,
             supplementalOrderCount: supplemental.activeCount,
             initializationState: finalState,
             issues: issues
@@ -295,7 +311,8 @@ public enum StandingOrdersDelivery {
     /// Best-effort: a store read failure logs and omits the slice (degrades
     /// gracefully — the base composition is still delivered).
     public static func asyncComposition(clientName: String? = nil) async -> Composition {
-        let base = composition(clientName: clientName)
+        let routingSnapshot = await SkillsModule.routingSnapshot()
+        let base = composition(clientName: clientName, routingSnapshot: routingSnapshot)
 
         // Resolve auto-inject flag: per-client override wins over global.
         let shouldInject: Bool = {

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -1128,7 +1128,7 @@ public actor SSEServer {
                     sessionID: sessionID,
                     clientName: nil,
                     uri: uri,
-                    contentHash: StandingOrdersDelivery.composition().contentHash
+                    contentHash: await StandingOrdersDelivery.asyncComposition().contentHash
                 )
                 let data = buildRPCResponse(id: requestId, result: [
                     "contents": [[
@@ -1295,7 +1295,7 @@ public actor SSEServer {
                 sessionID: resourceSessionID,
                 clientName: resourceClientName,
                 uri: params.uri,
-                contentHash: StandingOrdersDelivery.composition(clientName: resourceClientName).contentHash
+                contentHash: await StandingOrdersDelivery.asyncComposition(clientName: resourceClientName).contentHash
             )
             return result
         }
@@ -1593,7 +1593,9 @@ public actor SSEServer {
                         sessionID: sessionID,
                         clientName: legacy.clientName(sessionID: sessionID),
                         uri: uri,
-                        contentHash: StandingOrdersDelivery.composition().contentHash
+                        contentHash: await StandingOrdersDelivery.asyncComposition(
+                            clientName: legacy.clientName(sessionID: sessionID)
+                        ).contentHash
                     )
                 }
                 return buildRPCResponse(id: requestId, result: [

--- a/TheBridge/Server/ServerManager.swift
+++ b/TheBridge/Server/ServerManager.swift
@@ -375,7 +375,7 @@ public actor ServerManager {
                 sessionID: Self.stdioSessionID,
                 clientName: "stdio",
                 uri: params.uri,
-                contentHash: StandingOrdersDelivery.composition().contentHash
+                contentHash: await StandingOrdersDelivery.asyncComposition(clientName: "stdio").contentHash
             )
             return result
         }

--- a/TheBridgeTests/BridgeInitializeTests.swift
+++ b/TheBridgeTests/BridgeInitializeTests.swift
@@ -33,6 +33,26 @@ func runBridgeInitializeTests() async {
         )
     }
 
+    func routingSnapshot(
+        status: SkillRoutingSnapshotStatus,
+        count: Int,
+        reason: String = "test"
+    ) -> SkillRoutingSnapshot {
+        let rows: [Value] = (0..<count).map { index in
+            .object(["name": .string("Routing \(index)"), "source": .string("notion")])
+        }
+        return .init(
+            metadata: .init(
+                status: status,
+                source: .runtimeExposureGeneration,
+                snapshotID: "generation-test",
+                count: count,
+                reason: reason
+            ),
+            skills: rows
+        )
+    }
+
     // ── COMPLETE path: doctrine + manifest + metadata all present ──────
     await test("Init: fully-seeded doctrine classifies COMPLETE with matching hashes") {
         try await withInitTempHome {
@@ -41,7 +61,8 @@ func runBridgeInitializeTests() async {
             let receipt = BridgeInitializeService.buildReceipt(
                 context: ctx(),
                 supplemental: [],
-                telemetryEventRef: "evt-1"
+                telemetryEventRef: "evt-1",
+                routingSnapshot: routingSnapshot(status: .healthy, count: 8)
             )
             try expect(receipt.finalState == .complete, "expected COMPLETE, got \(receipt.finalState.rawValue)")
             try expect(receipt.expectedHash != nil, "manifest must carry an expected doctrine hash")
@@ -69,7 +90,8 @@ func runBridgeInitializeTests() async {
             defer { StandingOrdersStore.bundledSeedOverrideForTesting = nil }
             try StandingOrdersStore.shared.seedIfEmpty()
             let receipt = BridgeInitializeService.buildReceipt(
-                context: ctx(), supplemental: [], telemetryEventRef: "evt-1b")
+                context: ctx(), supplemental: [], telemetryEventRef: "evt-1b",
+                routingSnapshot: routingSnapshot(status: .healthy, count: 8))
             try expect(receipt.doctrineVersion == "v9.1.2",
                        "doctrineVersion from bundled seed manifest, got \(receipt.doctrineVersion)")
             try expect(receipt.finalState == .complete)
@@ -95,6 +117,52 @@ func runBridgeInitializeTests() async {
         }
     }
 
+    await test("Init: zero-entry routing snapshot is INCOMPLETE and never reported healthy") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(), supplemental: [], telemetryEventRef: "evt-zero-routing",
+                routingSnapshot: routingSnapshot(
+                    status: .empty,
+                    count: 0,
+                    reason: "verified_runtime_exposure_contains_no_routing_skills"
+                )
+            )
+            try expect(receipt.finalState == .incomplete)
+            try expect(receipt.routingRosterState == "missing")
+            try expect(receipt.routingRosterQuality == .empty)
+            try expect(receipt.routingSnapshot?.status == .empty)
+            try expect(receipt.routingSnapshot?.count == 0)
+            try expect(receipt.routingWarnings.contains(where: { $0.contains("contains_no_routing_skills") }))
+        }
+    }
+
+    await test("Init: healthy Runtime Exposure snapshot binds exact source, id, count, and reason") {
+        try await withInitTempHome {
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nx")
+            let supplied = routingSnapshot(status: .healthy, count: 8, reason: "verified_active_runtime_exposure_generation")
+            let receipt = BridgeInitializeService.buildReceipt(
+                context: ctx(), supplemental: [], telemetryEventRef: "evt-healthy-routing",
+                routingSnapshot: supplied
+            )
+            try expect(receipt.finalState == .complete)
+            try expect(receipt.routingRosterState == "loaded")
+            try expect(receipt.routingRosterQuality == .healthy)
+            try expect(receipt.routingSnapshot == supplied.metadata)
+            guard case .object(let value) = BridgeInitializeModule.receiptValue(receipt),
+                  case .object(let snapshot)? = value["routingSnapshot"] else {
+                throw TestError.assertion("bridge_initialize must serialize routingSnapshot evidence")
+            }
+            try expect(snapshot["status"] == .string("healthy"))
+            try expect(snapshot["source"] == .string("runtime_exposure_generation"))
+            try expect(snapshot["snapshot"] == .string("generation-test"))
+            try expect(snapshot["count"] == .int(8))
+            try expect(snapshot["reason"] == .string("verified_active_runtime_exposure_generation"))
+        }
+    }
+
     // ── DEGRADED path: doctrine present but hash drift ─────────────────
     await test("Init: doctrine hash drift classifies DEGRADED (integrity, not required-source)") {
         try await withInitTempHome {
@@ -108,7 +176,8 @@ func runBridgeInitializeTests() async {
             let receipt = BridgeInitializeService.buildReceipt(
                 context: ctx(),
                 supplemental: [],
-                telemetryEventRef: "evt-3"
+                telemetryEventRef: "evt-3",
+                routingSnapshot: routingSnapshot(status: .healthy, count: 8)
             )
             try expect(receipt.finalState == .degraded,
                        "hash drift must be DEGRADED, got \(receipt.finalState.rawValue)")
@@ -172,7 +241,8 @@ func runBridgeInitializeTests() async {
             let unavail = BridgeInitializeService.buildReceipt(
                 context: ctx(connectionState: "offline", macTools: false),
                 supplemental: [],
-                telemetryEventRef: "evt-5b"
+                telemetryEventRef: "evt-5b",
+                routingSnapshot: routingSnapshot(status: .healthy, count: 8)
             )
             try expect(unavail.finalState == .complete, "init is COMPLETE (doctrine seeded)")
             try expect(unavail.capabilityState == .unavailable,
@@ -226,7 +296,7 @@ func runBridgeInitializeTests() async {
                 "macToolsAvailable", "doctrineVersion", "integrityResult",
                 "routingRosterState", "routingWarnings", "supplementalOrderCounts",
                 "connectionState", "telemetryEventRef", "capabilityState",
-                "capabilityMatrix", "finalState",
+                "capabilityMatrix", "routingSnapshot", "finalState",
             ]
             for key in required {
                 try expect(d[key] != nil, "receipt Value missing required field '\(key)'")

--- a/TheBridgeTests/CapabilityPreflightTests.swift
+++ b/TheBridgeTests/CapabilityPreflightTests.swift
@@ -78,6 +78,16 @@ func runCapabilityPreflightTests() async {
         BridgeInitializeContext(client: "test", connectionState: connectionState,
                                 macToolsAvailable: macTools, bridgeState: "running", now: fixedClock)
     }
+    let healthyRouting = SkillRoutingSnapshot(
+        metadata: .init(
+            status: .healthy,
+            source: .runtimeExposureGeneration,
+            snapshotID: "preflight-test",
+            count: 8,
+            reason: "test"
+        ),
+        skills: (0..<8).map { .object(["name": .string("Routing \($0)")]) }
+    )
 
     // ── intent classification ──────────────────────────────────────────
     await test("Preflight: classify() is data-minimal (.none) by default") {
@@ -212,7 +222,8 @@ func runCapabilityPreflightTests() async {
                 probes: [RemindersCapabilityProbe(store: spy)]).run(intent: .remindersRead)
             let receipt = BridgeInitializeService.buildReceipt(
                 context: ctx(connectionState: "local", macTools: true), supplemental: [],
-                telemetryEventRef: "evt-p2", intent: .remindersRead, probeResults: probeResults)
+                telemetryEventRef: "evt-p2", intent: .remindersRead, probeResults: probeResults,
+                routingSnapshot: healthyRouting)
             try expect(receipt.finalState == .complete,
                        "init axis stays COMPLETE — a domain gap is NOT an init failure")
             try expect(receipt.capabilityState == .limited,

--- a/TheBridgeTests/ListRoutingSkillsMergeTests.swift
+++ b/TheBridgeTests/ListRoutingSkillsMergeTests.swift
@@ -100,6 +100,30 @@ func runListRoutingSkillsMergeTests() async {
                    "the routing surface must exclude a .command entry")
     }
 
+    await test("Runtime Exposure maps the complete authorized routing-owner set to eight exact identities") {
+        let expected: [(String, String)] = [
+            ("CONTENT Keepr", "11111111111111111111111111111111"),
+            ("executor", "22222222222222222222222222222222"),
+            ("FOCUS Keepr", "33333333333333333333333333333333"),
+            ("MAC Keepr", "44444444444444444444444444444444"),
+            ("NOTION Keepr", "55555555555555555555555555555555"),
+            ("PEOPLE Keepr", "66666666666666666666666666666666"),
+            ("SKILLS Keepr", "77777777777777777777777777777777"),
+            ("TIME Keepr", "88888888888888888888888888888888"),
+        ]
+        seedNotionSkills(expected.map { name, pageID in
+            ["name": name, "notionPageId": pageID, "enabled": true, "visibility": "routing"]
+        })
+        let gate = testExposureGate(expected.map { (pageID: $0.1, exposure: .routing) })
+        let rows = await mergedRoutingSkillsForTesting(exposureGate: gate)
+        let actual = Set(rows.compactMap { row -> String? in
+            guard case .object(let object) = row, case .string(let name)? = object["name"] else { return nil }
+            return name
+        })
+        try expect(actual == Set(expected.map(\.0)), "authorized routing-owner set drifted: \(actual.sorted())")
+        try expect(rows.count == 8, "Runtime Exposure must surface exactly eight routing owners")
+    }
+
     await test("mergedRoutingSkills: alphabetical ordering") {
         seedNotionSkills([
             ["name": "Zulu", "notionPageId": "aaaa1111bbbb2222cccc3333dddd4444", "enabled": true, "visibility": "routing"],

--- a/TheBridgeTests/MemoryModuleTests.swift
+++ b/TheBridgeTests/MemoryModuleTests.swift
@@ -718,7 +718,8 @@ func runMemoryModuleTests() async {
         // The global flag is UserDefaults.standard — in tests (hermetic temp
         // config env) it should be absent/false. asyncComposition must be
         // identical to the sync path when the flag is not set.
-        let sync = StandingOrdersDelivery.composition(clientName: nil)
+        let routingSnapshot = await SkillsModule.routingSnapshot()
+        let sync = StandingOrdersDelivery.composition(clientName: nil, routingSnapshot: routingSnapshot)
         let async_ = await StandingOrdersDelivery.asyncComposition(clientName: nil)
         try expect(sync.instructionsMarkdown == async_.instructionsMarkdown,
                    "async composition must match sync when auto-inject is OFF")

--- a/TheBridgeTests/RemoteGovernanceContinuityTests.swift
+++ b/TheBridgeTests/RemoteGovernanceContinuityTests.swift
@@ -277,7 +277,8 @@ private func withRemoteGovernanceHarness(
                 mode: .execute,
                 includeConstitution: false,
                 sessionRegistry: registry,
-                receiptStore: receiptStore
+                receiptStore: receiptStore,
+                routingSnapshot: remoteGovernanceHealthyRoutingSnapshot()
             )
             return BridgeInitializeModule.receiptValue(receipt)
         }
@@ -302,4 +303,17 @@ private func withRemoteGovernanceHarness(
     ))
 
     try await body(.init(root: root, registry: registry, router: router))
+}
+
+private func remoteGovernanceHealthyRoutingSnapshot() -> SkillRoutingSnapshot {
+    .init(
+        metadata: .init(
+            status: .healthy,
+            source: .runtimeExposureGeneration,
+            snapshotID: "remote-governance-test",
+            count: 3,
+            reason: "test"
+        ),
+        skills: (0..<3).map { .object(["name": .string("Routing \($0)")]) }
+    )
 }

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -54,7 +54,7 @@ func runRoutingIntegrityLayerTests() async {
                 supplemental: [],
                 telemetryEventRef: "evt-ril"
             )
-            try expect(receipt.schemaVersion == 3, "receipt schema must bump for RIL")
+            try expect(receipt.schemaVersion == 4, "receipt schema must include authoritative routing snapshot evidence")
             try expect(receipt.routingIntegrity.registryVersion == ToolSkillBindingRegistry.registryVersion)
             try expect(receipt.routingIntegrity.boundToolCount == ToolSkillBindingRegistry.bindings.count)
             try expect(receipt.routingIntegrity.manifestMarkerTools.contains(BridgeInitializeModule.toolName))
@@ -130,7 +130,19 @@ func runRoutingIntegrityLayerTests() async {
                         now: rilDate("2026-07-07")
                     )
                 },
-                preflightProvider: { CapabilityPreflightRegistry(probes: []) }
+                preflightProvider: { CapabilityPreflightRegistry(probes: []) },
+                routingSnapshotProvider: { _ in
+                    SkillRoutingSnapshot(
+                        metadata: .init(
+                            status: .healthy,
+                            source: .runtimeExposureGeneration,
+                            snapshotID: "ril-session-test",
+                            count: 3,
+                            reason: "test"
+                        ),
+                        skills: (0..<3).map { .object(["name": .string("Routing \($0)")]) }
+                    )
+                }
             ))
             await MessagesModule.register(on: router)
 

--- a/TheBridgeTests/SkillExposureAuthorityTests.swift
+++ b/TheBridgeTests/SkillExposureAuthorityTests.swift
@@ -1,6 +1,7 @@
 // SkillExposureAuthorityTests.swift — Runtime enrollment/exposure contract
 
 import Foundation
+import MCP
 import TheBridgeLib
 
 private let exposureNow = Date(timeIntervalSince1970: 1_785_196_800) // 2026-07-28T00:00:00Z; fixed
@@ -201,6 +202,112 @@ func runSkillExposureAuthorityTests() async {
         try expect(await store.activeGeneration() == nil, "staging must not activate")
         _ = try await store.promote(generationID: generation.generationID)
         try expect(await store.activeGeneration() == generation, "promoted generation failed read-back")
+    }
+
+    await test("routing snapshot is healthy only with a fresh non-empty Runtime Exposure projection") {
+        let row: Value = .object(["name": .string("Alpha"), "source": .string("notion")])
+        let freshGate = SkillRuntimeExposureGate(generation: publishedGeneration())
+        let healthy = runtimeRoutingSnapshotForTesting(items: [row], gate: freshGate, now: exposureNow)
+        try expect(healthy.metadata.status == .healthy)
+        try expect(healthy.metadata.source == .runtimeExposureGeneration)
+        try expect(healthy.metadata.snapshotID == "generation-1")
+        try expect(healthy.metadata.count == 1)
+        try expect(healthy.skills.count == 1)
+
+        let empty = runtimeRoutingSnapshotForTesting(items: [], gate: freshGate, now: exposureNow)
+        try expect(empty.metadata.status == .empty, "zero routing entries must never be healthy")
+        try expect(empty.metadata.count == 0)
+    }
+
+    await test("stale Runtime Exposure suppresses routing and reports degraded evidence") {
+        let row: Value = .object(["name": .string("Alpha")])
+        let stale = SkillRuntimeExposureGate(
+            generation: publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-25 * 3600))
+        )
+        let snapshot = runtimeRoutingSnapshotForTesting(items: [row], gate: stale, now: exposureNow)
+        try expect(snapshot.metadata.status == .degraded)
+        try expect(snapshot.metadata.count == 0, "suppressed routing must report the effective zero count")
+        try expect(snapshot.skills.isEmpty, "degraded ambient routing must fail closed")
+        try expect(snapshot.metadata.reason == "runtime_exposure_freshness_expired")
+    }
+
+    await test("unchanged complete shadow renews freshness without publishing a generation") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-renewal-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        let receipt = SkillExposureReconciliationReceipt(
+            mode: .shadow,
+            outcome: .shadowReady,
+            attemptedAt: exposureNow,
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [],
+            warnings: [],
+            changes: []
+        )
+        try await store.writeReceipt(receipt)
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(!gate.isDegraded(now: exposureNow), "unchanged shadow must renew freshness")
+        try expect(gate.freshnessRenewedAt == exposureNow)
+        try expect(await store.activeGenerationID() == staleGeneration.generationID,
+                   "shadow renewal must not activate its candidate")
+    }
+
+    await test("changed shadow does not renew freshness and still requires publish") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-changed-shadow-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady, attemptedAt: exposureNow,
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "changed-unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [], warnings: [], changes: ["exposure:Alpha:Routing->Standard"]
+        ))
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(gate.isDegraded(now: exposureNow), "a changed shadow must not renew active policy")
+        try expect(gate.freshnessRenewedAt == nil)
+        try expect(await store.activeGenerationID() == staleGeneration.generationID)
+    }
+
+    await test("corrupt active generation pointer is explicit missing authority, never legacy fallback") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-corrupt-pointer-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("{\"generationID\":\"missing-generation\"}".utf8)
+            .write(to: root.appendingPathComponent("active.json"), options: .atomic)
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        guard case .corrupt(let pointerID) = await store.routingAuthority() else {
+            throw TestError.assertion("corrupt pointer must not fall back to legacy routing")
+        }
+        try expect(pointerID == "missing-generation")
+    }
+
+    await test("malformed active pointer is explicit missing authority, never legacy fallback") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-malformed-pointer-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(to: root.appendingPathComponent("active.json"), options: .atomic)
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        guard case .corrupt(let pointerID) = await store.routingAuthority() else {
+            throw TestError.assertion("malformed pointer must not fall back to legacy routing")
+        }
+        try expect(pointerID == "unreadable-active-pointer")
     }
 
     await test("specialist lifecycle recognizes Revoked, Desolved, and effective dates") {

--- a/TheBridgeTests/SkillExposureProjectionTestSupport.swift
+++ b/TheBridgeTests/SkillExposureProjectionTestSupport.swift
@@ -24,6 +24,14 @@ func mergedRoutingSkillsForTesting(
     await SkillsModule.mergedRoutingSkills(exposureGate: exposureGate)
 }
 
+func runtimeRoutingSnapshotForTesting(
+    items: [Value],
+    gate: SkillRuntimeExposureGate,
+    now: Date
+) -> SkillRoutingSnapshot {
+    SkillsModule.runtimeRoutingSnapshot(items: items, gate: gate, now: now)
+}
+
 func testExposureGate(
     _ entries: [(pageID: String, exposure: SkillRuntimeExposure)],
     compiledAt: Date = Date()

--- a/TheBridgeTests/StandingOrdersTests.swift
+++ b/TheBridgeTests/StandingOrdersTests.swift
@@ -4,6 +4,7 @@
 // and per-client overlay matching.
 
 import Foundation
+import MCP
 import TheBridgeLib
 
 func runStandingOrdersTests() async {
@@ -172,7 +173,17 @@ func runStandingOrdersTests() async {
             try StandingOrdersStore.shared.resetForTesting()
             _ = try StandingOrdersStore.shared.write("# Standing Orders\n\ncanonical")
 
-            let composition = StandingOrdersDelivery.composition()
+            let routingSnapshot = SkillRoutingSnapshot(
+                metadata: .init(
+                    status: .healthy,
+                    source: .runtimeExposureGeneration,
+                    snapshotID: "standing-orders-test",
+                    count: 3,
+                    reason: "test"
+                ),
+                skills: (0..<3).map { .object(["name": .string("Routing \($0)")]) }
+            )
+            let composition = StandingOrdersDelivery.composition(routingSnapshot: routingSnapshot)
             try expect(composition.initializationReceipt.supplementalOrderCount == 0)
             try expect(composition.initializationReceipt.initializationState == .complete)
             try expect(composition.instructionsMarkdown.contains("- Supplemental orders: 0"))

--- a/TheBridgeTests/Wave1BrokerTests.swift
+++ b/TheBridgeTests/Wave1BrokerTests.swift
@@ -153,7 +153,7 @@ func runWave1BrokerTests() async {
                 )
             }
 
-            try expect(receipt.schemaVersion == 3)
+            try expect(receipt.schemaVersion == 4)
             try expect(receipt.session?.transportSessionId == "http-session-2")
             try expect(receipt.session?.mode == .execute)
             try expect(receipt.session?.governed == true)


### PR DESCRIPTION
## Stack

2 of 3. Base: `codex/routing-custody-wu0`. Review the WU0 draft first; WU2 targets this branch.

## What changed

Introduces a single authoritative Runtime Exposure routing projection shared by `bridge_initialize`, `skills_routing_list`, MCP instructions, constitution delivery, and related evidence. The projection exposes explicit status, source, snapshot ID, count, and reason.

## Why

The installed runtime could report initialization as healthy while `skills_routing_list` returned a clean zero-entry roster. That contradictory state caused connector recovery instructions to be unreliable.

## Impact

- A zero or missing routing snapshot can no longer report healthy.
- The current authorized routing-owner set is asserted exactly.
- An unchanged complete shadow can renew freshness; a changed shadow still requires publication.
- Active Runtime Exposure generations remain authoritative over ambient file-source routing.

Related: #137

## Verification

Exact candidate `01ab8f64376a40132f62fbc49297de63970c4006`:

- `make test-floor`: 3,583 passed, 0 failed.
- Tests cover healthy, zero, stale, corrupt, missing-pointer, unchanged-renewal, changed-no-renewal, bridge initialization evidence, and schema v4 behavior.

## Status

Draft review only. No application installation, merge, tag, or release is authorized.