### PR TITLE
Require scoped route receipts for compact connectors

### DIFF
--- a/TheBridge/Modules/Auth/ConnectorAuthContext.swift
+++ b/TheBridge/Modules/Auth/ConnectorAuthContext.swift
@@ -90,6 +90,7 @@ extension BearerValidationError {
         case .audienceMismatch: raw = "audience not accepted"
         case .expired: raw = "token expired"
         case .notYetValid: raw = "token not yet valid"
+        case .subjectMissing: raw = "token subject missing"
         case .misconfigured: raw = "connector key set not configured"
         case .malformedToken: raw = "malformed token"
         }

--- a/TheBridge/Modules/Auth/ConnectorBearerValidator.swift
+++ b/TheBridge/Modules/Auth/ConnectorBearerValidator.swift
@@ -92,6 +92,11 @@ public struct BridgeAccessToken: JWTPayload, Sendable, Equatable {
             }
         }
 
+        guard let subject = sub?.value.trimmingCharacters(in: .whitespacesAndNewlines),
+              !subject.isEmpty else {
+            throw BearerValidationError.subjectMissing
+        }
+
         guard let expected = BridgeAccessToken.expectation else {
             // No expectation configured ⇒ refuse rather than accept an
             // unbound token (fail-closed).
@@ -137,6 +142,8 @@ public enum BearerValidationError: Error, Equatable, Sendable {
     case audienceMismatch(expected: String, got: [String])
     case expired
     case notYetValid
+    /// A verified connector principal is mandatory for session and receipt custody.
+    case subjectMissing
     /// Validator has no keys / no issuer expectation (fail-closed).
     case misconfigured
     /// JWTKit rejected the token for any other structural reason.

--- a/TheBridge/Modules/Auth/TunnelAuthFailure.swift
+++ b/TheBridge/Modules/Auth/TunnelAuthFailure.swift
@@ -22,7 +22,7 @@ public enum TunnelAuthFailureReason: String, Sendable, Equatable, CaseIterable {
         case .misconfigured:
             self = .oauthInactive
         case .missingBearer, .malformedAuthorizationHeader, .signatureInvalid,
-             .notYetValid, .malformedToken:
+             .notYetValid, .subjectMissing, .malformedToken:
             self = .oauthRevoked
         }
     }

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -61,6 +61,34 @@ public enum SkillsModule {
 
     public static let moduleName = "skills"
 
+    /// Carries the handler-resolved parent doctrine identity through public
+    /// field projection. ToolRouter consumes and strips this key before the
+    /// result leaves dispatch; callers never receive it as envelope data.
+    static func attachingRoutingAuthorityEvidence(
+        to value: Value,
+        slug: String?,
+        name: String
+    ) -> Value {
+        guard case .object(var object) = value else { return value }
+        var evidence: [String: Value] = ["name": .string(name)]
+        if let slug { evidence["slug"] = .string(slug) }
+        object[ToolRouter.routingAuthorityEvidenceKey] = .object(evidence)
+        return .object(object)
+    }
+
+    static func projectSkillResult(_ value: Value, fields: [String]?) -> Value {
+        let evidence: Value? = {
+            guard case .object(let object) = value else { return nil }
+            return object[ToolRouter.routingAuthorityEvidenceKey]
+        }()
+        var projected = FieldsFilter.project(value, fields: fields)
+        if let evidence, case .object(var object) = projected {
+            object[ToolRouter.routingAuthorityEvidenceKey] = evidence
+            projected = .object(object)
+        }
+        return projected
+    }
+
     // MARK: - Auto-Routing Instructions (injected into MCP initialize response)
 
     /// Build a compact instructions string containing the routing skill index.
@@ -340,7 +368,18 @@ public enum SkillsModule {
                             parent: name,
                             intent: intentArg
                         )
-                        return FieldsFilter.project(fileResult, fields: fieldsArg)
+                        let fileSlug: String? = {
+                            if case .string(let slug)? = fileSkill.frontmatter["slug"] { return slug }
+                            return nil
+                        }()
+                        return Self.projectSkillResult(
+                            Self.attachingRoutingAuthorityEvidence(
+                                to: fileResult,
+                                slug: fileSlug,
+                                name: fileSkill.name
+                            ),
+                            fields: fieldsArg
+                        )
                     }
                     let closeMatches = closestSkillMatches(for: name)
                     let allSkills = listAvailableSkillNames()
@@ -372,7 +411,7 @@ public enum SkillsModule {
                         parent: name,
                         intent: intentArg
                     )
-                    return FieldsFilter.project(cachedResult, fields: fieldsArg)
+                    return Self.projectSkillResult(cachedResult, fields: fieldsArg)
                 }
 
                 guard skillConfig.enabled else {
@@ -430,9 +469,14 @@ public enum SkillsModule {
                    let cachedBody = await SkillBodyCacheStore.shared.read(pageId: pageIdRaw) {
                     // Build the envelope with ZERO network — no client is
                     // constructed or awaited on this branch.
-                    let result = await Self.buildPlainCacheHitEnvelope(
+                    var result = await Self.buildPlainCacheHitEnvelope(
                         skill: skillConfig,
                         cachedBody: cachedBody
+                    )
+                    result = Self.attachingRoutingAuthorityEvidence(
+                        to: result,
+                        slug: cachedBody.slug,
+                        name: skillConfig.name
                     )
                     await cache.set(cacheKey, content: result)
 
@@ -460,7 +504,7 @@ public enum SkillsModule {
                         parent: name,
                         intent: intentArg
                     )
-                    return FieldsFilter.project(plainHitResult, fields: fieldsArg)
+                    return Self.projectSkillResult(plainHitResult, fields: fieldsArg)
                 }
 
                 // Fetch from Notion API
@@ -576,6 +620,15 @@ public enum SkillsModule {
                         parentName: skillConfig.name,
                         dispatch: specialistDispatch
                     )
+                    let parentSlug = CachedSkillBody.propertyString(
+                        "Slug",
+                        in: .object(Self.flattenProperties(pageProperties))
+                    )
+                    result = Self.attachingRoutingAuthorityEvidence(
+                        to: result,
+                        slug: parentSlug,
+                        name: skillConfig.name
+                    )
                     await cache.set(cacheKey, content: result)
 
                     // body-cache: persist (miss) or bump + maybe revalidate
@@ -627,7 +680,7 @@ public enum SkillsModule {
                         parent: name,
                         intent: intentArg
                     )
-                    return FieldsFilter.project(liveResult, fields: fieldsArg)
+                    return Self.projectSkillResult(liveResult, fields: fieldsArg)
                 } catch let error as NotionClientError {
                     // F10: 403 handling — structured error + "Access Lost" badge
                     if case .httpError(let code, let msg) = error, code == 403 {

--- a/TheBridge/Server/MCPToolFactory.swift
+++ b/TheBridge/Server/MCPToolFactory.swift
@@ -67,6 +67,39 @@ public enum BridgeToolDescriptionRenderer {
 
 public enum MCPToolFactory {
 
+    private static let routingReceiptSchema: Value = .object([
+        "type": .string("object"),
+        "description": .string(
+            "Opaque, single-use route receipt returned by fetch_skill. Copy it verbatim; the server binds it to the authenticated principal and exact tool scope."
+        )
+    ])
+
+    /// Add routing-control inputs in one transport-independent location. Tool
+    /// handlers never see these keys; ToolRouter strips them before dispatch.
+    public static func inputSchema(for reg: ToolRegistration) -> Value {
+        guard ToolSkillBindingRegistry.binding(for: reg.name) != nil,
+              case .object(var schema) = reg.inputSchema else {
+            return reg.inputSchema
+        }
+        var properties: [String: Value]
+        if case .object(let existing)? = schema["properties"] {
+            properties = existing
+        } else {
+            properties = [:]
+        }
+        properties["_routingReceipt"] = routingReceiptSchema
+        properties["_routingReceipts"] = .object([
+            "type": .string("array"),
+            "description": .string(
+                "Route receipts returned by separate fetch_skill calls when this tool has multiple governing skills. Copy each receipt verbatim."
+            ),
+            "items": routingReceiptSchema,
+            "minItems": .int(1)
+        ])
+        schema["properties"] = .object(properties)
+        return .object(schema)
+    }
+
     /// The ONLY place a `ToolRegistration` becomes an MCP `Tool`.
     /// Both transports (ServerManager stdio + SSETransport HTTP) call this.
     public static func tool(for reg: ToolRegistration) -> Tool {
@@ -77,7 +110,7 @@ public enum MCPToolFactory {
             name: reg.name,
             title: displayTitle,
             description: BridgeToolDescriptionRenderer.render(reg),
-            inputSchema: reg.inputSchema,
+            inputSchema: inputSchema(for: reg),
             annotations: annotations
         )
     }

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -1007,7 +1007,13 @@ public actor SSEServer {
         let requestId = json["id"]
         let requestSessionID = request.header(HTTPHeaderName.sessionID)
         let sessionID = requestSessionID ?? UUID().uuidString
-        let brokerSessionID = requestSessionID ?? (origin == .remote ? "remote-connector-json" : sessionID)
+        // Compact connector clients can add, change, or omit Mcp-Session-Id
+        // between calls. Keep a stable audit label for this compatibility path,
+        // but never treat that shared label as routing authority: remote calls
+        // use explicit, principal-bound route receipts in ToolRouter.
+        let brokerSessionID = origin == .remote
+            ? ToolDispatchContext.remoteConnectorJSONSessionID
+            : (requestSessionID ?? sessionID)
         let principal = governancePrincipal ?? SessionRegistry.principalKey(subject: token.subject)
         let headers = Self.connectorJSONHeaders(sessionID: sessionID)
 
@@ -1096,7 +1102,8 @@ public actor SSEServer {
                     transportSessionId: brokerSessionID,
                     origin: origin,
                     client: origin == .remote ? "remote-connector" : nil,
-                    governancePrincipal: principal
+                    governancePrincipal: principal,
+                    routeAcknowledgementMode: origin == .remote ? .explicitReceipt : .transportSession
                 )
             )
             if !isError { await MainActor.run { onToolCall() } }

--- a/TheBridge/Server/SessionRegistry.swift
+++ b/TheBridge/Server/SessionRegistry.swift
@@ -61,25 +61,38 @@ public enum ToolDispatchOrigin: String, Codable, Sendable, Equatable {
 public struct ToolDispatchContext: Sendable, Equatable {
     @TaskLocal public static var current: ToolDispatchContext?
 
+    public enum RouteAcknowledgementMode: Sendable, Equatable {
+        case transportSession
+        case explicitReceipt
+    }
+
+    /// Stable audit/session label for the compact connector compatibility
+    /// path. Routing authority is never stored under this shared label; calls
+    /// on this path must present explicit, principal-bound receipts.
+    public static let remoteConnectorJSONSessionID = "remote-connector-json"
+
     public let transportSessionId: String?
     public let origin: ToolDispatchOrigin
     public let client: String?
     public let clientVersion: String?
     /// Verified OAuth subject key (`oauth-sub:<sub>`). Never request-supplied.
     public let governancePrincipal: String?
+    public let routeAcknowledgementMode: RouteAcknowledgementMode
 
     public init(
         transportSessionId: String?,
         origin: ToolDispatchOrigin,
         client: String? = nil,
         clientVersion: String? = nil,
-        governancePrincipal: String? = nil
+        governancePrincipal: String? = nil,
+        routeAcknowledgementMode: RouteAcknowledgementMode = .transportSession
     ) {
         self.transportSessionId = transportSessionId
         self.origin = origin
         self.client = client
         self.clientVersion = clientVersion
         self.governancePrincipal = SessionRegistry.normalizedPrincipalKey(governancePrincipal)
+        self.routeAcknowledgementMode = routeAcknowledgementMode
     }
 
     public static let localDefault = ToolDispatchContext(

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -435,13 +435,27 @@ public actor ToolRouter {
 
     private func fetchedAuthorityIDs(arguments: Value, result: Value) -> Set<String> {
         var candidates: [String] = []
-        if case .object(let object) = result {
-            for key in ["slug", "title", "name"] {
-                if case .string(let value)? = object[key] { candidates.append(value) }
+        if case .object(let object) = arguments {
+            // `id` is authoritative when present, so an accompanying `name`
+            // must never be allowed to mint authority. In that case use only
+            // the canonical identity returned by the successful fetch.
+            let hasAuthoritativeID: Bool = {
+                guard case .string(let id)? = object["id"] else { return false }
+                return !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }()
+            if !hasAuthoritativeID, case .string(let name)? = object["name"] {
+                // Specialist paths acknowledge their routing parent only.
+                // Treating every slash-delimited segment as an independent
+                // authority lets one success-shaped fetch overgrant a
+                // composed route (for example people-keepr/mac-message).
+                if let parent = name.split(separator: "/", maxSplits: 1).first {
+                    candidates.append(String(parent))
+                }
+            } else if case .object(let resultObject) = result {
+                for key in ["slug", "name"] {
+                    if case .string(let value)? = resultObject[key] { candidates.append(value) }
+                }
             }
-        }
-        if case .object(let object) = arguments, case .string(let name)? = object["name"] {
-            candidates.append(contentsOf: name.split(separator: "/").map(String.init))
         }
         let known = Set(ToolSkillBindingRegistry.bindings.flatMap { $0.governingSkills.map(\.slug) })
         return Set(candidates.map(ToolSkillBindingRegistry.normalizeAuthoritySlug)).intersection(known)

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -227,6 +227,11 @@ public actor ToolRouter {
     private let routingCustodyStore: RoutingCustodyStore
     private let worktreeOwnershipStore: WorktreeOwnershipStore
     private let worktreeOwnershipEnabled: Bool
+    /// Wall clock used only for issuing and validating route receipts. Keeping
+    /// this injectable makes the five-minute boundary testable without sleeps;
+    /// audit timestamps continue to use the real clock.
+    public typealias RouteReceiptNowProvider = @Sendable () -> Date
+    private let routeReceiptNowProvider: RouteReceiptNowProvider
 
     /// PKT-909 (Sell/Distribute v3 · 1) — license-gate seam. Production
     /// callers default to `LicenseManager.shared.currentStatus`; tests
@@ -244,6 +249,7 @@ public actor ToolRouter {
         routingCustodyStore: RoutingCustodyStore = .shared,
         worktreeOwnershipStore: WorktreeOwnershipStore = .shared,
         worktreeOwnershipEnabled: Bool = false,
+        routeReceiptNowProvider: @escaping RouteReceiptNowProvider = { Date() },
         licenseStatusProvider: @escaping LicenseStatusProvider = { await LicenseManager.shared.currentStatus() }
     ) {
         self.securityGate = securityGate
@@ -252,6 +258,7 @@ public actor ToolRouter {
         self.routingCustodyStore = routingCustodyStore
         self.worktreeOwnershipStore = worktreeOwnershipStore
         self.worktreeOwnershipEnabled = worktreeOwnershipEnabled
+        self.routeReceiptNowProvider = routeReceiptNowProvider
         self.licenseStatusProvider = licenseStatusProvider
     }
 
@@ -812,7 +819,7 @@ public actor ToolRouter {
                     arguments: arguments,
                     context: context,
                     binding: binding,
-                    now: Date()
+                    now: routeReceiptNowProvider()
                 ) {
                 case .accepted:
                     acknowledged = true
@@ -952,7 +959,7 @@ public actor ToolRouter {
                 arguments: executionArguments,
                 result: result,
                 context: context,
-                now: Date()
+                now: routeReceiptNowProvider()
             )
             let governed = await isGoverned(context)
             let governanceNote: String?

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -147,6 +147,11 @@ private struct DispatchMissKey: Hashable {
     let safeToolName: String
 }
 
+private enum RouteReceiptValidation: Equatable {
+    case accepted
+    case rejected(String)
+}
+
 private enum DispatchMissTelemetry {
     static let eventType = "dispatch_miss"
     static let windowSeconds: TimeInterval = 60
@@ -303,12 +308,6 @@ public actor ToolRouter {
         clientRouteAuthorities[sessionID]?.isEmpty == false
     }
 
-    /// Compatibility test seam. It grants the explicit registered scopes to
-    /// this one session, never a process-global marker.
-    public func markRoutingManifestFetched(sessionID: String) {
-        acknowledgeAllScopes(clientKey: sessionID)
-    }
-
     public func hasRouteAcknowledgement(sessionID: String, scopeID: String) -> Bool {
         guard let required = ToolSkillBindingRegistry.bindings.first(where: { $0.scopeID == scopeID }) else { return false }
         let present = clientRouteAuthorities[sessionID]?[scopeID] ?? []
@@ -330,16 +329,6 @@ public actor ToolRouter {
             byScope[scope, default: []].formUnion(authorityIDs)
         }
         clientRouteAuthorities[clientKey] = byScope
-    }
-
-    private func acknowledgeAllScopes(clientKey: String) {
-        for binding in ToolSkillBindingRegistry.bindings {
-            acknowledge(
-                scopes: Set([binding.scopeID]),
-                authorityIDs: Set(binding.governingSkills.map(\.slug)),
-                clientKey: clientKey
-            )
-        }
     }
 
     private func hasRouteAcknowledgement(context: ToolDispatchContext, binding: ToolSkillBinding) -> Bool {
@@ -365,30 +354,34 @@ public actor ToolRouter {
         context: ToolDispatchContext,
         binding: ToolSkillBinding,
         now: Date
-    ) -> Bool {
-        guard case .object(let object) = arguments else { return false }
+    ) -> RouteReceiptValidation {
+        guard case .object(let object) = arguments else { return .rejected("missing") }
         var values: [Value] = []
         if let single = object["_routingReceipt"] { values.append(single) }
         if case .array(let multiple)? = object["_routingReceipts"] { values.append(contentsOf: multiple) }
         let parsed = values.compactMap(RoutingAcknowledgementReceipt.parse)
-        guard parsed.count == values.count, !parsed.isEmpty else { return false }
+        guard !values.isEmpty else { return .rejected("missing") }
+        guard parsed.count == values.count else { return .rejected("malformed") }
 
         let expectedDigest = clientAuthorityDigest(context)
         var authorities = Set<String>()
         var nonces: [String] = []
         for receipt in parsed {
-            guard receipt.scopeID == binding.scopeID,
-                  receipt.principalDigest == expectedDigest,
-                  receipt.issuedAt <= now,
-                  receipt.expiresAt > now,
-                  issuedRouteReceipts[receipt.nonce] == receipt else { return false }
+            guard receipt.scopeID == binding.scopeID else { return .rejected("wrong_scope") }
+            guard receipt.principalDigest == expectedDigest else { return .rejected("wrong_principal") }
+            guard receipt.issuedAt <= now else { return .rejected("not_yet_valid") }
+            guard receipt.expiresAt > now else { return .rejected("expired") }
+            guard let issued = issuedRouteReceipts[receipt.nonce] else {
+                return .rejected("replayed_or_unknown")
+            }
+            guard issued == receipt else { return .rejected("tampered") }
             authorities.formUnion(receipt.authorityIDs)
             nonces.append(receipt.nonce)
         }
         let required = Set(binding.governingSkills.map(\.slug))
-        guard required.isSubset(of: authorities) else { return false }
+        guard required.isSubset(of: authorities) else { return .rejected("incomplete_authorities") }
         for nonce in nonces { issuedRouteReceipts.removeValue(forKey: nonce) }
-        return true
+        return .accepted
     }
 
     private func issueReceipt(
@@ -453,9 +446,9 @@ public actor ToolRouter {
         result: Value,
         context: ToolDispatchContext,
         now: Date
-    ) throws -> Value {
+    ) throws -> (result: Value, auditNote: String?) {
         guard ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) else {
-            return result
+            return (result, nil)
         }
 
         if let evidence = routingSnapshotEvidence(toolName: toolName, result: result) {
@@ -476,11 +469,7 @@ public actor ToolRouter {
         }
 
         var byScope: [String: Set<String>] = [:]
-        if toolName == BridgeInitializeModule.toolName || toolName == "skills_routing_list" {
-            for binding in ToolSkillBindingRegistry.bindings {
-                byScope[binding.scopeID] = Set(binding.governingSkills.map(\.slug))
-            }
-        } else if toolName == "fetch_skill" {
+        if toolName == "fetch_skill" {
             let fetched = fetchedAuthorityIDs(arguments: arguments, result: result)
             for binding in ToolSkillBindingRegistry.bindings {
                 let relevant = Set(binding.governingSkills.map(\.slug)).intersection(fetched)
@@ -488,20 +477,27 @@ public actor ToolRouter {
             }
         }
 
-        if let clientKey = context.transportSessionId, !clientKey.isEmpty {
+        guard !byScope.isEmpty else { return (result, nil) }
+
+        if context.routeAcknowledgementMode == .transportSession,
+           let clientKey = context.transportSessionId,
+           !clientKey.isEmpty {
             for (scope, authorities) in byScope {
                 acknowledge(scopes: Set([scope]), authorityIDs: authorities, clientKey: clientKey)
             }
-            return result
+            return (result, nil)
         }
 
         let receipts = byScope.sorted { $0.key < $1.key }.map {
             issueReceipt(authorityIDs: $0.value, scopeID: $0.key, context: context, now: now).value
         }
-        guard !receipts.isEmpty, case .object(var object) = result else { return result }
+        guard !receipts.isEmpty, case .object(var object) = result else { return (result, nil) }
         object["routingReceipts"] = .array(receipts)
         object["routingReceiptTTLSeconds"] = .int(300)
-        return .object(object)
+        object["routingReceiptUsage"] = .string(
+            "Copy the receipt matching the governed tool scope into _routingReceipt, or combine required skill receipts in _routingReceipts. Receipts are principal-bound, five-minute, and single-use."
+        )
+        return (.object(object), "route_receipt_issued")
     }
 
     /// Surface for MCP `tools/list` — empty until startup registration completes (FB-4).
@@ -756,6 +752,7 @@ public actor ToolRouter {
 
         // Routing receipts are control-plane metadata, never tool input.
         let executionArguments = argumentsWithoutRoutingReceipts(arguments)
+        var routeReceiptAuditNote: String?
 
         // Routing custody has three deliberately separate states:
         // 1. durable server readiness, 2. durable verified-principal
@@ -806,8 +803,25 @@ public actor ToolRouter {
                     reason: "no_verified_routing_snapshot"
                 )
             }
-            let acknowledged = hasRouteAcknowledgement(context: context, binding: binding)
-                || consumeRouteReceipts(arguments: arguments, context: context, binding: binding, now: Date())
+            let acknowledged: Bool
+            if context.routeAcknowledgementMode == .transportSession,
+               hasRouteAcknowledgement(context: context, binding: binding) {
+                acknowledged = true
+            } else {
+                switch consumeRouteReceipts(
+                    arguments: arguments,
+                    context: context,
+                    binding: binding,
+                    now: Date()
+                ) {
+                case .accepted:
+                    acknowledged = true
+                    routeReceiptAuditNote = "route_receipt_consumed"
+                case .rejected(let reason):
+                    acknowledged = false
+                    routeReceiptAuditNote = "route_receipt_rejected_\(reason)"
+                }
+            }
             if !acknowledged {
                 let governance = binding.governanceSummary
                 let duration = ContinuousClock.now - start
@@ -821,7 +835,9 @@ public actor ToolRouter {
                     outputSummary: "REJECTED: route_ack_required scope=\(binding.scopeID) (\(governance))",
                     durationMs: ms,
                     approvalStatus: .rejected,
-                    transportSessionId: context.transportSessionId
+                    origin: context.origin,
+                    transportSessionId: context.transportSessionId,
+                    governanceNote: routeReceiptAuditNote
                 ))
                 throw ToolRouterError.routeAcknowledgementRequired(
                     toolName: toolName,
@@ -856,7 +872,9 @@ public actor ToolRouter {
                 outputSummary: "REJECTED: \(reason)",
                 durationMs: ms,
                 approvalStatus: .rejected,
-                transportSessionId: context.transportSessionId
+                origin: context.origin,
+                transportSessionId: context.transportSessionId,
+                governanceNote: routeReceiptAuditNote
             ))
             throw ToolRouterError.securityRejection(toolName: toolName, reason: reason)
 
@@ -873,7 +891,9 @@ public actor ToolRouter {
                 outputSummary: "HANDOFF: \(command)",
                 durationMs: ms,
                 approvalStatus: .escalated,
-                transportSessionId: context.transportSessionId
+                origin: context.origin,
+                transportSessionId: context.transportSessionId,
+                governanceNote: routeReceiptAuditNote
             ))
             return .object([
                 "status": .string("handoff"),
@@ -927,7 +947,7 @@ public actor ToolRouter {
             } else {
                 result = try await invokeApprovedHandler()
             }
-            let routedResult = try applyRoutingEvidence(
+            let routingEvidence = try applyRoutingEvidence(
                 toolName: toolName,
                 arguments: executionArguments,
                 result: result,
@@ -937,17 +957,20 @@ public actor ToolRouter {
             let governed = await isGoverned(context)
             let governanceNote: String?
             let returnedResult: Value
+            var governanceNotes: [String] = []
+            if let routeReceiptAuditNote { governanceNotes.append(routeReceiptAuditNote) }
+            if let issuanceNote = routingEvidence.auditNote { governanceNotes.append(issuanceNote) }
             if Self.shouldAnnotateGovernance(
                 toolName: toolName,
                 context: context,
                 governed: governed
             ) {
-                governanceNote = "ungoverned_session"
-                returnedResult = Self.annotatedResult(routedResult)
+                governanceNotes.append("ungoverned_session")
+                returnedResult = Self.annotatedResult(routingEvidence.result)
             } else {
-                governanceNote = nil
-                returnedResult = routedResult
+                returnedResult = routingEvidence.result
             }
+            governanceNote = governanceNotes.isEmpty ? nil : governanceNotes.joined(separator: ";")
 
             // F2 + PKT-552: Fire-and-forget Notify-tier notification with structured context.
             // Runs after successful execution — informational only.
@@ -989,7 +1012,9 @@ public actor ToolRouter {
                 outputSummary: "ERROR: \(error.localizedDescription)",
                 durationMs: ms,
                 approvalStatus: .error,
-                transportSessionId: context.transportSessionId
+                origin: context.origin,
+                transportSessionId: context.transportSessionId,
+                governanceNote: routeReceiptAuditNote
             ))
             throw error
         }
@@ -1158,13 +1183,24 @@ public actor ToolRouter {
                         "recoveryTools": .array([.string(BridgeInitializeModule.toolName), .string("skills_routing_list")])
                     ])
                 case .routeAcknowledgementRequired(let name, let scopeID, let governance):
+                    let requiredSkillSlugs = ToolSkillBindingRegistry.binding(for: name)?
+                        .governingSkills.map(\.slug) ?? []
                     value = .object([
                         "ok": .bool(false),
                         "error": .string("route_ack_required"),
                         "tool": .string(name),
                         "scopeID": .string(scopeID),
                         "governingSkills": .string(governance),
-                        "recoveryTools": .array([.string("fetch_skill"), .string("skills_routing_list")])
+                        "requiredSkillSlugs": .array(requiredSkillSlugs.map(Value.string)),
+                        "recoveryTools": .array([.string("fetch_skill"), .string("skills_routing_list")]),
+                        "remediation": .object([
+                            "action": .string("fetch_skill"),
+                            "requiredSkillSlugs": .array(requiredSkillSlugs.map(Value.string)),
+                            "receiptArgument": .string(requiredSkillSlugs.count > 1 ? "_routingReceipts" : "_routingReceipt"),
+                            "note": .string(
+                                "skills_routing_list discovers routes but does not authorize this tool. Fetch every required skill and copy the matching receipt or receipts verbatim."
+                            )
+                        ])
                     ])
                 default:
                     value = nil
@@ -1276,7 +1312,7 @@ public enum ToolRouterError: Error, LocalizedError {
         case .bootstrapRequired(let name, let reason):
             return "bootstrap_required: \(name) cannot dispatch until bridge_initialize or skills_routing_list establishes a non-empty verified routing snapshot (reason=\(reason))."
         case .routeAcknowledgementRequired(let name, let scopeID, let governingSkills):
-            return "route_ack_required: \(name) requires the exact route scope \(scopeID). Call fetch_skill for the governing route (\(governingSkills)) or skills_routing_list on this client connection. bridge_initialize is also valid when a full initialization receipt is required."
+            return "route_ack_required: \(name) requires the exact route scope \(scopeID). Call fetch_skill for every governing route (\(governingSkills)) and pass the returned receipt or receipts with the tool call. bridge_initialize and skills_routing_list do not grant this scope."
         }
     }
 }

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -209,6 +209,9 @@ private extension UInt8 {
 
 /// Central dispatch hub. Every tool call flows through here.
 public actor ToolRouter {
+    /// Private-on-the-wire metadata shared with the fetch_skill handler.
+    /// Dispatch consumes and strips it before returning any public result.
+    public static let routingAuthorityEvidenceKey = "_bridgeRoutingAuthorityEvidence"
     private var registry: [String: ToolRegistration] = [:]
     private var manifestRevision: UInt64 = 0
     /// FB-4: withhold `tools/list` until `BridgeModuleRegistry` finishes so
@@ -433,46 +436,56 @@ public actor ToolRouter {
         return (snapshot, source, count)
     }
 
-    private func fetchedAuthorityIDs(arguments: Value, result: Value) -> Set<String> {
-        var candidates: [String] = []
-        if case .object(let object) = arguments {
-            // `id` is authoritative when present, so an accompanying `name`
-            // must never be allowed to mint authority. In that case use only
-            // the canonical identity returned by the successful fetch.
-            let hasAuthoritativeID: Bool = {
-                guard case .string(let id)? = object["id"] else { return false }
-                return !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            }()
-            if !hasAuthoritativeID, case .string(let name)? = object["name"] {
-                // Specialist paths acknowledge their routing parent only.
-                // Treating every slash-delimited segment as an independent
-                // authority lets one success-shaped fetch overgrant a
-                // composed route (for example people-keepr/mac-message).
-                if let parent = name.split(separator: "/", maxSplits: 1).first {
-                    candidates.append(String(parent))
-                }
-            } else if case .object(let resultObject) = result {
-                for key in ["slug", "name"] {
-                    if case .string(let value)? = resultObject[key] { candidates.append(value) }
-                }
-            }
+    private func publicResultAndAuthorityEvidence(
+        _ result: Value
+    ) -> (result: Value, slug: String?, name: String?) {
+        guard case .object(var object) = result else { return (result, nil, nil) }
+        guard case .object(let evidence)? = object.removeValue(forKey: Self.routingAuthorityEvidenceKey) else {
+            return (.object(object), nil, nil)
         }
+        let slug: String? = {
+            guard case .string(let value)? = evidence["slug"] else { return nil }
+            return value
+        }()
+        let name: String? = {
+            guard case .string(let value)? = evidence["name"] else { return nil }
+            return value
+        }()
+        return (.object(object), slug, name)
+    }
+
+    private func fetchedAuthorityIDs(slug: String?, name: String?) -> Set<String> {
         let known = Set(ToolSkillBindingRegistry.bindings.flatMap { $0.governingSkills.map(\.slug) })
-        return Set(candidates.map(ToolSkillBindingRegistry.normalizeAuthoritySlug)).intersection(known)
+        let normalizedName = name.map(ToolSkillBindingRegistry.normalizeAuthoritySlug)
+        if let slug, !slug.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let normalizedSlug = ToolSkillBindingRegistry.normalizeAuthoritySlug(slug)
+            // The Notion/file slug is authoritative. A distinct mutable name
+            // that also names a registered authority is an identity conflict,
+            // so issue no receipt rather than unioning or guessing.
+            if let normalizedName,
+               known.contains(normalizedName),
+               normalizedName != normalizedSlug {
+                return []
+            }
+            return known.contains(normalizedSlug) ? [normalizedSlug] : []
+        }
+        guard let normalizedName, known.contains(normalizedName) else { return [] }
+        return [normalizedName]
     }
 
     private func applyRoutingEvidence(
         toolName: String,
-        arguments: Value,
         result: Value,
         context: ToolDispatchContext,
         now: Date
     ) throws -> (result: Value, auditNote: String?) {
-        guard ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: result) else {
-            return (result, nil)
+        let routed = publicResultAndAuthorityEvidence(result)
+        let publicResult = routed.result
+        guard ToolSkillBindingRegistry.callSatisfiesManifestMarker(toolName: toolName, result: publicResult) else {
+            return (publicResult, nil)
         }
 
-        if let evidence = routingSnapshotEvidence(toolName: toolName, result: result) {
+        if let evidence = routingSnapshotEvidence(toolName: toolName, result: publicResult) {
             _ = try routingCustodyStore.recordBootstrap(
                 snapshotID: evidence.id,
                 source: evidence.source,
@@ -491,14 +504,14 @@ public actor ToolRouter {
 
         var byScope: [String: Set<String>] = [:]
         if toolName == "fetch_skill" {
-            let fetched = fetchedAuthorityIDs(arguments: arguments, result: result)
+            let fetched = fetchedAuthorityIDs(slug: routed.slug, name: routed.name)
             for binding in ToolSkillBindingRegistry.bindings {
                 let relevant = Set(binding.governingSkills.map(\.slug)).intersection(fetched)
                 if !relevant.isEmpty { byScope[binding.scopeID] = relevant }
             }
         }
 
-        guard !byScope.isEmpty else { return (result, nil) }
+        guard !byScope.isEmpty else { return (publicResult, nil) }
 
         if context.routeAcknowledgementMode == .transportSession,
            let clientKey = context.transportSessionId,
@@ -506,13 +519,13 @@ public actor ToolRouter {
             for (scope, authorities) in byScope {
                 acknowledge(scopes: Set([scope]), authorityIDs: authorities, clientKey: clientKey)
             }
-            return (result, nil)
+            return (publicResult, nil)
         }
 
         let receipts = byScope.sorted { $0.key < $1.key }.map {
             issueReceipt(authorityIDs: $0.value, scopeID: $0.key, context: context, now: now).value
         }
-        guard !receipts.isEmpty, case .object(var object) = result else { return (result, nil) }
+        guard !receipts.isEmpty, case .object(var object) = publicResult else { return (publicResult, nil) }
         object["routingReceipts"] = .array(receipts)
         object["routingReceiptTTLSeconds"] = .int(300)
         object["routingReceiptUsage"] = .string(
@@ -970,7 +983,6 @@ public actor ToolRouter {
             }
             let routingEvidence = try applyRoutingEvidence(
                 toolName: toolName,
-                arguments: executionArguments,
                 result: result,
                 context: context,
                 now: routeReceiptNowProvider()

--- a/TheBridgeTests/RemoteGovernanceContinuityTests.swift
+++ b/TheBridgeTests/RemoteGovernanceContinuityTests.swift
@@ -354,7 +354,11 @@ private func withRemoteGovernanceHarness(
                   case .string(let name)? = object["name"] else {
                 return .object(["error": .string("missing name")])
             }
-            return .object(["slug": .string(name), "content": .string("fixture")])
+            return .object([
+                "slug": .string(name),
+                "content": .string("fixture"),
+                ToolRouter.routingAuthorityEvidenceKey: .object(["name": .string(name)])
+            ])
         }
     ))
     await router.register(ToolRegistration(

--- a/TheBridgeTests/RemoteGovernanceContinuityTests.swift
+++ b/TheBridgeTests/RemoteGovernanceContinuityTests.swift
@@ -135,7 +135,7 @@ func runRemoteGovernanceContinuityTests() async {
         }
     }
 
-    await test("principal continuation survives rotation but route acknowledgement stays session-scoped") {
+    await test("principal continuation survives rotation but fetched route authority stays session-scoped") {
         try await withRemoteGovernanceHarness { harness in
             let principal = SessionRegistry.principalKey(subject: "manifest-user")!
             let sessionA = "manifest-a-\(UUID().uuidString)"
@@ -151,7 +151,8 @@ func runRemoteGovernanceContinuityTests() async {
                 )
             )
             try expect(!initResult.isError)
-            try expect(await harness.router.hasRoutingManifestMarker(sessionID: sessionA))
+            try expect(!(await harness.router.hasRoutingManifestMarker(sessionID: sessionA)),
+                       "bridge_initialize establishes readiness but must not authorize governed tools")
             try expect(!(await harness.router.hasRoutingManifestMarker(sessionID: principal)),
                        "verified principal must never become a client acknowledgement bucket")
             try expect(try await harness.registry.isGoverned(
@@ -180,7 +181,30 @@ func runRemoteGovernanceContinuityTests() async {
                     governancePrincipal: principal
                 )
             )
-            try expect(!roster.isError, "routing roster acknowledgement must succeed: \(roster.text)")
+            try expect(!roster.isError, "routing roster discovery must succeed: \(roster.text)")
+
+            let afterRoster = await harness.router.dispatchFormatted(
+                toolName: "notion_page_create",
+                arguments: .object([:]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(afterRoster.isError && afterRoster.text.contains("route_ack_required"),
+                       "routing roster discovery must not authorize a governed tool")
+
+            let fetched = await harness.router.dispatchFormatted(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("notion-keepr")]),
+                context: .init(
+                    transportSessionId: sessionB,
+                    origin: .remote,
+                    governancePrincipal: principal
+                )
+            )
+            try expect(!fetched.isError, "fetching the governing skill must succeed: \(fetched.text)")
 
             let bound = await harness.router.dispatchFormatted(
                 toolName: "notion_page_create",
@@ -318,6 +342,20 @@ private func withRemoteGovernanceHarness(
         description: "authoritative routing snapshot",
         inputSchema: .object(["type": .string("object")]),
         handler: { _ in remoteGovernanceHealthyRoutingSnapshot().value }
+    ))
+    await router.register(ToolRegistration(
+        name: "fetch_skill",
+        module: "skills",
+        tier: .open,
+        description: "route authority fixture",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { arguments in
+            guard case .object(let object) = arguments,
+                  case .string(let name)? = object["name"] else {
+                return .object(["error": .string("missing name")])
+            }
+            return .object(["slug": .string(name), "content": .string("fixture")])
+        }
     ))
     await router.register(ToolRegistration(
         name: "governance_write_probe",

--- a/TheBridgeTests/RemoteOAuthBearerTests.swift
+++ b/TheBridgeTests/RemoteOAuthBearerTests.swift
@@ -148,6 +148,23 @@ func runRemoteOAuthBearerTests() async {
 
     // MARK: - Validator: reject
 
+    await test("Validator: signed token without a usable subject is rejected") {
+        for subject in [nil, "", "   "] as [String?] {
+            let tok = try await keys.sign(
+                iss: kIssuer, aud: kResource, sub: subject, scope: "snippets.read"
+            )
+            do {
+                _ = try await validator(keys: keys.verifyKeys)
+                    .validate(authorizationHeader: "Bearer \(tok)")
+                throw TestError.assertion("sub-less token must be rejected")
+            } catch let error as BearerValidationError {
+                guard case .subjectMissing = error else {
+                    throw TestError.assertion("expected subjectMissing, got \(error)")
+                }
+            }
+        }
+    }
+
     await test("Validator: expired token rejected") {
         let tok = try await keys.sign(
             iss: kIssuer, aud: kResource, scope: "snippets.read",

--- a/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
+++ b/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
@@ -275,8 +275,23 @@ func runRemoteOAuthHardeningS4Tests() async {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
+        let advisoryKey = BridgeDefaults.brokerAdvisoryAnnotation
+        let previousAdvisory = UserDefaults.standard.object(forKey: advisoryKey)
+        UserDefaults.standard.set(true, forKey: advisoryKey)
+        defer {
+            if let previousAdvisory {
+                UserDefaults.standard.set(previousAdvisory, forKey: advisoryKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: advisoryKey)
+            }
+        }
+
         let audit = AuditLog()
         let custody = RoutingCustodyStore(root: root.appendingPathComponent("routing-custody", isDirectory: true))
+        let sessionRegistry = SessionRegistry(
+            path: root.appendingPathComponent("sessions/sessions.sqlite", isDirectory: false)
+        )
+        try await sessionRegistry.resetForTesting()
         _ = try custody.recordBootstrap(
             snapshotID: "compact-receipt-snapshot",
             source: "test",
@@ -286,6 +301,7 @@ func runRemoteOAuthHardeningS4Tests() async {
         let router = ToolRouter(
             securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
             auditLog: audit,
+            sessionRegistry: sessionRegistry,
             routingCustodyStore: custody
         )
         await router.register(ToolRegistration(
@@ -388,7 +404,10 @@ func runRemoteOAuthHardeningS4Tests() async {
         try expect(try s4CompactIsError(replay), "receipt replay must fail closed")
 
         let entries = await audit.entries(forSessionID: ToolDispatchContext.remoteConnectorJSONSessionID)
-        let receiptNotes = entries.compactMap(\.governanceNote).filter { $0.hasPrefix("route_receipt_") }
+        let receiptNotes = Set(entries
+            .compactMap(\.governanceNote)
+            .flatMap { $0.split(separator: ";").map(String.init) }
+            .filter { $0.hasPrefix("route_receipt_") })
         try expect(receiptNotes.contains("route_receipt_issued"))
         try expect(receiptNotes.contains("route_receipt_consumed"))
         try expect(receiptNotes.contains("route_receipt_rejected_wrong_principal"))

--- a/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
+++ b/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
@@ -50,12 +50,12 @@ private struct S4Keys {
     }
 
     func sign(
-        iss: String, aud: String, sub: String = "user-1", scope: String?
+        iss: String, aud: String, sub: String? = "user-1", scope: String?
     ) async throws -> String {
         try await signing.sign(BridgeAccessToken(
             iss: IssuerClaim(value: iss),
             aud: AudienceClaim(value: [aud]),
-            sub: SubjectClaim(value: sub),
+            sub: sub.map { SubjectClaim(value: $0) },
             exp: ExpirationClaim(value: Date().addingTimeInterval(300)),
             nbf: nil,
             scope: scope
@@ -104,6 +104,43 @@ func runRemoteOAuthHardeningS4Tests() async {
             resourceMetadataURL: s4PRM,
             strictScopes: false
         )
+    }
+
+    await test("GH #146 E2E: signed connector tokens without a usable subject are rejected before dispatch") {
+        let router = ToolRouter(
+            securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+            auditLog: AuditLog()
+        )
+        await router.register(ToolRegistration(
+            name: "skills_routing_list", module: "skills", tier: .open,
+            description: "must not run for a subject-less token",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in
+                throw TestError.assertion("subject-less bearer reached tool dispatch")
+            }
+        ))
+        let server = SSEServer(router: router, onToolCall: {}, connectorAuth: unscopedAuthCtx())
+        let body = Data(#"{"jsonrpc":"2.0","id":146,"method":"tools/call","params":{"name":"skills_routing_list","arguments":{}}}"#.utf8)
+
+        for subject in [nil, "", "   "] as [String?] {
+            let token = try await keys.sign(
+                iss: s4Issuer, aud: s4Resource, sub: subject, scope: "openid"
+            )
+            let response = await server.handleHTTPRequest(HTTPRequest(
+                method: "POST",
+                headers: [
+                    "Cf-Connecting-Ip": "203.0.113.146",
+                    "Authorization": "Bearer \(token)",
+                    "Mcp-Session-Id": "subless-\(UUID().uuidString)"
+                ],
+                body: body
+            ))
+            try expect(response.statusCode == 401,
+                       "subject-less connector token must be rejected with 401, got \(response.statusCode)")
+            let challenge = response.headers.first { $0.key.lowercased() == "www-authenticate" }?.value ?? ""
+            try expect(challenge.contains("auth_failed") && !challenge.contains("subject"),
+                       "public challenge must remain coarse: \(challenge)")
+        }
     }
 
     // MARK: - A1: contacts.read scope split (pure gate logic)
@@ -325,7 +362,11 @@ func runRemoteOAuthHardeningS4Tests() async {
                       case .string(let name)? = object["name"] else {
                     return .object(["error": .string("missing name")])
                 }
-                return .object(["slug": .string(name), "content": .string("fixture")])
+                return .object([
+                    "slug": .string(name),
+                    "content": .string("fixture"),
+                    ToolRouter.routingAuthorityEvidenceKey: .object(["name": .string(name)])
+                ])
             }
         ))
         await router.register(ToolRegistration(

--- a/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
+++ b/TheBridgeTests/RemoteOAuthHardeningS4Tests.swift
@@ -96,6 +96,15 @@ func runRemoteOAuthHardeningS4Tests() async {
             strictScopes: true
         )
     }
+    let unscopedAuthCtx: @Sendable () -> ConnectorAuthContext = {
+        ConnectorAuthContext(
+            validator: validator(),
+            sessionBinding: ConnectorSessionBinding(),
+            diagnostics: ConnectorAuthDiagnostics(),
+            resourceMetadataURL: s4PRM,
+            strictScopes: false
+        )
+    }
 
     // MARK: - A1: contacts.read scope split (pure gate logic)
 
@@ -258,6 +267,135 @@ func runRemoteOAuthHardeningS4Tests() async {
         // returns 200, crucially NOT a 401/403 auth refusal.
         try expect(resp.statusCode == 200,
                    "authorized contacts.read call must be dispatched (200), got \(resp.statusCode)")
+    }
+
+    await test("GH #146: compact connector requires principal-bound, exact-scope, single-use route receipts") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("route-receipt-s4-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audit = AuditLog()
+        let custody = RoutingCustodyStore(root: root.appendingPathComponent("routing-custody", isDirectory: true))
+        _ = try custody.recordBootstrap(
+            snapshotID: "compact-receipt-snapshot",
+            source: "test",
+            count: 2,
+            verifiedAt: Date()
+        )
+        let router = ToolRouter(
+            securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
+            auditLog: audit,
+            routingCustodyStore: custody
+        )
+        await router.register(ToolRegistration(
+            name: "skills_routing_list", module: "skills", tier: .open,
+            description: "routing discovery fixture",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { _ in
+                .object([
+                    "status": .string("healthy"), "source": .string("test"),
+                    "snapshot": .string("compact-receipt-snapshot"), "count": .int(2),
+                    "skills": .array([])
+                ])
+            }
+        ))
+        await router.register(ToolRegistration(
+            name: "fetch_skill", module: "skills", tier: .open,
+            description: "route authority fixture",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { arguments in
+                guard case .object(let object) = arguments,
+                      case .string(let name)? = object["name"] else {
+                    return .object(["error": .string("missing name")])
+                }
+                return .object(["slug": .string(name), "content": .string("fixture")])
+            }
+        ))
+        await router.register(ToolRegistration(
+            name: "messages_recent", module: "messages", tier: .open,
+            description: "bounded messages fixture",
+            inputSchema: .object(["type": .string("object")]),
+            handler: { arguments in
+                if case .object(let object) = arguments,
+                   object["_routingReceipt"] != nil || object["_routingReceipts"] != nil {
+                    throw TestError.assertion("routing control metadata reached messages_recent")
+                }
+                return .object(["ok": .bool(true), "messages": .array([])])
+            }
+        ))
+        let server = SSEServer(router: router, onToolCall: {}, connectorAuth: unscopedAuthCtx())
+        let token = try await keys.sign(
+            iss: s4Issuer, aud: s4Resource, sub: "route-user", scope: "openid"
+        )
+        let otherToken = try await keys.sign(
+            iss: s4Issuer, aud: s4Resource, sub: "other-route-user", scope: "openid"
+        )
+
+        let roster = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "conversation-a",
+            tool: "skills_routing_list", arguments: [:], id: 1
+        )
+        let rosterPayload = try s4CompactPayload(roster)
+        try expect(rosterPayload["routingReceipts"] == nil,
+                   "routing discovery must not issue route authority")
+
+        let beforeFetch = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "conversation-a",
+            tool: "messages_recent", arguments: [:], id: 2
+        )
+        try expect(try s4CompactIsError(beforeFetch))
+        try expect(try s4CompactText(beforeFetch).contains("route_ack_required"))
+
+        let peopleFetch = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "conversation-a",
+            tool: "fetch_skill", arguments: ["name": "people-keepr"], id: 3
+        )
+        let macFetch = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "churned-header",
+            tool: "fetch_skill", arguments: ["name": "mac-message"], id: 4
+        )
+        let peopleReceipt = try s4CompactReceipt(peopleFetch, scopeID: "tool:messages_recent")
+        let macReceipt = try s4CompactReceipt(macFetch, scopeID: "tool:messages_recent")
+        let receiptArguments = ["_routingReceipts": [peopleReceipt, macReceipt]]
+
+        let secondConversation = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "conversation-b",
+            tool: "messages_recent", arguments: [:], id: 5
+        )
+        try expect(try s4CompactIsError(secondConversation),
+                   "same principal in a fresh conversation must not inherit authority")
+
+        let wrongPrincipal = try await s4CompactToolCall(
+            server: server, token: otherToken, sessionID: "conversation-other",
+            tool: "messages_recent", arguments: receiptArguments, id: 6
+        )
+        try expect(try s4CompactIsError(wrongPrincipal),
+                   "a receipt must reject a different authenticated principal")
+
+        let accepted = try await s4CompactToolCall(
+            server: server, token: token, sessionID: nil,
+            tool: "messages_recent", arguments: receiptArguments, id: 7
+        )
+        try expect(!(try s4CompactIsError(accepted)),
+                   "valid receipts must survive header omission and authorize exactly once")
+        try expect((try s4CompactPayload(accepted))["ok"] as? Bool == true)
+
+        let replay = try await s4CompactToolCall(
+            server: server, token: token, sessionID: "another-header",
+            tool: "messages_recent", arguments: receiptArguments, id: 8
+        )
+        try expect(try s4CompactIsError(replay), "receipt replay must fail closed")
+
+        let entries = await audit.entries(forSessionID: ToolDispatchContext.remoteConnectorJSONSessionID)
+        let receiptNotes = entries.compactMap(\.governanceNote).filter { $0.hasPrefix("route_receipt_") }
+        try expect(receiptNotes.contains("route_receipt_issued"))
+        try expect(receiptNotes.contains("route_receipt_consumed"))
+        try expect(receiptNotes.contains("route_receipt_rejected_wrong_principal"))
+        try expect(receiptNotes.contains("route_receipt_rejected_replayed_or_unknown"))
+        let auditText = entries.map { "\($0.inputSummary) \($0.outputSummary)" }.joined(separator: "\n")
+        try expect(!auditText.contains("principalDigest") && !auditText.contains("nonce"),
+                   "audit summaries must not persist receipt secrets: \(auditText)")
     }
 
     // MARK: - A2: TransportRouter injection seam
@@ -501,4 +639,75 @@ func runRemoteOAuthHardeningS4Tests() async {
         try expect(!TransportRouter(environment: [:]).isActive(.streamableHTTP),
                    "streamableHTTP must stay off with env unset")
     }
+}
+
+private func s4CompactToolCall(
+    server: SSEServer,
+    token: String,
+    sessionID: String?,
+    tool: String,
+    arguments: [String: Any],
+    id: Int
+) async throws -> [String: Any] {
+    let body = try JSONSerialization.data(withJSONObject: [
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": ["name": tool, "arguments": arguments] as [String: Any],
+    ] as [String: Any])
+    var headers = [
+        "Cf-Connecting-Ip": "203.0.113.146",
+        "Authorization": "Bearer \(token)",
+    ]
+    if let sessionID { headers["Mcp-Session-Id"] = sessionID }
+    let response = await server.handleHTTPRequest(HTTPRequest(
+        method: "POST", headers: headers, body: body
+    ))
+    guard response.statusCode == 200, let responseBody = response.bodyData,
+          let object = try JSONSerialization.jsonObject(with: responseBody) as? [String: Any] else {
+        throw TestError.assertion("compact connector call \(tool) returned malformed HTTP \(response.statusCode)")
+    }
+    return object
+}
+
+private func s4CompactResult(_ response: [String: Any]) throws -> [String: Any] {
+    guard let result = response["result"] as? [String: Any] else {
+        throw TestError.assertion("compact response is missing result: \(response)")
+    }
+    return result
+}
+
+private func s4CompactText(_ response: [String: Any]) throws -> String {
+    let result = try s4CompactResult(response)
+    guard let content = result["content"] as? [[String: Any]],
+          let text = content.first?["text"] as? String else {
+        throw TestError.assertion("compact response is missing text content: \(result)")
+    }
+    return text
+}
+
+private func s4CompactIsError(_ response: [String: Any]) throws -> Bool {
+    let result = try s4CompactResult(response)
+    guard let isError = result["isError"] as? Bool else {
+        throw TestError.assertion("compact response is missing isError: \(result)")
+    }
+    return isError
+}
+
+private func s4CompactPayload(_ response: [String: Any]) throws -> [String: Any] {
+    let text = try s4CompactText(response)
+    guard let data = text.data(using: .utf8),
+          let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw TestError.assertion("tool text is not a JSON object: \(text)")
+    }
+    return payload
+}
+
+private func s4CompactReceipt(_ response: [String: Any], scopeID: String) throws -> [String: Any] {
+    let payload = try s4CompactPayload(response)
+    guard let receipts = payload["routingReceipts"] as? [[String: Any]],
+          let receipt = receipts.first(where: { $0["scopeID"] as? String == scopeID }) else {
+        throw TestError.assertion("fetch_skill did not issue receipt for \(scopeID): \(payload)")
+    }
+    return receipt
 }

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -430,6 +430,19 @@ func runRoutingIntegrityLayerTests() async {
             try expect(authoritativeIDAuthorities == Set(["people-keepr"]),
                        "an ignored name must not override id-derived authority: \(authoritativeIDAuthorities)")
 
+            let conflictingIdentity = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["id": .string(String(repeating: "f", count: 32))]),
+                context: context
+            )
+            guard case .object(let conflictingObject) = conflictingIdentity else {
+                throw TestError.assertion("conflicting identity fixture returned malformed output")
+            }
+            try expect(conflictingObject["routingReceipts"] == nil,
+                       "distinct registered slug/name identities must fail closed without a receipt")
+            try expect(conflictingObject[ToolRouter.routingAuthorityEvidenceKey] == nil,
+                       "internal authority evidence must never reach the caller")
+
             guard let peopleReceipt = receipt(people, scopeID: "tool:messages_send"),
                   let macReceipt = receipt(mac, scopeID: "tool:messages_send"),
                   let otherToolReceipt = receipt(people, scopeID: "tool:messages_recent") else {
@@ -573,7 +586,11 @@ func runRoutingIntegrityLayerTests() async {
                 handler: { arguments in
                     guard case .object(let object) = arguments,
                           case .string(let name)? = object["name"] else { return .object(["error": .string("missing")]) }
-                    return .object(["title": .string(name), "content": .string("fixture")])
+                    return .object([
+                        "title": .string(name),
+                        "content": .string("fixture"),
+                        ToolRouter.routingAuthorityEvidenceKey: .object(["name": .string(name)])
+                    ])
                 }
             ))
             await router.register(fakeMessagesSendRegistration())
@@ -724,20 +741,26 @@ private func registerRILFetchSkill(on router: ToolRouter) async {
             guard case .object(let object) = arguments else {
                 return .object(["error": .string("missing name")])
             }
-            if case .string(_)? = object["id"] {
+            if case .string(let id)? = object["id"] {
                 return .object([
                     "slug": .string("people-keepr"),
                     "title": .string("mac-message"),
-                    "content": .string("fixture")
+                    "content": .string("fixture"),
+                    ToolRouter.routingAuthorityEvidenceKey: .object([
+                        "slug": .string("people-keepr"),
+                        "name": .string(id == String(repeating: "f", count: 32) ? "mac-message" : "people-keepr")
+                    ])
                 ])
             }
             guard case .string(let name)? = object["name"] else {
                 return .object(["error": .string("missing name")])
             }
+            let parent = String(name.split(separator: "/", maxSplits: 1).first ?? "")
             return .object([
                 "slug": .string(name),
                 "title": .string(name.contains("/") ? "mac-message" : name),
-                "content": .string("fixture")
+                "content": .string("fixture"),
+                ToolRouter.routingAuthorityEvidenceKey: .object(["name": .string(parent)])
             ])
         }
     ))

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -45,6 +45,15 @@ func runRoutingIntegrityLayerTests() async {
                    "description budget breached: \(rendered.count)")
     }
 
+    await test("RIL discovery: governed tool schemas centrally advertise receipt inputs") {
+        guard case .object(let schema) = MCPToolFactory.inputSchema(for: fakeMessagesSendRegistration()),
+              case .object(let properties)? = schema["properties"] else {
+            throw TestError.assertion("governed schema is missing properties")
+        }
+        try expect(properties["_routingReceipt"] != nil, "single receipt input must be advertised")
+        try expect(properties["_routingReceipts"] != nil, "composed receipt input must be advertised")
+    }
+
     await test("RIL receipt: bridge_initialize carries registry snapshot") {
         try await withRILTempHome {
             try StandingOrdersStore.shared.resetForTesting()
@@ -116,7 +125,7 @@ func runRoutingIntegrityLayerTests() async {
         }
     }
 
-    await test("RIL gate: bridge_initialize marks only the current session; real messages_send no-send guard runs after marker") {
+    await test("RIL gate: only fetched governing skills authorize the current session") {
         try await withRILTempHome {
             try StandingOrdersStore.shared.resetForTesting()
             _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v7.0.2\n\nseed")
@@ -154,6 +163,7 @@ func runRoutingIntegrityLayerTests() async {
                     )
                 }
             ))
+            await registerRILFetchSkill(on: router)
             await MessagesModule.register(on: router)
 
             try await withNoDisabledTools {
@@ -167,7 +177,32 @@ func runRoutingIntegrityLayerTests() async {
                     context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
                 )
                 let marked = await router.hasRoutingManifestMarker(sessionID: "ril-session-b")
-                try expect(marked, "bridge_initialize must mark the session")
+                try expect(!marked, "bridge_initialize establishes readiness but must not authorize tools")
+
+                let beforeFetch = await router.dispatchFormatted(
+                    toolName: "messages_send",
+                    arguments: .object([
+                        "recipient": .string("+15555550123"),
+                        "body": .string("dry-run probe"),
+                        "confirm": .string("DRY_RUN")
+                    ]),
+                    context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
+                )
+                try expect(beforeFetch.isError && beforeFetch.text.contains("route_ack_required"),
+                           "initialization must not satisfy the governed route")
+
+                _ = try await router.dispatch(
+                    toolName: "fetch_skill",
+                    arguments: .object(["name": .string("people-keepr")]),
+                    context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
+                )
+                _ = try await router.dispatch(
+                    toolName: "fetch_skill",
+                    arguments: .object(["name": .string("mac-message")]),
+                    context: ToolDispatchContext(transportSessionId: "ril-session-b", origin: .local)
+                )
+                try expect(await router.hasRoutingManifestMarker(sessionID: "ril-session-b"),
+                           "both fetched authorities must satisfy messages_send")
 
                 let allowed = try await router.dispatch(
                     toolName: "messages_send",
@@ -207,7 +242,13 @@ func runRoutingIntegrityLayerTests() async {
             }
 
             let bTools = await log.entries(forSessionID: "ril-session-b").map(\.toolName)
-            try expect(bTools == [BridgeInitializeModule.toolName, "messages_send"],
+            try expect(bTools == [
+                BridgeInitializeModule.toolName,
+                "messages_send",
+                "fetch_skill",
+                "fetch_skill",
+                "messages_send"
+            ],
                        "session b audit sequence drift: \(bTools)")
             let cEntries = await log.entries(forSessionID: "ril-session-c")
             try expect(cEntries.count == 1 && cEntries[0].approvalStatus == .rejected)
@@ -236,6 +277,7 @@ func runRoutingIntegrityLayerTests() async {
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await registerRILRoutingList(on: routerBefore)
+            await registerRILFetchSkill(on: routerBefore)
             await routerBefore.register(fakeMessagesSendRegistration())
             let context = ToolDispatchContext(
                 transportSessionId: "restart-session",
@@ -244,6 +286,17 @@ func runRoutingIntegrityLayerTests() async {
                 governancePrincipal: "oauth-sub:restart-user"
             )
             _ = try await routerBefore.dispatch(toolName: "skills_routing_list", arguments: .object([:]), context: context)
+            let beforeFetch = await routerBefore.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(beforeFetch.isError && beforeFetch.text.contains("route_ack_required"),
+                       "routing discovery must not authorize the tool")
+            _ = try await routerBefore.dispatch(
+                toolName: "fetch_skill", arguments: .object(["name": .string("people-keepr")]), context: context
+            )
+            _ = try await routerBefore.dispatch(
+                toolName: "fetch_skill", arguments: .object(["name": .string("mac-message")]), context: context
+            )
             _ = try await routerBefore.dispatch(toolName: "messages_send", arguments: .object([:]), context: context)
 
             // Simulates replacing/relaunching the app: same Application Support
@@ -256,6 +309,7 @@ func runRoutingIntegrityLayerTests() async {
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await registerRILRoutingList(on: routerAfter)
+            await registerRILFetchSkill(on: routerAfter)
             await routerAfter.register(fakeMessagesSendRegistration())
 
             let rejected = await routerAfter.dispatchFormatted(
@@ -267,6 +321,17 @@ func runRoutingIntegrityLayerTests() async {
                 toolName: "skills_routing_list", arguments: .object([:]), context: context
             )
             try expect(!roster.isError)
+            let afterRoster = await routerAfter.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(afterRoster.isError && afterRoster.text.contains("route_ack_required"),
+                       "routing discovery after replacement must not authorize the tool")
+            _ = try await routerAfter.dispatch(
+                toolName: "fetch_skill", arguments: .object(["name": .string("people-keepr")]), context: context
+            )
+            _ = try await routerAfter.dispatch(
+                toolName: "fetch_skill", arguments: .object(["name": .string("mac-message")]), context: context
+            )
             let allowed = await routerAfter.dispatchFormatted(
                 toolName: "messages_send", arguments: .object([:]), context: context
             )
@@ -274,7 +339,7 @@ func runRoutingIntegrityLayerTests() async {
         }
     }
 
-    await test("RIL no-session receipt is exact-scope, principal-bound, expiring, and one-time") {
+    await test("RIL explicit receipt is exact-scope, principal-bound, composed, and one-time") {
         try await withRILTempHome {
             let store = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
             let router = ToolRouter(
@@ -284,26 +349,55 @@ func runRoutingIntegrityLayerTests() async {
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await registerRILRoutingList(on: router)
+            await registerRILFetchSkill(on: router)
             await router.register(fakeMessagesSendRegistration())
             let context = ToolDispatchContext(
-                transportSessionId: nil,
+                transportSessionId: ToolDispatchContext.remoteConnectorJSONSessionID,
                 origin: .local,
-                client: "no-stable-session"
+                client: "compact-connector",
+                governancePrincipal: "oauth-sub:receipt-user",
+                routeAcknowledgementMode: .explicitReceipt
             )
             let roster = try await router.dispatch(
                 toolName: "skills_routing_list", arguments: .object([:]), context: context
             )
-            guard case .object(let rosterObject) = roster,
-                  case .array(let receipts)? = rosterObject["routingReceipts"],
-                  let receipt = receipts.first(where: {
+            guard case .object(let rosterObject) = roster else {
+                throw TestError.assertion("routing list fixture returned malformed output")
+            }
+            try expect(rosterObject["routingReceipts"] == nil,
+                       "routing discovery must not issue authority receipts")
+
+            let people = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("people-keepr")]),
+                context: context
+            )
+            let mac = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("mac-message")]),
+                context: context
+            )
+            func messagesReceipt(_ output: Value) -> Value? {
+                guard case .object(let object) = output,
+                      case .array(let receipts)? = object["routingReceipts"] else { return nil }
+                return receipts.first(where: {
                       guard case .object(let object) = $0,
                             case .string("tool:messages_send")? = object["scopeID"] else { return false }
                       return true
-                  }) else {
-                throw TestError.assertion("routing list did not issue an exact messages_send receipt")
+                })
+            }
+            guard let peopleReceipt = messagesReceipt(people),
+                  let macReceipt = messagesReceipt(mac) else {
+                throw TestError.assertion("fetch_skill did not issue both messages_send authority receipts")
             }
 
-            let args: Value = .object(["_routingReceipt": receipt])
+            let withoutReceipt = await router.dispatchFormatted(
+                toolName: "messages_send", arguments: .object([:]), context: context
+            )
+            try expect(withoutReceipt.isError && withoutReceipt.text.contains("route_ack_required"),
+                       "stable compact alias must never become an implicit authority bucket")
+
+            let args: Value = .object(["_routingReceipts": .array([peopleReceipt, macReceipt])])
             let first = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
             try expect(!first.isError, "fresh receipt must authorize once: \(first.text)")
             let replay = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
@@ -313,7 +407,13 @@ func runRoutingIntegrityLayerTests() async {
             let wrongClient = await router.dispatchFormatted(
                 toolName: "messages_send",
                 arguments: args,
-                context: ToolDispatchContext(transportSessionId: nil, origin: .local, client: "other-client")
+                context: ToolDispatchContext(
+                    transportSessionId: ToolDispatchContext.remoteConnectorJSONSessionID,
+                    origin: .local,
+                    client: "compact-connector",
+                    governancePrincipal: "oauth-sub:other-user",
+                    routeAcknowledgementMode: .explicitReceipt
+                )
             )
             try expect(wrongClient.isError && wrongClient.text.contains("route_ack_required"))
         }
@@ -477,6 +577,23 @@ private func registerRILRoutingList(on router: ToolRouter) async {
                 ),
                 skills: (0..<8).map { .object(["name": .string("Routing \($0)")]) }
             ).value
+        }
+    ))
+}
+
+private func registerRILFetchSkill(on router: ToolRouter) async {
+    await router.register(ToolRegistration(
+        name: "fetch_skill",
+        module: "skills",
+        tier: .open,
+        description: "route authority fixture",
+        inputSchema: .object(["type": .string("object")]),
+        handler: { arguments in
+            guard case .object(let object) = arguments,
+                  case .string(let name)? = object["name"] else {
+                return .object(["error": .string("missing name")])
+            }
+            return .object(["slug": .string(name), "content": .string("fixture")])
         }
     ))
 }

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -339,13 +339,16 @@ func runRoutingIntegrityLayerTests() async {
         }
     }
 
-    await test("RIL explicit receipt is exact-scope, principal-bound, composed, and one-time") {
+    await test("RIL explicit receipt rejects every invalid class and consumes exactly once") {
         try await withRILTempHome {
             let store = RoutingCustodyStore(root: BridgePaths.applicationSupport(.routingCustody))
+            let audit = AuditLog()
+            let clock = RILRouteReceiptClock(Date(timeIntervalSince1970: 1_800_000_000))
             let router = ToolRouter(
                 securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()),
-                auditLog: AuditLog(),
+                auditLog: audit,
                 routingCustodyStore: store,
+                routeReceiptNowProvider: { clock.now() },
                 licenseStatusProvider: { .trial(daysRemaining: 5) }
             )
             await registerRILRoutingList(on: router)
@@ -377,18 +380,24 @@ func runRoutingIntegrityLayerTests() async {
                 arguments: .object(["name": .string("mac-message")]),
                 context: context
             )
-            func messagesReceipt(_ output: Value) -> Value? {
+            func receipt(_ output: Value, scopeID: String) -> Value? {
                 guard case .object(let object) = output,
                       case .array(let receipts)? = object["routingReceipts"] else { return nil }
                 return receipts.first(where: {
                       guard case .object(let object) = $0,
-                            case .string("tool:messages_send")? = object["scopeID"] else { return false }
+                            case .string(scopeID)? = object["scopeID"] else { return false }
                       return true
                 })
             }
-            guard let peopleReceipt = messagesReceipt(people),
-                  let macReceipt = messagesReceipt(mac) else {
-                throw TestError.assertion("fetch_skill did not issue both messages_send authority receipts")
+            func replacing(_ value: Value, key: String, with replacement: Value) -> Value {
+                guard case .object(var object) = value else { return value }
+                object[key] = replacement
+                return .object(object)
+            }
+            guard let peopleReceipt = receipt(people, scopeID: "tool:messages_send"),
+                  let macReceipt = receipt(mac, scopeID: "tool:messages_send"),
+                  let otherToolReceipt = receipt(people, scopeID: "tool:messages_recent") else {
+                throw TestError.assertion("fetch_skill did not issue the required exact-scope receipts")
             }
 
             let withoutReceipt = await router.dispatchFormatted(
@@ -397,14 +406,54 @@ func runRoutingIntegrityLayerTests() async {
             try expect(withoutReceipt.isError && withoutReceipt.text.contains("route_ack_required"),
                        "stable compact alias must never become an implicit authority bucket")
 
-            let args: Value = .object(["_routingReceipts": .array([peopleReceipt, macReceipt])])
-            let first = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
-            try expect(!first.isError, "fresh receipt must authorize once: \(first.text)")
-            let replay = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
-            try expect(replay.isError && replay.text.contains("route_ack_required"),
-                       "receipt replay must fail closed: \(replay.text)")
+            let malformed = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": .string("not-a-receipt")]),
+                context: context
+            )
+            try expect(malformed.isError && malformed.text.contains("route_ack_required"))
 
-            let wrongClient = await router.dispatchFormatted(
+            let wrongScope = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": otherToolReceipt]),
+                context: context
+            )
+            try expect(wrongScope.isError && wrongScope.text.contains("route_ack_required"))
+
+            let prematureReceipt = replacing(
+                peopleReceipt,
+                key: "issuedAt",
+                with: .string("2099-01-01T00:00:00.000Z")
+            )
+            let premature = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": prematureReceipt]),
+                context: context
+            )
+            try expect(premature.isError && premature.text.contains("route_ack_required"))
+
+            let tamperedReceipt = replacing(
+                peopleReceipt,
+                key: "authorityIDs",
+                with: .array([.string("people-keepr"), .string("mac-message")])
+            )
+            let tampered = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": tamperedReceipt]),
+                context: context
+            )
+            try expect(tampered.isError && tampered.text.contains("route_ack_required"))
+
+            let incomplete = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": peopleReceipt]),
+                context: context
+            )
+            try expect(incomplete.isError && incomplete.text.contains("route_ack_required"),
+                       "one governing skill must not satisfy a composed route")
+
+            let args: Value = .object(["_routingReceipts": .array([peopleReceipt, macReceipt])])
+            let wrongPrincipal = await router.dispatchFormatted(
                 toolName: "messages_send",
                 arguments: args,
                 context: ToolDispatchContext(
@@ -415,7 +464,54 @@ func runRoutingIntegrityLayerTests() async {
                     routeAcknowledgementMode: .explicitReceipt
                 )
             )
-            try expect(wrongClient.isError && wrongClient.text.contains("route_ack_required"))
+            try expect(wrongPrincipal.isError && wrongPrincipal.text.contains("route_ack_required"))
+
+            let first = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
+            try expect(!first.isError, "fresh receipt must authorize once: \(first.text)")
+            let replay = await router.dispatchFormatted(toolName: "messages_send", arguments: args, context: context)
+            try expect(replay.isError && replay.text.contains("route_ack_required"),
+                       "receipt replay must fail closed: \(replay.text)")
+
+            let expiringPeople = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("people-keepr")]),
+                context: context
+            )
+            let expiringMac = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("mac-message")]),
+                context: context
+            )
+            guard let expiringPeopleReceipt = receipt(expiringPeople, scopeID: "tool:messages_send"),
+                  let expiringMacReceipt = receipt(expiringMac, scopeID: "tool:messages_send") else {
+                throw TestError.assertion("fetch_skill did not issue expiring receipt fixtures")
+            }
+            clock.advance(by: 301)
+            let expired = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object([
+                    "_routingReceipts": .array([expiringPeopleReceipt, expiringMacReceipt])
+                ]),
+                context: context
+            )
+            try expect(expired.isError && expired.text.contains("route_ack_required"))
+
+            let notes = await audit.entries(forSessionID: ToolDispatchContext.remoteConnectorJSONSessionID)
+                .compactMap(\.governanceNote)
+            for expected in [
+                "route_receipt_rejected_missing",
+                "route_receipt_rejected_malformed",
+                "route_receipt_rejected_wrong_scope",
+                "route_receipt_rejected_not_yet_valid",
+                "route_receipt_rejected_tampered",
+                "route_receipt_rejected_incomplete_authorities",
+                "route_receipt_rejected_wrong_principal",
+                "route_receipt_consumed",
+                "route_receipt_rejected_replayed_or_unknown",
+                "route_receipt_rejected_expired",
+            ] {
+                try expect(notes.contains(expected), "missing audit evidence for \(expected): \(notes)")
+            }
         }
     }
 
@@ -596,4 +692,25 @@ private func registerRILFetchSkill(on router: ToolRouter) async {
             return .object(["slug": .string(name), "content": .string("fixture")])
         }
     ))
+}
+
+private final class RILRouteReceiptClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    init(_ value: Date) {
+        self.value = value
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        value = value.addingTimeInterval(interval)
+        lock.unlock()
+    }
 }

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -394,6 +394,42 @@ func runRoutingIntegrityLayerTests() async {
                 object[key] = replacement
                 return .object(object)
             }
+            let compound = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object(["name": .string("people-keepr/mac-message")]),
+                context: context
+            )
+            guard let compoundReceipt = receipt(compound, scopeID: "tool:messages_send") else {
+                throw TestError.assertion("compound fetch did not issue its parent authority receipt")
+            }
+            let compoundAttempt = await router.dispatchFormatted(
+                toolName: "messages_send",
+                arguments: .object(["_routingReceipt": compoundReceipt]),
+                context: context
+            )
+            try expect(compoundAttempt.isError && compoundAttempt.text.contains("route_ack_required"),
+                       "one compound fetch must not overgrant both authorities")
+
+            let authoritativeID = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object([
+                    "id": .string("0123456789abcdef0123456789abcdef"),
+                    "name": .string("mac-message")
+                ]),
+                context: context
+            )
+            guard let authoritativeIDReceipt = receipt(authoritativeID, scopeID: "tool:messages_send"),
+                  case .object(let authoritativeIDObject) = authoritativeIDReceipt,
+                  case .array(let authoritativeIDValues)? = authoritativeIDObject["authorityIDs"] else {
+                throw TestError.assertion("authoritative id fetch did not issue a receipt")
+            }
+            let authoritativeIDAuthorities: Set<String> = Set(authoritativeIDValues.compactMap {
+                guard case .string(let value) = $0 else { return nil }
+                return value
+            })
+            try expect(authoritativeIDAuthorities == Set(["people-keepr"]),
+                       "an ignored name must not override id-derived authority: \(authoritativeIDAuthorities)")
+
             guard let peopleReceipt = receipt(people, scopeID: "tool:messages_send"),
                   let macReceipt = receipt(mac, scopeID: "tool:messages_send"),
                   let otherToolReceipt = receipt(people, scopeID: "tool:messages_recent") else {
@@ -685,11 +721,24 @@ private func registerRILFetchSkill(on router: ToolRouter) async {
         description: "route authority fixture",
         inputSchema: .object(["type": .string("object")]),
         handler: { arguments in
-            guard case .object(let object) = arguments,
-                  case .string(let name)? = object["name"] else {
+            guard case .object(let object) = arguments else {
                 return .object(["error": .string("missing name")])
             }
-            return .object(["slug": .string(name), "content": .string("fixture")])
+            if case .string(_)? = object["id"] {
+                return .object([
+                    "slug": .string("people-keepr"),
+                    "title": .string("mac-message"),
+                    "content": .string("fixture")
+                ])
+            }
+            guard case .string(let name)? = object["name"] else {
+                return .object(["error": .string("missing name")])
+            }
+            return .object([
+                "slug": .string(name),
+                "title": .string(name.contains("/") ? "mac-message" : name),
+                "content": .string("fixture")
+            ])
         }
     ))
 }

--- a/TheBridgeTests/SkillsModuleTests.swift
+++ b/TheBridgeTests/SkillsModuleTests.swift
@@ -383,6 +383,126 @@ func runSkillsModuleTests() async {
         try expect(dict["maturity"] == .string("Stable"), "maturity missing")
     }
 
+    await test("fetch_skill preserves resolved authority through UUID projection and fuzzy name lookup") {
+        let defaultsKey = BridgeDefaults.skills
+        let previousSkills = UserDefaults.standard.data(forKey: defaultsKey)
+        defer {
+            if let previousSkills {
+                UserDefaults.standard.set(previousSkills, forKey: defaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+            }
+        }
+
+        let knownAuthorities = Set(
+            ToolSkillBindingRegistry.bindings.flatMap { $0.governingSkills.map(\.slug) }
+        )
+        let activeGeneration = await SkillRuntimeGenerationStore.shared.activeGeneration()
+        let publishedAuthority = activeGeneration?.entries.first(where: {
+            knownAuthorities.contains(ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug))
+        })
+        if activeGeneration != nil, publishedAuthority == nil {
+            throw TestError.assertion("active skill generation has no receipt-governing authority fixture")
+        }
+        let pageID = publishedAuthority?.notionPageUUID ?? "14614614614614614614614614614614"
+        let authority = publishedAuthority.map {
+            ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug)
+        } ?? "people-keepr"
+        let config: [[String: Any]] = [[
+            "name": authority,
+            "notionPageId": pageID,
+            "enabled": true,
+            "visibility": "routing"
+        ]]
+        UserDefaults.standard.set(
+            try JSONSerialization.data(withJSONObject: config),
+            forKey: defaultsKey
+        )
+        let cached = CachedSkillBody(
+            pageId: pageID,
+            slug: authority,
+            version: "1.0.0",
+            status: "Testing",
+            maturity: "Stable",
+            markdown: "# PEOPLE Keepr\nDoctrine fixture.",
+            title: authority,
+            url: "https://notion.example/\(authority)",
+            properties: .object([
+                "Slug": .string(authority),
+                "Version": .string("1.0.0"),
+                "Status": .string("Testing"),
+                "Maturity": .string("Stable")
+            ]),
+            lastEditedTime: "2026-08-14T00:00:00.000Z",
+            writtenAt: Date(),
+            ttlHours: 24,
+            callCount: 1
+        )
+        let previousBody = await SkillBodyCacheStore.shared.read(pageId: pageID)
+        try await SkillBodyCacheStore.shared.write(cached)
+
+        func restoreBodyCache() async {
+            if let previousBody {
+                try? await SkillBodyCacheStore.shared.write(previousBody)
+            } else {
+                await SkillBodyCacheStore.shared.evict(pageId: pageID)
+            }
+        }
+
+        do {
+            let context = ToolDispatchContext(
+                transportSessionId: ToolDispatchContext.remoteConnectorJSONSessionID,
+                origin: .remote,
+                client: "skills-integration",
+                governancePrincipal: "oauth-sub:skills-integration",
+                routeAcknowledgementMode: .explicitReceipt
+            )
+            func authorityIDs(_ value: Value) -> Set<String> {
+                guard case .object(let object) = value,
+                      case .array(let receipts)? = object["routingReceipts"] else { return [] }
+                return Set(receipts.flatMap { receipt -> [String] in
+                    guard case .object(let object) = receipt,
+                          case .array(let values)? = object["authorityIDs"] else { return [] }
+                    return values.compactMap { value in
+                        guard case .string(let string) = value else { return nil }
+                        return string
+                    }
+                })
+            }
+
+            let projected = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object([
+                    "id": .string(pageID),
+                    "fields": .array([.string("content"), .string("uuid"), .string("version")])
+                ]),
+                context: context
+            )
+            guard case .object(let projectedObject) = projected else {
+                throw TestError.assertion("UUID projection returned malformed output")
+            }
+            try expect(authorityIDs(projected).contains(authority),
+                       "UUID projection must retain the resolved authority for receipt issuance")
+            try expect(projectedObject[ToolRouter.routingAuthorityEvidenceKey] == nil,
+                       "internal authority evidence must be stripped from projected output")
+
+            let fuzzy = try await router.dispatch(
+                toolName: "fetch_skill",
+                arguments: .object([
+                    "name": .string("sk \(authority)"),
+                    "fields": .array([.string("content")])
+                ]),
+                context: context
+            )
+            try expect(authorityIDs(fuzzy).contains(authority),
+                       "a successful fuzzy lookup must issue authority for its resolved canonical skill")
+        } catch {
+            await restoreBodyCache()
+            throw error
+        }
+        await restoreBodyCache()
+    }
+
     // ============================================================
     // MARK: - Skill-system ownership and routing governance
     // ============================================================


### PR DESCRIPTION
## Summary

- replace the compact connector's persistent principal acknowledgement bucket with explicit scoped routing receipts
- issue receipts only from successful `fetch_skill` calls and centrally advertise/strip `_routingReceipt` and `_routingReceipts`
- bind receipts to the verified OAuth principal, exact governed-tool scope, authority set, five-minute lifetime, nonce, and atomic single use
- bind fetched authority to the actual routing parent: slash-delimited specialist paths cannot acknowledge multiple authorities, result titles cannot grant authority, and an authoritative UUID ignores any accompanying name
- audit receipt issuance, consumption, and rejection metadata without recording receipt values
- add deterministic coverage for every receipt rejection class, clean-machine isolation, compound-path overgrant, and UUID/name precedence

## Root cause

Compact connector continuity was keyed to the verified OAuth principal so header churn did not break routing. That acknowledgement bucket lived for the Bridge process lifetime, allowing a later ChatGPT conversation under the same principal to inherit authority without a fresh skill fetch.

The first PR CI run also exposed a test-isolation defect: the compact receipt test used `SessionRegistry.shared`, so a governed row persisted on the developer Mac made an exact audit-note assertion pass while the clean runner correctly composed `route_receipt_issued;ungoverned_session`. The test now injects a temporary registry, fixes the advisory preference deterministically, and asserts semicolon-delimited audit event tokens.

A subsequent adversarial diff review found a second authority-confusion path: receipt derivation split the caller's slash-delimited `name` and considered result `title` values. A success-shaped fetch such as `people-keepr/mac-message` could therefore mint both authorities even when only the parent route was fetched. The final implementation grants only the requested routing parent for name-based fetches; UUID-based fetches use returned canonical `slug`/`name` identity and never the ignored name or page title.

## User and developer impact

Each compact-connector conversation must now fetch every governing route and present the matching receipt or receipts. A valid receipt authorizes one exact governed call. Missing, malformed, expired, replayed, wrong-tool, incomplete-authority, tampered, wrong-principal, compound-name, or identity-confused receipts fail closed before the module handler runs. Standards-compliant session-based clients retain their existing routing behavior.

## Validation

- final head: `fdca5e0aeb9691899e9fb66282ba15a99ec537b7`
- local `swift build -c debug`: passed
- local `make test-floor`: **3,595 passed, 0 failed** (floor: 3,556)
- [GitHub Actions run 31768046269](https://github.com/KUP-IP/the-bridge/actions/runs/31768046269): release build and test floor passed on exact final head; **3,595 passed, 0 failed**
- deterministic regression proves a compound `people-keepr/mac-message` fetch cannot satisfy the two-authority Messages route
- deterministic regression proves a conflicting `name` cannot override authority derived from an authoritative skill UUID
- signed installed candidate from pre-review head `fbb67fa`: version 4.0.2 build 91, clean provenance
- two fresh ChatGPT conversations against that installed candidate proved conversation isolation, principal binding, and single-use behavior:
  - Conversation A routed bounded read: approved
  - Conversation B unrouted bounded read: rejected with `route_ack_required`
  - Conversation B routed retry: approved
  - Conversation A consumed-receipt replay: rejected with `route_ack_required`
- Bridge audit correlated **approved → rejected → approved → rejected** through `remote-connector-json`
- installed-browser proof predates the final compound-authority hardening; that final production delta is verified by deterministic local tests plus the clean-runner release build and full suite above
- no Messages send, draft, or mutation was performed; receipt values were not exposed

## Release boundary

This remains a draft for independent review. No merge, tag, release, or customer publication is authorized. The repository currently has no independent reviewer configured. The stale doctrine-core handshake warning remains a release-stage follow-up and does not affect this scoped receipt implementation.

Closes #146
