### PR TITLE
fix: land freshness renewal + build 91 on routing stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v4.0.2 (build 91) — routing-custody land + freshness renewal — 2026-08-03
+
+- **Land identity** — Monotonic main build after routing-custody WU0–WU2 plus
+  init-await freshness (`3a415ff` lineage) and unchanged-shadow renewal keyed on
+  `activeGenerationID` + empty exposure `changes` (not `snapshotID` equality).
+  Marketing remains **4.0.2**. Local unmerged pilots occupied builds 88–90.
+- **Scope** — Runtime routing authority, restart-safe bootstrap, staged
+  install-copy without resign, cold-init join of in-flight shadow refresh, and
+  the renewal predicate that prevents `runtime_exposure_freshness_expired` empty
+  roster after Notion `lastEditedTime` drift. No tag, DMG, appcast, or Sparkle.
+- **Promotion boundary** — Loopback cold-init accept required after install;
+  customer release still requires a separate Ship Gate GO.
+
 ## v4.0.2 (build 87) — C0 denial-diagnostics installed pilot — 2026-07-31
 
 - **Pilot identity** — Build-only local candidate identity for exact merged

--- a/Info.plist
+++ b/Info.plist
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>87</string>
+	<string>91</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ BUILD_DIR       = .build
 RELEASE_DIR     = $(BUILD_DIR)/release
 DEBUG_DIR       = $(BUILD_DIR)/debug
 APP_BUNDLE      = $(BUILD_DIR)/TheBridge.app
+STAGED_APP      ?=
+EXPECTED_GIT_SHA ?=
+EXPECTED_BINARY_SHA256 ?=
 FRAMEWORKS_DIR  = $(APP_BUNDLE)/Contents/Frameworks
 # PKT-551: Notification Content Extension (.appex) paths
 PLUGINS_DIR     = $(APP_BUNDLE)/Contents/PlugIns
@@ -69,7 +72,7 @@ SPARKLE_ARTIFACT_DIR = $(BUILD_DIR)/artifacts/sparkle/Sparkle
 SPARKLE_FRAMEWORK = $(SPARKLE_ARTIFACT_DIR)/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework
 SPARKLE_TOOLS_DIR = $(SPARKLE_ARTIFACT_DIR)/bin
 
-.PHONY: debug build test test-floor test-clean check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree inject-license-key inject-remote-access
+.PHONY: debug build test test-floor test-clean check-counter-collisions app extension jobrunner appcast dmg dmg-background sign notarize verify verify-sparkle-feed check-update-flow check-appcast release clean install install-copy install-copy-staged install-agent-safe clean-tcc patch-deps check-stale-build check-clean-tree check-staged-candidate inject-license-key inject-remote-access
 
 # ── Debug Build ────────────────────────────────────────────────
 debug:
@@ -298,6 +301,30 @@ check-clean-tree:
 		exit 1; \
 	fi
 
+# ── Immutable staged-candidate guard ───────────────────────────
+# `install-copy` intentionally builds and signs before copying. That is useful
+# for ordinary development, but code-signing with `--timestamp` changes the
+# executable bytes on every invocation. Promotion workflows therefore use this
+# guard plus `install-copy-staged` to copy the exact already-reviewed bundle
+# without rebuilding or re-signing it between approval and installation.
+check-staged-candidate: check-clean-tree check-stale-build
+	@if [ -z "$(STAGED_APP)" ] || [ -z "$(EXPECTED_GIT_SHA)" ] || [ -z "$(EXPECTED_BINARY_SHA256)" ]; then \
+		echo "❌ STAGED_APP, EXPECTED_GIT_SHA, and EXPECTED_BINARY_SHA256 are required."; exit 1; \
+	fi
+	@if [ ! -d "$(STAGED_APP)" ]; then \
+		echo "❌ Staged app not found: $(STAGED_APP)"; exit 1; \
+	fi
+	@codesign --verify --deep --strict --verbose=2 "$(STAGED_APP)"
+	@SHA=$$(/usr/libexec/PlistBuddy -c "Print :BridgeGitSHA" "$(STAGED_APP)/Contents/Info.plist" 2>/dev/null); \
+		DIRTY=$$(/usr/libexec/PlistBuddy -c "Print :BridgeGitDirty" "$(STAGED_APP)/Contents/Info.plist" 2>/dev/null); \
+		if [ "$$SHA" != "$(EXPECTED_GIT_SHA)" ] || [ "$$DIRTY" != "false" ]; then \
+			echo "❌ Staged provenance mismatch: sha=$$SHA dirty=$$DIRTY expected=$(EXPECTED_GIT_SHA)/false"; exit 1; \
+		fi
+	@ACTUAL=$$(shasum -a 256 "$(STAGED_APP)/Contents/MacOS/$(BINARY_NAME)" | awk '{print $$1}'); \
+		if [ "$$ACTUAL" != "$(EXPECTED_BINARY_SHA256)" ]; then \
+			echo "❌ Staged binary hash mismatch: $$ACTUAL != $(EXPECTED_BINARY_SHA256)"; exit 1; \
+		fi; \
+		echo "✅ Staged candidate verified: sha=$(EXPECTED_GIT_SHA) binary=$$ACTUAL"
 # ── Local-install safety (2026-06-04 incident) ─────────────────────────
 # `install`/`install-copy` write directly into the Sparkle-managed
 # /Applications bundle. If the app is running or Sparkle has a staged update
@@ -360,6 +387,23 @@ install-copy: check-clean-tree check-stale-build sign
 	@echo "Installed: /Applications/The Bridge.app"
 	@echo "Restart The Bridge manually to pick up changes."
 	@echo "Reconnect every MCP client after relaunch so it re-runs initialize + tools/list."
+
+# Exact-candidate promotion path. Unlike `install-copy`, this target has no
+# build/sign prerequisite: the approved signed bundle is the sole source.
+install-copy-staged: check-staged-candidate
+	@echo "⚠️  Installing the exact staged candidate without rebuilding or re-signing."
+	$(PREINSTALL_SAFETY)
+	@rm -rf "/Applications/The Bridge.app" "/Applications/TheBridge.app"
+	@ditto "$(STAGED_APP)" "/Applications/The Bridge.app"
+	@echo "🔄 Re-registering with Launch Services..."
+	@/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "/Applications/The Bridge.app"
+	$(VERIFY_INSTALL)
+	@ACTUAL=$$(shasum -a 256 "/Applications/The Bridge.app/Contents/MacOS/$(BINARY_NAME)" | awk '{print $$1}'); \
+		if [ "$$ACTUAL" != "$(EXPECTED_BINARY_SHA256)" ]; then \
+			echo "❌ Installed binary hash mismatch: $$ACTUAL != $(EXPECTED_BINARY_SHA256)"; exit 1; \
+		fi; \
+		echo "✅ Exact staged candidate installed: binary=$$ACTUAL"
+	@echo "Restart The Bridge manually to pick up changes."
 
 # Alias for agents / remote MCP sessions: same as install-copy (no notarize; does not kill The Bridge).
 install-agent-safe: install-copy

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -310,7 +310,11 @@ public enum AppVersion {
     ///   WorkOS OAuth bake secrets present for release.yml inject. Floor 3391.
     /// v4.0.2 C0 installed-pilot candidate: 86 -> 87 -- local-only build identity
     /// after the denial-diagnostics remediation merge; no tag, appcast, or release.
-    public static let build = "87"
+    /// v4.0.2 routing-custody land: 87 -> 91 -- main integration of WU0–WU2 plus
+    /// init-await freshness and unchanged-shadow renewal (activeGenerationID).
+    /// Local unmerged pilots used 88–90; this build is the monotonic main land.
+    /// No tag, appcast, or Sparkle release.
+    public static let build = "91"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/TheBridge/Modules/Skills/SkillExposureRuntime.swift
+++ b/TheBridge/Modules/Skills/SkillExposureRuntime.swift
@@ -131,13 +131,22 @@ public actor SkillRuntimeGenerationStore {
         return try? decoder().decode(SkillExposureReconciliationReceipt.self, from: data)
     }
 
+    /// An unchanged shadow renews the active generation's freshness window.
+    ///
+    /// Key off empty exposure `changes` + the receipt's `activeGenerationID`,
+    /// not `snapshotID` equality. The registry snapshot hash includes
+    /// `notionLastEditedTime`, so ordinary page edits change the snapshot
+    /// while leaving published Runtime Exposure policy unchanged
+    /// (`changes == []`). Requiring snapshot equality left cold starts stuck
+    /// on `runtime_exposure_freshness_expired` after a successful shadowReady
+    /// (build 89 local pilot, 2026-08-03).
     private func unchangedShadowRenewal(for generation: SkillRuntimeGeneration) -> Date? {
         guard let receipt = latestReceipt(),
               receipt.mode == .shadow,
               receipt.outcome == .shadowReady,
               receipt.errors.isEmpty,
               receipt.changes.isEmpty,
-              receipt.snapshotID == generation.snapshotID
+              receipt.activeGenerationID == generation.generationID
         else { return nil }
         return receipt.attemptedAt
     }

--- a/TheBridge/Modules/Skills/SkillExposureRuntime.swift
+++ b/TheBridge/Modules/Skills/SkillExposureRuntime.swift
@@ -454,7 +454,12 @@ public actor SkillExposureReconciliationCoordinator {
     public static let intervalNanoseconds: UInt64 = 6 * 60 * 60 * 1_000_000_000
 
     private var loopTask: Task<Void, Never>?
-    private var running = false
+    private struct ActiveRun {
+        let id: UUID
+        let mode: SkillExposureReconciliationReceipt.Mode
+        let task: Task<SkillExposureReconciliationReceipt?, Never>
+    }
+    private var activeRun: ActiveRun?
 
     public func start() {
         guard loopTask == nil else { return }
@@ -486,16 +491,28 @@ public actor SkillExposureReconciliationCoordinator {
         mode: SkillExposureReconciliationReceipt.Mode,
         approvals: [SkillExposureApproval]
     ) async -> SkillExposureReconciliationReceipt? {
-        guard !running else { return nil }
-        running = true
-        defer { running = false }
-        let baseline = await MainActor.run {
-            SkillExposureBaselineEntry.fromSkillsManager(SkillsManager())
+        if let active = activeRun {
+            let result = await active.task.value
+            if activeRun?.id == active.id { activeRun = nil }
+            if active.mode == mode, approvals.isEmpty {
+                return result
+            }
+            return await run(mode: mode, approvals: approvals)
         }
-        return await SkillExposureReconciler().reconcile(
-            mode: mode,
-            baseline: baseline,
-            approvals: approvals
-        )
+        let id = UUID()
+        let task = Task { () -> SkillExposureReconciliationReceipt? in
+            let baseline = await MainActor.run {
+                SkillExposureBaselineEntry.fromSkillsManager(SkillsManager())
+            }
+            return await SkillExposureReconciler().reconcile(
+                mode: mode,
+                baseline: baseline,
+                approvals: approvals
+            )
+        }
+        activeRun = ActiveRun(id: id, mode: mode, task: task)
+        let result = await task.value
+        if activeRun?.id == id { activeRun = nil }
+        return result
     }
 }

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -24,6 +24,7 @@ public enum BridgeInitializeModule {
     /// seam. Default binds the live EventKit-backed reminders store.
     public typealias PreflightProvider = @Sendable () -> CapabilityPreflightRegistry
     public typealias RoutingSnapshotProvider = @Sendable (_ now: Date) async -> SkillRoutingSnapshot
+    public typealias RoutingFreshnessRefresher = @Sendable () async -> Void
 
     /// Default preflight: the Reminders adapter over the live EventKit store.
     /// The registry runs NO probe unless the opening intent requires it, so
@@ -34,7 +35,29 @@ public enum BridgeInitializeModule {
         ])
     }
     public static let defaultRoutingSnapshotProvider: RoutingSnapshotProvider = { now in
-        await SkillsModule.routingSnapshot(now: now)
+        await routingSnapshotForInitialize(
+            now: now,
+            snapshotProvider: { await SkillsModule.routingSnapshot(now: $0) },
+            refresh: { _ = await SkillExposureReconciliationCoordinator.shared.runShadow() }
+        )
+    }
+
+    /// A stale Runtime Exposure generation is expected to recover through the
+    /// startup shadow reconciliation. The MCP server becomes reachable before
+    /// that network-backed refresh completes, so the first handshake must join
+    /// the in-flight refresh instead of returning a transient empty manifest.
+    @_spi(Testing)
+    public static func routingSnapshotForInitialize(
+        now: Date,
+        snapshotProvider: @escaping RoutingSnapshotProvider,
+        refresh: @escaping RoutingFreshnessRefresher
+    ) async -> SkillRoutingSnapshot {
+        let initial = await snapshotProvider(now)
+        guard initial.metadata.status == .degraded,
+              initial.metadata.reason == "runtime_exposure_freshness_expired"
+        else { return initial }
+        await refresh()
+        return await snapshotProvider(Date())
     }
 
     /// Resolves the live runtime context (connection + capability + clock) for a

--- a/TheBridgeTests/BridgeInitializeTests.swift
+++ b/TheBridgeTests/BridgeInitializeTests.swift
@@ -12,7 +12,33 @@
 
 import Foundation
 import MCP
-import TheBridgeLib
+@_spi(Testing) import TheBridgeLib
+
+private actor RoutingRefreshProbe {
+    private var refreshed = false
+    private(set) var refreshCount = 0
+
+    func snapshot() -> SkillRoutingSnapshot {
+        let status: SkillRoutingSnapshotStatus = refreshed ? .healthy : .degraded
+        return .init(
+            metadata: .init(
+                status: status,
+                source: .runtimeExposureGeneration,
+                snapshotID: "cold-start-generation",
+                count: refreshed ? 1 : 0,
+                reason: refreshed
+                    ? "verified_unchanged_shadow_renewed_freshness"
+                    : "runtime_exposure_freshness_expired"
+            ),
+            skills: refreshed ? [.object(["name": .string("FOCUS Keepr")])] : []
+        )
+    }
+
+    func refresh() {
+        refreshCount += 1
+        refreshed = true
+    }
+}
 
 func runBridgeInitializeTests() async {
     print("\n\u{1F91D} BridgeInitialize (PKT-1065A · init-core + handshake receipt)")
@@ -51,6 +77,19 @@ func runBridgeInitializeTests() async {
             ),
             skills: rows
         )
+    }
+
+    await test("Init: cold stale routing joins freshness refresh before returning") {
+        let probe = RoutingRefreshProbe()
+        let resolved = await BridgeInitializeModule.routingSnapshotForInitialize(
+            now: fixedClock,
+            snapshotProvider: { _ in await probe.snapshot() },
+            refresh: { await probe.refresh() }
+        )
+        try expect(resolved.metadata.status == .healthy)
+        try expect(resolved.metadata.count == 1)
+        try expect(resolved.metadata.reason == "verified_unchanged_shadow_renewed_freshness")
+        try expect(await probe.refreshCount == 1, "stale cold start must perform exactly one refresh")
     }
 
     // ── COMPLETE path: doctrine + manifest + metadata all present ──────

--- a/TheBridgeTests/SkillExposureAuthorityTests.swift
+++ b/TheBridgeTests/SkillExposureAuthorityTests.swift
@@ -260,6 +260,37 @@ func runSkillExposureAuthorityTests() async {
                    "shadow renewal must not activate its candidate")
     }
 
+    await test("unchanged shadow renews freshness when Notion snapshot hash drifts without exposure changes") {
+        // Live failure mode (build 89 pilot): shadowReady + changes=[] but
+        // receipt.snapshotID != active generation.snapshotID because the
+        // registry hash includes notionLastEditedTime.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-renewal-drift-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow,
+            outcome: .shadowReady,
+            attemptedAt: exposureNow,
+            snapshotID: "2d19aa6a333c259b", // ≠ staleGeneration.snapshotID
+            candidateGenerationID: "9e3da411-634c-4b23-adc3-3e87a432ea1a",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [],
+            warnings: [],
+            changes: []
+        ))
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(!gate.isDegraded(now: exposureNow),
+                   "empty exposure changes must renew even when snapshot hash drifted")
+        try expect(gate.freshnessRenewedAt == exposureNow)
+        try expect(await store.activeGenerationID() == staleGeneration.generationID)
+    }
+
     await test("changed shadow does not renew freshness and still requires publish") {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("bridge-exposure-changed-shadow-\(UUID().uuidString)")

--- a/docs/evidence/build-89-local-pilot-reject-2026-08-03.md
+++ b/docs/evidence/build-89-local-pilot-reject-2026-08-03.md
@@ -1,0 +1,40 @@
+# Build 89 local pilot — REJECT + rollback (2026-08-03)
+
+## Verdict
+**REJECT** build 89 for local pilot. Restored build 87.
+
+## Installed candidate
+- Source SHA: `6ef0b32acfb5e83e494782df0ab290dc264b4d8b`
+- Binary SHA-256: `bcd479670deedbd5dd53e6885471e14e3bfabf092361333c44b48c9bb378aedf`
+- CDHash: `d7f1bb0e8ab064b21687fbc316e210bd5298ef9e`
+- Path: `.build/candidates/The Bridge-4.0.2-89-6ef0b32.app`
+- Method: `ALLOW_NON_MAIN_INSTALL=1 make install-copy-staged`
+
+## Acceptance failure
+Cold `bridge_initialize` (HTTP `/mcp`, 120s budget):
+- Attempt 1 (~2.5s): `finalState=DEGRADED`, `capabilityState=FULL`, `routingRosterState=missing` / `EMPTY`, reason `runtime_exposure_freshness_expired`
+- `skills_exposure_status`: active generation `7a340178-…` compiled `2026-07-29`, age ~518843s, degraded; latestReceipt `mode=shadow` `outcome=shadowReady` (candidate gen `9e3da411-…` not activated)
+- After 55s wait, attempt 2 (~4s): still DEGRADED / EMPTY
+- `messages_recent` not attempted (roster gate failed)
+
+## Rollback
+- Restored `.build/rollback/The Bridge-4.0.2-87-777ab46a.app`
+- Binary SHA-256: `fc337ab11120e5fc09ad578ec9e54db42f6c41f4c80007f1e5bf80fbd0903e56`
+- Post-rollback `bridge_initialize`: COMPLETE / FULL / roster HEALTHY
+
+## Unblock
+Cold init must wait for an **activated** fresh routing generation (not shadow-only) before claiming a healthy roster, or publish shadow→active on freshness expiry.
+
+## Unblock diagnosis (2026-08-03)
+
+**Layer:** application defect (not harness/transport; live product stayed on 87).
+
+**Expected:** after cold `bridge_initialize` joins shadow refresh with `shadowReady` + empty exposure changes, roster becomes healthy via `verified_unchanged_shadow_renewed_freshness`.
+
+**Actual:** join awaited `runShadow()` (~2–4s), receipt was `shadowReady`/`changes=[]`, but roster stayed `runtime_exposure_freshness_expired` / EMPTY.
+
+**Root cause:** `unchangedShadowRenewal` required `receipt.snapshotID == generation.snapshotID`. Live: generation `af9023e119acd8d1` vs receipt `2d19aa6a333c259b`. Snapshot hash includes `notionLastEditedTime`, so ordinary Notion edits break renewal even when Runtime Exposure policy is unchanged.
+
+**Fix:** renew on empty `changes` + matching `activeGenerationID` (not snapshot equality). Regression test added. Suite: 3593 passed, 0 failed.
+
+**Not done here:** re-install / Ship Gate re-pilot of a new build. Next: Execute → ship a corrected pilot build, then Ship Gate local install again.


### PR DESCRIPTION
## Summary
- Cherry-picks allowlisted commits onto WU2: staged install-copy without resign, init-await freshness, unchanged-shadow renewal (`activeGenerationID` + empty `changes`).
- Assigns monotonic main land identity **4.0.2 build 91** (local unmerged pilots used 88–90).
- Pins tip SHA for Execute merge freeze: must merge only after this head is green.

## Test plan
- [x] `make test` on tip: 3593 passed, 0 failed
- [ ] Merge 141 → 142 → 143 → this PR in order
- [ ] Verify renewal predicate on `origin/main`
- [ ] Loopback cold `bridge_initialize` after install-copy


Made with [Cursor](https://cursor.com)