### PR TITLE
A1: product-default reconciliation without merging command bodies

### DIFF
--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -829,7 +829,23 @@ public final class CommandBridgeController: NSObject {
     /// the prior app's focused editable control (issue #129). Never
     /// copies to the clipboard. On failure, records a status and still
     /// closes the palette so the operator is not stuck in the overlay.
+    /// Compatibility-required commands fail closed: no insert, no fire.
     private func commitBody(_ body: String, slug: String) {
+        let gate: CommandStore.ExecutionGate
+        do {
+            gate = try store.executionGate(slug: slug)
+        } catch {
+            _ = applyCommit(.unavailable(name: slug, reason: error.localizedDescription))
+            hide()
+            print("[CommandBridge] command execution gated: \(error.localizedDescription)")
+            return
+        }
+        if case .compatibilityRequired(let evidence) = gate {
+            _ = applyCommit(.unavailable(name: slug, reason: evidence))
+            hide()
+            print("[CommandBridge] command execution gated: \(evidence)")
+            return
+        }
         let target = priorApp
         let pid = insertTargetPID(target)
         let outcome = applyCommit(.paste(body), intoProcess: pid)

--- a/TheBridge/Modules/Commands/CommandCustodyBackend.swift
+++ b/TheBridge/Modules/Commands/CommandCustodyBackend.swift
@@ -8,9 +8,11 @@
 //   state.json                         atomic active-revision pointer
 //   revisions/revision-<uuid>/
 //     layers.json                       overrides, custom metadata, tombstones,
-//                                       and favorite command IDs
+//                                       favorite command IDs, and optional
+//                                       adopted-base descriptors (A1; decodeIfPresent)
 //     telemetry/usage.json             non-body activity data
 //     bodies/<immutable-command-id>.md command-body payloads only
+//     adopted-bases/<immutable-id>.md  last-adopted product body (A1; optional)
 //     manifest.json                     SHA-256 for every payload file
 //   live-telemetry/usage.json          ordinary activity overlay only
 //
@@ -27,6 +29,7 @@ final class CommandCustodyBackend: @unchecked Sendable {
     private static let layersFile = "layers.json"
     private static let revisionTelemetryFile = "telemetry/usage.json"
     private static let manifestFile = "manifest.json"
+    private static let adoptedBasesDirectory = "adopted-bases"
 
     private let storageRoot: URL?
     private let productDefaultsOverride: [CommandStore.ProductDefault]?
@@ -180,7 +183,11 @@ final class CommandCustodyBackend: @unchecked Sendable {
         if let defaultCommand = productDefaults.first(where: { $0.id == id }) {
             if isEquivalent(updated, to: defaultCommand) {
                 snapshot.localOverrides.removeValue(forKey: id)
+                snapshot.adoptedBases.removeValue(forKey: id)
             } else {
+                if snapshot.localOverrides[id] == nil {
+                    snapshot.adoptedBases[id] = AdoptedBase(defaultCommand)
+                }
                 snapshot.localOverrides[id] = updated
             }
         } else {
@@ -213,6 +220,7 @@ final class CommandCustodyBackend: @unchecked Sendable {
 
         if productDefaults.contains(where: { $0.id == id }) {
             snapshot.localOverrides.removeValue(forKey: id)
+            snapshot.adoptedBases.removeValue(forKey: id)
             snapshot.tombstones.insert(id)
         } else {
             snapshot.customCommands.removeValue(forKey: id)
@@ -246,6 +254,108 @@ final class CommandCustodyBackend: @unchecked Sendable {
         // This is deliberately not a revision write. Ordinary telemetry cannot
         // rewrite command bodies, metadata, tombstones, or favorite layout.
         try writeLiveTelemetryLocked(snapshot.usage)
+    }
+
+    // MARK: - Product-default reconciliation (A1)
+
+    func reconciliations() throws -> [CommandStore.CommandReconciliation] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let snapshot = try readableSnapshotLocked() else { return [] }
+        return productDefaults.compactMap { makeReconciliationLocked(incoming: $0, snapshot: snapshot) }
+    }
+
+    func reconciliation(slug: String) throws -> CommandStore.CommandReconciliation? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let incoming = productDefaults.first(where: { $0.slug == slug }) else { return nil }
+        guard let snapshot = try readableSnapshotLocked() else {
+            return makeReconciliationLocked(incoming: incoming, snapshot: .empty)
+        }
+        return makeReconciliationLocked(incoming: incoming, snapshot: snapshot)
+    }
+
+    func applyReconciliation(
+        slug: String,
+        action: CommandStore.ReconciliationAction
+    ) throws -> CommandStore.CommandReconciliation {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let incoming = productDefaults.first(where: { $0.slug == slug }) else {
+            throw CommandStore.StoreError.reconciliationNotApplicable(slug)
+        }
+        var snapshot = try mutableSnapshotLocked()
+        guard snapshot.productDefaultsActive, !snapshot.tombstones.contains(incoming.id) else {
+            throw CommandStore.StoreError.reconciliationNotApplicable(slug)
+        }
+
+        switch action {
+        case .restoreBase:
+            guard let adopted = snapshot.adoptedBases[incoming.id] else {
+                throw CommandStore.StoreError.adoptedBaseMissing(slug)
+            }
+            let restored = StoredCommand(adopted, id: incoming.id, slug: incoming.slug)
+            if isEquivalent(restored, to: incoming) {
+                snapshot.localOverrides.removeValue(forKey: incoming.id)
+                snapshot.adoptedBases.removeValue(forKey: incoming.id)
+            } else {
+                snapshot.localOverrides[incoming.id] = restored
+            }
+
+        case .adoptIncoming:
+            snapshot.localOverrides.removeValue(forKey: incoming.id)
+            snapshot.adoptedBases.removeValue(forKey: incoming.id)
+
+        case .copySelectedChange(let source, let field):
+            let sourceDefault: CommandStore.ProductDefault
+            switch source {
+            case .base:
+                guard let adopted = snapshot.adoptedBases[incoming.id] else {
+                    throw CommandStore.StoreError.adoptedBaseMissing(slug)
+                }
+                sourceDefault = adopted.asProductDefault(
+                    id: incoming.id,
+                    slug: incoming.slug,
+                    initialKeySlot: incoming.initialKeySlot
+                )
+            case .incoming:
+                sourceDefault = incoming
+            }
+
+            var local = snapshot.localOverrides[incoming.id] ?? StoredCommand(incoming)
+            if snapshot.localOverrides[incoming.id] == nil {
+                snapshot.adoptedBases[incoming.id] = AdoptedBase(incoming)
+            }
+            switch field {
+            case .name: local.name = sourceDefault.name
+            case .icon: local.icon = sourceDefault.icon
+            case .color: local.color = sourceDefault.color
+            case .body: local.body = sourceDefault.body
+            }
+            if isEquivalent(local, to: incoming) {
+                snapshot.localOverrides.removeValue(forKey: incoming.id)
+                snapshot.adoptedBases.removeValue(forKey: incoming.id)
+            } else {
+                snapshot.localOverrides[incoming.id] = local
+            }
+        }
+
+        try publishLocked(snapshot)
+        guard let result = makeReconciliationLocked(incoming: incoming, snapshot: snapshot) else {
+            throw CommandStore.StoreError.reconciliationNotApplicable(slug)
+        }
+        return result
+    }
+
+    func executionGate(slug: String) throws -> CommandStore.ExecutionGate {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let incoming = productDefaults.first(where: { $0.slug == slug }) else {
+            return .open
+        }
+        guard let snapshot = try readableSnapshotLocked() else { return .open }
+        return makeReconciliationLocked(incoming: incoming, snapshot: snapshot)?.executionGate ?? .open
     }
 
     // MARK: - Test seams
@@ -596,6 +706,7 @@ final class CommandCustodyBackend: @unchecked Sendable {
         }
         let requiredBodyPaths = (Array(layers.localOverrides.keys) + Array(layers.customCommands.keys))
             .map(bodyRelativePath(for:))
+            + layers.adoptedBases.keys.map(adoptedBaseRelativePath(for:))
         guard requiredBodyPaths.allSatisfy({ manifest.payloadSHA256[$0] != nil }) else {
             throw CommandStore.StoreError.corruptRevision("manifest is missing a command-body hash for \(id)")
         }
@@ -614,7 +725,12 @@ final class CommandCustodyBackend: @unchecked Sendable {
             ),
             tombstones: Set(layers.hiddenDefaultTombstones),
             favorites: try favoriteMap(from: layers.favoriteLayout),
-            usage: telemetry.lastUsedAt
+            usage: telemetry.lastUsedAt,
+            adoptedBases: try readAdoptedBases(
+                layers.adoptedBases,
+                revisionID: id,
+                revisionRoot: revisionRoot
+            )
         )
         if mergeLiveTelemetry, let live = readLiveTelemetryLocked() {
             for (id, date) in live {
@@ -648,7 +764,8 @@ final class CommandCustodyBackend: @unchecked Sendable {
                 localOverrides: snapshot.localOverrides.mapValues { $0.withoutBody },
                 customCommands: snapshot.customCommands.mapValues { $0.withoutBody },
                 hiddenDefaultTombstones: snapshot.tombstones.sorted(),
-                favoriteLayout: snapshot.favorites.mapKeys { String($0) }
+                favoriteLayout: snapshot.favorites.mapKeys { String($0) },
+                adoptedBases: snapshot.adoptedBases.mapValues { $0.withoutBody }
             )
             let telemetry = Telemetry(
                 schemaVersion: Self.schemaVersion,
@@ -663,6 +780,12 @@ final class CommandCustodyBackend: @unchecked Sendable {
                 try writeData(
                     Data(stored.body.utf8),
                     to: staging.appendingPathComponent(bodyRelativePath(for: stored.id))
+                )
+            }
+            for (id, adopted) in snapshot.adoptedBases {
+                try writeData(
+                    Data(adopted.body.utf8),
+                    to: staging.appendingPathComponent(adoptedBaseRelativePath(for: id))
                 )
             }
 
@@ -820,6 +943,11 @@ final class CommandCustodyBackend: @unchecked Sendable {
                 throw CommandStore.StoreError.corruptRevision("invalid local override \(id)")
             }
         }
+        for (id, adopted) in snapshot.adoptedBases {
+            guard snapshot.localOverrides[id] != nil, isSafeID(id), isSafeAdoptedBase(adopted) else {
+                throw CommandStore.StoreError.corruptRevision("invalid adopted base \(id)")
+            }
+        }
         for (id, stored) in snapshot.customCommands {
             guard defaultsByID[id] == nil, stored.id == id, isSafeStoredCommand(stored),
                   allIDs.insert(id).inserted, allSlugs.insert(stored.slug).inserted
@@ -856,6 +984,88 @@ final class CommandCustodyBackend: @unchecked Sendable {
             && stored.body == productDefault.body
     }
 
+    private func makeReconciliationLocked(
+        incoming: CommandStore.ProductDefault,
+        snapshot: Snapshot
+    ) -> CommandStore.CommandReconciliation? {
+        if snapshot.productDefaultsActive == false { return nil }
+        if snapshot.tombstones.contains(incoming.id) { return nil }
+
+        let localStored = snapshot.localOverrides[incoming.id]
+        let adopted = snapshot.adoptedBases[incoming.id]
+        let localCommand = localStored.map { stored in
+            CommandStore.Command(
+                id: stored.id,
+                slug: stored.slug,
+                name: stored.name,
+                icon: stored.icon,
+                color: stored.color,
+                keySlot: snapshot.favorites.first(where: { $0.value == stored.id })?.key,
+                lastUsedAt: snapshot.usage[stored.id],
+                body: stored.body
+            )
+        }
+        let base = adopted.map {
+            $0.asProductDefault(
+                id: incoming.id,
+                slug: incoming.slug,
+                initialKeySlot: incoming.initialKeySlot
+            )
+        }
+        let (classification, gate, updateAvailable) = classifyLocked(
+            local: localStored,
+            incoming: incoming,
+            adopted: adopted
+        )
+        return CommandStore.CommandReconciliation(
+            commandID: incoming.id,
+            slug: incoming.slug,
+            base: base ?? (localStored == nil ? incoming : nil),
+            local: localCommand,
+            incoming: incoming,
+            classification: classification,
+            updateAvailable: updateAvailable,
+            executionGate: gate
+        )
+    }
+
+    private func classifyLocked(
+        local: StoredCommand?,
+        incoming: CommandStore.ProductDefault,
+        adopted: AdoptedBase?
+    ) -> (CommandStore.UpdateClassification, CommandStore.ExecutionGate, Bool) {
+        guard local != nil else {
+            return (.current, .open, false)
+        }
+
+        let adoptedSchema = adopted?.schemaVersion
+            ?? CommandStore.ProductDefault.currentCatalogSchemaVersion
+        let adoptedBehavior = adopted?.behaviorVersion
+            ?? CommandStore.ProductDefault.currentCatalogBehaviorVersion
+        let adoptedCaps = Set(adopted?.requiredCapabilities ?? [])
+        let incomingCaps = Set(incoming.requiredCapabilities)
+
+        if incoming.schemaVersion != adoptedSchema || incomingCaps != adoptedCaps {
+            let evidence = [
+                "schemaVersion \(adoptedSchema)→\(incoming.schemaVersion)",
+                "requiredCapabilities \(sortedCaps(adoptedCaps))→\(sortedCaps(incomingCaps))"
+            ].joined(separator: "; ")
+            return (
+                .compatibilityRequired,
+                .compatibilityRequired(evidence: evidence),
+                true
+            )
+        }
+        if incoming.behaviorVersion != adoptedBehavior {
+            return (.behavioral, .open, true)
+        }
+        return (.editorial, .open, true)
+    }
+
+    private func sortedCaps(_ caps: Set<String>) -> String {
+        "[" + caps.sorted().joined(separator: ",") + "]"
+    }
+
     // MARK: - Revision payload parsing
 
     private func readStoredCommands(
@@ -879,6 +1089,37 @@ final class CommandCustodyBackend: @unchecked Sendable {
             result[id] = StoredCommand(
                 id: descriptor.id,
                 slug: descriptor.slug,
+                name: descriptor.name,
+                icon: descriptor.icon,
+                color: descriptor.color,
+                body: body
+            )
+        }
+        return result
+    }
+
+    private func readAdoptedBases(
+        _ descriptors: [String: AdoptedBaseDescriptor],
+        revisionID: String,
+        revisionRoot: URL
+    ) throws -> [String: AdoptedBase] {
+        var result: [String: AdoptedBase] = [:]
+        for (id, descriptor) in descriptors {
+            guard isSafeID(id) else {
+                throw CommandStore.StoreError.corruptRevision("invalid adopted-base identity \(id)")
+            }
+            let url = revisionRoot.appendingPathComponent(adoptedBaseRelativePath(for: id))
+            guard let data = try? Data(contentsOf: url),
+                  let body = String(data: data, encoding: .utf8)
+            else {
+                throw CommandStore.StoreError.corruptRevision(
+                    "missing or invalid adopted base for \(revisionID)/\(id)"
+                )
+            }
+            result[id] = AdoptedBase(
+                schemaVersion: descriptor.schemaVersion,
+                behaviorVersion: descriptor.behaviorVersion,
+                requiredCapabilities: descriptor.requiredCapabilities,
                 name: descriptor.name,
                 icon: descriptor.icon,
                 color: descriptor.color,
@@ -960,6 +1201,10 @@ final class CommandCustodyBackend: @unchecked Sendable {
         "bodies/\(commandID).md"
     }
 
+    private func adoptedBaseRelativePath(for commandID: String) -> String {
+        "\(Self.adoptedBasesDirectory)/\(commandID).md"
+    }
+
     /// `FileManager` can enumerate the same temporary directory through its
     /// canonical `/private/var` spelling while the caller supplied `/var`.
     /// Never derive a manifest path with a blind string replacement: canonical
@@ -1036,6 +1281,10 @@ final class CommandCustodyBackend: @unchecked Sendable {
         isSafeID(command.id) && isSafeSlug(command.slug)
     }
 
+    private func isSafeAdoptedBase(_ base: AdoptedBase) -> Bool {
+        base.schemaVersion >= 1 && base.behaviorVersion >= 1
+    }
+
     private func isSafeRelativePath(_ value: String) -> Bool {
         !value.hasPrefix("/")
             && !value.contains("..")
@@ -1074,6 +1323,44 @@ final class CommandCustodyBackend: @unchecked Sendable {
         var customCommands: [String: StoredDescriptor]
         var hiddenDefaultTombstones: [String]
         var favoriteLayout: [String: String]
+        var adoptedBases: [String: AdoptedBaseDescriptor]
+
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion, productDefaultsActive, localOverrides, customCommands
+            case hiddenDefaultTombstones, favoriteLayout, adoptedBases
+        }
+
+        init(
+            schemaVersion: Int,
+            productDefaultsActive: Bool,
+            localOverrides: [String: StoredDescriptor],
+            customCommands: [String: StoredDescriptor],
+            hiddenDefaultTombstones: [String],
+            favoriteLayout: [String: String],
+            adoptedBases: [String: AdoptedBaseDescriptor]
+        ) {
+            self.schemaVersion = schemaVersion
+            self.productDefaultsActive = productDefaultsActive
+            self.localOverrides = localOverrides
+            self.customCommands = customCommands
+            self.hiddenDefaultTombstones = hiddenDefaultTombstones
+            self.favoriteLayout = favoriteLayout
+            self.adoptedBases = adoptedBases
+        }
+
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            schemaVersion = try values.decode(Int.self, forKey: .schemaVersion)
+            productDefaultsActive = try values.decode(Bool.self, forKey: .productDefaultsActive)
+            localOverrides = try values.decode([String: StoredDescriptor].self, forKey: .localOverrides)
+            customCommands = try values.decode([String: StoredDescriptor].self, forKey: .customCommands)
+            hiddenDefaultTombstones = try values.decode([String].self, forKey: .hiddenDefaultTombstones)
+            favoriteLayout = try values.decode([String: String].self, forKey: .favoriteLayout)
+            adoptedBases = try values.decodeIfPresent(
+                [String: AdoptedBaseDescriptor].self,
+                forKey: .adoptedBases
+            ) ?? [:]
+        }
     }
 
     private struct Telemetry: Codable {
@@ -1124,8 +1411,98 @@ final class CommandCustodyBackend: @unchecked Sendable {
             )
         }
 
+        init(_ adopted: AdoptedBase, id: String, slug: String) {
+            self.init(
+                id: id,
+                slug: slug,
+                name: adopted.name,
+                icon: adopted.icon,
+                color: adopted.color,
+                body: adopted.body
+            )
+        }
+
         var withoutBody: StoredDescriptor {
             StoredDescriptor(id: id, slug: slug, name: name, icon: icon, color: color)
+        }
+    }
+
+    private struct AdoptedBaseDescriptor: Codable {
+        var schemaVersion: Int
+        var behaviorVersion: Int
+        var requiredCapabilities: [String]
+        var name: String
+        var icon: CommandStore.Icon
+        var color: CommandStore.NotionColor?
+    }
+
+    private struct AdoptedBase: Equatable {
+        var schemaVersion: Int
+        var behaviorVersion: Int
+        var requiredCapabilities: [String]
+        var name: String
+        var icon: CommandStore.Icon
+        var color: CommandStore.NotionColor?
+        var body: String
+
+        init(
+            schemaVersion: Int,
+            behaviorVersion: Int,
+            requiredCapabilities: [String],
+            name: String,
+            icon: CommandStore.Icon,
+            color: CommandStore.NotionColor?,
+            body: String
+        ) {
+            self.schemaVersion = schemaVersion
+            self.behaviorVersion = behaviorVersion
+            self.requiredCapabilities = requiredCapabilities
+            self.name = name
+            self.icon = icon
+            self.color = color
+            self.body = body
+        }
+
+        init(_ productDefault: CommandStore.ProductDefault) {
+            self.init(
+                schemaVersion: productDefault.schemaVersion,
+                behaviorVersion: productDefault.behaviorVersion,
+                requiredCapabilities: productDefault.requiredCapabilities,
+                name: productDefault.name,
+                icon: productDefault.icon,
+                color: productDefault.color,
+                body: productDefault.body
+            )
+        }
+
+        var withoutBody: AdoptedBaseDescriptor {
+            AdoptedBaseDescriptor(
+                schemaVersion: schemaVersion,
+                behaviorVersion: behaviorVersion,
+                requiredCapabilities: requiredCapabilities,
+                name: name,
+                icon: icon,
+                color: color
+            )
+        }
+
+        func asProductDefault(
+            id: String,
+            slug: String,
+            initialKeySlot: Int?
+        ) -> CommandStore.ProductDefault {
+            CommandStore.ProductDefault(
+                id: id,
+                slug: slug,
+                name: name,
+                icon: icon,
+                color: color,
+                initialKeySlot: initialKeySlot,
+                body: body,
+                schemaVersion: schemaVersion,
+                behaviorVersion: behaviorVersion,
+                requiredCapabilities: requiredCapabilities
+            )
         }
     }
 
@@ -1154,6 +1531,7 @@ final class CommandCustodyBackend: @unchecked Sendable {
         var tombstones: Set<String>
         var favorites: [Int: String]
         var usage: [String: Date]
+        var adoptedBases: [String: AdoptedBase]
 
         static let empty = Snapshot(
             productDefaultsActive: false,
@@ -1161,7 +1539,8 @@ final class CommandCustodyBackend: @unchecked Sendable {
             customCommands: [:],
             tombstones: [],
             favorites: [:],
-            usage: [:]
+            usage: [:],
+            adoptedBases: [:]
         )
     }
 }

--- a/TheBridge/Modules/Commands/CommandStore.swift
+++ b/TheBridge/Modules/Commands/CommandStore.swift
@@ -31,7 +31,14 @@ public final class CommandStore: @unchecked Sendable {
     /// Product defaults are supplied by the application bundle. They are read
     /// as an authority layer and are never written into an operator's local
     /// custody store merely because the application is replaced.
+    ///
+    /// A1 metadata (`schemaVersion`, `behaviorVersion`, `requiredCapabilities`)
+    /// is structured catalog evidence. Wording lives in `body` and never
+    /// participates in compatibility gating.
     public struct ProductDefault: Equatable, Sendable {
+        public static let currentCatalogSchemaVersion = 1
+        public static let currentCatalogBehaviorVersion = 1
+
         public var id: String
         public var slug: String
         public var name: String
@@ -39,6 +46,9 @@ public final class CommandStore: @unchecked Sendable {
         public var color: NotionColor?
         public var initialKeySlot: Int?
         public var body: String
+        public var schemaVersion: Int
+        public var behaviorVersion: Int
+        public var requiredCapabilities: [String]
 
         public init(
             id: String,
@@ -47,7 +57,10 @@ public final class CommandStore: @unchecked Sendable {
             icon: Icon,
             color: NotionColor? = nil,
             initialKeySlot: Int? = nil,
-            body: String
+            body: String,
+            schemaVersion: Int = ProductDefault.currentCatalogSchemaVersion,
+            behaviorVersion: Int = ProductDefault.currentCatalogBehaviorVersion,
+            requiredCapabilities: [String] = []
         ) {
             self.id = id
             self.slug = slug
@@ -56,7 +69,58 @@ public final class CommandStore: @unchecked Sendable {
             self.color = color
             self.initialKeySlot = initialKeySlot
             self.body = body
+            self.schemaVersion = schemaVersion
+            self.behaviorVersion = behaviorVersion
+            self.requiredCapabilities = requiredCapabilities
         }
+    }
+
+    /// Settings-facing update class. Compatibility-required is the only class
+    /// that closes the execution gate, and only from schema/capability evidence.
+    public enum UpdateClassification: String, Sendable, Equatable {
+        case current
+        case editorial
+        case behavioral
+        case compatibilityRequired
+    }
+
+    public enum ExecutionGate: Sendable, Equatable {
+        case open
+        case compatibilityRequired(evidence: String)
+    }
+
+    public enum ReconciliationField: String, Sendable, Equatable {
+        case name
+        case icon
+        case color
+        case body
+    }
+
+    public enum ReconciliationSource: String, Sendable, Equatable {
+        case base
+        case incoming
+    }
+
+    /// Explicit operator actions. There is no automatic natural-language body
+    /// merge path; `copySelectedChange` copies one whole field.
+    public enum ReconciliationAction: Sendable, Equatable {
+        case restoreBase
+        case adoptIncoming
+        case copySelectedChange(source: ReconciliationSource, field: ReconciliationField)
+    }
+
+    /// Base = last-adopted product default. Local = operator override.
+    /// Incoming = current application catalog entry. Unmodified commands have
+    /// no local override; incoming is the effective body.
+    public struct CommandReconciliation: Equatable, Sendable {
+        public var commandID: String
+        public var slug: String
+        public var base: ProductDefault?
+        public var local: Command?
+        public var incoming: ProductDefault
+        public var classification: UpdateClassification
+        public var updateAvailable: Bool
+        public var executionGate: ExecutionGate
     }
 
     /// Deterministic fault points used only by the custody regression suite.
@@ -160,6 +224,8 @@ public final class CommandStore: @unchecked Sendable {
         case corruptRevision(String)
         case injectedFailure(TestFaultPoint)
         case ioFailure(underlying: Error)
+        case adoptedBaseMissing(String)
+        case reconciliationNotApplicable(String)
 
         public var errorDescription: String? {
             switch self {
@@ -174,6 +240,10 @@ public final class CommandStore: @unchecked Sendable {
             case .injectedFailure(let point):
                 return "Injected command custody failure at \(point)."
             case .ioFailure(let e): return "Command store I/O failed: \(e.localizedDescription)"
+            case .adoptedBaseMissing(let s):
+                return "No adopted product-default base is on file for '\(s)'."
+            case .reconciliationNotApplicable(let s):
+                return "Product-default reconciliation does not apply to '\(s)'."
             }
         }
     }
@@ -251,6 +321,28 @@ public final class CommandStore: @unchecked Sendable {
     /// Stamp lastUsedAt to now. Called when the command fires from the popup.
     public func recordUse(slug: String, at when: Date = Date()) throws {
         try custody.recordUse(slug: slug, at: when)
+    }
+
+    // MARK: - Product-default reconciliation (A1)
+
+    public func reconciliations() throws -> [CommandReconciliation] {
+        try custody.reconciliations()
+    }
+
+    public func reconciliation(slug: String) throws -> CommandReconciliation? {
+        try custody.reconciliation(slug: slug)
+    }
+
+    @discardableResult
+    public func applyReconciliation(
+        slug: String,
+        action: ReconciliationAction
+    ) throws -> CommandReconciliation {
+        try custody.applyReconciliation(slug: slug, action: action)
+    }
+
+    public func executionGate(slug: String) throws -> ExecutionGate {
+        try custody.executionGate(slug: slug)
     }
 
     // MARK: - Slugification

--- a/TheBridgeTests/CommandReconciliationTests.swift
+++ b/TheBridgeTests/CommandReconciliationTests.swift
@@ -1,0 +1,268 @@
+// CommandReconciliationTests.swift — A1 / GitHub #140
+//
+// Product-default reconciliation: unmodified defaults advance, local
+// overrides stay byte-for-byte, incoming stays inspectable, and only
+// schema/capability evidence closes the execution gate.
+
+import AppKit
+import Foundation
+import TheBridgeLib
+
+func runCommandReconciliationTests() async {
+    print("\n[Command reconciliation A1 / #140]")
+
+    await test("A1 unmodified defaults advance when the catalog body changes") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            let original = try requireCommand(store, slug: "initiate")
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].body = "incoming-unmodified-body"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let advanced = try requireCommand(incomingStore, slug: "initiate")
+            try expect(advanced.body == "incoming-unmodified-body")
+            try expect(advanced.id == original.id)
+            let state = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(state.local == nil)
+            try expect(state.incoming.body == "incoming-unmodified-body")
+            try expect(state.classification == .current)
+            try expect(state.updateAvailable == false)
+            try expect(state.executionGate == .open)
+        }
+    }
+
+    await test("A1 modified defaults retain the local body byte-for-byte") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "initiate")
+            local.body = "operator-override-body\nexact-bytes"
+            _ = try store.update(local)
+            let retained = try requireCommand(store, slug: "initiate")
+            try expect(retained.body == "operator-override-body\nexact-bytes")
+
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].body = "incoming-catalog-body"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let afterUpdate = try requireCommand(incomingStore, slug: "initiate")
+            try expect(afterUpdate.body == "operator-override-body\nexact-bytes",
+                       "catalog replacement overwrote the local override")
+            let state = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(state.local?.body == "operator-override-body\nexact-bytes")
+            try expect(state.incoming.body == "incoming-catalog-body")
+            try expect(state.base?.body == CommandStore.defaultProductCatalog[0].body)
+            try expect(state.updateAvailable == true)
+        }
+    }
+
+    await test("A1 incoming defaults remain inspectable separately from local") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "propose")
+            local.body = "local-propose"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[1].body = "incoming-propose"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let state = try requireReconciliation(incomingStore, slug: "propose")
+            try expect(state.local?.body == "local-propose")
+            try expect(state.incoming.body == "incoming-propose")
+            try expect(state.local?.body != state.incoming.body)
+            try expect(try incomingStore.get(slug: "propose")?.body == "local-propose")
+        }
+    }
+
+    await test("A1 has no automatic body-merge path") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "review")
+            local.body = "LOCAL-ONLY"
+            local.name = "Review Local"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[5].body = "INCOMING-ONLY"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let effective = try requireCommand(incomingStore, slug: "review")
+            try expect(effective.body == "LOCAL-ONLY")
+            try expect(!effective.body.contains("INCOMING-ONLY"))
+            let copied = try incomingStore.applyReconciliation(
+                slug: "review",
+                action: .copySelectedChange(source: .incoming, field: .body)
+            )
+            try expect(copied.local?.body == "INCOMING-ONLY",
+                       "copy-selected-change must copy the whole body field")
+            try expect(copied.local?.name == "Review Local",
+                       "copying body must not rewrite other local fields")
+            try expect(copied.local?.body != "LOCAL-ONLY\nINCOMING-ONLY")
+            try expect(copied.local?.body != "LOCAL-ONLYINCOMING-ONLY")
+        }
+    }
+
+    await test("A1 wording-only incoming changes classify as editorial and stay executable") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "initiate")
+            local.body = "custom-initiate"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].body = "wording-only incoming"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let state = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(state.classification == .editorial)
+            try expect(state.executionGate == .open)
+            try expect(try incomingStore.executionGate(slug: "initiate") == .open)
+        }
+    }
+
+    await test("A1 behaviorVersion changes classify as behavioral without closing the gate") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "initiate")
+            local.body = "custom-initiate"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].behaviorVersion = 2
+            incomingCatalog[0].body = "behavioral incoming"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let state = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(state.classification == .behavioral)
+            try expect(state.executionGate == .open)
+            try expect(try incomingStore.get(slug: "initiate")?.body == "custom-initiate")
+        }
+    }
+
+    await test("A1 schema/capability evidence classifies compatibility-required and gates fire") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommand(store, slug: "initiate")
+            local.body = "custom-initiate"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].schemaVersion = 2
+            incomingCatalog[0].requiredCapabilities = ["commands.reconciliation.v2"]
+            incomingCatalog[0].body = "incompatible incoming"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let state = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(state.classification == .compatibilityRequired)
+            try expect(state.updateAvailable == true)
+            guard case .compatibilityRequired(let evidence) = state.executionGate else {
+                throw TestError.assertion("expected compatibility-required gate")
+            }
+            try expect(evidence.contains("schemaVersion 1→2"))
+            try expect(evidence.contains("commands.reconciliation.v2"))
+
+            let cb = InMemoryClipboard(initial: "prior")
+            let inserter = RecordingTextInserter()
+            let coord = CommandPaletteCoordinator(
+                provider: StaticCommandDescriptorProvider(),
+                manager: CommandsManager(fetcher: { _ in "{}" })
+            )
+            let ctrl = await CommandBridgeController(
+                hotkey: .productionDefault,
+                clipboard: cb,
+                inserter: inserter,
+                coordinator: coord,
+                store: incomingStore
+            )
+            await ctrl.fireSlug("initiate")
+            try expect(await ctrl.lastInsertedText == nil,
+                       "compatibility-required must not insert")
+            try expect(cb.writeCount == 0)
+            try expect(cb.readString() == "prior")
+        }
+    }
+
+    await test("A1 restore/adopt/copy-selected-change are explicit and reversible") {
+        try await withReconciliationStore { store, root in
+            try store.seedIfEmpty()
+            let originalBody = try requireCommand(store, slug: "initiate").body
+            var local = try requireCommand(store, slug: "initiate")
+            local.body = "override-v1"
+            local.name = "Initiate Local"
+            _ = try store.update(local)
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[0].body = "incoming-v2"
+            incomingCatalog[0].name = "Initiate Incoming"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+
+            let before = try requireReconciliation(incomingStore, slug: "initiate")
+            try expect(before.local?.body == "override-v1")
+
+            let restored = try incomingStore.applyReconciliation(slug: "initiate", action: .restoreBase)
+            try expect(restored.local?.body == originalBody || restored.local == nil)
+            let afterRestore = try requireCommand(incomingStore, slug: "initiate")
+            try expect(afterRestore.body == originalBody)
+            _ = try incomingStore.update(local)
+            try expect(try requireCommand(incomingStore, slug: "initiate").body == "override-v1")
+
+            let copied = try incomingStore.applyReconciliation(
+                slug: "initiate",
+                action: .copySelectedChange(source: .incoming, field: .name)
+            )
+            try expect(copied.local?.name == "Initiate Incoming")
+            try expect(copied.local?.body == "override-v1")
+            let reversedName = try incomingStore.applyReconciliation(
+                slug: "initiate",
+                action: .copySelectedChange(source: .base, field: .name)
+            )
+            try expect(reversedName.local?.name == "Initiate")
+            try expect(reversedName.local?.body == "override-v1")
+
+            let adopted = try incomingStore.applyReconciliation(slug: "initiate", action: .adoptIncoming)
+            try expect(adopted.local == nil)
+            try expect(try requireCommand(incomingStore, slug: "initiate").body == "incoming-v2")
+            _ = try incomingStore.update(local)
+            try expect(try requireCommand(incomingStore, slug: "initiate").body == "override-v1")
+        }
+    }
+
+    await test("A1 replays an A0 legacy override without rewriting it") {
+        try await withReconciliationStore { store, root in
+            var fixture = CommandStore.currentLegacyProductionFixture
+            guard let executeIndex = fixture.firstIndex(where: { $0.slug == "execute" }) else {
+                throw TestError.assertion("fixture missing Execute")
+            }
+            fixture[executeIndex].body = "a0-legacy-override\r\nexact"
+            try store.installLegacyFixtureForTesting(fixture)
+            try store.setKeySlot(slug: "execute", slot: fixture[executeIndex].keySlot)
+            try expect(try requireCommand(store, slug: "execute").body == "a0-legacy-override\r\nexact")
+
+            var incomingCatalog = CommandStore.defaultProductCatalog
+            incomingCatalog[4].body = "a1-incoming-execute"
+            let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
+            let state = try requireReconciliation(incomingStore, slug: "execute")
+            try expect(state.local?.body == "a0-legacy-override\r\nexact")
+            try expect(state.incoming.body == "a1-incoming-execute")
+            try expect(state.classification == .editorial)
+            try expect(state.executionGate == .open)
+            try expect(try requireCommand(incomingStore, slug: "execute").body
+                       == "a0-legacy-override\r\nexact")
+        }
+    }
+}
+
+private func withReconciliationStore(
+    _ body: (CommandStore, URL) async throws -> Void
+) async throws {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory
+        .appendingPathComponent("CommandReconciliation-A1-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: root) }
+    try await body(CommandStore(storageRoot: root), root)
+}
+
+private func requireCommand(_ store: CommandStore, slug: String) throws -> CommandStore.Command {
+    guard let command = try store.get(slug: slug) else {
+        throw TestError.assertion("missing command \(slug)")
+    }
+    return command
+}
+
+private func requireReconciliation(
+    _ store: CommandStore,
+    slug: String
+) throws -> CommandStore.CommandReconciliation {
+    guard let state = try store.reconciliation(slug: slug) else {
+        throw TestError.assertion("missing reconciliation for \(slug)")
+    }
+    return state
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -858,6 +858,10 @@ await runCommandStoreTests()
 // recovery proof for the legacy command store.
 await runCommandCustodyTests()
 
+// GitHub #140 A1: product-default reconciliation, classifications, and
+// compatibility-required execution gating. No automatic body merge.
+await runCommandReconciliationTests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-custody-a0.md
+++ b/docs/commands-custody-a0.md
@@ -115,3 +115,7 @@ run the same suite with `BRIDGE_A0_LEGACY_FIXTURE_ROOT` set to the legacy
 temporary root, migrates only the copy, and compares its effective state and
 locally-custodied body bytes against the source. It never writes the supplied
 directory.
+
+A1 (`docs/commands-reconciliation-a1.md`) adds optional `adoptedBases` on
+`layers.json` and `adopted-bases/<id>.md` bodies. Schema version remains 2.
+Existing A0 revisions without those keys stay valid.

--- a/docs/commands-reconciliation-a1.md
+++ b/docs/commands-reconciliation-a1.md
@@ -1,0 +1,64 @@
+# Command reconciliation A1
+
+GitHub issue #140, packet A1 adds product-default reconciliation on top of A0
+custody. Schema version stays **2**. There is no automatic natural-language
+body merge, Search UI, developer publication, or install.
+
+## Authority
+
+| Reference | Meaning |
+| --- | --- |
+| **Incoming** | Current application catalog (`CommandStore.defaultProductCatalog`, or a test-injected catalog). |
+| **Local** | Operator override in `localOverrides`. Absent when the built-in is unmodified. |
+| **Base** | Last-adopted product default, snapshotted when an override is first created. Stored as metadata in `layers.json` (`adoptedBases`, `decodeIfPresent`) and body bytes in `adopted-bases/<id>.md`. Never inlined into `layers.json`. |
+
+Unmodified built-ins have no local override. The effective body is always the
+incoming catalog entry, so application updates advance those defaults at read
+time without writing custody. A0 already behaved this way; A1 makes incoming
+inspectable as a first-class Settings model.
+
+## Classification
+
+Classification compares **incoming structured metadata** to the last-adopted
+base (A0-era overrides with no snapshot fall back to catalog schema 1 /
+behavior 1 / no required capabilities):
+
+1. Incoming `schemaVersion` or `requiredCapabilities` differ → **Compatibility-required**. Execution gate closes. Evidence is the concrete schema/capability delta.
+2. Else incoming `behaviorVersion` differs → **Behavioral**. Gate stays open.
+3. Else an override exists → **Editorial** (name, icon, color, or wording). Gate stays open.
+4. Else → **Current**. No update available.
+
+Wording-only catalog edits never disable a command.
+
+## Actions
+
+All three are explicit. None merge body hunks.
+
+| Action | Effect | Reverse |
+| --- | --- | --- |
+| `restoreBase` | Local := adopted base. Drops the override when that equals incoming. Fails closed if no adopted base is on file. | Re-apply the previous local via `update`, or `copySelectedChange`. |
+| `adoptIncoming` | Drop the override. Incoming becomes effective. | Re-apply the previous local via `update`. |
+| `copySelectedChange(source, field)` | Copy one whole field (`name` / `icon` / `color` / `body`) from base or incoming. | Copy the same field from the other source. |
+
+Prior A0 revisions remain in `state.json` history; none of these actions
+rewrite legacy `index.json` / `<slug>.md`.
+
+## Execution gating
+
+`CommandBridgeController.fireSlug` / `fireSlot` consult
+`CommandStore.executionGate(slug:)`. Compatibility-required commands commit
+`.unavailable` and do not insert. Editorial and behavioral updates stay
+fireable. Custom commands are not reconciled and stay open.
+
+## Settings model
+
+`CommandReconciliation` is the Settings-facing contract: `base`, `local`,
+`incoming`, `classification`, `updateAvailable`, `executionGate`. This packet
+does not add Search UI.
+
+## Compatibility with A0
+
+Existing schema-2 revisions without `adoptedBases` decode as an empty map and
+remain valid. Restore/copy-from-base are unavailable until an A1 override
+creation snapshots a base; adopt-incoming and copy-from-incoming still work.
+Operator override bodies are never rewritten by catalog replacement.


### PR DESCRIPTION
## Summary
- Adds product-default reconciliation on top of A0 custody: unmodified defaults adopt incoming catalog bodies, local overrides stay byte-for-byte, and execution closes only on schema or capability evidence.
- Public Settings API covers restore / adopt / copy-selected-change (whole fields only; no NL hunk merge). Fire path consults `executionGate(slug:)`.
- Source Tested on `0822e45`: TheBridgeTests **3675 passed, 0 failed** (floor 3666 → 3675). REVIEW-FIRST: do not merge, tag, or `install-copy`.

## Test plan
- [ ] Confirm A0 `CommandCustodyTests` still pass, including live fixture copy
- [ ] Confirm A1 `CommandReconciliationTests` (9) pass
- [ ] Unmodified default advances from catalog; override is not rewritten
- [ ] Wording-only / behaviorVersion change does not close the fire path
- [ ] Schema or requiredCapabilities mismatch sets `compatibilityRequired` and refuses commit
- [ ] `restoreBase` throws `adoptedBaseMissing` for A0-era overrides with no snapshot (honest leftover; do not invent a catalog base)

Closes nothing. Program issue: #140. Packet: PKT-1249 A1.


Made with [Cursor](https://cursor.com)