### PR TITLE
fix: make routing bootstrap restart-safe

### DIFF
--- a/TheBridge/Core/BridgePaths.swift
+++ b/TheBridge/Core/BridgePaths.swift
@@ -58,6 +58,7 @@ public enum BridgePaths {
         case screen         = "screen"
         case config         = "config"
         case sessions       = "sessions"        // MCP session durability snapshots
+        case routingCustody = "routing-custody" // durable routing bootstrap + principal-continuation evidence
         case registry       = "registry"        // data-source registry config (registry.json)
         case registryCache  = "registry-cache"  // per-entity read-through row cache
         case voiceMemos     = "voice-memos"     // Voice Memos curator manifest + state

--- a/TheBridge/Server/RoutingCustodyStore.swift
+++ b/TheBridge/Server/RoutingCustodyStore.swift
@@ -1,0 +1,432 @@
+// RoutingCustodyStore.swift
+//
+// Durable, content-free custody for routing bootstrap and verified-principal
+// continuation. Client route acknowledgements intentionally do NOT live here:
+// they are connection-scoped and remain in ToolRouter memory.
+
+import CryptoKit
+import Foundation
+import MCP
+
+public struct RoutingAcknowledgementReceipt: Codable, Sendable, Equatable {
+    public static let schemaVersion = 1
+
+    public let schemaVersion: Int
+    public let authorityIDs: [String]
+    public let scopeID: String
+    public let principalDigest: String
+    public let issuedAt: Date
+    public let expiresAt: Date
+    public let nonce: String
+
+    public init(
+        authorityIDs: [String],
+        scopeID: String,
+        principalDigest: String,
+        issuedAt: Date,
+        expiresAt: Date,
+        nonce: String = UUID().uuidString.lowercased()
+    ) {
+        self.schemaVersion = Self.schemaVersion
+        self.authorityIDs = authorityIDs.sorted()
+        self.scopeID = scopeID
+        self.principalDigest = principalDigest
+        self.issuedAt = issuedAt
+        self.expiresAt = expiresAt
+        self.nonce = nonce
+    }
+
+    public var value: Value {
+        .object([
+            "schemaVersion": .int(schemaVersion),
+            "authorityIDs": .array(authorityIDs.map(Value.string)),
+            "scopeID": .string(scopeID),
+            "principalDigest": .string(principalDigest),
+            "issuedAt": .string(Self.iso(issuedAt)),
+            "expiresAt": .string(Self.iso(expiresAt)),
+            "nonce": .string(nonce),
+        ])
+    }
+
+    public static func parse(_ value: Value) -> RoutingAcknowledgementReceipt? {
+        guard case .object(let object) = value,
+              case .int(let schemaVersion)? = object["schemaVersion"],
+              schemaVersion == Self.schemaVersion,
+              case .array(let authorities)? = object["authorityIDs"],
+              case .string(let scopeID)? = object["scopeID"],
+              case .string(let principalDigest)? = object["principalDigest"],
+              case .string(let issuedAt)? = object["issuedAt"],
+              case .string(let expiresAt)? = object["expiresAt"],
+              case .string(let nonce)? = object["nonce"],
+              let issued = isoFormatter.date(from: issuedAt),
+              let expires = isoFormatter.date(from: expiresAt)
+        else { return nil }
+        let ids = authorities.compactMap { if case .string(let value) = $0 { return value } else { return nil } }
+        guard ids.count == authorities.count, !ids.isEmpty else { return nil }
+        return RoutingAcknowledgementReceipt(
+            authorityIDs: ids,
+            scopeID: scopeID,
+            principalDigest: principalDigest,
+            issuedAt: issued,
+            expiresAt: expires,
+            nonce: nonce
+        )
+    }
+
+    private static func iso(_ date: Date) -> String { isoFormatter.string(from: date) }
+    private static var isoFormatter: ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
+}
+
+public struct ServerRoutingReadiness: Codable, Sendable, Equatable {
+    public let snapshotDigest: String
+    public let source: String
+    public let count: Int
+    public let verifiedAt: Date
+
+    public init(snapshotDigest: String, source: String, count: Int, verifiedAt: Date) {
+        self.snapshotDigest = snapshotDigest
+        self.source = source
+        self.count = count
+        self.verifiedAt = verifiedAt
+    }
+}
+
+public struct PrincipalRoutingContinuation: Codable, Sendable, Equatable {
+    public let principalDigest: String
+    public let authorityID: String
+    public let snapshotDigest: String
+    public let continuedAt: Date
+}
+
+public enum RoutingCustodyError: Error, LocalizedError, Equatable {
+    case corrupt(String)
+    case injectedFailure(RoutingCustodyStore.TestFaultPoint)
+
+    public var errorDescription: String? {
+        switch self {
+        case .corrupt(let detail): return "Routing custody is corrupt: \(detail)"
+        case .injectedFailure(let point): return "Injected routing-custody failure at \(point.rawValue)"
+        }
+    }
+}
+
+/// Atomic, schema-versioned store with checksum validation and prior-valid
+/// recovery. Payloads contain identifiers/digests only; no doctrine, message,
+/// command, or other user-authored body is persisted.
+public final class RoutingCustodyStore: @unchecked Sendable {
+    public static let shared = RoutingCustodyStore()
+    public static let schemaVersion = 1
+
+    public enum TestFaultPoint: String, Sendable, Equatable {
+        case beforeRevisionFinalize
+        case beforeActivation
+    }
+
+    private let lock = NSLock()
+    private let root: URL
+    private var faultPoint: TestFaultPoint?
+
+    public init(root: URL = BridgePaths.applicationSupport(.routingCustody)) {
+        self.root = root
+    }
+
+    private var revisionsRoot: URL { root.appendingPathComponent("revisions", isDirectory: true) }
+    private var stateURL: URL { root.appendingPathComponent("state.json") }
+
+    public func serverReadiness() throws -> ServerRoutingReadiness? {
+        lock.lock(); defer { lock.unlock() }
+        return try readableSnapshotLocked()?.serverRoutingReady
+    }
+
+    public func hasPrincipalContinuation(_ principalKey: String) throws -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard let snapshot = try readableSnapshotLocked() else { return false }
+        return snapshot.principalContinuations[Self.principalDigest(principalKey)] != nil
+    }
+
+    @discardableResult
+    public func recordBootstrap(
+        snapshotID: String,
+        source: String,
+        count: Int,
+        verifiedAt: Date = Date()
+    ) throws -> ServerRoutingReadiness {
+        guard count > 0 else { throw RoutingCustodyError.corrupt("zero routing skills cannot be ready") }
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = try mutableSnapshotLocked()
+        if let existing = snapshot.serverRoutingReady,
+           existing.snapshotDigest == Self.digest("routing-snapshot:\(snapshotID)"),
+           existing.source == source,
+           existing.count == count {
+            return existing
+        }
+        let readiness = ServerRoutingReadiness(
+            snapshotDigest: Self.digest("routing-snapshot:\(snapshotID)"),
+            source: source,
+            count: count,
+            verifiedAt: verifiedAt
+        )
+        snapshot.serverRoutingReady = readiness
+        // Continuations are bound to the routing authority snapshot that
+        // was verified when they were issued. A changed snapshot requires
+        // a fresh bridge_initialize before principal continuation resumes.
+        snapshot.principalContinuations = snapshot.principalContinuations.filter {
+            $0.value.snapshotDigest == readiness.snapshotDigest
+        }
+        try publishLocked(snapshot)
+        return readiness
+    }
+
+    public func recordPrincipalContinuation(
+        principalKey: String,
+        authorityID: String,
+        at date: Date = Date()
+    ) throws {
+        let digest = Self.principalDigest(principalKey)
+        lock.lock(); defer { lock.unlock() }
+        var snapshot = try mutableSnapshotLocked()
+        guard let readiness = snapshot.serverRoutingReady else {
+            throw RoutingCustodyError.corrupt("principal continuation cannot precede server routing readiness")
+        }
+        if let existing = snapshot.principalContinuations[digest],
+           existing.authorityID == authorityID,
+           existing.snapshotDigest == readiness.snapshotDigest {
+            return
+        }
+        let continuation = PrincipalRoutingContinuation(
+            principalDigest: digest,
+            authorityID: authorityID,
+            snapshotDigest: readiness.snapshotDigest,
+            continuedAt: date
+        )
+        snapshot.principalContinuations[digest] = continuation
+        try publishLocked(snapshot)
+    }
+
+    public static func principalDigest(_ principalKey: String) -> String {
+        digest("routing-principal:\(principalKey)")
+    }
+
+    public func activeRevisionIDForTesting() throws -> String? {
+        lock.lock(); defer { lock.unlock() }
+        guard FileManager.default.fileExists(atPath: stateURL.path) else { return nil }
+        return try readStateLocked().activeRevisionID
+    }
+
+    public func priorRevisionIDsForTesting() throws -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return try readStateLocked().priorRevisionIDs
+    }
+
+    public func setFaultForTesting(_ point: TestFaultPoint?) {
+        lock.lock(); defer { lock.unlock() }
+        faultPoint = point
+    }
+
+    public func corruptPayloadForTesting(revisionID: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        try Data("corrupt".utf8).write(
+            to: revisionURL(revisionID).appendingPathComponent("custody.json"),
+            options: .atomic
+        )
+    }
+
+    public func resetForTesting() throws {
+        lock.lock(); defer { lock.unlock() }
+        if FileManager.default.fileExists(atPath: root.path) {
+            try FileManager.default.removeItem(at: root)
+        }
+        faultPoint = nil
+    }
+
+    private func readableSnapshotLocked() throws -> Snapshot? {
+        guard FileManager.default.fileExists(atPath: stateURL.path) else { return nil }
+        do {
+            let state = try readStateLocked()
+            return try readRevisionLocked(state.activeRevisionID)
+        } catch {
+            guard let state = try? readStateLocked() else {
+                throw RoutingCustodyError.corrupt("active state has no trusted recovery chain: \(error.localizedDescription)")
+            }
+            for revisionID in state.priorRevisionIDs {
+                if let prior = try? readRevisionLocked(revisionID) { return prior }
+            }
+            throw RoutingCustodyError.corrupt("no manifest-valid prior revision: \(error.localizedDescription)")
+        }
+    }
+
+    private func mutableSnapshotLocked() throws -> Snapshot {
+        guard FileManager.default.fileExists(atPath: stateURL.path) else { return .empty }
+        do {
+            let state = try readStateLocked()
+            return try readRevisionLocked(state.activeRevisionID)
+        } catch {
+            guard let state = try? readStateLocked() else {
+                throw RoutingCustodyError.corrupt("active state has no trusted recovery chain: \(error.localizedDescription)")
+            }
+            for revisionID in state.priorRevisionIDs {
+                if let prior = try? readRevisionLocked(revisionID) {
+                    let history = unique([state.activeRevisionID] + state.priorRevisionIDs).filter { $0 != revisionID }
+                    try writeJSON(
+                        ActiveState(schemaVersion: Self.schemaVersion, activeRevisionID: revisionID, priorRevisionIDs: history),
+                        to: stateURL
+                    )
+                    return prior
+                }
+            }
+            throw RoutingCustodyError.corrupt("no manifest-valid prior revision: \(error.localizedDescription)")
+        }
+    }
+
+    private func publishLocked(_ snapshot: Snapshot) throws {
+        try validate(snapshot)
+        try ensureDirectory(root)
+        try ensureDirectory(revisionsRoot)
+        let revisionID = "revision-\(UUID().uuidString.lowercased())"
+        let staging = revisionsRoot.appendingPathComponent(".\(revisionID).staging", isDirectory: true)
+        let final = revisionURL(revisionID)
+        let fm = FileManager.default
+        try ensureDirectory(staging)
+        do {
+            let payloadURL = staging.appendingPathComponent("custody.json")
+            try writeJSON(snapshot, to: payloadURL)
+            let manifest = RevisionManifest(
+                schemaVersion: Self.schemaVersion,
+                revisionID: revisionID,
+                createdAt: Date(),
+                payloadSHA256: Self.digest(try Data(contentsOf: payloadURL))
+            )
+            try writeJSON(manifest, to: staging.appendingPathComponent("manifest.json"))
+            try injectFault(.beforeRevisionFinalize)
+            try fm.moveItem(at: staging, to: final)
+            try injectFault(.beforeActivation)
+            let previous = try? readStateLocked()
+            let history = unique(([previous?.activeRevisionID].compactMap { $0 }) + (previous?.priorRevisionIDs ?? []))
+                .filter { $0 != revisionID }
+            try writeJSON(
+                ActiveState(schemaVersion: Self.schemaVersion, activeRevisionID: revisionID, priorRevisionIDs: history),
+                to: stateURL
+            )
+        } catch {
+            if fm.fileExists(atPath: staging.path) { try? fm.removeItem(at: staging) }
+            throw error
+        }
+    }
+
+    private func readRevisionLocked(_ revisionID: String) throws -> Snapshot {
+        guard isSafeRevisionID(revisionID) else { throw RoutingCustodyError.corrupt("unsafe revision ID") }
+        let revision = revisionURL(revisionID)
+        let manifest: RevisionManifest
+        do {
+            manifest = try decoder.decode(RevisionManifest.self, from: Data(contentsOf: revision.appendingPathComponent("manifest.json")))
+        } catch {
+            throw RoutingCustodyError.corrupt("cannot decode manifest for \(revisionID)")
+        }
+        guard manifest.schemaVersion == Self.schemaVersion, manifest.revisionID == revisionID else {
+            throw RoutingCustodyError.corrupt("manifest identity mismatch for \(revisionID)")
+        }
+        let payload = try Data(contentsOf: revision.appendingPathComponent("custody.json"))
+        guard Self.digest(payload) == manifest.payloadSHA256 else {
+            throw RoutingCustodyError.corrupt("payload checksum mismatch for \(revisionID)")
+        }
+        let snapshot = try decoder.decode(Snapshot.self, from: payload)
+        try validate(snapshot)
+        return snapshot
+    }
+
+    private func readStateLocked() throws -> ActiveState {
+        let state = try decoder.decode(ActiveState.self, from: Data(contentsOf: stateURL))
+        guard state.schemaVersion == Self.schemaVersion,
+              isSafeRevisionID(state.activeRevisionID),
+              state.priorRevisionIDs.allSatisfy(isSafeRevisionID) else {
+            throw RoutingCustodyError.corrupt("invalid active-state identity")
+        }
+        return state
+    }
+
+    private func validate(_ snapshot: Snapshot) throws {
+        guard snapshot.schemaVersion == Self.schemaVersion else {
+            throw RoutingCustodyError.corrupt("snapshot schema mismatch")
+        }
+        if let ready = snapshot.serverRoutingReady {
+            guard ready.count > 0, Self.isSHA256(ready.snapshotDigest), !ready.source.isEmpty else {
+                throw RoutingCustodyError.corrupt("invalid server readiness")
+            }
+        } else if !snapshot.principalContinuations.isEmpty {
+            throw RoutingCustodyError.corrupt("continuations exist without readiness")
+        }
+        for (key, continuation) in snapshot.principalContinuations {
+            guard key == continuation.principalDigest,
+                  Self.isSHA256(key),
+                  !continuation.authorityID.isEmpty,
+                  continuation.snapshotDigest == snapshot.serverRoutingReady?.snapshotDigest else {
+                throw RoutingCustodyError.corrupt("invalid principal continuation")
+            }
+        }
+    }
+
+    private func ensureDirectory(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    }
+
+    private func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+        try ensureDirectory(url.deletingLastPathComponent())
+        try encoder.encode(value).write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private var encoder: JSONEncoder {
+        let value = JSONEncoder()
+        value.outputFormatting = [.prettyPrinted, .sortedKeys]
+        value.dateEncodingStrategy = .iso8601
+        return value
+    }
+
+    private var decoder: JSONDecoder {
+        let value = JSONDecoder()
+        value.dateDecodingStrategy = .iso8601
+        return value
+    }
+
+    private func revisionURL(_ id: String) -> URL { revisionsRoot.appendingPathComponent(id, isDirectory: true) }
+    private func isSafeRevisionID(_ value: String) -> Bool {
+        value.hasPrefix("revision-") && !value.contains("..") && !value.contains("/")
+    }
+    private func injectFault(_ point: TestFaultPoint) throws {
+        if faultPoint == point { throw RoutingCustodyError.injectedFailure(point) }
+    }
+    private func unique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+    private static func isSHA256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { $0.isHexDigit }
+    }
+    private static func digest(_ string: String) -> String { digest(Data(string.utf8)) }
+    private static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private struct ActiveState: Codable {
+        let schemaVersion: Int
+        let activeRevisionID: String
+        let priorRevisionIDs: [String]
+    }
+    private struct RevisionManifest: Codable {
+        let schemaVersion: Int
+        let revisionID: String
+        let createdAt: Date
+        let payloadSHA256: String
+    }
+    private struct Snapshot: Codable, Equatable {
+        let schemaVersion: Int
+        var serverRoutingReady: ServerRoutingReadiness?
+        var principalContinuations: [String: PrincipalRoutingContinuation]
+        static let empty = Snapshot(schemaVersion: RoutingCustodyStore.schemaVersion, serverRoutingReady: nil, principalContinuations: [:])
+    }
+}

--- a/TheBridge/Server/RoutingIntegrityLayer.swift
+++ b/TheBridge/Server/RoutingIntegrityLayer.swift
@@ -40,6 +40,11 @@ public struct ToolSkillBinding: Sendable, Codable, Equatable, Hashable {
             .map { "\($0.slug) (\($0.role))" }
             .joined(separator: ", ")
     }
+
+    /// Exact acknowledgement scope. Scopes are intentionally tool-specific:
+    /// acknowledging Messages reads never authorizes Notion or calendar work,
+    /// and no process-wide/global marker exists.
+    public var scopeID: String { "tool:\(toolName)" }
 }
 
 public struct RoutingIntegrityReceipt: Sendable, Codable, Equatable {
@@ -255,12 +260,45 @@ public enum ToolSkillBindingRegistry {
         manifestMarkerTools.contains(toolName)
     }
 
+    public static var allScopeIDs: Set<String> {
+        Set(bindings.map(\.scopeID))
+    }
+
+    public static func scopeID(for toolName: String) -> String? {
+        binding(for: toolName)?.scopeID
+    }
+
+    public static func scopeIDs(governedBy authoritySlug: String) -> Set<String> {
+        let normalized = normalizeAuthoritySlug(authoritySlug)
+        return Set(bindings.compactMap { binding in
+            binding.governingSkills.contains { normalizeAuthoritySlug($0.slug) == normalized }
+                ? binding.scopeID
+                : nil
+        })
+    }
+
+    public static func normalizeAuthoritySlug(_ raw: String) -> String {
+        let lowered = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(with: Locale(identifier: "en_US_POSIX"))
+        let words = lowered.split { !$0.isLetter && !$0.isNumber }.map(String.init)
+        return words.joined(separator: "-")
+    }
+
     public static func callSatisfiesManifestMarker(toolName: String, result: Value) -> Bool {
         guard isManifestMarkerTool(toolName) else { return false }
         if toolName == BridgeInitializeModule.toolName,
            case .object(let dict) = result,
            case .string(let finalState)? = dict["finalState"] {
             return finalState != StandingOrdersStore.InitializationState.incomplete.rawValue
+        }
+        if toolName == "skills_routing_list",
+           case .object(let dict) = result,
+           case .string(SkillRoutingSnapshotStatus.healthy.rawValue)? = dict["status"],
+           case .int(let count)? = dict["count"] {
+            return count > 0
+        }
+        if toolName == "fetch_skill", case .object(let dict) = result {
+            return dict["error"] == nil && (dict["title"] != nil || dict["slug"] != nil || dict["content"] != nil)
         }
         return true
     }

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -209,11 +209,17 @@ public actor ToolRouter {
     /// FB-4: withhold `tools/list` until `BridgeModuleRegistry` finishes so
     /// clients never cache a partial surface during startup registration.
     private var modulesRegistrationComplete = false
-    private var routingManifestSessionIDs: Set<String> = []
+    /// Ephemeral, exact-scope acknowledgements. A new transport session starts
+    /// empty even when the same verified principal has durable continuation.
+    private var clientRouteAuthorities: [String: [String: Set<String>]] = [:]
+    /// One-time receipts support local callers that genuinely have no stable
+    /// session identifier. Receipts never survive process restart or replay.
+    private var issuedRouteReceipts: [String: RoutingAcknowledgementReceipt] = [:]
     private var dispatchMissWindows: [DispatchMissKey: Date] = [:]
     private let securityGate: SecurityGate
     private let auditLog: AuditLog
     private let sessionRegistry: SessionRegistry
+    private let routingCustodyStore: RoutingCustodyStore
     private let worktreeOwnershipStore: WorktreeOwnershipStore
     private let worktreeOwnershipEnabled: Bool
 
@@ -230,6 +236,7 @@ public actor ToolRouter {
         securityGate: SecurityGate,
         auditLog: AuditLog,
         sessionRegistry: SessionRegistry = .shared,
+        routingCustodyStore: RoutingCustodyStore = .shared,
         worktreeOwnershipStore: WorktreeOwnershipStore = .shared,
         worktreeOwnershipEnabled: Bool = false,
         licenseStatusProvider: @escaping LicenseStatusProvider = { await LicenseManager.shared.currentStatus() }
@@ -237,6 +244,7 @@ public actor ToolRouter {
         self.securityGate = securityGate
         self.auditLog = auditLog
         self.sessionRegistry = sessionRegistry
+        self.routingCustodyStore = routingCustodyStore
         self.worktreeOwnershipStore = worktreeOwnershipStore
         self.worktreeOwnershipEnabled = worktreeOwnershipEnabled
         self.licenseStatusProvider = licenseStatusProvider
@@ -288,44 +296,212 @@ public actor ToolRouter {
         modulesRegistrationComplete
     }
 
-    /// Test/diagnostic seam for PKT-1094: a session is marked only after a
-    /// successful bridge_initialize / fetch_skill / routing-skill manifest call.
-    /// Marks may be transport session ids or verified principal keys.
+    /// Compatibility diagnostic: true when this exact client session has at
+    /// least one exact-scope acknowledgement. Principal keys are never client
+    /// acknowledgement buckets.
     public func hasRoutingManifestMarker(sessionID: String) -> Bool {
-        routingManifestSessionIDs.contains(sessionID)
+        clientRouteAuthorities[sessionID]?.isEmpty == false
     }
 
+    /// Compatibility test seam. It grants the explicit registered scopes to
+    /// this one session, never a process-global marker.
     public func markRoutingManifestFetched(sessionID: String) {
-        routingManifestSessionIDs.insert(sessionID)
+        acknowledgeAllScopes(clientKey: sessionID)
+    }
+
+    public func hasRouteAcknowledgement(sessionID: String, scopeID: String) -> Bool {
+        guard let required = ToolSkillBindingRegistry.bindings.first(where: { $0.scopeID == scopeID }) else { return false }
+        let present = clientRouteAuthorities[sessionID]?[scopeID] ?? []
+        return Set(required.governingSkills.map(\.slug)).isSubset(of: present)
     }
 
     private func isGoverned(_ context: ToolDispatchContext) async -> Bool? {
-        try? await sessionRegistry.isGoverned(
+        if (try? await sessionRegistry.isGoverned(
             transportSessionId: context.transportSessionId,
             principalKey: context.governancePrincipal
+        )) == true { return true }
+        guard let principal = context.governancePrincipal else { return false }
+        return (try? routingCustodyStore.hasPrincipalContinuation(principal)) == true
+    }
+
+    private func acknowledge(scopes: Set<String>, authorityIDs: Set<String>, clientKey: String) {
+        var byScope = clientRouteAuthorities[clientKey] ?? [:]
+        for scope in scopes {
+            byScope[scope, default: []].formUnion(authorityIDs)
+        }
+        clientRouteAuthorities[clientKey] = byScope
+    }
+
+    private func acknowledgeAllScopes(clientKey: String) {
+        for binding in ToolSkillBindingRegistry.bindings {
+            acknowledge(
+                scopes: Set([binding.scopeID]),
+                authorityIDs: Set(binding.governingSkills.map(\.slug)),
+                clientKey: clientKey
+            )
+        }
+    }
+
+    private func hasRouteAcknowledgement(context: ToolDispatchContext, binding: ToolSkillBinding) -> Bool {
+        guard let clientKey = context.transportSessionId, !clientKey.isEmpty else { return false }
+        let present = clientRouteAuthorities[clientKey]?[binding.scopeID] ?? []
+        return Set(binding.governingSkills.map(\.slug)).isSubset(of: present)
+    }
+
+    private func clientAuthorityDigest(_ context: ToolDispatchContext) -> String {
+        if let principal = context.governancePrincipal {
+            return RoutingCustodyStore.principalDigest("verified:\(principal)")
+        }
+        if let session = context.transportSessionId, !session.isEmpty {
+            return RoutingCustodyStore.principalDigest("session:\(session)")
+        }
+        return RoutingCustodyStore.principalDigest(
+            "local-no-session:\(context.origin.rawValue):\(context.client ?? "anonymous")"
         )
     }
 
-    private func hasRoutingManifestMarker(context: ToolDispatchContext) -> Bool {
-        if let sessionID = context.transportSessionId,
-           !sessionID.isEmpty,
-           routingManifestSessionIDs.contains(sessionID) {
-            return true
+    private func consumeRouteReceipts(
+        arguments: Value,
+        context: ToolDispatchContext,
+        binding: ToolSkillBinding,
+        now: Date
+    ) -> Bool {
+        guard case .object(let object) = arguments else { return false }
+        var values: [Value] = []
+        if let single = object["_routingReceipt"] { values.append(single) }
+        if case .array(let multiple)? = object["_routingReceipts"] { values.append(contentsOf: multiple) }
+        let parsed = values.compactMap(RoutingAcknowledgementReceipt.parse)
+        guard parsed.count == values.count, !parsed.isEmpty else { return false }
+
+        let expectedDigest = clientAuthorityDigest(context)
+        var authorities = Set<String>()
+        var nonces: [String] = []
+        for receipt in parsed {
+            guard receipt.scopeID == binding.scopeID,
+                  receipt.principalDigest == expectedDigest,
+                  receipt.issuedAt <= now,
+                  receipt.expiresAt > now,
+                  issuedRouteReceipts[receipt.nonce] == receipt else { return false }
+            authorities.formUnion(receipt.authorityIDs)
+            nonces.append(receipt.nonce)
         }
-        if let principal = context.governancePrincipal,
-           routingManifestSessionIDs.contains(principal) {
-            return true
-        }
-        return false
+        let required = Set(binding.governingSkills.map(\.slug))
+        guard required.isSubset(of: authorities) else { return false }
+        for nonce in nonces { issuedRouteReceipts.removeValue(forKey: nonce) }
+        return true
     }
 
-    private func markRoutingManifestFetched(context: ToolDispatchContext) {
-        if let sessionID = context.transportSessionId, !sessionID.isEmpty {
-            routingManifestSessionIDs.insert(sessionID)
+    private func issueReceipt(
+        authorityIDs: Set<String>,
+        scopeID: String,
+        context: ToolDispatchContext,
+        now: Date
+    ) -> RoutingAcknowledgementReceipt {
+        issuedRouteReceipts = issuedRouteReceipts.filter { $0.value.expiresAt > now }
+        let roundedNow = Date(timeIntervalSince1970: floor(now.timeIntervalSince1970 * 1_000) / 1_000)
+        let receipt = RoutingAcknowledgementReceipt(
+            authorityIDs: Array(authorityIDs),
+            scopeID: scopeID,
+            principalDigest: clientAuthorityDigest(context),
+            issuedAt: roundedNow,
+            expiresAt: roundedNow.addingTimeInterval(300)
+        )
+        issuedRouteReceipts[receipt.nonce] = receipt
+        return receipt
+    }
+
+    private func argumentsWithoutRoutingReceipts(_ arguments: Value) -> Value {
+        guard case .object(var object) = arguments else { return arguments }
+        object.removeValue(forKey: "_routingReceipt")
+        object.removeValue(forKey: "_routingReceipts")
+        return .object(object)
+    }
+
+    private func routingSnapshotEvidence(toolName: String, result: Value) -> (id: String, source: String, count: Int)? {
+        guard case .object(let outer) = result else { return nil }
+        let object: [String: Value]
+        if toolName == BridgeInitializeModule.toolName,
+           case .object(let nested)? = outer["routingSnapshot"] {
+            object = nested
+        } else {
+            object = outer
         }
-        if let principal = context.governancePrincipal {
-            routingManifestSessionIDs.insert(principal)
+        guard case .string(SkillRoutingSnapshotStatus.healthy.rawValue)? = object["status"],
+              case .string(let source)? = object["source"],
+              case .string(let snapshot)? = object["snapshot"],
+              case .int(let count)? = object["count"], count > 0 else { return nil }
+        return (snapshot, source, count)
+    }
+
+    private func fetchedAuthorityIDs(arguments: Value, result: Value) -> Set<String> {
+        var candidates: [String] = []
+        if case .object(let object) = result {
+            for key in ["slug", "title", "name"] {
+                if case .string(let value)? = object[key] { candidates.append(value) }
+            }
         }
+        if case .object(let object) = arguments, case .string(let name)? = object["name"] {
+            candidates.append(contentsOf: name.split(separator: "/").map(String.init))
+        }
+        let known = Set(ToolSkillBindingRegistry.bindings.flatMap { $0.governingSkills.map(\.slug) })
+        return Set(candidates.map(ToolSkillBindingRegistry.normalizeAuthoritySlug)).intersection(known)
+    }
+
+    private func applyRoutingEvidence(
+        toolName: String,
+        arguments: Value,
+        result: Value,
+        context: ToolDispatchContext,
+        now: Date
+    ) throws -> Value {
+        guard ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) else {
+            return result
+        }
+
+        if let evidence = routingSnapshotEvidence(toolName: toolName, result: result) {
+            _ = try routingCustodyStore.recordBootstrap(
+                snapshotID: evidence.id,
+                source: evidence.source,
+                count: evidence.count,
+                verifiedAt: now
+            )
+            if toolName == BridgeInitializeModule.toolName,
+               let principal = context.governancePrincipal {
+                try routingCustodyStore.recordPrincipalContinuation(
+                    principalKey: principal,
+                    authorityID: BridgeInitializeModule.toolName,
+                    at: now
+                )
+            }
+        }
+
+        var byScope: [String: Set<String>] = [:]
+        if toolName == BridgeInitializeModule.toolName || toolName == "skills_routing_list" {
+            for binding in ToolSkillBindingRegistry.bindings {
+                byScope[binding.scopeID] = Set(binding.governingSkills.map(\.slug))
+            }
+        } else if toolName == "fetch_skill" {
+            let fetched = fetchedAuthorityIDs(arguments: arguments, result: result)
+            for binding in ToolSkillBindingRegistry.bindings {
+                let relevant = Set(binding.governingSkills.map(\.slug)).intersection(fetched)
+                if !relevant.isEmpty { byScope[binding.scopeID] = relevant }
+            }
+        }
+
+        if let clientKey = context.transportSessionId, !clientKey.isEmpty {
+            for (scope, authorities) in byScope {
+                acknowledge(scopes: Set([scope]), authorityIDs: authorities, clientKey: clientKey)
+            }
+            return result
+        }
+
+        let receipts = byScope.sorted { $0.key < $1.key }.map {
+            issueReceipt(authorityIDs: $0.value, scopeID: $0.key, context: context, now: now).value
+        }
+        guard !receipts.isEmpty, case .object(var object) = result else { return result }
+        object["routingReceipts"] = .array(receipts)
+        object["routingReceiptTTLSeconds"] = .int(300)
+        return .object(object)
     }
 
     /// Surface for MCP `tools/list` — empty until startup registration completes (FB-4).
@@ -578,41 +754,81 @@ public actor ToolRouter {
             }
         }
 
-        // PKT-1094: per-tool routing manifest gate. Runs AFTER the broker's
-        // origin-level gates above (control-plane block, governed-remote-session)
-        // so a foundational "you're not initialized" rejection always takes
-        // precedence over this finer-grained "you haven't fetched THIS tool's
-        // governing skill route" one — calling bridge_initialize satisfies both
-        // at once (it is itself a manifest-marker tool), so there is no case
-        // where reordering costs a legitimate caller an extra round trip.
-        // Remote OAuth principals share the marker across Mcp-Session-Id churn.
-        // No correlatable identity (nil transport + nil principal) keeps the
-        // legacy skip — same as the prior `if let sessionID` gate.
-        let hasCorrelatableIdentity =
-            (context.transportSessionId?.isEmpty == false)
-            || (context.governancePrincipal != nil)
-        if hasCorrelatableIdentity,
-           ToolSkillBindingRegistry.requiresManifestFetch(toolName),
-           !hasRoutingManifestMarker(context: context) {
-            let binding = ToolSkillBindingRegistry.binding(for: toolName)
-            let governance = binding?.governanceSummary ?? "unregistered"
-            let duration = ContinuousClock.now - start
-            let ms = Double(duration.components.attoseconds) / 1_000_000_000_000_000.0
-                + Double(duration.components.seconds) * 1000.0
-            await auditLog.append(AuditEntry(
-                timestamp: Date(),
-                toolName: toolName,
-                tier: tool.tier,
-                inputSummary: stringifySummary(arguments),
-                outputSummary: "REJECTED: routing manifest required (\(governance))",
-                durationMs: ms,
-                approvalStatus: .rejected,
-                transportSessionId: context.transportSessionId
-            ))
-            throw ToolRouterError.routingManifestRequired(
-                toolName: toolName,
-                governingSkills: governance
-            )
+        // Routing receipts are control-plane metadata, never tool input.
+        let executionArguments = argumentsWithoutRoutingReceipts(arguments)
+
+        // Routing custody has three deliberately separate states:
+        // 1. durable server readiness, 2. durable verified-principal
+        // continuation, 3. ephemeral exact client-route acknowledgement.
+        // A restart may preserve 1+2, but it never invents 3 for a new client
+        // session. This makes the recovery instruction honest and prevents a
+        // single principal marker from authorizing unrelated tool families.
+        let hasClientIdentity = context.transportSessionId?.isEmpty == false
+            || context.governancePrincipal != nil
+            || context.client?.isEmpty == false
+        if hasClientIdentity,
+           let binding = ToolSkillBindingRegistry.binding(for: toolName),
+           binding.requiresManifestFetch {
+            let readiness: ServerRoutingReadiness?
+            do {
+                readiness = try routingCustodyStore.serverReadiness()
+            } catch {
+                await auditLog.append(AuditEntry(
+                    timestamp: Date(),
+                    toolName: toolName,
+                    tier: effectiveTier,
+                    inputSummary: stringifySummary(executionArguments),
+                    outputSummary: "REJECTED: bootstrap_required routing_custody_corrupt",
+                    durationMs: Self.elapsedMs(since: start),
+                    approvalStatus: .rejected,
+                    origin: context.origin,
+                    transportSessionId: context.transportSessionId
+                ))
+                throw ToolRouterError.bootstrapRequired(
+                    toolName: toolName,
+                    reason: "routing_custody_corrupt: \(error.localizedDescription)"
+                )
+            }
+            guard readiness != nil else {
+                await auditLog.append(AuditEntry(
+                    timestamp: Date(),
+                    toolName: toolName,
+                    tier: effectiveTier,
+                    inputSummary: stringifySummary(executionArguments),
+                    outputSummary: "REJECTED: bootstrap_required no_verified_routing_snapshot",
+                    durationMs: Self.elapsedMs(since: start),
+                    approvalStatus: .rejected,
+                    origin: context.origin,
+                    transportSessionId: context.transportSessionId
+                ))
+                throw ToolRouterError.bootstrapRequired(
+                    toolName: toolName,
+                    reason: "no_verified_routing_snapshot"
+                )
+            }
+            let acknowledged = hasRouteAcknowledgement(context: context, binding: binding)
+                || consumeRouteReceipts(arguments: arguments, context: context, binding: binding, now: Date())
+            if !acknowledged {
+                let governance = binding.governanceSummary
+                let duration = ContinuousClock.now - start
+                let ms = Double(duration.components.attoseconds) / 1_000_000_000_000_000.0
+                    + Double(duration.components.seconds) * 1000.0
+                await auditLog.append(AuditEntry(
+                    timestamp: Date(),
+                    toolName: toolName,
+                    tier: tool.tier,
+                    inputSummary: stringifySummary(executionArguments),
+                    outputSummary: "REJECTED: route_ack_required scope=\(binding.scopeID) (\(governance))",
+                    durationMs: ms,
+                    approvalStatus: .rejected,
+                    transportSessionId: context.transportSessionId
+                ))
+                throw ToolRouterError.routeAcknowledgementRequired(
+                    toolName: toolName,
+                    scopeID: binding.scopeID,
+                    governingSkills: governance
+                )
+            }
         }
 
         // SecurityGate enforcement (async for request-tier approvals)
@@ -620,7 +836,7 @@ public actor ToolRouter {
             toolName: toolName,
             tier: effectiveTier,
             neverAutoApprove: neverAutoApprove,
-            arguments: arguments,
+            arguments: executionArguments,
             module: tool.module
         )
 
@@ -636,7 +852,7 @@ public actor ToolRouter {
                 timestamp: Date(),
                 toolName: toolName,
                 tier: effectiveTier,
-                inputSummary: stringifySummary(arguments),
+                inputSummary: stringifySummary(executionArguments),
                 outputSummary: "REJECTED: \(reason)",
                 durationMs: ms,
                 approvalStatus: .rejected,
@@ -653,7 +869,7 @@ public actor ToolRouter {
                 timestamp: Date(),
                 toolName: toolName,
                 tier: effectiveTier,
-                inputSummary: stringifySummary(arguments),
+                inputSummary: stringifySummary(executionArguments),
                 outputSummary: "HANDOFF: \(command)",
                 durationMs: ms,
                 approvalStatus: .escalated,
@@ -674,7 +890,7 @@ public actor ToolRouter {
         // caller cannot manufacture it through MCP arguments.
         let exactApprovalReceipt: SecurityApprovalReceipt? =
             effectiveTier == .request && neverAutoApprove
-            ? SecurityApprovalReceipt.issue(toolName: toolName, arguments: arguments, context: context)
+            ? SecurityApprovalReceipt.issue(toolName: toolName, arguments: executionArguments, context: context)
             : nil
         do {
             // C0: one shared fail-closed guard after authorization/governance gates
@@ -683,7 +899,7 @@ public actor ToolRouter {
             if worktreeOwnershipEnabled {
                 worktreeAuthorization = try await WorktreeOwnershipGuard.authorizeToolMutation(
                     toolName: toolName,
-                    arguments: arguments,
+                    arguments: executionArguments,
                     store: worktreeOwnershipStore
                 )
             } else {
@@ -691,7 +907,7 @@ public actor ToolRouter {
             }
             defer { worktreeAuthorization?.release() }
             let invokeHandler: @Sendable () async throws -> Value = {
-                try await tool.handler(arguments)
+                try await tool.handler(executionArguments)
             }
             let invokeApprovedHandler: @Sendable () async throws -> Value = {
                 if let exactApprovalReceipt {
@@ -711,6 +927,13 @@ public actor ToolRouter {
             } else {
                 result = try await invokeApprovedHandler()
             }
+            let routedResult = try applyRoutingEvidence(
+                toolName: toolName,
+                arguments: executionArguments,
+                result: result,
+                context: context,
+                now: Date()
+            )
             let governed = await isGoverned(context)
             let governanceNote: String?
             let returnedResult: Value
@@ -720,14 +943,10 @@ public actor ToolRouter {
                 governed: governed
             ) {
                 governanceNote = "ungoverned_session"
-                returnedResult = Self.annotatedResult(result)
+                returnedResult = Self.annotatedResult(routedResult)
             } else {
                 governanceNote = nil
-                returnedResult = result
-            }
-
-            if ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) {
-                markRoutingManifestFetched(context: context)
+                returnedResult = routedResult
             }
 
             // F2 + PKT-552: Fire-and-forget Notify-tier notification with structured context.
@@ -735,8 +954,8 @@ public actor ToolRouter {
             if effectiveTier == .notify {
                 let context = ToolRouter.makeExecutionContext(
                     toolName: toolName,
-                    arguments: arguments,
-                    summary: stringifySummary(arguments)
+                    arguments: executionArguments,
+                    summary: stringifySummary(executionArguments)
                 )
                 await securityGate.sendExecutionNotification(context: context)
             }
@@ -748,7 +967,7 @@ public actor ToolRouter {
                 timestamp: Date(),
                 toolName: toolName,
                 tier: effectiveTier,
-                inputSummary: stringifySummary(arguments),
+                inputSummary: stringifySummary(executionArguments),
                 outputSummary: stringifySummary(returnedResult),
                 durationMs: ms,
                 approvalStatus: .approved,
@@ -766,7 +985,7 @@ public actor ToolRouter {
                 timestamp: Date(),
                 toolName: toolName,
                 tier: effectiveTier,
-                inputSummary: stringifySummary(arguments),
+                inputSummary: stringifySummary(executionArguments),
                 outputSummary: "ERROR: \(error.localizedDescription)",
                 durationMs: ms,
                 approvalStatus: .error,
@@ -921,9 +1140,45 @@ public actor ToolRouter {
             }()
             return (text: text, isError: structuredFailure)
         } catch {
-            // v3.0·0.5: central param-misnomer recovery. If the agent sent
-            // a known wrong key, append a did-you-mean so it self-corrects
-            // without reading source. Applies to all 162 tools at once.
+            // v3.0·0.5: central param-misnomer recovery. Structured routing
+            // recovery is resolved first; every error path remains single-shot
+            // and never invokes the handler a second time.
+            // Recovery-state failures are structured on every transport. The
+            // human message remains present, but clients can branch on the
+            // stable `error` code without scraping prose.
+            if let routingError = error as? ToolRouterError {
+                let value: Value?
+                switch routingError {
+                case .bootstrapRequired(let name, let reason):
+                    value = .object([
+                        "ok": .bool(false),
+                        "error": .string("bootstrap_required"),
+                        "tool": .string(name),
+                        "reason": .string(reason),
+                        "recoveryTools": .array([.string(BridgeInitializeModule.toolName), .string("skills_routing_list")])
+                    ])
+                case .routeAcknowledgementRequired(let name, let scopeID, let governance):
+                    value = .object([
+                        "ok": .bool(false),
+                        "error": .string("route_ack_required"),
+                        "tool": .string(name),
+                        "scopeID": .string(scopeID),
+                        "governingSkills": .string(governance),
+                        "recoveryTools": .array([.string("fetch_skill"), .string("skills_routing_list")])
+                    ])
+                default:
+                    value = nil
+                }
+                if let value {
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    let data = try? encoder.encode(value)
+                    return (text: data.flatMap { String(data: $0, encoding: .utf8) } ?? routingError.localizedDescription,
+                            isError: true)
+                }
+            }
+            // If the agent sent a known wrong key, append a did-you-mean so it
+            // self-corrects without reading source. Applies to all tools at once.
             var msg = "Error: \(error.localizedDescription)"
             let acceptedKeys: Set<String> = {
                 guard let registration = registry[toolName],
@@ -1007,7 +1262,8 @@ public enum ToolRouterError: Error, LocalizedError {
     case unknownTool(String)
     case invalidArguments(toolName: String, reason: String)
     case securityRejection(toolName: String, reason: String)
-    case routingManifestRequired(toolName: String, governingSkills: String)
+    case bootstrapRequired(toolName: String, reason: String)
+    case routeAcknowledgementRequired(toolName: String, scopeID: String, governingSkills: String)
 
     public var errorDescription: String? {
         switch self {
@@ -1017,8 +1273,10 @@ public enum ToolRouterError: Error, LocalizedError {
             return "\(name): \(reason)"
         case .securityRejection(let name, let reason):
             return "Security gate rejected \(name): \(reason)"
-        case .routingManifestRequired(let name, let governingSkills):
-            return "\(name) requires a routing manifest before dispatch. Fetch the governing skill route first (\(governingSkills)) or run bridge_initialize for this session."
+        case .bootstrapRequired(let name, let reason):
+            return "bootstrap_required: \(name) cannot dispatch until bridge_initialize or skills_routing_list establishes a non-empty verified routing snapshot (reason=\(reason))."
+        case .routeAcknowledgementRequired(let name, let scopeID, let governingSkills):
+            return "route_ack_required: \(name) requires the exact route scope \(scopeID). Call fetch_skill for the governing route (\(governingSkills)) or skills_routing_list on this client connection. bridge_initialize is also valid when a full initialization receipt is required."
         }
     }
 }

--- a/TheBridgeTests/RemoteGovernanceContinuityTests.swift
+++ b/TheBridgeTests/RemoteGovernanceContinuityTests.swift
@@ -135,7 +135,7 @@ func runRemoteGovernanceContinuityTests() async {
         }
     }
 
-    await test("routing-manifest marker follows principal across session rotation") {
+    await test("principal continuation survives rotation but route acknowledgement stays session-scoped") {
         try await withRemoteGovernanceHarness { harness in
             let principal = SessionRegistry.principalKey(subject: "manifest-user")!
             let sessionA = "manifest-a-\(UUID().uuidString)"
@@ -152,8 +152,35 @@ func runRemoteGovernanceContinuityTests() async {
             )
             try expect(!initResult.isError)
             try expect(await harness.router.hasRoutingManifestMarker(sessionID: sessionA))
-            try expect(await harness.router.hasRoutingManifestMarker(sessionID: principal),
-                       "bridge_initialize must mark the verified principal for churn continuity")
+            try expect(!(await harness.router.hasRoutingManifestMarker(sessionID: principal)),
+                       "verified principal must never become a client acknowledgement bucket")
+            try expect(try await harness.registry.isGoverned(
+                transportSessionId: sessionB,
+                principalKey: principal
+            ), "verified principal continuation must still govern the rotated session")
+
+            let beforeAck = await harness.router.dispatchFormatted(
+                toolName: "notion_page_create",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(beforeAck.isError, "rotated session must require its own route acknowledgement")
+            try expect(beforeAck.text.contains("route_ack_required"), "unexpected recovery error: \(beforeAck.text)")
+
+            let roster = await harness.router.dispatchFormatted(
+                toolName: "skills_routing_list",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!roster.isError, "routing roster acknowledgement must succeed: \(roster.text)")
 
             let bound = await harness.router.dispatchFormatted(
                 toolName: "notion_page_create",
@@ -164,10 +191,8 @@ func runRemoteGovernanceContinuityTests() async {
                     governancePrincipal: principal
                 )
             )
-            try expect(!bound.isError, "manifest-bound notify on rotated session must pass: \(bound.text)")
+            try expect(!bound.isError, "manifest-bound notify after exact client ack must pass: \(bound.text)")
             try expect(bound.text.contains("notion-create-ok"), "unexpected body: \(bound.text)")
-            try expect(!bound.text.contains("routing manifest"),
-                       "must not re-demand routing manifest after principal-marked initialize: \(bound.text)")
         }
     }
 
@@ -248,7 +273,10 @@ private func withRemoteGovernanceHarness(
     let router = ToolRouter(
         securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
         auditLog: AuditLog(),
-        sessionRegistry: registry
+        sessionRegistry: registry,
+        routingCustodyStore: RoutingCustodyStore(
+            root: root.appendingPathComponent("routing-custody", isDirectory: true)
+        )
     )
     let receiptStore = HandshakeReceiptStore(
         baseDir: root.appendingPathComponent("handshakes", isDirectory: true)
@@ -282,6 +310,14 @@ private func withRemoteGovernanceHarness(
             )
             return BridgeInitializeModule.receiptValue(receipt)
         }
+    ))
+    await router.register(ToolRegistration(
+        name: "skills_routing_list",
+        module: "skills",
+        tier: .open,
+        description: "authoritative routing snapshot",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in remoteGovernanceHealthyRoutingSnapshot().value }
     ))
     await router.register(ToolRegistration(
         name: "governance_write_probe",

--- a/TheBridgeTests/RoutingCustodyStoreTests.swift
+++ b/TheBridgeTests/RoutingCustodyStoreTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import TheBridgeLib
+
+func runRoutingCustodyStoreTests() async {
+    print("\n🧾 Routing custody — atomic durable bootstrap")
+
+    await test("routing custody: interrupted activation leaves prior revision active") {
+        try withRoutingCustodyRoot { root in
+            let store = RoutingCustodyStore(root: root)
+            let first = try store.recordBootstrap(
+                snapshotID: "snapshot-a",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(1)
+            )
+            let activeBefore = try store.activeRevisionIDForTesting()
+            store.setFaultForTesting(.beforeActivation)
+            do {
+                _ = try store.recordBootstrap(
+                    snapshotID: "snapshot-b",
+                    source: "runtime_exposure_generation",
+                    count: 9,
+                    verifiedAt: routingCustodyDate(2)
+                )
+                throw TestError.assertion("injected activation failure did not fire")
+            } catch RoutingCustodyError.injectedFailure(.beforeActivation) {
+                // expected
+            }
+            store.setFaultForTesting(nil)
+            try expect(try store.activeRevisionIDForTesting() == activeBefore)
+            try expect(try store.serverReadiness() == first)
+        }
+    }
+
+    await test("routing custody: corrupt active revision falls back to manifest-valid prior") {
+        try withRoutingCustodyRoot { root in
+            let store = RoutingCustodyStore(root: root)
+            let prior = try store.recordBootstrap(
+                snapshotID: "snapshot-prior",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(1)
+            )
+            _ = try store.recordBootstrap(
+                snapshotID: "snapshot-corrupt",
+                source: "runtime_exposure_generation",
+                count: 9,
+                verifiedAt: routingCustodyDate(2)
+            )
+            guard let corruptID = try store.activeRevisionIDForTesting() else {
+                throw TestError.assertion("missing active revision")
+            }
+            try store.corruptPayloadForTesting(revisionID: corruptID)
+            try expect(try store.serverReadiness() == prior,
+                       "read recovery must select the prior checksum-valid revision")
+        }
+    }
+
+    await test("routing custody: replacement store reads the same durable state") {
+        try withRoutingCustodyRoot { root in
+            let firstStore = RoutingCustodyStore(root: root)
+            let expected = try firstStore.recordBootstrap(
+                snapshotID: "replacement-proof",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(1)
+            )
+            try firstStore.recordPrincipalContinuation(
+                principalKey: "oauth-sub:replacement-user",
+                authorityID: BridgeInitializeModule.toolName,
+                at: routingCustodyDate(2)
+            )
+
+            let replacementStore = RoutingCustodyStore(root: root)
+            try expect(try replacementStore.serverReadiness() == expected)
+            try expect(try replacementStore.hasPrincipalContinuation("oauth-sub:replacement-user"))
+        }
+    }
+
+    await test("routing custody: unchanged bootstrap and continuation are idempotent") {
+        try withRoutingCustodyRoot { root in
+            let store = RoutingCustodyStore(root: root)
+            _ = try store.recordBootstrap(
+                snapshotID: "idempotent-snapshot",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(1)
+            )
+            try store.recordPrincipalContinuation(
+                principalKey: "oauth-sub:idempotent-user",
+                authorityID: BridgeInitializeModule.toolName,
+                at: routingCustodyDate(2)
+            )
+            let activeBefore = try store.activeRevisionIDForTesting()
+            let historyBefore = try store.priorRevisionIDsForTesting()
+
+            _ = try store.recordBootstrap(
+                snapshotID: "idempotent-snapshot",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(3)
+            )
+            try store.recordPrincipalContinuation(
+                principalKey: "oauth-sub:idempotent-user",
+                authorityID: BridgeInitializeModule.toolName,
+                at: routingCustodyDate(4)
+            )
+
+            try expect(try store.activeRevisionIDForTesting() == activeBefore)
+            try expect(try store.priorRevisionIDsForTesting() == historyBefore)
+        }
+    }
+
+    await test("routing custody: files are owner-only and persist digests rather than principal text") {
+        try withRoutingCustodyRoot { root in
+            let store = RoutingCustodyStore(root: root)
+            _ = try store.recordBootstrap(
+                snapshotID: "permissions-proof",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: routingCustodyDate(1)
+            )
+            let rawPrincipal = "oauth-sub:DO-NOT-PERSIST-RAW"
+            try store.recordPrincipalContinuation(
+                principalKey: rawPrincipal,
+                authorityID: BridgeInitializeModule.toolName,
+                at: routingCustodyDate(2)
+            )
+
+            let fm = FileManager.default
+            let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: [.isDirectoryKey])
+            var combined = Data()
+            while let url = enumerator?.nextObject() as? URL {
+                let isDirectory = try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
+                let attributes = try fm.attributesOfItem(atPath: url.path)
+                let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+                try expect(mode & 0o777 == (isDirectory ? 0o700 : 0o600),
+                           "unexpected permissions \(String(mode, radix: 8)) at \(url.lastPathComponent)")
+                if !isDirectory { combined.append(try Data(contentsOf: url)) }
+            }
+            try expect(!String(decoding: combined, as: UTF8.self).contains(rawPrincipal),
+                       "raw principal leaked into routing custody")
+        }
+    }
+}
+
+private func withRoutingCustodyRoot(_ body: (URL) throws -> Void) throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("routing-custody-tests-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    try body(root)
+}
+
+private func routingCustodyDate(_ offset: TimeInterval) -> Date {
+    Date(timeIntervalSince1970: 1_800_000_000 + offset)
+}

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -16,7 +16,13 @@ func runRoutingIntegrityLayerTests() async {
             tier: .open,
             description: "Send an iMessage or SMS after explicit approval.",
             inputSchema: .object(["type": .string("object")]),
-            handler: { _ in .object(["ok": .bool(true), "sent": .bool(true)]) }
+            handler: { arguments in
+                if case .object(let object) = arguments,
+                   object["_routingReceipt"] != nil || object["_routingReceipts"] != nil {
+                    throw TestError.assertion("routing control metadata reached the tool handler")
+                }
+                return .object(["ok": .bool(true), "sent": .bool(true)])
+            }
         )
     }
 
@@ -71,12 +77,15 @@ func runRoutingIntegrityLayerTests() async {
         }
     }
 
-    await test("RIL gate: fresh session cannot dispatch messages_send before manifest marker") {
+    await test("RIL gate: fresh install reports bootstrap_required before any route acknowledgement") {
         try await withRILTempHome {
             let log = AuditLog()
             let router = ToolRouter(
                 securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
                 auditLog: log,
+                routingCustodyStore: RoutingCustodyStore(
+                    root: BridgePaths.applicationSupport(.routingCustody)
+                ),
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await MessagesModule.register(on: router)
@@ -93,19 +102,17 @@ func runRoutingIntegrityLayerTests() async {
                     )
                     throw TestError.assertion("messages_send reached handler without manifest marker")
                 } catch let error as ToolRouterError {
-                    if case .routingManifestRequired(let toolName, let governingSkills) = error {
+                    if case .bootstrapRequired(let toolName, let reason) = error {
                         try expect(toolName == "messages_send")
-                        try expect(governingSkills.contains("people-keepr"))
+                        try expect(reason.contains("no_verified_routing_snapshot"))
                     } else {
                         throw TestError.assertion("wrong ToolRouterError case: \(error)")
                     }
                 }
             }
             let entries = await log.entries(forSessionID: "ril-session-a")
-            try expect(entries.count == 1, "expected exactly one rejected audit entry, got \(entries.count)")
-            try expect(entries[0].toolName == "messages_send")
-            try expect(entries[0].approvalStatus == .rejected)
-            try expect(entries[0].outputSummary.contains("routing manifest required"))
+            try expect(entries.count == 1 && entries[0].approvalStatus == .rejected,
+                       "bootstrap rejection must be audited exactly once")
         }
     }
 
@@ -118,6 +125,9 @@ func runRoutingIntegrityLayerTests() async {
             let router = ToolRouter(
                 securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
                 auditLog: log,
+                routingCustodyStore: RoutingCustodyStore(
+                    root: BridgePaths.applicationSupport(.routingCustody)
+                ),
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await router.register(BridgeInitializeModule.makeTool(
@@ -187,7 +197,11 @@ func runRoutingIntegrityLayerTests() async {
                     )
                     throw TestError.assertion("marker leaked across sessions")
                 } catch let error as ToolRouterError {
-                    if case .routingManifestRequired = error { /* expected */ }
+                    if case .routeAcknowledgementRequired(let tool, let scope, let governance) = error {
+                        try expect(tool == "messages_send")
+                        try expect(scope == "tool:messages_send")
+                        try expect(governance.contains("people-keepr"))
+                    }
                     else { throw TestError.assertion("wrong error for unmarked second session: \(error)") }
                 }
             }
@@ -197,6 +211,170 @@ func runRoutingIntegrityLayerTests() async {
                        "session b audit sequence drift: \(bTools)")
             let cEntries = await log.entries(forSessionID: "ril-session-c")
             try expect(cEntries.count == 1 && cEntries[0].approvalStatus == .rejected)
+        }
+    }
+
+    await test("RIL restart: durable readiness survives replacement while client route acknowledgement does not") {
+        try await withRILTempHome {
+            let store = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
+            _ = try store.recordBootstrap(
+                snapshotID: "restart-snapshot",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: rilDate("2026-07-07")
+            )
+            try store.recordPrincipalContinuation(
+                principalKey: "oauth-sub:restart-user",
+                authorityID: BridgeInitializeModule.toolName,
+                at: rilDate("2026-07-07")
+            )
+
+            let routerBefore = ToolRouter(
+                securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+                auditLog: AuditLog(),
+                routingCustodyStore: store,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await registerRILRoutingList(on: routerBefore)
+            await routerBefore.register(fakeMessagesSendRegistration())
+            let context = ToolDispatchContext(
+                transportSessionId: "restart-session",
+                origin: .remote,
+                client: "connector",
+                governancePrincipal: "oauth-sub:restart-user"
+            )
+            _ = try await routerBefore.dispatch(toolName: "skills_routing_list", arguments: .object([:]), context: context)
+            _ = try await routerBefore.dispatch(toolName: "messages_send", arguments: .object([:]), context: context)
+
+            // Simulates replacing/relaunching the app: same Application Support
+            // state, fresh ToolRouter memory.
+            let replacementStore = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
+            let routerAfter = ToolRouter(
+                securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+                auditLog: AuditLog(),
+                routingCustodyStore: replacementStore,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await registerRILRoutingList(on: routerAfter)
+            await routerAfter.register(fakeMessagesSendRegistration())
+
+            let rejected = await routerAfter.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(rejected.isError && rejected.text.contains("route_ack_required"),
+                       "replacement must retain bootstrap but demand a fresh client ack: \(rejected.text)")
+            let roster = await routerAfter.dispatchFormatted(
+                toolName: "skills_routing_list", arguments: .object([:]), context: context
+            )
+            try expect(!roster.isError)
+            let allowed = await routerAfter.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(!allowed.isError && allowed.text.contains("sent"))
+        }
+    }
+
+    await test("RIL no-session receipt is exact-scope, principal-bound, expiring, and one-time") {
+        try await withRILTempHome {
+            let store = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
+            let router = ToolRouter(
+                securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+                auditLog: AuditLog(),
+                routingCustodyStore: store,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await registerRILRoutingList(on: router)
+            await router.register(fakeMessagesSendRegistration())
+            let context = ToolDispatchContext(
+                transportSessionId: nil,
+                origin: .local,
+                client: "no-stable-session"
+            )
+            let roster = try await router.dispatch(
+                toolName: "skills_routing_list", arguments: .object([:]), context: context
+            )
+            guard case .object(let rosterObject) = roster,
+                  case .array(let receipts)? = rosterObject["routingReceipts"],
+                  let receipt = receipts.first(where: {
+                      guard case .object(let object) = $0,
+                            case .string("tool:messages_send")? = object["scopeID"] else { return false }
+                      return true
+                  }) else {
+                throw TestError.assertion("routing list did not issue an exact messages_send receipt")
+            }
+
+            let args: Value = .object(["_routingReceipt": receipt])
+            let first = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
+            try expect(!first.isError, "fresh receipt must authorize once: \(first.text)")
+            let replay = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
+            try expect(replay.isError && replay.text.contains("route_ack_required"),
+                       "receipt replay must fail closed: \(replay.text)")
+
+            let wrongClient = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: args,
+                context: ToolDispatchContext(transportSessionId: nil, origin: .local, client: "other-client")
+            )
+            try expect(wrongClient.isError && wrongClient.text.contains("route_ack_required"))
+        }
+    }
+
+    await test("RIL fetch_skill acknowledgements compose required authorities without leaking scopes") {
+        try await withRILTempHome {
+            let store = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
+            _ = try store.recordBootstrap(
+                snapshotID: "scope-snapshot",
+                source: "runtime_exposure_generation",
+                count: 8,
+                verifiedAt: rilDate("2026-07-07")
+            )
+            let router = ToolRouter(
+                securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+                auditLog: AuditLog(),
+                routingCustodyStore: store,
+                licenseStatusProvider: { .trial(daysRemaining: 5) }
+            )
+            await router.register(ToolRegistration(
+                name: "fetch_skill", module: "skills", tier: .open,
+                description: "route authority fixture",
+                inputSchema: .object(["type": .string("object")]),
+                handler: { arguments in
+                    guard case .object(let object) = arguments,
+                          case .string(let name)? = object["name"] else { return .object(["error": .string("missing")]) }
+                    return .object(["title": .string(name), "content": .string("fixture")])
+                }
+            ))
+            await router.register(fakeMessagesSendRegistration())
+            await router.register(ToolRegistration(
+                name: "notion_page_create", module: "notion", tier: .open,
+                description: "unrelated scope fixture", inputSchema: .object(["type": .string("object")]),
+                handler: { _ in .object(["created": .bool(true)]) }
+            ))
+            let context = ToolDispatchContext(transportSessionId: "scope-session", origin: .local)
+            _ = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("PEOPLE Keepr")]),
+                context: context
+            )
+            let partial = await router.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(partial.isError && partial.text.contains("route_ack_required"),
+                       "people authority alone must not satisfy mac-message")
+            _ = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("mac-message")]),
+                context: context
+            )
+            let messages = await router.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(!messages.isError)
+            let notion = await router.dispatchFormatted(
+                toolName: "notion_page_create", arguments: .object([:]), context: context
+            )
+            try expect(notion.isError && notion.text.contains("route_ack_required"),
+                       "Messages route must not authorize Notion")
         }
     }
 
@@ -279,4 +457,26 @@ private func restore(defaults: UserDefaults, key: String, value: Any?) {
     } else {
         defaults.removeObject(forKey: key)
     }
+}
+
+private func registerRILRoutingList(on router: ToolRouter) async {
+    await router.register(ToolRegistration(
+        name: "skills_routing_list",
+        module: "skills",
+        tier: .open,
+        description: "healthy routing fixture",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { _ in
+            SkillRoutingSnapshot(
+                metadata: .init(
+                    status: .healthy,
+                    source: .runtimeExposureGeneration,
+                    snapshotID: "ril-routing-list",
+                    count: 8,
+                    reason: "test"
+                ),
+                skills: (0..<8).map { .object(["name": .string("Routing \($0)")]) }
+            ).value
+        }
+    ))
 }

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -774,6 +774,7 @@ await runBridgeInitializeTests()  // PKT-1065A: canonical bridge_initialize init
 await runWave1BrokerTests()       // Bridge Evolution Contract W1: session broker + constitution bundle + D9c remote block
 await runGovernancePropagationTests() // PKT-1124 W2C: real Streamable-HTTP governance session key propagation
 await runRemoteGovernanceContinuityTests() // principal-keyed remote governance + routing-manifest continuity across session churn
+await runRoutingCustodyStoreTests() // WU2: atomic durable routing bootstrap + checksum recovery
 await runCapabilityPreflightTests() // PKT-1065C: intent-sensitive capability preflight + Reminders adapter
 await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)

--- a/TheBridgeTests/ToolArgumentAliasTests.swift
+++ b/TheBridgeTests/ToolArgumentAliasTests.swift
@@ -198,7 +198,7 @@ func runToolArgumentAliasTests() async {
             .deletingLastPathComponent()
             .appendingPathComponent("TheBridge/Server/ToolRouter.swift")
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
-        let handlerCalls = source.components(separatedBy: "try await tool.handler(arguments)").count - 1
+        let handlerCalls = source.components(separatedBy: "try await tool.handler(").count - 1
         try expect(handlerCalls == 1, "ToolRouter handler call-site count drifted to \(handlerCalls)")
 
         guard let catchRange = source.range(of: "        } catch {\n            // v3.0·0.5: central param-misnomer recovery"),


### PR DESCRIPTION
## Stack

3 of 3. Base: `codex/routing-custody-wu1`. Review WU0 and WU1 first.

## What changed

Separates routing custody into three explicit states:

1. Durable server-routing readiness.
2. Durable digest-only verified-principal continuation.
3. Ephemeral, exact-tool client route acknowledgement.

Adds schema-versioned, checksum-verified atomic routing custody revisions with prior-valid recovery, owner-only permissions, idempotent unchanged writes, and one-time sessionless receipts bound to exact scope, client/principal digest, authority set, expiry, and nonce. Routing control metadata is removed before approval, auditing, worktree authorization, or handler dispatch.

## Why

After Bridge restart or application replacement, clients could receive a routing-manifest error that referenced unavailable or misleading recovery behavior. The previous in-memory principal marker also allowed acknowledgement to span unrelated tool scopes.

## Impact

- Returns machine-readable `bootstrap_required` or `route_ack_required` recovery states.
- A restart preserves verified server and principal continuity but requires a fresh client-route acknowledgement.
- `fetch_skill` acknowledgements compose only the requested governing authorities.
- Exact `messages_send` confirmation remains unchanged: delivery still requires `confirm: "SEND"`.

Related: #137

## Verification

Exact candidate `be85d3d8fd68ac22bca80fbe5cbaaffc9fb1db77`:

- `swift build -c debug`: passed.
- `make test-floor`: 3,591 passed, 0 failed; required floor 3,556.
- Forced-failure coverage proves interrupted activation retains the prior revision, corrupt active payload recovery, application replacement continuity, idempotent writes, owner-only storage, no raw-principal persistence, exact-scope receipts, expiry/binding, and replay rejection.
- The real Messages path reaches its no-send confirmation guard; no message was sent.

## Remaining risk

Installed-app restart behavior has not yet been piloted from `/Applications`. This draft is not approved for installation, merge, tag, or release.