### PR TITLE
Insert command text at the active cursor instead of copying to the clipboard

### DIFF
--- a/TheBridge/App/AppDelegate.swift
+++ b/TheBridge/App/AppDelegate.swift
@@ -966,7 +966,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// when off. The descriptor source is the EXISTING skills registry
     /// (`RegistrySkillsCommandProvider` over `BridgeDefaults.skills`):
     /// every enabled registry entry is a selectable command. On Enter the
-    /// resolved page body is written to the system clipboard.
+    /// resolved page body is inserted at the focused cursor (issue #129).
     private func maybeStartCommandsPalette() {
         guard Self.shouldStartCommandsPalette() else {
             print("[The Bridge] Commands palette disabled (master toggle off; set \(CommandsPaletteGate.enableEnvKey)=1 to force on)")
@@ -1042,7 +1042,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         if !box.isRegistered, case .collision = box.lastRegisterStatus {
             scheduleLaunchHotkeyRetry()
         }
-        print("[The Bridge] Commands palette enabled — registry-backed, clipboard-only — hot-key \(registered ? "registered" : "registration FAILED") (\(hotkey.displayString))")
+        print("[The Bridge] Commands palette enabled — registry-backed, cursor-insert — hot-key \(registered ? "registered" : "registration FAILED") (\(hotkey.displayString))")
     }
 
     /// Number of launch-retry attempts remaining for a transient ⌃⌘B

--- a/TheBridge/App/CommandBox.swift
+++ b/TheBridge/App/CommandBox.swift
@@ -1,4 +1,4 @@
-// CommandBox.swift — Commands palette (clipboard-only) — reusable types
+// CommandBox.swift — Commands palette (shared types) — reusable types
 // TheBridge · App
 //
 // PKT-878 v3.6.3: the legacy NSTableView-backed `CommandBoxController` +
@@ -10,14 +10,16 @@
 //
 //   • HotkeyConfig            — Carbon RegisterEventHotKey config + persisted
 //                                 load/save + Cocoa→Carbon recorder mapping
-//   • ClipboardWriting        — protocol seam over NSPasteboard (write-only)
+//   • ClipboardWriting        — protocol seam over NSPasteboard (probe
+//                                 only on the fire path — issue #129)
 //   • InMemoryClipboard       — test double (write + read-back + write count)
 //   • SystemClipboard         — NSPasteboard.general adapter (replace contents)
 //
-// PERMISSION MODEL (unchanged): Carbon `RegisterEventHotKey` is a HOT-KEY
-// REGISTRATION, not an event tap — no Input Monitoring or Accessibility
-// TCC grant. The pasteboard write needs no TCC grant either. With
-// paste-back deleted years ago, there is no CGEvent synthesis anywhere.
+// PERMISSION MODEL: Carbon `RegisterEventHotKey` is a HOT-KEY
+// REGISTRATION, not an event tap — no Input Monitoring grant. Cursor
+// insert (issue #129) lives in CommandCursorInsert.swift and requires
+// Accessibility. The pasteboard seam is retained so tests can prove the
+// fire path never writes it.
 
 import Foundation
 import AppKit

--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -17,12 +17,13 @@
 //     typing (search results). Recents is in-memory session-only (locked
 //     decision Q1).
 //
-// Behaviour locked by PKT-878:
-//   • Number key 1–0 → fires the assigned favorite → copies its
-//     markdown body to the system pasteboard → closes.
+// Behaviour locked by PKT-878 + issue #129:
+//   • Number key 1–0 → fires the assigned favorite → inserts its
+//     markdown body at the focused cursor in the prior app → closes.
+//     The clipboard is never read or written on this path.
 //   • ↓ → opens the recents slide-in (140ms ease).
 //   • Typing → substring search across all commands, ranked by recency.
-//   • Enter or click on a row → fires the selected command (copy +
+//   • Enter or click on a row → fires the selected command (insert +
 //     close). Esc / focus-loss → closes without writing.
 //   • Open animation: 180ms ease-out, opacity 0→1, scale 0.94→1.0,
 //     with a 10ms cascade stagger across the 10 bubbles.
@@ -32,7 +33,9 @@
 //   • `HotkeyConfig`            — Carbon `RegisterEventHotKey` config
 //                                  + persisted-load + Cocoa→Carbon recorder
 //   • `ClipboardWriting`/`InMemoryClipboard`/`SystemClipboard`
-//                                  — write-only pasteboard seam
+//                                  — retained as a probe seam so tests
+//                                  can prove the fire path never writes
+//   • `CommandTextInserting`       — cursor-insert seam (#129)
 //   • Carbon hot-key REGISTRATION shape (InstallEventHandler +
 //     RegisterEventHotKey) — pulled into `registerHotkey()` below
 //     unchanged in semantics so the operator-smoke contract is
@@ -47,7 +50,7 @@
 // without activating the app, the SwiftUI rendering, and the focus-loss
 // dismiss all require a real login session. The DECISION layers below
 // (the state machine, the placement math, the search ranking, the
-// recents tracker, the commit→clipboard write, the animation config)
+// recents tracker, the commit→cursor insert, the animation config)
 // are PURE and unit-tested headlessly.
 
 import Foundation
@@ -245,21 +248,16 @@ public enum CommandBridgePanelMode: Sendable, Equatable {
 //     • Owns the borderless NSPanel and the SwiftUI host inside it.
 //     • Owns the lifecycle state machine (closed → opening → open →
 //       closing) and the secondary panel mode (none / recents / search).
-//     • On commit: writes the resolved command body to the system
-//       pasteboard via the `ClipboardWriting` seam and closes.
+//     • On commit: inserts the resolved command body at the focused
+//       editable control of the previously-frontmost app via
+//       `CommandTextInserting`. The clipboard is not used.
 //
-//   PERMISSION MODEL (v3.7.6 — paste-back ADDED): Carbon
+//   PERMISSION MODEL (issue #129 — cursor insert): Carbon
 //   `RegisterEventHotKey` is still a HOT-KEY REGISTRATION, not an event
-//   tap — no Input Monitoring grant. NSPasteboard write still needs no
-//   TCC grant and stays UNCONDITIONAL on every commit. What is NEW: after
-//   the clipboard write, the fire path optionally synthesizes ⌘V into the
-//   previously-frontmost app via CGEvent (mirroring `CGEventModule.postKey`).
-//   That single synthesis is GATED on `AXIsProcessTrusted()`; when the
-//   Accessibility grant is absent we skip the keystroke entirely (the
-//   clipboard already holds the body — a graceful manual-paste fallback)
-//   and surface the system grant prompt once. The pure `applyCommit`
-//   primitive is unchanged (clipboard-only) so its headless contract
-//   stays byte-for-byte; paste-back lives on `fireSlot` / `fireSlug`.
+//   tap — no Input Monitoring grant. Insertion requires Accessibility
+//   (`AXIsProcessTrusted()`). When the grant is absent, or there is no
+//   focused editable target, the fire path fails closed with an explicit
+//   status and does NOT copy to the clipboard as a fallback.
 // ============================================================
 
 @MainActor
@@ -278,6 +276,7 @@ public final class CommandBridgeController: NSObject {
 
     private var hotkey: HotkeyConfig
     private let clipboard: ClipboardWriting
+    private let inserter: CommandTextInserting
     private let coordinator: CommandPaletteCoordinator
     private let store: CommandStore
     private let recents: CommandBridgeRecents
@@ -302,8 +301,8 @@ public final class CommandBridgeController: NSObject {
     /// the next app boot — the "standard boot-up location" the operator asked for.
     private var rememberedOrigin: CGPoint?
 
-    /// (v3.7.6) The app that was frontmost the instant before we showed, so
-    /// paste-into-app can re-activate it and synthesize ⌘V. Captured in
+    /// The app that was frontmost the instant before we showed, so
+    /// cursor-insert can target its focused AX element. Captured in
     /// `show()` BEFORE `orderFrontRegardless()`.
     private var priorApp: NSRunningApplication?
 
@@ -320,10 +319,11 @@ public final class CommandBridgeController: NSObject {
     /// in tests / shells that don't wire it. Returns whether it presented.
     public var presentDashboard: (() -> Void)?
 
-    /// (v3.7.6) Whether paste-into-app is enabled. Default ON per the brief.
-    /// The clipboard write is ALWAYS performed regardless of this flag; this
-    /// only governs the post-write ⌘V synthesis.
-    public var pasteIntoAppEnabled: Bool = true
+    /// Last insert attempt from `applyCommit` / `fireSlot` / `fireSlug`.
+    /// Tests assert this instead of reading the pasteboard.
+    public private(set) var lastInsertOutcome: CommandInsertOutcome?
+    /// Body delivered on the last successful insert (nil when skipped/failed).
+    public private(set) var lastInsertedText: String?
 
     /// Cancels a pending close `orderOut` when re-opened mid-dismiss.
     private var dismissGeneration: UInt = 0
@@ -339,11 +339,13 @@ public final class CommandBridgeController: NSObject {
 
     public init(hotkey: HotkeyConfig = .productionDefault,
                 clipboard: ClipboardWriting = SystemClipboard(),
+                inserter: CommandTextInserting = AccessibilityCommandInserter(),
                 coordinator: CommandPaletteCoordinator,
                 store: CommandStore = .shared,
                 recents: CommandBridgeRecents = .shared) {
         self.hotkey = hotkey
         self.clipboard = clipboard
+        self.inserter = inserter
         self.coordinator = coordinator
         self.store = store
         self.recents = recents
@@ -351,10 +353,24 @@ public final class CommandBridgeController: NSObject {
     }
 
     /// Convenience for tests / shells that don't pass a hotkey.
+    /// Defaults the inserter to `RecordingTextInserter` so headless tests
+    /// never type into the host process.
     public convenience init(clipboard: ClipboardWriting,
                             coordinator: CommandPaletteCoordinator) {
         self.init(hotkey: .productionDefault,
                   clipboard: clipboard,
+                  inserter: RecordingTextInserter(),
+                  coordinator: coordinator)
+    }
+
+    /// Test seam: inject both the clipboard probe (must stay untouched)
+    /// and a recording / forced-outcome inserter.
+    public convenience init(clipboard: ClipboardWriting,
+                            inserter: CommandTextInserting,
+                            coordinator: CommandPaletteCoordinator) {
+        self.init(hotkey: .productionDefault,
+                  clipboard: clipboard,
+                  inserter: inserter,
                   coordinator: coordinator)
     }
 
@@ -791,12 +807,12 @@ public final class CommandBridgeController: NSObject {
 
     // MARK: - Commit (number key / Enter / row click)
     //
-    //   Three commit shapes, all routing through the single
-    //   `applyCommit(.paste(body))` write so the clipboard contract is
-    //   one-line-tested.
+    //   Three commit shapes, all routing through `applyCommit(.paste(body))`
+    //   so the cursor-insert contract is one-line-tested. The injected
+    //   clipboard is a probe only — this path never writes it.
 
     /// Fire the favorite assigned to slot `slot` (0…9). If the slot is
-    /// empty this is a no-op (no clipboard clobber, panel stays open).
+    /// empty this is a no-op (no insert, clipboard untouched, panel stays).
     public func fireSlot(_ slot: Int) {
         guard let cmd = (try? store.command(forKeySlot: slot)) ?? nil else { return }
         commitBody(cmd.body, slug: cmd.slug)
@@ -809,92 +825,65 @@ public final class CommandBridgeController: NSObject {
         commitBody(cmd.body, slug: cmd.slug)
     }
 
-    /// (v3.7.6) Shared fire path for `fireSlot` / `fireSlug`. Writes the body
-    /// to the clipboard (UNCONDITIONAL — same `applyCommit` primitive the
-    /// headless test pins), records the use, closes the panel, then optionally
-    /// pastes into the previously-frontmost app. The clipboard half is
-    /// unchanged from the prior two call sites; only the paste-back tail is new.
+    /// Shared fire path for `fireSlot` / `fireSlug`. Inserts the body at
+    /// the prior app's focused editable control (issue #129). Never
+    /// copies to the clipboard. On failure, records a status and still
+    /// closes the palette so the operator is not stuck in the overlay.
     private func commitBody(_ body: String, slug: String) {
-        applyCommit(.paste(body))              // unconditional clipboard write
-        try? store.recordUse(slug: slug)
-        recents.record(slug)
-        let target = priorApp                  // snapshot the target before we close
+        let target = priorApp
+        let pid = insertTargetPID(target)
+        let outcome = applyCommit(.paste(body), intoProcess: pid)
+        if outcome?.succeeded == true {
+            try? store.recordUse(slug: slug)
+            recents.record(slug)
+        }
         hide()
-        if pasteIntoAppEnabled, !body.isEmpty {
-            pasteIntoPriorApp(target)
+        if outcome?.succeeded == true,
+           let target,
+           target.processIdentifier != NSRunningApplication.current.processIdentifier {
+            target.activate(options: [])
+        }
+        if let outcome, !outcome.succeeded {
+            print("[CommandBridge] \(outcome.userMessage)")
         }
     }
 
-    // MARK: - Paste-into-app (v3.7.6 — CGEvent ⌘V, AX-gated)
-
-    /// Re-activate the previously-frontmost app and synthesize ⌘V so the just-
-    /// copied body lands in its focused field. GATED on `AXIsProcessTrusted()`:
-    ///   • No prior app, or the prior app IS us → skip (nothing to paste into).
-    ///   • Not AX-trusted → skip the keystroke (clipboard already holds the
-    ///     body, so manual ⌘V is the graceful fallback) and surface the system
-    ///     grant prompt ONCE via `AXIsProcessTrustedWithOptions(prompt:true)`.
-    ///   • Trusted → activate the target, then after ~100ms post a ⌘V key
-    ///     press through `.cghidEventTap` (mirrors `CGEventModule.postKey`).
-    /// Secure text fields silently swallow synthetic paste — that degrades to
-    /// the clipboard fallback, which is acceptable.
-    private func pasteIntoPriorApp(_ target: NSRunningApplication?) {
-        guard let target else { return }
-        let me = NSRunningApplication.current
-        guard target.processIdentifier != me.processIdentifier else { return }
-
-        guard AXIsProcessTrusted() else {
-            // Not trusted — clipboard fallback stands; nudge the one-time grant
-            // prompt so the user can enable real paste-back next time. The
-            // option key is the string literal "AXTrustedCheckOptionPrompt" (not
-            // the `kAXTrustedCheckOptionPrompt` global, which Swift 6 strict
-            // concurrency flags as shared-mutable — same workaround as
-            // PermissionManager.requestAccessibilityAccess()).
-            _ = AXIsProcessTrustedWithOptions(
-                ["AXTrustedCheckOptionPrompt": true] as CFDictionary
-            )
-            return
-        }
-
-        // Re-activate the target so the keystroke is routed to its key window.
-        target.activate(options: [])
-
-        // Let the activation settle, then post ⌘V. ~100ms mirrors the brief.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.10) {
-            Self.postCommandV()
-        }
+    /// Destination pid for insert: the captured prior app, unless it is us.
+    private func insertTargetPID(_ target: NSRunningApplication?) -> pid_t? {
+        guard let target else { return nil }
+        let me = NSRunningApplication.current.processIdentifier
+        guard target.processIdentifier != me else { return nil }
+        return target.processIdentifier
     }
 
-    /// Synthesize a ⌘V key press via CGEvent. Mirrors `CGEventModule.postKey`:
-    /// `.hidSystemState` source, `kVK_ANSI_V` virtual key, `.maskCommand`
-    /// flag, posted to `.cghidEventTap`. Static + side-effect-only.
-    private nonisolated static func postCommandV() {
-        guard let src = CGEventSource(stateID: .hidSystemState) else { return }
-        let v = CGKeyCode(kVK_ANSI_V)
-        guard
-            let down = CGEvent(keyboardEventSource: src, virtualKey: v, keyDown: true),
-            let up   = CGEvent(keyboardEventSource: src, virtualKey: v, keyDown: false)
-        else { return }
-        down.flags = .maskCommand
-        up.flags = .maskCommand
-        down.post(tap: .cghidEventTap)
-        up.post(tap: .cghidEventTap)
-    }
-
-    /// Clipboard-only commit: on `.paste(body)` write the resolved body
-    /// to the clipboard (replace contents — no save/restore). On
-    /// `.notFound` / `.unavailable` write nothing. Same shape as the
-    /// legacy `CommandBoxController.applyCommit` so the headless
-    /// `applyCommit(.paste / .notFound / .unavailable)` test contract is
-    /// preserved byte-for-byte.
-    public func applyCommit(_ result: CommandPaletteCommitResult) {
+    /// Cursor-insert commit (issue #129). `.paste(body)` delivers through
+    /// `CommandTextInserting` and never writes the clipboard. `.notFound`
+    /// / `.unavailable` / empty body skip insert. The injected clipboard
+    /// is retained only so tests can assert `writeCount == 0`.
+    @discardableResult
+    public func applyCommit(
+        _ result: CommandPaletteCommitResult,
+        intoProcess pid: pid_t? = nil
+    ) -> CommandInsertOutcome? {
+        _ = clipboard  // probe only — never writeString / readString here
+        lastInsertedText = nil
         switch result {
         case .paste(let body):
-            guard !body.isEmpty else { return }
-            clipboard.writeString(body)
+            guard !body.isEmpty else {
+                lastInsertOutcome = .emptyBody
+                return .emptyBody
+            }
+            let outcome = inserter.insert(body, intoProcess: pid)
+            lastInsertOutcome = outcome
+            if outcome.succeeded { lastInsertedText = body }
+            return outcome
         case .notFound:
-            break
+            lastInsertOutcome = nil
+            return nil
         case .unavailable(_, let reason):
+            lastInsertOutcome = nil
             print("[CommandBridge] command body unavailable: \(reason)")
+            return nil
         }
     }
 
@@ -1062,14 +1051,14 @@ public final class CommandBridgeController: NSObject {
     }
 
     /// Fire a typed search result's destination (R2). The single routing seam
-    /// (one switch, not 4 ad-hoc branches). Commands paste-and-close exactly as
+    /// (one switch, not 4 ad-hoc branches). Commands insert-and-close exactly as
     /// before; skills open their source; jobs/tools deep-link into Settings via
     /// the identity-correct `AppDelegate.shared` + SettingsNavigation (PKT-1005
     /// plumbing). The bar is hidden after navigating so the destination has focus.
     public func fireDestination(_ destination: BridgeSearchDestination) {
         switch destination {
         case .command(let slug):
-            fireSlug(slug)                 // paste body + close (existing path)
+            fireSlug(slug)                 // insert body + close (existing path)
 
         case .skillNotion(let pageId, let url):
             openURLString(url ?? SkillPlatform.notion.canonicalURL(uuid: pageId)

--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -1,0 +1,285 @@
+// CommandCursorInsert.swift — issue #129 (cursor insert, never clipboard)
+// TheBridge · Modules · Commands
+//
+// Command activation delivers the resolved body into the focused editable
+// control of the previously-frontmost app. The clipboard is not read,
+// written, cleared, or used as a paste vehicle — even temporarily.
+//
+// Two layers:
+//   • CommandTextSplicer — pure UTF-16 splice (caret insert / selection
+//     replace). Headlessly testable with no Accessibility grant.
+//   • CommandTextInserting — injectable delivery seam. Production is
+//     AccessibilityCommandInserter (AX focused element). Tests inject
+//     RecordingTextInserter so the suite never types into the host.
+
+import Foundation
+import AppKit
+import ApplicationServices
+import CoreGraphics
+
+// ============================================================
+// MARK: - Outcome
+// ============================================================
+
+/// Result of attempting to insert a command body at the cursor.
+public enum CommandInsertOutcome: Sendable, Equatable {
+    /// Body landed in the focused editable control.
+    case inserted(replacedSelection: Bool, characters: Int)
+    /// Resolved body was empty — nothing to insert, clipboard untouched.
+    case emptyBody
+    /// No focused editable AX target in the destination process.
+    case noEditableTarget
+    /// Accessibility TCC is missing. Prompted once; never clipboard-fallback.
+    case accessibilityDenied
+    /// Focused element existed but AX / synthetic insert failed.
+    case insertFailed(reason: String)
+
+    public var succeeded: Bool {
+        if case .inserted = self { return true }
+        return false
+    }
+
+    /// Operator-visible status. Failures are explicit; success is quiet.
+    public var userMessage: String {
+        switch self {
+        case .inserted:
+            return "Inserted at cursor"
+        case .emptyBody:
+            return "Command body is empty"
+        case .noEditableTarget:
+            return "No editable field in the frontmost app"
+        case .accessibilityDenied:
+            return "Accessibility permission required to insert commands"
+        case .insertFailed(let reason):
+            return "Could not insert command — \(reason)"
+        }
+    }
+}
+
+// ============================================================
+// MARK: - Pure splice (UTF-16, matching AX CFRange)
+// ============================================================
+
+public struct CommandTextSplice: Sendable, Equatable {
+    public let newValue: String
+    public let replacedSelection: Bool
+    public let newCaretUTF16: Int
+
+    public init(newValue: String, replacedSelection: Bool, newCaretUTF16: Int) {
+        self.newValue = newValue
+        self.replacedSelection = replacedSelection
+        self.newCaretUTF16 = newCaretUTF16
+    }
+}
+
+/// UTF-16 splice used by the AX `AXValue` + `AXSelectedTextRange` path.
+/// `location` / `length` are AX `CFRange` units (UTF-16), not Swift
+/// `Character` indices — emoji / combining marks stay on AX's index space.
+public enum CommandTextSplicer {
+    public static func splice(
+        value: String,
+        selectedLocationUTF16: Int,
+        selectedLengthUTF16: Int,
+        insertion: String
+    ) -> CommandTextSplice {
+        let utf16 = Array(value.utf16)
+        let loc = max(0, min(selectedLocationUTF16, utf16.count))
+        let len = max(0, min(selectedLengthUTF16, utf16.count - loc))
+        let insertUTF16 = Array(insertion.utf16)
+        var combined: [UInt16] = []
+        combined.reserveCapacity(utf16.count - len + insertUTF16.count)
+        combined.append(contentsOf: utf16[..<loc])
+        combined.append(contentsOf: insertUTF16)
+        combined.append(contentsOf: utf16[(loc + len)...])
+        let newValue = String(utf16CodeUnits: combined, count: combined.count)
+        return CommandTextSplice(
+            newValue: newValue,
+            replacedSelection: len > 0,
+            newCaretUTF16: loc + insertUTF16.count
+        )
+    }
+}
+
+// ============================================================
+// MARK: - Insert seam
+// ============================================================
+
+public protocol CommandTextInserting: AnyObject, Sendable {
+    /// Insert `text` into the focused editable control of `pid` (the
+    /// previously-frontmost app). `pid == nil` means "no destination" —
+    /// production fails closed; the recording double still records.
+    @MainActor
+    func insert(_ text: String, intoProcess pid: pid_t?) -> CommandInsertOutcome
+}
+
+/// Test double. Never touches NSPasteboard or the live AX tree.
+public final class RecordingTextInserter: CommandTextInserting, @unchecked Sendable {
+    public private(set) var inserts: [(text: String, pid: pid_t?)] = []
+    /// Forced outcome for the next (and subsequent) inserts. `.inserted`
+    /// character counts are rewritten from the actual payload.
+    public var forcedOutcome: CommandInsertOutcome
+
+    public init(forcedOutcome: CommandInsertOutcome = .inserted(replacedSelection: false, characters: 0)) {
+        self.forcedOutcome = forcedOutcome
+    }
+
+    @MainActor
+    public func insert(_ text: String, intoProcess pid: pid_t?) -> CommandInsertOutcome {
+        if text.isEmpty { return .emptyBody }
+        inserts.append((text, pid))
+        if case .inserted(let replaced, _) = forcedOutcome {
+            return .inserted(replacedSelection: replaced, characters: text.count)
+        }
+        return forcedOutcome
+    }
+}
+
+// ============================================================
+// MARK: - Production AX inserter
+// ============================================================
+
+/// Inserts via the focused AX element of the destination process.
+/// Never reads or writes `NSPasteboard`. Fail-closed: missing grant or
+/// missing editable target returns a status outcome, not a clipboard copy.
+public final class AccessibilityCommandInserter: CommandTextInserting, @unchecked Sendable {
+    public init() {}
+
+    @MainActor
+    public func insert(_ text: String, intoProcess pid: pid_t?) -> CommandInsertOutcome {
+        if text.isEmpty { return .emptyBody }
+
+        guard AXIsProcessTrusted() else {
+            _ = AXIsProcessTrustedWithOptions(
+                ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+            )
+            return .accessibilityDenied
+        }
+
+        guard let pid, pid > 0 else { return .noEditableTarget }
+
+        let appEl = AXUIElementCreateApplication(pid)
+        var focusedRef: CFTypeRef?
+        let focusErr = AXUIElementCopyAttributeValue(
+            appEl, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+        guard focusErr == .success, let focusedRef else {
+            return .noEditableTarget
+        }
+        let focused = focusedRef as! AXUIElement
+
+        let role = stringAttr(focused, kAXRoleAttribute as String) ?? ""
+        if role == "AXSecureTextField" {
+            return .noEditableTarget
+        }
+
+        let selectedRange = cfRangeAttr(focused, kAXSelectedTextRangeAttribute as String)
+        let replaced = (selectedRange?.length ?? 0) > 0
+
+        if isSettable(focused, kAXSelectedTextAttribute as String) {
+            let setErr = AXUIElementSetAttributeValue(
+                focused, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
+            if setErr == .success {
+                placeCaret(focused, afterUTF16: (selectedRange?.location ?? 0) + text.utf16.count)
+                return .inserted(replacedSelection: replaced, characters: text.count)
+            }
+        }
+
+        if isSettable(focused, kAXValueAttribute as String),
+           let current = stringAttr(focused, kAXValueAttribute as String),
+           let range = selectedRange {
+            let spliced = CommandTextSplicer.splice(
+                value: current,
+                selectedLocationUTF16: range.location,
+                selectedLengthUTF16: range.length,
+                insertion: text
+            )
+            let setErr = AXUIElementSetAttributeValue(
+                focused, kAXValueAttribute as CFString, spliced.newValue as CFTypeRef)
+            if setErr == .success {
+                placeCaret(focused, afterUTF16: spliced.newCaretUTF16)
+                return .inserted(replacedSelection: spliced.replacedSelection, characters: text.count)
+            }
+        }
+
+        if looksEditable(role: role, element: focused) {
+            do {
+                try postUnicode(text)
+                return .inserted(replacedSelection: replaced, characters: text.count)
+            } catch {
+                return .insertFailed(reason: "synthetic typing failed")
+            }
+        }
+
+        return .noEditableTarget
+    }
+
+    // MARK: AX helpers
+
+    private func stringAttr(_ el: AXUIElement, _ name: String) -> String? {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(el, name as CFString, &ref)
+        guard err == .success else { return nil }
+        return ref as? String
+    }
+
+    private func cfRangeAttr(_ el: AXUIElement, _ name: String) -> CFRange? {
+        var ref: CFTypeRef?
+        let err = AXUIElementCopyAttributeValue(el, name as CFString, &ref)
+        guard err == .success, let ref else { return nil }
+        let axVal = ref as! AXValue
+        var range = CFRange()
+        guard AXValueGetValue(axVal, .cfRange, &range) else { return nil }
+        return range
+    }
+
+    private func isSettable(_ el: AXUIElement, _ name: String) -> Bool {
+        var settable: DarwinBoolean = false
+        let err = AXUIElementIsAttributeSettable(el, name as CFString, &settable)
+        return err == .success && settable.boolValue
+    }
+
+    private func looksEditable(role: String, element: AXUIElement) -> Bool {
+        let editable: Set<String> = [
+            "AXTextField", "AXTextArea", "AXComboBox", "AXSearchField", "AXText"
+        ]
+        if editable.contains(role) { return true }
+        return isSettable(element, kAXValueAttribute as String)
+            || isSettable(element, kAXSelectedTextAttribute as String)
+    }
+
+    private func placeCaret(_ el: AXUIElement, afterUTF16 loc: Int) {
+        var range = CFRange(location: loc, length: 0)
+        guard let axRange = AXValueCreate(.cfRange, &range) else { return }
+        _ = AXUIElementSetAttributeValue(
+            el, kAXSelectedTextRangeAttribute as CFString, axRange)
+    }
+
+    /// Unicode CGEvent typing — no pasteboard. Last-resort when AX set
+    /// fails but the focused element still looks like an editor.
+    private func postUnicode(_ text: String) throws {
+        guard let src = CGEventSource(stateID: .hidSystemState) else {
+            throw CommandInsertSynthError.source
+        }
+        let utf16 = Array(text.utf16)
+        let chunkSize = 20
+        var idx = 0
+        while idx < utf16.count {
+            let end = min(idx + chunkSize, utf16.count)
+            let chunk = Array(utf16[idx..<end])
+            guard let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+            else { throw CommandInsertSynthError.event }
+            chunk.withUnsafeBufferPointer { buf in
+                down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: buf.baseAddress)
+                up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: buf.baseAddress)
+            }
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            idx = end
+        }
+    }
+}
+
+private enum CommandInsertSynthError: Error {
+    case source
+    case event
+}

--- a/TheBridge/Modules/Commands/CommandPalette.swift
+++ b/TheBridge/Modules/Commands/CommandPalette.swift
@@ -2,10 +2,11 @@
 // TheBridge · Modules · Commands
 //
 // This consumes the GUI shell (CommandBox.swift — Carbon hot-key +
-// non-activating NSPanel + a single clipboard write) and the W2 data
-// layer (CommandsManager — /markdown fetch + mention resolve + TTL
-// cache + offline-fallback). This file owns the GUI-FREE glue that
-// joins them, all of it headlessly testable:
+// non-activating NSPanel) and the W2 data layer (CommandsManager —
+// /markdown fetch + mention resolve + TTL cache + offline-fallback).
+// The GUI shell inserts the resolved body at the focused cursor
+// (issue #129) and never writes the clipboard. This file owns the
+// GUI-FREE glue that joins them, all of it headlessly testable:
 //
 //   1. CommandDescriptor          — palette-row metadata (id/name/abbr/
 //                                    group/tags). The BODY is NOT held
@@ -35,15 +36,15 @@
 //                                    the resolved body via the injected
 //                                    CommandsManager (NO duplicate fetch/
 //                                    cache — it calls W2). Returns the
-//                                    plain-text body the GUI shell writes
-//                                    to the system clipboard.
+//                                    plain-text body the GUI shell inserts
+//                                    at the focused cursor.
 //
 // HONEST GUI CEILING (NOT papered over): the hot-key actually firing and
 // the NSPanel receiving keystrokes require a live WindowServer/login
 // session and cannot be asserted headlessly — an explicit operator
-// manual-smoke. The clipboard WRITE itself is headlessly verified (write
-// → read back via the ClipboardWriting seam). Everything in THIS file is
-// pure and 100%-green-tested.
+// manual-smoke. Cursor insert is headlessly verified via the
+// `CommandTextInserting` seam (clipboard writeCount stays 0). Everything
+// in THIS file is pure and 100%-green-tested.
 
 import Foundation
 
@@ -287,14 +288,13 @@ public struct CommandsPaletteGate: Sendable, Equatable {
 
 /// What happens when the user commits (Enter) on a query/selection.
 public enum CommandPaletteCommitResult: Sendable, Equatable {
-    /// Resolved body (plain text). The GUI shell writes this to the
-    /// system clipboard (replace contents — no save/restore); the user
-    /// pastes it themselves. The case name is retained for source/test
-    /// stability — it now means "this is the body to put on the
-    /// clipboard", NOT a synthetic paste into another app.
+    /// Resolved body (plain text). The GUI shell inserts this at the
+    /// focused cursor in the previously-frontmost app. The case name is
+    /// retained for source/test stability — it now means "this is the
+    /// body to insert", NOT a clipboard write and NOT a synthetic ⌘V.
     case paste(String)
-    /// The query matched no command — nothing to paste. The GUI shell
-    /// keeps the panel open (no destructive paste of a wrong command).
+    /// The query matched no command — nothing to insert. The GUI shell
+    /// keeps the panel open (no destructive insert of a wrong command).
     case notFound(query: String)
     /// A command matched but its body could not be fetched AND there was
     /// no offline-fallback cache (CommandsManager surfaced .unavailable).
@@ -453,7 +453,7 @@ public struct CommandPalettePresentation: Sendable, Equatable {
     /// True ⇒ keep the panel open (let the user retry / re-type).
     /// False ⇒ the body was copied; dismiss after the confirmation.
     public let staysOpen: Bool
-    /// True ⇒ the body was written to the clipboard; the panel should
+    /// True ⇒ the body was inserted at the cursor; the panel should
     /// flash this confirmation briefly then auto-dismiss.
     public let isConfirmation: Bool
 
@@ -469,7 +469,7 @@ public struct CommandPalettePresentation: Sendable, Equatable {
 /// state is unit-asserted exhaustively.
 public enum CommandPalettePresenter {
 
-    /// The auto-dismiss delay (ms) for the "Copied ‹name›" confirmation.
+    /// The auto-dismiss delay (ms) for the "Inserted ‹name›" confirmation.
     public static let confirmationDismissMillis = 900
 
     /// cmd-ux W3 (Q1=b): empty-state guidance shown when the palette has
@@ -490,7 +490,7 @@ public enum CommandPalettePresenter {
         switch result {
         case .paste:
             return CommandPalettePresentation(
-                message: "Copied \(name)",
+                message: "Inserted \(name)",
                 staysOpen: false,
                 isConfirmation: true
             )
@@ -509,8 +509,48 @@ public enum CommandPalettePresenter {
         }
     }
 
+    /// Map an insert outcome to panel copy. Failures stay open with an
+    /// explicit status; success dismisses. Never implies a clipboard write.
+    public static func presentInsert(
+        _ outcome: CommandInsertOutcome,
+        name: String
+    ) -> CommandPalettePresentation {
+        switch outcome {
+        case .inserted:
+            return CommandPalettePresentation(
+                message: "Inserted \(name)",
+                staysOpen: false,
+                isConfirmation: true
+            )
+        case .emptyBody:
+            return CommandPalettePresentation(
+                message: "Command body is empty",
+                staysOpen: true,
+                isConfirmation: false
+            )
+        case .noEditableTarget:
+            return CommandPalettePresentation(
+                message: "No editable field in the frontmost app",
+                staysOpen: true,
+                isConfirmation: false
+            )
+        case .accessibilityDenied:
+            return CommandPalettePresentation(
+                message: "Accessibility permission required to insert commands",
+                staysOpen: true,
+                isConfirmation: false
+            )
+        case .insertFailed(let reason):
+            return CommandPalettePresentation(
+                message: "Could not insert command — \(reason)",
+                staysOpen: true,
+                isConfirmation: false
+            )
+        }
+    }
+
     /// Presentation for an Enter on an empty query: a pure no-op —
-    /// nothing copied, panel stays, no message.
+    /// nothing inserted, panel stays, no message.
     public static var emptyQueryNoOp: CommandPalettePresentation {
         CommandPalettePresentation(message: "", staysOpen: true, isConfirmation: false)
     }

--- a/TheBridge/Modules/SkillsManager.swift
+++ b/TheBridge/Modules/SkillsManager.swift
@@ -55,7 +55,7 @@ public enum SkillVisibility: String, Sendable, CaseIterable, Equatable {
     /// Fetchable via `fetch_skill` only; omitted from routing list.
     case standard
     /// cmd-ux W3: appears in the global Commands palette (the hot-key
-    /// command box copies the page body to the clipboard). Still
+    /// command box inserts the page body at the focused cursor). Still
     /// fetchable by name via `fetch_skill`; NOT in the routing list.
     case command
 }

--- a/TheBridge/UI/Sections/CommandsEditorView.swift
+++ b/TheBridge/UI/Sections/CommandsEditorView.swift
@@ -559,7 +559,7 @@ public struct CommandsEditorView: View {
                     .fixedSize()
                     .accessibilityLabel("Command body view")
                     Spacer()
-                    Text("Copied to clipboard as plain-text markdown")
+                    Text("Inserted at the cursor as plain-text markdown")
                         .font(BridgeTokens.Typeface.micro)
                         .foregroundStyle(BridgeTokens.fg5)
                         .lineLimit(1)

--- a/TheBridgeTests/CommandBridgeControllerTests.swift
+++ b/TheBridgeTests/CommandBridgeControllerTests.swift
@@ -14,8 +14,8 @@
 //   (D) CommandBridgeViewModel.buildSlotRows / buildRecentRows /
 //       queryDidChange — the pure builders driving the SwiftUI tray and
 //       secondary panel.
-//   (E) CommandBridgeController.applyCommit clipboard contract preserved
-//       byte-for-byte from the retired CommandBoxController.
+//   (E) CommandBridgeController.applyCommit cursor-insert contract
+//       (issue #129 — clipboard stays untouched).
 //   (F) Lifecycle reset shape (open → closed) without touching AppKit.
 //   (G) Hot-key plumbing-failure shape: modifier-less ⇒ .plumbingFailure.
 
@@ -184,18 +184,19 @@ func runCommandBridgeControllerTests() async {
         try expect(rows.isEmpty, "no MRU ⇒ no recents")
     }
 
-    // ── (E) Clipboard contract — applyCommit preserved byte-for-byte ─
+    // ── (E) Cursor-insert contract — applyCommit never writes clipboard ─
 
-    await test("applyCommit(.paste) writes the resolved body once (clipboard contract)") {
+    await test("applyCommit(.paste) inserts the resolved body once (clipboard untouched)") {
         let cb = InMemoryClipboard(initial: "prior")
         let mgr = CommandsManager(fetcher: { _ in "{}" })
         let coord = CommandPaletteCoordinator(
             provider: StaticCommandDescriptorProvider(), manager: mgr)
         let ctrl = await CommandBridgeController(clipboard: cb, coordinator: coord)
         await ctrl.applyCommit(.paste("hello-bridge"))
-        try expect(cb.readString() == "hello-bridge",
-                   "exact body must reach the clipboard, got \(cb.readString() ?? "nil")")
-        try expect(cb.writeCount == 1, "exactly one write, got \(cb.writeCount)")
+        try expect(await ctrl.lastInsertedText == "hello-bridge",
+                   "exact body must reach the inserter, got \(await ctrl.lastInsertedText ?? "nil")")
+        try expect(cb.writeCount == 0, "fire path must not write clipboard, got \(cb.writeCount)")
+        try expect(cb.readString() == "prior", "clipboard must stay byte-for-byte, got \(cb.readString() ?? "nil")")
     }
 
     await test("applyCommit(.notFound) writes nothing (no clobber)") {
@@ -207,6 +208,7 @@ func runCommandBridgeControllerTests() async {
         await ctrl.applyCommit(.notFound(query: "zzzz"))
         try expect(cb.writeCount == 0, "no write on .notFound")
         try expect(cb.readString() == "prior", "clipboard untouched on no-match")
+        try expect(await ctrl.lastInsertedText == nil)
     }
 
     await test("applyCommit(.paste) with empty body no-ops (no blank clobber)") {
@@ -218,6 +220,7 @@ func runCommandBridgeControllerTests() async {
         await ctrl.applyCommit(.paste(""))
         try expect(cb.writeCount == 0, "empty body must NOT blank-clobber")
         try expect(cb.readString() == "prior", "clipboard untouched on empty body")
+        try expect(await ctrl.lastInsertOutcome == .emptyBody)
     }
 
     // ── (F) Lifecycle defaults (closed at init, no panel constructed) ─

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -1,0 +1,209 @@
+// CommandCursorInsertTests.swift — issue #129
+// TheBridge · Tests
+//
+// Headless coverage for cursor-insert command activation:
+//   (A) CommandTextSplicer — caret insert, selection replace, Unicode,
+//       multiline, UTF-16 emoji, range clamp.
+//   (B) CommandInsertOutcome.userMessage — fail-closed copy.
+//   (C) CommandBridgeController.applyCommit — inserts via seam, never
+//       writes the clipboard; no-target / AX-denied leave the clipboard
+//       byte-for-byte unchanged.
+// Live AX insertion against a native field + a browser input remains
+// the operator smoke ceiling (docs/operator/command-bridge-smoke-checklist.md).
+
+import Foundation
+import TheBridgeLib
+
+func runCommandCursorInsertTests() async {
+    print("\n\u{1F4DD} Command Cursor Insert Tests (issue #129)")
+
+    func coord() -> CommandPaletteCoordinator {
+        CommandPaletteCoordinator(
+            provider: StaticCommandDescriptorProvider(),
+            manager: CommandsManager(fetcher: { _ in "{}" }))
+    }
+
+    // ── (A) Pure splice ─────────────────────────────────────────────
+
+    await test("Splicer: caret insert (zero-length selection) leaves surroundings") {
+        let s = CommandTextSplicer.splice(
+            value: "hello world",
+            selectedLocationUTF16: 6,
+            selectedLengthUTF16: 0,
+            insertion: "there "
+        )
+        try expect(s.newValue == "hello there world", "got \(s.newValue)")
+        try expect(!s.replacedSelection, "caret insert is not a replace")
+        try expect(s.newCaretUTF16 == 12, "caret after inserted UTF-16, got \(s.newCaretUTF16)")
+    }
+
+    await test("Splicer: non-empty selection is replaced") {
+        let s = CommandTextSplicer.splice(
+            value: "hello world",
+            selectedLocationUTF16: 6,
+            selectedLengthUTF16: 5,
+            insertion: "bridge"
+        )
+        try expect(s.newValue == "hello bridge", "got \(s.newValue)")
+        try expect(s.replacedSelection, "non-empty range must flag replace")
+        try expect(s.newCaretUTF16 == 12, "got \(s.newCaretUTF16)")
+    }
+
+    await test("Splicer: multiline + Unicode + Markdown survive byte-for-byte") {
+        let insertion = "# H1\n\n- a — b\n[link](https://www.notion.so/p)\n✅ ünïçødé"
+        let s = CommandTextSplicer.splice(
+            value: ">>><<<",
+            selectedLocationUTF16: 3,
+            selectedLengthUTF16: 0,
+            insertion: insertion
+        )
+        try expect(s.newValue == ">>>" + insertion + "<<<", "got \(s.newValue)")
+        try expect(s.newValue.contains("\n"), "newlines must be preserved")
+        try expect(s.newValue.contains("ünïçødé"), "unicode must be preserved")
+        try expect(s.newValue.contains("✅"), "emoji must be preserved")
+    }
+
+    await test("Splicer: emoji selection uses UTF-16 units (👍 is 2)") {
+        let thumb = "👍"
+        try expect(thumb.utf16.count == 2, "sanity: thumbs-up is a surrogate pair")
+        let s = CommandTextSplicer.splice(
+            value: "ab👍cd",
+            selectedLocationUTF16: 2,
+            selectedLengthUTF16: 2,
+            insertion: "X"
+        )
+        try expect(s.newValue == "abXcd", "got \(s.newValue)")
+        try expect(s.replacedSelection)
+        try expect(s.newCaretUTF16 == 3, "got \(s.newCaretUTF16)")
+    }
+
+    await test("Splicer: out-of-range location/length clamp instead of trap") {
+        let s = CommandTextSplicer.splice(
+            value: "ab",
+            selectedLocationUTF16: 99,
+            selectedLengthUTF16: 50,
+            insertion: "Z"
+        )
+        try expect(s.newValue == "abZ", "got \(s.newValue)")
+        try expect(!s.replacedSelection)
+    }
+
+    // ── (B) Status copy ─────────────────────────────────────────────
+
+    await test("Outcome.userMessage: no-target and AX-denied are explicit") {
+        try expect(CommandInsertOutcome.noEditableTarget.userMessage
+                   == "No editable field in the frontmost app")
+        try expect(CommandInsertOutcome.accessibilityDenied.userMessage
+                   == "Accessibility permission required to insert commands")
+        try expect(CommandInsertOutcome.emptyBody.userMessage
+                   == "Command body is empty")
+        try expect(!CommandInsertOutcome.noEditableTarget.succeeded)
+        try expect(CommandInsertOutcome.inserted(replacedSelection: true, characters: 3).succeeded)
+    }
+
+    await test("Presenter presentInsert: failures stay open, success dismisses") {
+        let ok = CommandPalettePresenter.presentInsert(
+            .inserted(replacedSelection: false, characters: 4), name: "Sig")
+        try expect(ok.message == "Inserted Sig", "got '\(ok.message)'")
+        try expect(!ok.staysOpen)
+        try expect(ok.isConfirmation)
+
+        let miss = CommandPalettePresenter.presentInsert(.noEditableTarget, name: "Sig")
+        try expect(miss.message == "No editable field in the frontmost app")
+        try expect(miss.staysOpen)
+        try expect(!miss.isConfirmation)
+
+        let ax = CommandPalettePresenter.presentInsert(.accessibilityDenied, name: "Sig")
+        try expect(ax.message.contains("Accessibility"))
+        try expect(ax.staysOpen)
+    }
+
+    // ── (C) applyCommit never touches the clipboard ─────────────────
+
+    await test("applyCommit(.paste) inserts the body and leaves the clipboard untouched") {
+        let cb = InMemoryClipboard(initial: "user-prior-clip")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.paste("hello-bridge"))
+        try expect(cb.writeCount == 0, "fire path must not write clipboard, got \(cb.writeCount)")
+        try expect(cb.readString() == "user-prior-clip",
+                   "prior clipboard must be byte-for-byte unchanged, got \(cb.readString() ?? "nil")")
+        try expect(ins.inserts.map(\.text) == ["hello-bridge"])
+        try expect(await ctrl.lastInsertedText == "hello-bridge")
+        guard case .inserted(_, let n) = outcome else {
+            throw TestError.assertion("expected .inserted, got \(String(describing: outcome))")
+        }
+        try expect(n == "hello-bridge".count)
+    }
+
+    await test("applyCommit(.paste) preserves exact markdown / Unicode / newlines on insert") {
+        let cb = InMemoryClipboard(initial: "PRIOR")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let body = "# H1\n\n- a — b\n[link](https://www.notion.so/p)\n✅ ünïçødé"
+        await ctrl.applyCommit(.paste(body))
+        try expect(ins.inserts.first?.text == body, "got \(ins.inserts.first?.text ?? "nil")")
+        try expect(cb.readString() == "PRIOR")
+        try expect(cb.writeCount == 0)
+    }
+
+    await test("applyCommit(.paste) with empty body skips insert and does not clobber clipboard") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.paste(""))
+        try expect(outcome == .emptyBody)
+        try expect(ins.inserts.isEmpty, "empty body must not reach the inserter")
+        try expect(cb.writeCount == 0)
+        try expect(cb.readString() == "prior")
+        try expect(await ctrl.lastInsertedText == nil)
+    }
+
+    await test("applyCommit(.notFound) inserts nothing and leaves clipboard untouched") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.notFound(query: "zzzz"))
+        try expect(outcome == nil, "notFound is not an insert attempt")
+        try expect(ins.inserts.isEmpty)
+        try expect(cb.writeCount == 0)
+        try expect(cb.readString() == "prior")
+    }
+
+    await test("no editable target: reports failure and does not write clipboard") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter(forcedOutcome: .noEditableTarget)
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.paste("BODY"))
+        try expect(outcome == .noEditableTarget)
+        try expect(ins.inserts.map(\.text) == ["BODY"], "attempt still recorded")
+        try expect(cb.writeCount == 0, "must not silently copy as fallback")
+        try expect(cb.readString() == "prior")
+        try expect(await ctrl.lastInsertedText == nil)
+        try expect(await ctrl.lastInsertOutcome == .noEditableTarget)
+    }
+
+    await test("accessibility denied: reports failure and does not write clipboard") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter(forcedOutcome: .accessibilityDenied)
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.paste("BODY"))
+        try expect(outcome == .accessibilityDenied)
+        try expect(cb.writeCount == 0)
+        try expect(cb.readString() == "prior")
+        try expect(await ctrl.lastInsertedText == nil)
+    }
+
+    await test("selection-replace outcome is forwarded from the inserter") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter(
+            forcedOutcome: .inserted(replacedSelection: true, characters: 0))
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        let outcome = await ctrl.applyCommit(.paste("repl"))
+        guard case .inserted(let replaced, _) = outcome else {
+            throw TestError.assertion("expected inserted, got \(String(describing: outcome))")
+        }
+        try expect(replaced, "forced replace flag must round-trip")
+        try expect(cb.writeCount == 0)
+    }
+}

--- a/TheBridgeTests/CommandPaletteTests.swift
+++ b/TheBridgeTests/CommandPaletteTests.swift
@@ -696,15 +696,15 @@ func runCommandPaletteTests() async {
     }
 
     // ============================================================
-    // MARK: (H) Clipboard-only commit — CommandBridgeController.applyCommit
-    //   The on-Enter behaviour: .paste → WRITE the body to the clipboard
-    //   (replace contents, NO save/restore); .notFound / .unavailable →
-    //   write NOTHING. Driven through an InMemoryClipboard so the write
-    //   is read back in-test (now headlessly verifiable). NO panel / NO
-    //   hot-key constructed — only the pure commit decision.
+    // MARK: (H) Cursor-insert commit — CommandBridgeController.applyCommit
+    //   The on-Enter behaviour: .paste → INSERT the body via the
+    //   CommandTextInserting seam; clipboard writeCount stays 0.
+    //   .notFound / .unavailable → insert NOTHING. Driven through an
+    //   InMemoryClipboard probe so "never wrote" is headlessly
+    //   verifiable. NO panel / NO hot-key constructed.
     // ============================================================
 
-    await test("applyCommit(.paste) WRITES the resolved body to the clipboard") {
+    await test("applyCommit(.paste) INSERTS the resolved body and does not write the clipboard") {
         let cb = InMemoryClipboard(initial: "user-prior-clip")
         let mgr = CommandsManager(fetcher: { _ in mdJSON("x") })
         let ctrl = await CommandBridgeController(
@@ -712,14 +712,14 @@ func runCommandPaletteTests() async {
             coordinator: CommandPaletteCoordinator(
                 provider: StaticCommandDescriptorProvider(), manager: mgr))
         await ctrl.applyCommit(.paste("=== resolved body ==="))
-        try expect(cb.readString() == "=== resolved body ===",
-                   "the clipboard must hold exactly the resolved body, got \(cb.readString() ?? "nil")")
-        try expect(cb.writeCount == 1, "exactly one clipboard write, got \(cb.writeCount)")
+        try expect(await ctrl.lastInsertedText == "=== resolved body ===",
+                   "the inserter must receive exactly the resolved body, got \(await ctrl.lastInsertedText ?? "nil")")
+        try expect(cb.writeCount == 0, "fire path must not write clipboard, got \(cb.writeCount)")
+        try expect(cb.readString() == "user-prior-clip",
+                   "prior clipboard must be unchanged, got \(cb.readString() ?? "nil")")
     }
 
-    await test("applyCommit(.paste) does NOT preserve the prior clipboard (replace-only)") {
-        // The corrected invariant superseding the deleted save/restore:
-        // the user WANTS the body on the clipboard; the original is gone.
+    await test("applyCommit(.paste) MUST preserve the prior clipboard (issue #129)") {
         let cb = InMemoryClipboard(initial: "user-prior-clip")
         let mgr = CommandsManager(fetcher: { _ in mdJSON("x") })
         let ctrl = await CommandBridgeController(
@@ -727,8 +727,9 @@ func runCommandPaletteTests() async {
             coordinator: CommandPaletteCoordinator(
                 provider: StaticCommandDescriptorProvider(), manager: mgr))
         await ctrl.applyCommit(.paste("new-body"))
-        try expect(cb.readString() == "new-body",
-                   "there is NO restore — prior clip must be overwritten, got \(cb.readString() ?? "nil")")
+        try expect(cb.readString() == "user-prior-clip",
+                   "clipboard must be byte-for-byte unchanged, got \(cb.readString() ?? "nil")")
+        try expect(await ctrl.lastInsertedText == "new-body")
     }
 
     await test("applyCommit(.notFound) writes NOTHING (no guessed command on the clipboard)") {
@@ -742,6 +743,7 @@ func runCommandPaletteTests() async {
         try expect(cb.writeCount == 0, "a not-found commit must NOT write, got writeCount=\(cb.writeCount)")
         try expect(cb.readString() == "user-prior-clip",
                    "the clipboard must be left untouched on no-match, got \(cb.readString() ?? "nil")")
+        try expect(await ctrl.lastInsertedText == nil)
     }
 
     await test("applyCommit(.unavailable) writes NOTHING (no destructive clobber)") {
@@ -767,10 +769,11 @@ func runCommandPaletteTests() async {
         try expect(cb.writeCount == 0,
                    "an empty resolved body must NOT blank-clobber the clipboard, got \(cb.writeCount)")
         try expect(cb.readString() == "user-prior-clip", "clipboard untouched on empty body")
+        try expect(await ctrl.lastInsertOutcome == .emptyBody)
     }
 
-    await test("applyCommit(.paste) preserves exact markdown bytes onto the clipboard") {
-        let cb = InMemoryClipboard()
+    await test("applyCommit(.paste) preserves exact markdown bytes onto the inserter") {
+        let cb = InMemoryClipboard(initial: "PRIOR")
         let mgr = CommandsManager(fetcher: { _ in mdJSON("x") })
         let ctrl = await CommandBridgeController(
             clipboard: cb,
@@ -778,13 +781,15 @@ func runCommandPaletteTests() async {
                 provider: StaticCommandDescriptorProvider(), manager: mgr))
         let body = "# H1\n\n- a — b\n[link](https://www.notion.so/p)\n✅ ünïçødé"
         await ctrl.applyCommit(.paste(body))
-        try expect(cb.readString() == body,
-                   "the resolved markdown must reach the clipboard byte-for-byte, got \(cb.readString() ?? "nil")")
+        try expect(await ctrl.lastInsertedText == body,
+                   "the resolved markdown must reach the inserter byte-for-byte, got \(await ctrl.lastInsertedText ?? "nil")")
+        try expect(cb.readString() == "PRIOR")
+        try expect(cb.writeCount == 0)
     }
 
-    await test("Coordinator(query) → applyCommit writes the W2-resolved body end-to-end") {
+    await test("Coordinator(query) → applyCommit inserts the W2-resolved body end-to-end") {
         // The full headless path: typed query → registry fuzzy match →
-        // W2 body fetch+resolve → clipboard write (read back in-test).
+        // W2 body fetch+resolve → cursor insert (clipboard untouched).
         let (d, suite) = makeIsolatedDefaults()
         seedRegistry(d, key: BridgeDefaults.skills, [
             (name: "Email Signature", pageId: pidSig, enabled: true),
@@ -797,12 +802,14 @@ func runCommandPaletteTests() async {
         let coord = CommandPaletteCoordinator(
             provider: isolatedRegistryProvider(suiteName: suite, storageKey: BridgeDefaults.skills),
             manager: mgr)
-        let cb = InMemoryClipboard()
+        let cb = InMemoryClipboard(initial: "user-prior-clip")
         let ctrl = await CommandBridgeController(clipboard: cb, coordinator: coord)
         let result = await coord.commit(query: "Email Signature")
         await ctrl.applyCommit(result)
-        try expect(cb.readString() == "RESOLVED SIGNATURE BODY",
-                   "the end-to-end path must land the W2-resolved body on the clipboard, got \(cb.readString() ?? "nil")")
+        try expect(await ctrl.lastInsertedText == "RESOLVED SIGNATURE BODY",
+                   "the end-to-end path must land the W2-resolved body on the inserter, got \(await ctrl.lastInsertedText ?? "nil")")
+        try expect(cb.writeCount == 0)
+        try expect(cb.readString() == "user-prior-clip")
         try expect(fetched.replacingOccurrences(of: "-", with: "") == pidSig,
                    "must fetch the matched registry entry's page id, got \(fetched)")
     }
@@ -899,11 +906,11 @@ func runCommandPaletteTests() async {
     //   ceiling; THIS decision is asserted exhaustively.
     // ============================================================
 
-    await test("Presenter: .paste ⇒ \"Copied ‹name›\", panel DISMISSES (confirmation)") {
+    await test("Presenter: .paste ⇒ \"Inserted ‹name›\", panel DISMISSES (confirmation)") {
         let p = CommandPalettePresenter.present(.paste("body"), name: "Email Signature")
-        try expect(p.message == "Copied Email Signature", "got '\(p.message)'")
-        try expect(p.staysOpen == false, "a successful copy must dismiss the panel")
-        try expect(p.isConfirmation, "a copy is a flash-then-dismiss confirmation")
+        try expect(p.message == "Inserted Email Signature", "got '\(p.message)'")
+        try expect(p.staysOpen == false, "a successful insert must dismiss the panel")
+        try expect(p.isConfirmation, "an insert is a flash-then-dismiss confirmation")
     }
 
     await test("Presenter: .notFound ⇒ \"No match for ‹query›\", panel STAYS, no copy") {

--- a/TheBridgeTests/SkillVsCommandSplitTests.swift
+++ b/TheBridgeTests/SkillVsCommandSplitTests.swift
@@ -13,9 +13,9 @@
 //     fetches, one payload. The agent gets the whole page.
 //
 //   • Hot-key command (CommandsManager.body → CommandPaletteCoordinator
-//     .commit → CommandBridgeController clipboard): BODY-ONLY markdown via
+//     .commit → CommandBridgeController insert): BODY-ONLY markdown via
 //     /markdown. It must NEVER fetch or leak page `properties` — the
-//     user pastes a clean body, not a metadata dump.
+//     user receives a clean body at the cursor, not a metadata dump.
 //
 // ZERO network: the command path is driven through an INJECTED body
 // fetcher; the fetch_skill path through the production envelope builder
@@ -40,11 +40,11 @@ func runSkillVsCommandSplitTests() async {
     // ── LOCK 1: command commit path yields ONLY the markdown body ─────
     //
     //   Drive the EXACT production path the hot-key uses — coordinator
-    //   commit → applyCommit → clipboard — with an injected body fetcher.
-    //   The clipboard payload must be byte-for-byte the resolved
+    //   commit → applyCommit → inserter — with an injected body fetcher.
+    //   The inserted payload must be byte-for-byte the resolved
     //   markdown. If a future change ever folded page `properties` into
     //   the command path, the injected body (which carries NO property
-    //   text) could not still equal the clipboard verbatim.
+    //   text) could not still equal the inserted text verbatim.
     await test("LOCK: CommandsManager/coordinator commit yields ONLY the markdown body (no properties)") {
         // The body deliberately contains NO property-shaped text. A
         // synthetic getPage-style properties dict is built but is NEVER
@@ -66,6 +66,7 @@ func runSkillVsCommandSplitTests() async {
             return mdJSON(body)   // /markdown body ONLY — never properties
         })
         let cb = InMemoryClipboard(initial: "user-prior-clip")
+        let ins = RecordingTextInserter()
         let coord = CommandPaletteCoordinator(
             provider: StaticCommandDescriptorProvider([
                 CommandDescriptor(id: pageId, name: "Email Signature",
@@ -73,7 +74,7 @@ func runSkillVsCommandSplitTests() async {
             ]),
             manager: mgr)
         let ctrl = await CommandBridgeController(
-            clipboard: cb, coordinator: coord)
+            clipboard: cb, inserter: ins, coordinator: coord)
 
         let result = await coord.commit(
             CommandDescriptor(id: pageId, name: "Email Signature", abbreviation: "sig"))
@@ -85,21 +86,23 @@ func runSkillVsCommandSplitTests() async {
         // (1) The committed payload is EXACTLY the resolved markdown body.
         try expect(pasted == body,
                    "commit payload must be the verbatim body, got \(pasted)")
-        // (2) The clipboard holds ONLY that body — nothing else merged in.
-        try expect(cb.readString() == body,
-                   "clipboard must hold ONLY the markdown body, got \(cb.readString() ?? "nil")")
-        try expect(cb.writeCount == 1, "exactly one clipboard write, got \(cb.writeCount)")
+        // (2) The inserter holds ONLY that body — nothing else merged in.
+        try expect(ins.inserts.first?.text == body,
+                   "inserter must hold ONLY the markdown body, got \(ins.inserts.first?.text ?? "nil")")
+        try expect(cb.writeCount == 0, "command path must not write clipboard, got \(cb.writeCount)")
+        try expect(cb.readString() == "user-prior-clip",
+                   "clipboard must stay untouched, got \(cb.readString() ?? "nil")")
         // (3) Exactly ONE fetch — the /markdown body fetch. There is no
         //     second getPage/properties fetch in the command path.
         try expect(fetchCalls.count == 1,
                    "the command path must do exactly ONE (body) fetch, got \(fetchCalls.count)")
         // (4) Hard anti-leak: no property name/value can appear on the
-        //     clipboard (the body never contained them, and the path has
+        //     inserted body (the body never contained them, and the path has
         //     no properties input — this pins the consequence).
-        let clip = cb.readString() ?? ""
+        let inserted = ins.inserts.first?.text ?? ""
         for needle in ["Status", "Published", "Owner", "DO-NOT-LEAK", "select", "rich_text"] {
-            try expect(!clip.contains(needle),
-                       "page-property text \"\(needle)\" must NEVER reach the command clipboard")
+            try expect(!inserted.contains(needle),
+                       "page-property text \"\(needle)\" must NEVER reach the command insert")
         }
     }
 

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -788,6 +788,7 @@ await runCommandPaletteTests()    // cmd-w3: palette search + gate + AppDelegate
 await runSkillVsCommandSplitTests() // cmd-ux: LOCK the skill-vs-command body/properties split
 await runCommandsControllerTests()  // cmd-ux W1/W2: CommandsController observable state machine + status/focus model
 await runCommandBridgeControllerTests()  // PKT-878 v3.6.3: SwiftUI Command Bridge popup — placement/recents/anim/builders
+await runCommandCursorInsertTests()      // issue #129: cursor insert, clipboard untouched, fail-closed no-target
 await runBridgeSearchTests()             // PKT-1006 R2: multi-entity search — fuzzy/ranking/grouping + skill-source destination routing
 await runCommandBridgeLayoutTests()      // v4 round-2: adaptive palette width clamp + remembered drag-origin clamp
 await runCommandVisibilityTests()   // cmd-ux W3: .command visibility axis — Codable, palette filter, picker write-back, empty-state

--- a/docs/operator/command-bridge-smoke-checklist.md
+++ b/docs/operator/command-bridge-smoke-checklist.md
@@ -4,12 +4,14 @@ This checklist covers the manual smoke surface for the Command Bridge
 popup rebuild. The DECISION layer underneath is fully unit-tested
 headlessly — see `TheBridgeTests/CommandBridgeControllerTests.swift`
 for placement math, recents MRU, animation config, view-model
-builders, the clipboard contract, lifecycle defaults, and the
+builders, the cursor-insert contract (issue #129), lifecycle defaults, and the
 modifier-less hot-key plumbing-failure shape. What this document
 catches is the **AppKit ceiling**: the global hot-key actually firing
 on a live WindowServer, a borderless NSPanel becoming key without
 activating the app, the SwiftUI Liquid Glass rendering, multi-display
-placement, the macOS reduce-motion path, and focus-loss dismissal.
+placement, the macOS reduce-motion path, focus-loss dismissal, and
+direct cursor insert into a native field plus a browser input
+(Accessibility grant required; clipboard must stay unchanged).
 
 ## Build & launch
 
@@ -51,8 +53,10 @@ placement, the macOS reduce-motion path, and focus-loss dismissal.
       Initiate or `5` for Execute on the default engineering palette)
       fires that command:
   - [ ] The popup closes
-  - [ ] The system clipboard now holds the exact markdown body of the
-        fired command (`pbpaste` to verify byte-for-byte)
+  - [ ] The command body is inserted at the cursor in the previously
+        focused editable field (not copied to the clipboard)
+  - [ ] `pbpaste` still shows whatever was on the clipboard *before*
+        the fire — byte-for-byte unchanged
   - [ ] The command's lastUsedAt is updated (visible next time you
         open the popup and press ↓ — the row will show "just now")
 - [ ] Pressing a number key for an **unassigned** slot is a no-op:
@@ -70,9 +74,9 @@ placement, the macOS reduce-motion path, and focus-loss dismissal.
 - [ ] Each row shows: icon · name · relative timestamp ("just now",
       "2m ago", "yesterday", "3d ago") · keycap label if the command
       has an assigned slot
-- [ ] Press Enter → the top-selected row fires (clipboard write +
-      close)
-- [ ] Click a row → that command fires (clipboard write + close)
+- [ ] Press Enter → the top-selected row fires (cursor insert +
+      close; clipboard unchanged)
+- [ ] Click a row → that command fires (cursor insert + close)
 
 ## Search-as-you-type
 
@@ -120,6 +124,24 @@ placement, the macOS reduce-motion path, and focus-loss dismissal.
       ⚠ collision and **keeps the prior working combo** alive
 - [ ] Try a modifier-less key → the recorder refuses to record it
 
+## Cursor insert (issue #129) — Accessibility smoke
+
+Requires The Bridge Accessibility grant. Put a unique token on the
+clipboard first (`echo UNIQUE-CLIP-TOKEN | pbcopy`) so you can prove
+it was not overwritten.
+
+- [ ] Native field: focus TextEdit (or Notes) with the caret in the
+      body. Fire a command. The body inserts at the caret. `pbpaste`
+      is still `UNIQUE-CLIP-TOKEN`.
+- [ ] Selection replace: select a word in that field, fire again. The
+      selection is replaced by the command body. Clipboard unchanged.
+- [ ] Browser input: focus a text input in Safari or Chrome, fire a
+      command. The body inserts in that field. Clipboard unchanged.
+- [ ] No target: click the desktop (no focused field) and fire. The
+      clipboard is still `UNIQUE-CLIP-TOKEN`. Console shows
+      `[CommandBridge] No editable field in the frontmost app` (or the
+      Accessibility-permission message if the grant is missing).
+
 ## Negative paths
 
 - [ ] Disable the palette via Settings → Commands master toggle →
@@ -139,8 +161,9 @@ operator smoke. Re-running the harness covers them:
 - Animation config + reduce-motion collapse
   (`CommandBridgeAnimation.locked` / `.reduced`)
 - View-model builders (`buildSlotRows` / `buildRecentRows`)
-- The clipboard contract (`applyCommit(.paste / .notFound /
-  .unavailable)`)
+- The cursor-insert contract (`applyCommit(.paste / .notFound /
+  .unavailable)` never writes the clipboard; no-target / AX-denied
+  fail closed — `TheBridgeTests/CommandCursorInsertTests.swift`)
 - The modifier-less hot-key refusal → `.plumbingFailure` (NEVER
   `.collision`)
 

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -35,7 +35,11 @@
 #   (state complete|partial|none, entityUrl, applied/failed), relation
 #   preflight, updatePage applied vs canonicalized vs rejected. Measured
 #   3652 passed, 0 failed on feat/issue-138-registry-repair-envelope.
-FLOOR="${BRIDGE_TEST_FLOOR:-3652}"
+# 2026-08-15: 3652 → 3666 (+14) — issue #129: command activation inserts at
+#   the focused cursor (AX / synthetic Unicode), never reads or writes the
+#   clipboard; fail-closed no-target / Accessibility-denied. Measured
+#   3666 passed, 0 failed on feat/issue-129-command-cursor-insert.
+FLOOR="${BRIDGE_TEST_FLOOR:-3666}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Command activation now inserts the resolved body at the focused editable control in the previously-frontmost app (AX `AXSelectedText` / `AXValue` splice, Unicode CGEvent last resort). The clipboard is never read, written, or used as a paste vehicle.
- Fail-closed when Accessibility is missing or there is no editable target: explicit status, no clipboard fallback. Hotkeys and command selection are unchanged.
- Headless coverage for caret insert, selection replace, Unicode/multiline, clipboard-unchanged, and no-target / AX-denied. Floor 3652 → 3666.

Closes #129. Leaves #140 open (command-system program).

## Test plan
- [x] `swift build -c debug --product TheBridgeTests` then `.build/.../TheBridgeTests` — **3666 passed, 0 failed** on this branch
- [ ] Manual AX smoke (native TextEdit/Notes field + Safari/Chrome input): insert at caret, replace selection, `pbpaste` unchanged; no-target does not clobber clipboard
- [ ] Confirm Settings → Commands hotkey still opens/closes the palette


Made with [Cursor](https://cursor.com)