### PR TITLE
Stop WS-F keychain-skip test racing provision timeout

### DIFF
--- a/TheBridgeTests/EnableCloudAccessFlowTests.swift
+++ b/TheBridgeTests/EnableCloudAccessFlowTests.swift
@@ -141,13 +141,6 @@ private final class ManualClock: CloudClock, @unchecked Sendable {
     }
 }
 
-/// Clock that resolves every sleep immediately — used where we want the
-/// timeout guard to lose the race (it fires instantly but the work already
-/// completed) OR to drive an instant-timeout case.
-private final class ImmediateClock: CloudClock, @unchecked Sendable {
-    func sleep(seconds: Double) async throws { /* return at once */ }
-}
-
 private final class FakeTokenExchange: CloudTokenExchanging, @unchecked Sendable {
     let token: String
     let throwsError: Bool
@@ -363,7 +356,7 @@ func runEnableCloudAccessFlowTests() async {
                 defaults: defaults,
                 config: wsfConfig,
                 provisionBaseURL: "https://mock.local",
-                clock: ImmediateClock()
+                clock: ManualClock()   // never auto-times-out; an instant clock races the 30s guard
             )
         }
         await MainActor.run { flow.start() }


### PR DESCRIPTION
## Summary
- Main CI on `ec542f7` (PR #152 merge) failed 3623/3624 on an unrelated flake: `WS-F flow: Keychain token present → skips sign-in → .connected (no browser)` got `.failed(.provisionTimeout)`.
- The Voice Memo Memory summary tests all passed on that same run. This PR only changes the success-path clock to `ManualClock` so the 30s provision guard cannot win a TaskGroup race against an instantly resolving sleep.

## Test plan
- [x] Confirm the flaked assertion is the only ImmediateClock success-path usage
- [ ] GitHub CI `make test-floor` green (floor 3624, 0 failed)
- [ ] Do not merge until the PR check completes, then confirm the resulting `main` run is green


Made with [Cursor](https://cursor.com)