### PR TITLE
Name voice memo overlap rejections as summary

### DIFF
--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -485,10 +485,13 @@ public enum VoiceMemoProcessor {
             entity: entity
         )
 
-        // PKT-MEM-132 D49 — protect BOTH the body summary and every property
-        // value that will actually be sent to Notion.
+        // PKT-MEM-132 D49 — protect the semantic summary (page body, and a
+        // rich_text property when one exists) plus every other property that
+        // will actually be sent to Notion. Report the canonical `summary` key
+        // when the prose overlaps the transcript, even if the live registry
+        // maps that key to a non-text column such as `Relevant`.
         if let rejected = VoiceMemoTranscriptOverlapGuard.firstRejectedField(
-            in: ["memoryBody": semanticSummary], transcript: transcript
+            in: ["summary": semanticSummary], transcript: transcript
         ) {
             throw VoiceMemoError.transcriptOverlapRejected(entityKey, rejected.key, rejected.runLength)
         }

--- a/TheBridgeTests/VoiceMemoPlayerAttachTests.swift
+++ b/TheBridgeTests/VoiceMemoPlayerAttachTests.swift
@@ -199,6 +199,9 @@ func runVoiceMemoPlayerAttachTests() async {
     print("\n\u{1F517} PKT-1064 — originating-Player relation attach + verify")
 
     // 1. Attaches the default originating player on memory_keep create.
+    //    Live Memory shape (summary → Relevant select): prose must not enter
+    //    the select, retired parser keys must be dropped, title + Player stay,
+    //    and the semantic summary lands in the Notion body append.
     await test("PKT-1064: memory_keep attaches the originating Player relation at create") {
         let router = ToolRouter(securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()), auditLog: AuditLog())
         let state = MemoryKeepStubState()
@@ -217,6 +220,17 @@ func runVoiceMemoPlayerAttachTests() async {
         try expect(fields["players"] == .string(kIsaiahPlayerId),
                    "create must carry players=\(kIsaiahPlayerId), got \(String(describing: fields["players"]))")
         try expect(detail.contains(kIsaiahPlayerId), "detail should record the attached player")
+        try expect(fields["title"] == .string("Preferred stack"),
+                   "title must still be written, got \(String(describing: fields["title"]))")
+        try expect(fields["summary"] == nil,
+                   "select-backed summary/Relevant must not receive prose, got \(String(describing: fields["summary"]))")
+        try expect(fields["alias"] == nil && fields["status"] == nil && fields["type"] == nil,
+                   "retired parser Memory fields must be filtered, got \(fields)")
+        let appended = await state.appendedChildrenJSON
+        try expect(appended.contains("Keep this: my preferred stack is Bridge plus Cursor."),
+                   "semantic summary must appear in the Notion body append, got \(appended)")
+        try expect(!appended.contains("Keep this note."),
+                   "raw transcript must not leak into the Notion body, got \(appended)")
     }
 
     // 2. Verify read-back confirms the relation is present.


### PR DESCRIPTION
## Summary
- Current `main` (`b56cf965`, PR #151) still fails CI on `overlap_executeMemoryKeep_verbatimFieldsOverride_throwsBeforeAnyWrite` because transcript overlap on the page-body semantic summary was reported as `memoryBody`.
- Report that rejection as canonical `summary` so existing overlap tests and callers stay aligned, without sending prose to a select-backed `Relevant` property.
- Fold live-schema assertions into the existing Player-attach test: no `summary` on `registry_create`, retired parser fields filtered, title + Player retained, semantic summary in the Notion body, no raw transcript leak.

## Test plan
- [x] Local `.build/debug/TheBridgeTests`: **3624 passed, 0 failed** (floor 3624)
- [x] `overlap_executeMemoryKeep_verbatimFieldsOverride_throwsBeforeAnyWrite` green
- [x] `GH #81 item 2: top-level 'summary' arg reaches the write` still green (rich_text fixture)
- [x] `PKT-1064: memory_keep attaches the originating Player relation at create` now asserts live `Relevant: select` routing
- [ ] GitHub CI `make test-floor` on this PR
- [ ] Merge only after CI is green; running app SHA is still older than this fix


Made with [Cursor](https://cursor.com)