### PR TITLE
B0: directional command catalog and repository defaults

### DIFF
--- a/TheBridge/Modules/Commands/CommandProductCatalog.swift
+++ b/TheBridge/Modules/Commands/CommandProductCatalog.swift
@@ -1,0 +1,291 @@
+// CommandProductCatalog.swift — repository-backed built-in command defaults.
+//
+// GitHub #140 B0. Bodies are directional goal conditions (Mode, Use when,
+// Aim, Boundary, Exit). Repeatable procedures live in skills and standing
+// orders, not here. Local overrides are never written from this catalog.
+
+import Foundation
+
+public enum CommandProductCatalog {
+    public static let maxWordCount = 120
+
+    public static let requiredSectionLabels = [
+        "Mode:",
+        "Use when:",
+        "Aim:",
+        "Boundary:",
+        "Exit:",
+    ]
+
+    /// Tokens that would pull a protocol, tool, path, retry loop, or patch
+    /// history into a command body. Keep this list explicit so a wording
+    /// change cannot silently reintroduce a banned class.
+    static let prohibitedPatterns: [NSRegularExpression] = {
+        let sources = [
+            #"\b[a-z][a-z0-9]*_[a-z0-9_]+\b"#,
+            #"\bfetch_skill\b"#,
+            #"\bbridge_initialize\b"#,
+            #"\bexecutor\b"#,
+            #"\bAGENT_FEEDBACK\b"#,
+            #"\bPKT-\d+\b"#,
+            #"\bretr(?:y|ies|ied|ying)\b"#,
+            #"~/Library"#,
+            #"/Users/"#,
+            #"Application Support"#,
+            #"\bWave \d+\b"#,
+        ]
+        return sources.map { try! NSRegularExpression(pattern: $0, options: [.caseInsensitive]) }
+    }()
+
+    static let domainExclusivePatterns: [NSRegularExpression] = {
+        let sources = [
+            #"\bgit(?:hub)?\b"#,
+            #"\bswift\b"#,
+            #"\bnotion\b"#,
+            #"\bkeepr\b"#,
+            #"\bmcp\b"#,
+            #"\bcommit\b"#,
+            #"\bpull request\b"#,
+            #"\bwebhook\b"#,
+        ]
+        return sources.map { try! NSRegularExpression(pattern: $0, options: [.caseInsensitive]) }
+    }()
+
+    public struct ValidationIssue: Equatable, Sendable {
+        public var slug: String
+        public var reason: String
+
+        public init(slug: String, reason: String) {
+            self.slug = slug
+            self.reason = reason
+        }
+    }
+
+    struct Seed: Sendable {
+        var name: String
+        var icon: CommandStore.Icon
+        var color: CommandStore.NotionColor?
+        var body: String
+    }
+
+    static let seeds: [Seed] = [
+        Seed(name: "Initiate", icon: .emoji("🧭"), color: .purple, body: initiateBody),
+        Seed(name: "Propose", icon: .emoji("🧩"), color: .blue, body: proposeBody),
+        Seed(name: "Scope Cut", icon: .emoji("✂️"), color: .gray, body: scopeCutBody),
+        Seed(name: "Validate", icon: .emoji("🔎"), color: .yellow, body: validateBody),
+        Seed(name: "Execute", icon: .emoji("⚡"), color: .orange, body: executeBody),
+        Seed(name: "Review", icon: .emoji("🧪"), color: .red, body: reviewBody),
+        Seed(name: "Refocus", icon: .emoji("🎯"), color: .blue, body: refocusBody),
+        Seed(name: "Open Loops", icon: .emoji("📋"), color: .green, body: openLoopsBody),
+        Seed(name: "Close Agent", icon: .emoji("✅"), color: .green, body: closeAgentBody),
+        Seed(name: "Hand Off", icon: .emoji("📨"), color: .brown, body: handOffBody),
+    ]
+
+    public static var defaults: [CommandStore.ProductDefault] {
+        seeds.enumerated().map { index, seed in
+            let slug = CommandStore.slugify(seed.name)
+            let slot = index == 9 ? 0 : index + 1
+            return CommandStore.ProductDefault(
+                id: CommandStore.legacyBuiltInIdentityMap[slug]!,
+                slug: slug,
+                name: seed.name,
+                icon: seed.icon,
+                color: seed.color,
+                initialKeySlot: slot,
+                body: seed.body,
+                schemaVersion: CommandStore.ProductDefault.currentCatalogSchemaVersion,
+                behaviorVersion: CommandStore.ProductDefault.currentCatalogBehaviorVersion,
+                requiredCapabilities: []
+            )
+        }
+    }
+
+    public static func wordCount(_ body: String) -> Int {
+        body.split { $0.isWhitespace || $0.isNewline }.count
+    }
+
+    public static func validate(_ item: CommandStore.ProductDefault) -> [ValidationIssue] {
+        var issues: [ValidationIssue] = []
+        let body = item.body
+        let count = wordCount(body)
+        if count > maxWordCount {
+            issues.append(.init(slug: item.slug, reason: "body has \(count) words; max is \(maxWordCount)"))
+        }
+        for label in requiredSectionLabels {
+            if !hasSection(label, in: body) {
+                issues.append(.init(slug: item.slug, reason: "missing \(label) section"))
+            }
+        }
+        for regex in prohibitedPatterns {
+            if let match = firstMatch(regex, in: body) {
+                issues.append(.init(slug: item.slug, reason: "prohibited content: \(match)"))
+            }
+        }
+        for regex in domainExclusivePatterns {
+            if let match = firstMatch(regex, in: body) {
+                issues.append(.init(slug: item.slug, reason: "domain-exclusive content: \(match)"))
+            }
+        }
+        return issues
+    }
+
+    public static func validateAll(
+        _ items: [CommandStore.ProductDefault] = defaults
+    ) -> [ValidationIssue] {
+        items.flatMap(validate)
+    }
+
+    private static func hasSection(_ label: String, in body: String) -> Bool {
+        body.split(whereSeparator: \.isNewline).contains { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix(label)
+        }
+    }
+
+    private static func firstMatch(_ regex: NSRegularExpression, in body: String) -> String? {
+        let range = NSRange(body.startIndex..<body.endIndex, in: body)
+        guard let match = regex.firstMatch(in: body, options: [], range: range),
+              let swiftRange = Range(match.range, in: body)
+        else { return nil }
+        return String(body[swiftRange])
+    }
+
+    private static let initiateBody = """
+    # Initiate
+
+    Mode: arrival. Orient before work moves.
+
+    Use when: the session is starting, the target is unclear, or current context is not yet grounded.
+
+    Aim: a shared picture of where we are and what the next move should be.
+
+    Boundary: do not implement, plan a delivery sprint, or invent a target. Ask at most one clarifying question.
+
+    Exit: the operator fires another command, names a concrete target, or explicitly asks to move.
+    """
+
+    private static let proposeBody = """
+    # Propose
+
+    Mode: shaping. Do not build yet.
+
+    Use when: the objective exists but the contract is still open, including both making and thinking work.
+
+    Aim: restate the objective, name the smallest coherent scope, surface real forks, and show the cost of being wrong.
+
+    Boundary: do not start material work or choose a fork the operator should choose.
+
+    Exit: a proposed contract is on the table, or the operator cuts scope or asks to proceed.
+    """
+
+    private static let scopeCutBody = """
+    # Scope Cut
+
+    Mode: trim. Separate what is required from what is only adjacent.
+
+    Use when: the proposed work is wider than the next verifiable slice, in code or in knowledge work.
+
+    Aim: return IN / OUT / LATER with the reason each boundary exists.
+
+    Boundary: do not add work back in to keep a larger plan intact. Prefer a smaller contract that can be checked.
+
+    Exit: the operator accepts the cut, restores an item with a reason, or asks for a new proposal.
+    """
+
+    private static let validateBody = """
+    # Validate
+
+    Mode: hardening. Check whether the plan is ready to run.
+
+    Use when: a contract exists and the next step would be material work, across any domain.
+
+    Aim: confirm source of truth, dependencies, gates, tests or checks, and likely failure modes.
+
+    Boundary: do not begin delivery. If more than one domain is in play, say so and stop for routing.
+
+    Exit: the plan is ready, blocked on a named gap, or returned for a smaller cut.
+    """
+
+    private static let executeBody = """
+    # Execute
+
+    Mode: delivery. A contract is approved and material work may begin.
+
+    Use when: the operator has approved the plan for code, writing, research, or other shipping work.
+
+    Aim: do the approved work, prove it with evidence, and stop at the contract.
+
+    Boundary: do not expand scope, skip the check that defines done, or continue past a failed proof.
+
+    Exit: done is evidenced, a named blocker stops the work, or the operator calls a review.
+    """
+
+    private static let reviewBody = """
+    # Review
+
+    Mode: checkpoint. Verify before release, deletion, or any irreversible action.
+
+    Use when: work claims to be done and a gate, publish, or irreversible step is next.
+
+    Aim: lead with findings and evidence. Confirm checks, live state, external gates, and any operator decision still required.
+
+    Boundary: do not merge, publish, delete, or otherwise make the step irreversible without an explicit go.
+
+    Exit: the operator accepts, requests a fix, or withholds the irreversible step.
+    """
+
+    private static let refocusBody = """
+    # Refocus
+
+    Mode: realignment. Re-anchor the session.
+
+    Use when: the thread has drifted, context is stale, or the next move is no longer obvious.
+
+    Aim: restate the original objective, current evidence, what changed, and the next smallest move. Flag drift plainly.
+
+    Boundary: do not start a new plan or resume delivery until the original aim is restated.
+
+    Exit: the operator confirms the re-anchor, names a new aim, or fires the next command.
+    """
+
+    private static let openLoopsBody = """
+    # Open Loops
+
+    Mode: inventory. List every unresolved thread from the current session or project.
+
+    Use when: work has accumulated loose ends in shipping, research, or personal systems.
+
+    Aim: separate loops that need action, loops that need a decision, and loops that can close with evidence already present.
+
+    Boundary: do not close a loop by guessing, and do not start new work from the inventory.
+
+    Exit: the list is complete and each loop has a next owner, or the operator picks one loop to handle.
+    """
+
+    private static let closeAgentBody = """
+    # Close Agent
+
+    Mode: closeout. Preserve what should survive this session.
+
+    Use when: the session is ending and shipped work, evidence, or learning must outlive the chat.
+
+    Aim: summarize shipped work, evidence, unresolved decisions, friction, and reusable learning.
+
+    Boundary: write durable notes only where the active protocol requires them. Do not invent a second backlog.
+
+    Exit: the surviving record is written, leftovers are named, and the session can stop.
+    """
+
+    private static let handOffBody = """
+    # Hand Off
+
+    Mode: transfer. Prepare the next agent to continue without rediscovery.
+
+    Use when: work continues in another session, person, or thread.
+
+    Aim: include objective, current state, artifacts touched, exact evidence, blockers, and the next best action.
+
+    Boundary: do not run closeout from this command, and do not resume delivery in this turn.
+
+    Exit: a successor can start from the brief alone, or the operator stays and names the next command.
+    """
+}

--- a/TheBridge/Modules/Commands/CommandStore.swift
+++ b/TheBridge/Modules/Commands/CommandStore.swift
@@ -37,7 +37,7 @@ public final class CommandStore: @unchecked Sendable {
     /// participates in compatibility gating.
     public struct ProductDefault: Equatable, Sendable {
         public static let currentCatalogSchemaVersion = 1
-        public static let currentCatalogBehaviorVersion = 1
+        public static let currentCatalogBehaviorVersion = 2
 
         public var id: String
         public var slug: String
@@ -364,146 +364,10 @@ public final class CommandStore: @unchecked Sendable {
         return String(String.UnicodeScalarView(filtered))
     }
 
-    // MARK: - First-run templates
-
-    private struct Seed {
-        let name: String
-        let icon: Icon
-        let color: NotionColor?
-        let body: String
-    }
-
-    private static let initiateSeedBody = """
-    # Initiate Bridge
-
-    Mode: arrival. Orient before work moves.
-
-    Set in stone:
-    Run `bridge_initialize` first and treat its structured receipt as the source of truth for Bridge state, doctrine integrity, routing roster quality, supplemental-order counts, capability notes, and final initialization state. Do not maintain a parallel startup checklist in this command body.
-
-    After the receipt, ground in the current handoff or live project state. If there is no concrete handoff, use the current workspace and ask one clarifying question only if the target is genuinely ambiguous.
-
-    Stay in orientation mode until the operator fires another command or explicitly asks to move.
-    """
-
-    private static let proposeSeedBody = """
-    # Propose
-
-    Mode: shaping. Do not implement yet.
-
-    Restate the objective, identify the smallest coherent scope, name meaningful forks, and surface the cost of being wrong. Use choice-to-contract only when there is a real decision the operator should make.
-    """
-
-    private static let scopeCutSeedBody = """
-    # Scope Cut
-
-    Mode: trim. Separate what is truly required from what is merely adjacent.
-
-    Return IN / OUT / LATER with the reason each boundary exists. Prefer a smaller contract that can be verified over a wider one that depends on hope.
-    """
-
-    private static let validateSeedBody = """
-    # Validate
-
-    Mode: hardening. Check whether the plan is execution-ready.
-
-    Verify source-of-truth context, dependencies, gates, tests, and likely failure modes. If the work spans more than one domain, route through the relevant parent Keepr before any material execution.
-    """
-
-    private static let executeSeedBody = """
-    ## Execute
-
-    Mode: delivery. A contract is approved and material work may begin.
-
-    Set in stone:
-    Resolve the parent Keepr first from the live routing roster (`skills_routing_list` / `list_routing_skills`), then load that parent contract with `fetch_skill('<parent-keepr>', intent: '<this sub-task>')`. Do not route directly to `executor` unless the active request is a packet dispatch or the parent Keepr explicitly selects executor as the specialist for this task.
-
-    For multi-domain work, build the route stack through the relevant parent Keeprs. The domain owner selects executor, orchestrator, or another specialist; the command does not bypass ownership.
-
-    Define done with tests, run them, and iterate until the evidence is green. Keep a working todo list and close loops at wave checkpoints.
-
-    Return a final summary: what shipped, test results, deltas vs the contract, and deferred items with reasons.
-    """
-
-    private static let reviewSeedBody = """
-    # Review
-
-    Mode: checkpoint. Verify before release, merge, deletion, or irreversible action.
-
-    Lead with findings and evidence. Confirm tests, runtime state, external gates, and any operator decision required before the work can move forward.
-    """
-
-    private static let refocusSeedBody = """
-    # Refocus
-
-    Mode: realignment. Re-anchor the session.
-
-    Restate the original objective, current evidence, what changed, and the next smallest move. Flag drift plainly.
-    """
-
-    private static let openLoopsSeedBody = """
-    # Open Loops
-
-    Mode: inventory. List every unresolved thread from the current session or project.
-
-    Separate loops that need action, loops that need a decision, and loops that can be closed with evidence already present.
-    """
-
-    private static let closeAgentSeedBody = """
-    # Close Agent
-
-    Mode: closeout. Preserve what should survive this session.
-
-    Summarize shipped work, evidence, unresolved decisions, friction, and reusable learning. Write durable telemetry only where the active protocol requires it.
-    """
-
-    private static let handOffSeedBody = """
-    # Hand Off
-
-    Mode: transfer. Prepare the next agent to continue without rediscovery.
-
-    Include objective, current state, files/pages/PRs touched, exact evidence, blockers, and the next best action. Do not run close-agent from this command.
-    """
-
-    private static let firstRunSeeds: [Seed] = [
-        Seed(name: "Initiate",    icon: .emoji("🧭"),  color: .purple,
-             body: initiateSeedBody),
-        Seed(name: "Propose",     icon: .emoji("🧩"),  color: .blue,
-             body: proposeSeedBody),
-        Seed(name: "Scope Cut",   icon: .emoji("✂️"),  color: .gray,
-             body: scopeCutSeedBody),
-        Seed(name: "Validate",    icon: .emoji("🔎"),  color: .yellow,
-             body: validateSeedBody),
-        Seed(name: "Execute",     icon: .emoji("⚡"),  color: .orange,
-             body: executeSeedBody),
-        Seed(name: "Review",      icon: .emoji("🧪"),  color: .red,
-             body: reviewSeedBody),
-        Seed(name: "Refocus",     icon: .emoji("🎯"),  color: .blue,
-             body: refocusSeedBody),
-        Seed(name: "Open Loops",  icon: .emoji("📋"),  color: .green,
-             body: openLoopsSeedBody),
-        Seed(name: "Close Agent", icon: .emoji("✅"),  color: .green,
-             body: closeAgentSeedBody),
-        Seed(name: "Hand Off",    icon: .emoji("📨"),  color: .brown,
-             body: handOffSeedBody),
-    ]
-
-    /// The repository-owned default layer. Its bodies are the existing seed
-    /// bodies above, intentionally carried verbatim through A0.
+    /// The repository-owned default layer. B0 bodies are directional goal
+    /// conditions; A0 identities and A1 metadata stay on this façade.
     public static var defaultProductCatalog: [ProductDefault] {
-        firstRunSeeds.enumerated().map { index, seed in
-            let slug = slugify(seed.name)
-            let slot = index == 9 ? 0 : index + 1
-            return ProductDefault(
-                id: legacyBuiltInIdentityMap[slug]!,
-                slug: slug,
-                name: seed.name,
-                icon: seed.icon,
-                color: seed.color,
-                initialKeySlot: slot,
-                body: seed.body
-            )
-        }
+        CommandProductCatalog.defaults
     }
 
     /// A byte-for-byte representative of the pre-A0 production store: the

--- a/TheBridgeTests/CommandDirectionalCatalogTests.swift
+++ b/TheBridgeTests/CommandDirectionalCatalogTests.swift
@@ -1,0 +1,145 @@
+// CommandDirectionalCatalogTests.swift — B0 / GitHub #140
+//
+// Repository-backed directional defaults: five-part bodies, length and
+// prohibited-content validation, coding and knowledge-work neutrality,
+// and A0/A1 override preservation.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandDirectionalCatalogTests() async {
+    print("\n[Command directional catalog B0 / #140]")
+
+    await test("B0 live built-ins have stable repository identities") {
+        let catalog = CommandStore.defaultProductCatalog
+        try expect(catalog.count == 10)
+        try expect(CommandStore.legacyBuiltInIdentityMap.count == 10)
+        let expectedSlugs = [
+            "initiate", "propose", "scope-cut", "validate", "execute",
+            "review", "refocus", "open-loops", "close-agent", "hand-off",
+        ]
+        try expect(catalog.map(\.slug) == expectedSlugs)
+        for item in catalog {
+            try expect(CommandStore.legacyBuiltInIdentityMap[item.slug] == item.id)
+            try expect(item.id.hasPrefix("bridge.command.builtin."))
+            try expect(item.schemaVersion == 1)
+            try expect(item.behaviorVersion == 2)
+            try expect(item.requiredCapabilities.isEmpty)
+        }
+        try expect(catalog[0].initialKeySlot == 1)
+        try expect(catalog[9].initialKeySlot == 0)
+    }
+
+    await test("B0 every default meets the directional content contract") {
+        let issues = CommandProductCatalog.validateAll()
+        try expect(issues.isEmpty, issues.map { "\($0.slug): \($0.reason)" }.joined(separator: "; "))
+        for item in CommandStore.defaultProductCatalog {
+            try expect(CommandProductCatalog.wordCount(item.body) <= 120)
+            for label in CommandProductCatalog.requiredSectionLabels {
+                try expect(
+                    item.body.split(whereSeparator: \.isNewline).contains {
+                        $0.trimmingCharacters(in: .whitespaces).hasPrefix(label)
+                    },
+                    "\(item.slug) missing \(label)"
+                )
+            }
+        }
+    }
+
+    await test("B0 defaults stay useful for coding and knowledge-work tasks") {
+        let codingTask = "Ship the failing payment test without expanding scope."
+        let knowledgeTask = "Decide whether to keep the weekly review ritual."
+        for item in CommandStore.defaultProductCatalog {
+            try expect(!item.body.isEmpty)
+            try expect(
+                CommandProductCatalog.validate(item).isEmpty,
+                "\(item.slug) is not domain-neutral"
+            )
+            // The body is a lens, not a procedure: both task types can use it.
+            try expect(item.body.contains("Use when:"))
+            _ = codingTask
+            _ = knowledgeTask
+        }
+        let execute = CommandStore.defaultProductCatalog.first { $0.slug == "execute" }!
+        try expect(execute.body.contains("code, writing, research, or other shipping work"))
+        let openLoops = CommandStore.defaultProductCatalog.first { $0.slug == "open-loops" }!
+        try expect(openLoops.body.contains("shipping, research, or personal systems"))
+    }
+
+    await test("B0 exact-name and ID lookup resolve the live palette") {
+        try await withDirectionalStore { store, _ in
+            try store.seedIfEmpty()
+            let byName = try store.search("Initiate")
+            try expect(byName.contains { $0.slug == "initiate" && $0.name == "Initiate" })
+            let bySlug = try store.get(slug: "close-agent")
+            try expect(bySlug?.id == "bridge.command.builtin.close-agent")
+            let listed = try store.list()
+            try expect(listed.contains { $0.id == "bridge.command.builtin.hand-off" && $0.slug == "hand-off" })
+            try expect(listed.contains { $0.name == "Scope Cut" && $0.id == "bridge.command.builtin.scope-cut" })
+        }
+    }
+
+    await test("B0 installed-store fixture keeps overrides while defaults stay repository-backed") {
+        try await withDirectionalStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireDirectionalCommand(store, slug: "execute")
+            local.body = "operator-execute-override\nexact-bytes"
+            _ = try store.update(local)
+            try expect(try requireDirectionalCommand(store, slug: "execute").body
+                       == "operator-execute-override\nexact-bytes")
+
+            let incoming = CommandStore(storageRoot: root)
+            try expect(try requireDirectionalCommand(incoming, slug: "execute").body
+                       == "operator-execute-override\nexact-bytes",
+                       "B0 catalog rewrite overwrote a local override")
+            try expect(try requireDirectionalCommand(incoming, slug: "initiate").body
+                       == CommandStore.defaultProductCatalog[0].body)
+            let issues = CommandProductCatalog.validateAll()
+            try expect(issues.isEmpty)
+            let state = try incoming.reconciliation(slug: "execute")
+            try expect(state?.local?.body == "operator-execute-override\nexact-bytes")
+            try expect(state?.incoming.body == CommandStore.defaultProductCatalog[4].body)
+            try expect(state?.executionGate == .open)
+        }
+    }
+
+    await test("B0 validation rejects tool IDs, paths, retries, and overlong bodies") {
+        var item = CommandStore.defaultProductCatalog[0]
+        item.body = """
+        # Initiate
+        Mode: arrival.
+        Use when: starting.
+        Aim: ground.
+        Boundary: none.
+        Exit: next.
+        Run fetch_skill then retry ~/Library/Application Support/The Bridge.
+        """
+        let issues = CommandProductCatalog.validate(item)
+        try expect(issues.contains { $0.reason.contains("prohibited") })
+
+        item.body = (["word"] + Array(repeating: "padding", count: 120)).joined(separator: " ")
+        let longIssues = CommandProductCatalog.validate(item)
+        try expect(longIssues.contains { $0.reason.contains("words") })
+    }
+}
+
+private func withDirectionalStore(
+    _ body: (CommandStore, URL) async throws -> Void
+) async throws {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory
+        .appendingPathComponent("CommandDirectional-B0-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: root) }
+    try await body(CommandStore(storageRoot: root), root)
+}
+
+private func requireDirectionalCommand(
+    _ store: CommandStore,
+    slug: String
+) throws -> CommandStore.Command {
+    guard let command = try store.get(slug: slug) else {
+        throw TestError.assertion("missing command \(slug)")
+    }
+    return command
+}

--- a/TheBridgeTests/CommandReconciliationTests.swift
+++ b/TheBridgeTests/CommandReconciliationTests.swift
@@ -119,7 +119,7 @@ func runCommandReconciliationTests() async {
             local.body = "custom-initiate"
             _ = try store.update(local)
             var incomingCatalog = CommandStore.defaultProductCatalog
-            incomingCatalog[0].behaviorVersion = 2
+            incomingCatalog[0].behaviorVersion = CommandStore.ProductDefault.currentCatalogBehaviorVersion + 1
             incomingCatalog[0].body = "behavioral incoming"
             let incomingStore = CommandStore(storageRoot: root, productDefaults: incomingCatalog)
             let state = try requireReconciliation(incomingStore, slug: "initiate")

--- a/TheBridgeTests/CommandStoreTests.swift
+++ b/TheBridgeTests/CommandStoreTests.swift
@@ -173,7 +173,7 @@ func runCommandStoreTests() async {
         }
     }
 
-    await test("seeded Initiate command delegates to bridge_initialize") {
+    await test("seeded Initiate command is a directional arrival mode") {
         try await withTempHome { _ in
             try CommandStore.shared.resetForTesting()
             try CommandStore.shared.seedIfEmpty()
@@ -181,16 +181,16 @@ func runCommandStoreTests() async {
                 try expect(false, "expected Initiate seed to exist")
                 return
             }
-            try expect(initiate.body.contains("bridge_initialize"),
-                       "Initiate seed must call the canonical initializer")
-            try expect(initiate.body.contains("structured receipt"),
-                       "Initiate seed must treat the receipt as source of truth")
-            try expect(initiate.body.contains("Do not maintain a parallel startup checklist"),
-                       "Initiate seed must avoid duplicating the initializer protocol")
+            try expect(initiate.body.contains("Mode: arrival"),
+                       "Initiate must be an arrival mode")
+            try expect(initiate.body.contains("Use when:"),
+                       "Initiate must use the five-part directional contract")
+            try expect(!initiate.body.contains("bridge_initialize"),
+                       "Initiate must not embed the initializer tool ID")
         }
     }
 
-    await test("seeded Execute command routes through parent Keepr before executor") {
+    await test("seeded Execute command is a directional delivery mode without tool routing") {
         try await withTempHome { _ in
             try CommandStore.shared.resetForTesting()
             try CommandStore.shared.seedIfEmpty()
@@ -198,14 +198,14 @@ func runCommandStoreTests() async {
                 try expect(false, "expected Execute seed to exist")
                 return
             }
-            try expect(execute.body.contains("skills_routing_list"),
-                       "Execute seed must load the live routing roster")
-            try expect(execute.body.contains("parent Keepr"),
-                       "Execute seed must route through a parent Keepr")
-            try expect(execute.body.contains("Do not route directly to `executor`"),
-                       "Execute seed must explicitly prevent direct executor routing")
-            try expect(!execute.body.contains("fetch_skill('executor')"),
-                       "Execute seed must not tell agents to fetch executor directly")
+            try expect(execute.body.contains("Mode: delivery"),
+                       "Execute must be a delivery mode")
+            try expect(!execute.body.contains("skills_routing_list"),
+                       "Execute must not embed the routing roster tool ID")
+            try expect(!execute.body.contains("executor"),
+                       "Execute must not name executor; routing stays in skills")
+            try expect(!execute.body.contains("fetch_skill"),
+                       "Execute must not tell agents to fetch a skill")
         }
     }
 

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -863,6 +863,10 @@ await runCommandCustodyTests()
 // compatibility-required execution gating. No automatic body merge.
 await runCommandReconciliationTests()
 
+// GitHub #140 B0: directional repository defaults, length/content
+// validation, and A0/A1 override preservation.
+await runCommandDirectionalCatalogTests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-custody-a0.md
+++ b/docs/commands-custody-a0.md
@@ -119,3 +119,7 @@ directory.
 A1 (`docs/commands-reconciliation-a1.md`) adds optional `adoptedBases` on
 `layers.json` and `adopted-bases/<id>.md` bodies. Schema version remains 2.
 Existing A0 revisions without those keys stay valid.
+
+B0 (`docs/commands-directional-b0.md`) rewrites catalog bodies to the
+directional contract and sets `behaviorVersion` to 2. Schema version stays 1
+on the catalog; custody schema stays 2.

--- a/docs/commands-directional-b0.md
+++ b/docs/commands-directional-b0.md
@@ -1,0 +1,53 @@
+# Command directional catalog B0
+
+GitHub issue #140, packet B0 rewrites the ten built-in Command Bridge defaults
+as concise directional goal conditions. Skills and standing orders own
+repeatable procedures. A0 identities and A1 reconciliation stay in force.
+There is no Search UI, developer publication, merge, tag, or install in this
+packet.
+
+## Authority
+
+`CommandProductCatalog` is the repository SSOT for built-in bodies. 
+`CommandStore.defaultProductCatalog` is a façade over that catalog.
+
+| Layer | Owner | B0 change |
+| --- | --- | --- |
+| Immutable ID / slug / slot / icon / color | A0 | Unchanged |
+| Body contract | B0 | Mode, Use when, Aim, Boundary, Exit. ≤120 words. No tool IDs, paths, retries, or patch history |
+| `schemaVersion` | A1 | Stays **1** |
+| `behaviorVersion` | B0 | **2** — directional contract vs the A0 protocol-style bodies |
+| Local overrides | A0/A1 | Never overwritten by the catalog rewrite |
+
+Unmodified built-ins adopt the incoming directional body at read time (A1
+Current). Overrides stay byte-for-byte. An A0-era override against behavior 1
+classifies as Behavioral, not Compatibility-required; the fire path stays open.
+
+## Live palette
+
+| Slot | Slug | Name | Mode |
+| --- | --- | --- | --- |
+| 1 | `initiate` | Initiate | arrival |
+| 2 | `propose` | Propose | shaping |
+| 3 | `scope-cut` | Scope Cut | trim |
+| 4 | `validate` | Validate | hardening |
+| 5 | `execute` | Execute | delivery |
+| 6 | `review` | Review | checkpoint |
+| 7 | `refocus` | Refocus | realignment |
+| 8 | `open-loops` | Open Loops | inventory |
+| 9 | `close-agent` | Close Agent | closeout |
+| 0 | `hand-off` | Hand Off | transfer |
+
+Decide and Synthesize are out of scope. Hotkeys are unchanged.
+
+## Validation
+
+`CommandProductCatalog.validateAll()` is the static gate: word count, required
+section labels, prohibited tool/path/retry/patch tokens, and domain-exclusive
+terms that would make a default coding-only or knowledge-work-only.
+
+## Related
+
+- [`commands-custody-a0.md`](commands-custody-a0.md)
+- [`commands-reconciliation-a1.md`](commands-reconciliation-a1.md)
+- [`operator/commands-engineering-palette.md`](operator/commands-engineering-palette.md)

--- a/docs/commands-reconciliation-a1.md
+++ b/docs/commands-reconciliation-a1.md
@@ -62,3 +62,6 @@ Existing schema-2 revisions without `adoptedBases` decode as an empty map and
 remain valid. Restore/copy-from-base are unavailable until an A1 override
 creation snapshots a base; adopt-incoming and copy-from-incoming still work.
 Operator override bodies are never rewritten by catalog replacement.
+
+B0 (`docs/commands-directional-b0.md`) changes catalog `behaviorVersion` to 2
+for the directional rewrite. That is behavioral, not compatibility-required.

--- a/docs/operator/commands-engineering-palette.md
+++ b/docs/operator/commands-engineering-palette.md
@@ -1,28 +1,38 @@
 # Bridge Command Engineering Palette
 
-Operator reference for the 10-slot Command Bridge palette (keys **1–0**). Bodies live on disk at `~/Library/Application Support/The Bridge/commands/` (`index.json` + `<slug>.md`); this doc is the contract map only.
+Operator reference for the 10-slot Command Bridge palette (keys **1–0**).
+Product defaults live in the repository (`CommandProductCatalog`). Local
+overrides and custom commands live in durable custody and are never overwritten
+by an app update. This page must match the live catalog.
 
 ## Slot map
 
-| Key | Slug | Display name | Intent |
-|-----|------|--------------|--------|
-| **1** | `initiate` | Initiate Bridge | Full handshake + mentor mode until operator pivots |
-| **2** | `propose` | Propose | Step-by-step proposal thought process + light contract; C2C survey on real forks only |
-| **3** | `scope-cut` | Scope Cut | Trim IN/OUT after propose, before validate |
-| **4** | `validate` | Validate | Optional spec hardening + orchestrator dispatch |
-| **5** | `execute` | Execute | Post-approval sprint (*Plan approved…* opener) |
-| **6** | `review` | Review | Destructive/release checkpoint — operator GO required |
-| **7** | `refocus` | Refocus | Mini-handshake realignment mid-session |
-| **8** | `open-loops` | Loops | Phase A: inventory · Phase B: survey-driven close (lighter choice-to-contract per loop) |
-| **9** | `close-agent` | Close Agent | Telemetry, AGENT_FEEDBACK, Bridge memory, **Notion AI LOG Session row + URL**, close-agent protocol |
-| **0** | `hand-off` | Hand Off | Fresh-agent prompt when work continues elsewhere |
+| Key | Slug | Display name | Mode |
+|-----|------|--------------|------|
+| **1** | `initiate` | Initiate | Arrival. Orient before work moves. |
+| **2** | `propose` | Propose | Shaping. Do not build yet. |
+| **3** | `scope-cut` | Scope Cut | Trim required work from adjacent work. |
+| **4** | `validate` | Validate | Hardening. Is the plan ready to run? |
+| **5** | `execute` | Execute | Delivery of an approved contract. |
+| **6** | `review` | Review | Checkpoint before an irreversible step. |
+| **7** | `refocus` | Refocus | Re-anchor a drifted session. |
+| **8** | `open-loops` | Open Loops | Inventory unresolved threads. |
+| **9** | `close-agent` | Close Agent | Preserve what should survive the session. |
+| **0** | `hand-off` | Hand Off | Prepare the next agent without rediscovery. |
+
+Each body is a five-part directional goal condition: **Mode**, **Use when**,
+**Aim**, **Boundary**, **Exit**. ≤120 words. No tool IDs, paths, retries, or
+historical patches. Repeatable procedures belong in skills and standing orders.
 
 ## Lifecycle
 
 ```
-Initiate → Propose → Scope Cut → Validate → Execute → Review → Refocus → Loops → Close Agent → Hand Off
+Initiate → Propose → Scope Cut → Validate → Execute → Review → Refocus → Open Loops → Close Agent → Hand Off
                               ↘ Execute (fast ship) ↗
 ```
+
+The same palette is for coding and non-coding work. Nothing in a default body
+assumes a repository, a database, or a particular host.
 
 ## Stacking (multi-key paste)
 
@@ -30,37 +40,37 @@ Command Bridge fires one body per key. Paste keys back-to-back in one prompt.
 
 | Stack | Keys | When |
 |-------|------|------|
-| Full pipeline | 2 → 3 → 4 → 5 | Big/multi-domain work |
+| Full pipeline | 2 → 3 → 4 → 5 | Big or multi-domain work |
 | Fast ship | 2 → 5 | Scope already tight; skip validate |
 | Scope trim | 2 → 3 → 2 | Propose overscoped — cut then re-propose |
 | Post-ship | 5 → 6 | Execute then review checkpoint |
 | Continue | 6 → 7 → 2 | Review → refocus → new propose |
-| Loop open | 8 | Phase A inventory only (default single fire) |
-| Loop close | 8 (re-fire or stack) | Phase B: closing survey per fork, then evidence-backed close |
-| Session end | 8 → 9 | Close loops then close-agent |
-| Continue elsewhere | 9 → 0 | Close-agent then handoff prompt |
-| End only | 9 | Session ends at close-agent |
-
-## Voice
-
-Each command opens with identity and why the moment matters, then separates set-in-stone protocol from creative latitude — not generic checklist drones.
+| Loop inventory | 8 | List unresolved threads |
+| Session end | 8 → 9 | Inventory then closeout |
+| Continue elsewhere | 9 → 0 | Closeout then handoff brief |
+| End only | 9 | Session ends at closeout |
 
 ## Composition rules
 
-- **Propose** is planning-only — no executor fetch, no implement language.
-- **Execute** opens *Plan approved. Execute per contract below.* — never reuse propose language.
-- **Validate** is operator-fired; default path is **2 → 5** not **2 → 4 → 5**.
-- **Execute size gate:** >3 files OR >2 domains → orchestrator before material work.
-- **Loops (8):** Phase B uses lighter choice-to-contract surveys before closing ambiguous loops — operator chooses forks, agent executes.
-- **Hand Off (0)** does not run close-agent — that is **Close Agent (9)**.
-- **Close Agent (9)** writes a short `memory_remember` session summary (scope `project`, ~7d TTL) and a **Notion AI LOG Session** row (DS `992fd5ac-d938-4be4-95fb-8ef18bd86bba`) — **URL required in the closeout receipt**.
+- **Propose** does not start material work.
+- **Execute** runs only after an approved contract.
+- **Validate** is optional; the default path is **2 → 5**, not **2 → 4 → 5**.
+- **Hand Off (0)** does not run closeout — that is **Close Agent (9)**.
+- Local overrides stay local. Incoming defaults are inspectable through A1
+  reconciliation; bodies are never auto-merged.
 
 ## Test harness note
 
-`CommandsModuleTests` must use `BridgePaths.overrideHomeForTesting` before `CommandStore.shared.resetForTesting()`. Without it, `make test` wipes the live command store. Fixed 2026-06-29 after a production wipe from an un-sandboxed test run.
+`CommandsModuleTests` must use `BridgePaths.overrideHomeForTesting` before
+`CommandStore.shared.resetForTesting()`. Without it, `make test` wipes the live
+command store. Fixed 2026-06-29 after a production wipe from an un-sandboxed
+test run.
 
 ## Related
 
-- [`skill-command-routing-schema.md`](skill-command-routing-schema.md) — slug naming conventions
+- [`../../docs/commands-directional-b0.md`](../commands-directional-b0.md) — B0 contract
+- [`../../docs/commands-custody-a0.md`](../commands-custody-a0.md) — custody
+- [`../../docs/commands-reconciliation-a1.md`](../commands-reconciliation-a1.md) — reconciliation
+- [`skill-command-routing-schema.md`](skill-command-routing-schema.md) — slug naming
 - [`TheBridge/App/CommandBridge.swift`](../../TheBridge/App/CommandBridge.swift) — hot-key UI
-- [`TheBridge/Modules/Commands/CommandStore.swift`](../../TheBridge/Modules/Commands/CommandStore.swift) — persistence
+- [`TheBridge/Modules/Commands/CommandProductCatalog.swift`](../../TheBridge/Modules/Commands/CommandProductCatalog.swift) — live defaults


### PR DESCRIPTION
## Summary
- Replaces built-in command bodies with directional goal conditions (Mode, Use when, Aim, Boundary, Exit). Catalog SSOT is `CommandProductCatalog`; `behaviorVersion` is 2. IDs, slugs, slots, icons, and colors are unchanged.
- Does not retire `AGENT_FEEDBACK.md` (B1) and does not change hotkeys.
- Rebased onto `origin/main` after A1 merge (`d3ecbc0`). Source Tested on `139daf0`: TheBridgeTests **3689 passed, 0 failed**.

## Test plan
- [ ] CommandDirectionalCatalogTests pass
- [ ] Initiate/Execute no longer embed tool IDs
- [ ] Catalog word-count and prohibited-term validation hold
- [ ] A1 reconciliation still green on this SHA

Program issue: #140. Packet: PKT-1250 B0. REVIEW-FIRST packet executed; operator GO is to land on main for honest Done (E0 requires predecessors merged).


Made with [Cursor](https://cursor.com)