### PR TITLE
Add reversible Search favorite slots without mutating command bodies

### DIFF
--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -1150,6 +1150,8 @@ public final class CommandBridgeViewModel: ObservableObject {
     /// (PKT-1006 R2) Keyboard-selected typed search result id ("<kind>:<id>").
     /// ↑/↓ move it across groups; Enter fires its destination. nil → none.
     @Published public var selectedResultID: String? = nil
+    /// C0 Search favorite picker / Replace-Swap-Cancel prompt.
+    @Published public var favoriteSession = FavoriteLayoutSession()
     /// (v3.7.6) Monotonic focus token. The controller bumps this on EVERY
     /// show() (the panel is reused, so `.onAppear` only fires once); the view
     /// observes it and re-claims first responder on the query field.
@@ -1218,6 +1220,114 @@ public final class CommandBridgeViewModel: ObservableObject {
         let all = (try? store.list()) ?? []
         self.slotRows = Self.buildSlotRows(from: all)
         self.recentRows = Self.buildRecentRows(from: all, order: recents.ordered)
+        let layout = (try? store.favoriteLayout()) ?? FavoriteLayout()
+        if favoriteSession.current != layout && favoriteSession.pending == nil {
+            favoriteSession.current = layout
+        }
+    }
+
+    public func beginFavoritePicker(slug: String) {
+        var session = favoriteSession
+        session.openPicker(slug: slug)
+        favoriteSession = session
+    }
+
+    public func cancelFavoritePrompt() {
+        var session = favoriteSession
+        if session.pending != nil {
+            session.cancelPrompt()
+        } else {
+            session.closePicker()
+        }
+        favoriteSession = session
+    }
+
+    @discardableResult
+    public func handleFavoriteDigit(_ displayOrStoreSlot: Int) -> Bool {
+        if favoriteSession.pending != nil { return true }
+        guard let slug = favoriteSession.pickerSlug else { return false }
+        return assignFavorite(slug: slug, slot: displayOrStoreSlot)
+    }
+
+    public func assignFavorite(slug: String, slot: Int) -> Bool {
+        var session = favoriteSession
+        if let next = session.chooseSlot(slot, for: slug) {
+            favoriteSession = session
+            persistFavoriteLayout(next)
+            return true
+        }
+        favoriteSession = session
+        return favoriteSession.pending != nil
+    }
+
+    public func resolveFavoriteReplace() {
+        var session = favoriteSession
+        if let next = session.resolveReplace() {
+            favoriteSession = session
+            persistFavoriteLayout(next)
+        }
+    }
+
+    public func resolveFavoriteSwap() {
+        var session = favoriteSession
+        if let next = session.resolveSwap() {
+            favoriteSession = session
+            persistFavoriteLayout(next)
+        }
+    }
+
+    public func removeFavorite(slug: String) {
+        var session = favoriteSession
+        let next = session.remove(slug: slug)
+        favoriteSession = session
+        persistFavoriteLayout(next)
+    }
+
+    public func undoFavoriteLayout() {
+        var session = favoriteSession
+        if let previous = session.undo() {
+            favoriteSession = session
+            persistFavoriteLayout(previous, recordUndo: false)
+        }
+    }
+
+    public func selectedCommandSlug() -> String? {
+        guard let id = selectedResultID,
+              let result = searchResults.first(where: { $0.id == id }),
+              result.kind == .command
+        else { return nil }
+        return result.entityId
+    }
+
+    public func commandDisplayName(_ slug: String) -> String {
+        if let name = slotRows.compactMap(\.command).first(where: { $0.slug == slug })?.name {
+            return name
+        }
+        if let name = recentRows.first(where: { $0.slug == slug })?.name {
+            return name
+        }
+        if let title = searchResults.first(where: { $0.kind == .command && $0.entityId == slug })?.title {
+            return title
+        }
+        return (try? store.get(slug: slug))?.name ?? slug
+    }
+
+    private func persistFavoriteLayout(_ layout: FavoriteLayout, recordUndo: Bool = true) {
+        do {
+            try store.applyFavoriteLayout(layout)
+            if !recordUndo {
+                favoriteSession.current = layout
+            }
+            favoriteSession = favoriteSession
+            reload()
+            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                queryDidChange(query)
+            }
+        } catch {
+            favoriteSession = FavoriteLayoutSession(
+                current: (try? store.favoriteLayout()) ?? FavoriteLayout()
+            )
+        }
     }
 
     /// Search-as-you-type. Empty query → panelMode = .none and rows hidden.
@@ -1393,6 +1503,7 @@ public struct CommandBridgeRootView: View {
     // dragging by rasterizing the haloed text into a stable layer (no per-frame
     // shadow recompute), then release it on drag end.
     @State private var isDraggingWindow = false
+    @State private var hoveredSearchID: String?
 
     private var anim: CommandBridgeAnimation {
         reduceMotion ? .reduced : .locked
@@ -1438,11 +1549,25 @@ public struct CommandBridgeRootView: View {
         .background(WindowAccessor { paletteWindow = $0 })
         .simultaneousGesture(windowDrag)
         .background(KeyHandler(
-            onNumber: { n in model.onFireSlot(n) },
+            onNumber: { n in
+                if model.handleFavoriteDigit(n) { return }
+                model.onFireSlot(n)
+            },
+            onOptionNumber: { n in
+                if let slug = model.selectedCommandSlug() {
+                    _ = model.assignFavorite(slug: slug, slot: n)
+                }
+            },
             onArrowDown: { model.moveSelection(1) },
             onArrowUp: { model.moveSelection(-1) },
             onReturn: { commitTopSelection() },
-            onEscape: { model.onEscape() }
+            onEscape: {
+                if model.favoriteSession.pickerSlug != nil || model.favoriteSession.pending != nil {
+                    model.cancelFavoritePrompt()
+                } else {
+                    model.onEscape()
+                }
+            }
         ))
         .onAppear { queryFocused = true }
         // Re-assert field focus whenever the controller bumps the token (the
@@ -1578,7 +1703,13 @@ public struct CommandBridgeRootView: View {
                     onReturn: { commitTopSelection() },
                     onArrowDown: { model.moveSelection(1) },
                     onArrowUp: { model.moveSelection(-1) },
-                    onEscape: { model.onEscape() }
+                    onEscape: {
+                        if model.favoriteSession.pickerSlug != nil || model.favoriteSession.pending != nil {
+                            model.cancelFavoritePrompt()
+                        } else {
+                            model.onEscape()
+                        }
+                    }
                 )
                 .frame(maxWidth: .infinity)
             }
@@ -1678,6 +1809,13 @@ public struct CommandBridgeRootView: View {
                 if model.searchResults.isEmpty {
                     panelEmptyHint("No match for \"\(q)\".")
                 }
+                if let pickerSlug = model.favoriteSession.pickerSlug,
+                   model.favoriteSession.pending == nil {
+                    favoriteSlotPicker(slug: pickerSlug)
+                }
+                if let prompt = model.favoriteSession.pending {
+                    favoriteConflictPrompt(prompt)
+                }
             }
         }
         .padding(BridgeTokens.Space.s2)
@@ -1763,53 +1901,165 @@ public struct CommandBridgeRootView: View {
                            selected: Bool,
                            highlight: String) -> some View {
         let kindColor = NotionPalette.color(named: result.kind.colorTag) ?? BridgeTokens.fg2
-        Button {
-            model.onFireDestination(result.destination)
-        } label: {
-            HStack(spacing: BridgeTokens.Space.s4 - 2) {
-                // Color indicator dot — the kind's hue.
-                Circle()
-                    .fill(kindColor)
-                    .frame(width: 9, height: 9)
-                    .shadow(color: kindColor.opacity(0.6), radius: 2.5)
-                    .frame(width: 28, height: 28)
+        let isCommand = result.kind == .command
+        let slot = isCommand ? model.favoriteSession.current.slot(of: result.entityId) : nil
+        let showStar = isCommand && (
+            selected
+            || hoveredSearchID == result.id
+            || slot != nil
+            || model.favoriteSession.pickerSlug == result.entityId
+        )
+        HStack(spacing: 0) {
+            Button {
+                model.onFireDestination(result.destination)
+            } label: {
+                HStack(spacing: BridgeTokens.Space.s4 - 2) {
+                    Circle()
+                        .fill(kindColor)
+                        .frame(width: 9, height: 9)
+                        .shadow(color: kindColor.opacity(0.6), radius: 2.5)
+                        .frame(width: 28, height: 28)
 
-                VStack(alignment: .leading, spacing: 1) {
-                    highlightedName(result.title, query: highlight)
-                        .font(BridgeTokens.Typeface.name)
-                        .foregroundStyle(BridgeTokens.fg1)
-                        .lineLimit(1)
-                        .legibilityHalo()
-                    if let subtitle = result.subtitle, !subtitle.isEmpty {
-                        Text(subtitle)
-                            .font(BridgeTokens.Typeface.meta)
-                            .foregroundStyle(BridgeTokens.fg5)
+                    VStack(alignment: .leading, spacing: 1) {
+                        highlightedName(result.title, query: highlight)
+                            .font(BridgeTokens.Typeface.name)
+                            .foregroundStyle(BridgeTokens.fg1)
                             .lineLimit(1)
                             .legibilityHalo()
+                        if let subtitle = result.subtitle, !subtitle.isEmpty {
+                            Text(subtitle)
+                                .font(BridgeTokens.Typeface.meta)
+                                .foregroundStyle(BridgeTokens.fg5)
+                                .lineLimit(1)
+                                .legibilityHalo()
+                        }
                     }
+
+                    Spacer(minLength: BridgeTokens.Space.s1)
+
+                    Text(result.kind.tag)
+                        .font(.system(size: 9.5, weight: .semibold, design: .rounded))
+                        .foregroundStyle(kindColor)
+                        .padding(.horizontal, BridgeTokens.Space.s2)
+                        .frame(minHeight: 18)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(kindColor.opacity(0.16))
+                                .overlay(Capsule(style: .continuous)
+                                    .strokeBorder(kindColor.opacity(0.34), lineWidth: 0.5))
+                        )
                 }
-
-                Spacer(minLength: BridgeTokens.Space.s1)
-
-                // Type tag chip — kind label, kind-tinted fill + ink.
-                Text(result.kind.tag)
-                    .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-                    .foregroundStyle(kindColor)
-                    .padding(.horizontal, BridgeTokens.Space.s2)
-                    .frame(minHeight: 18)
-                    .background(
-                        Capsule(style: .continuous)
-                            .fill(kindColor.opacity(0.16))
-                            .overlay(Capsule(style: .continuous)
-                                .strokeBorder(kindColor.opacity(0.34), lineWidth: 0.5))
-                    )
+                .padding(.leading, BridgeTokens.Space.s3)
+                .padding(.trailing, showStar ? BridgeTokens.Space.s1 : BridgeTokens.Space.s3)
+                .frame(height: 46)
+                .background(rowBackground(selected: selected))
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, BridgeTokens.Space.s3)
-            .frame(height: 46)
-            .background(rowBackground(selected: selected))
+            .buttonStyle(.plain)
+
+            if isCommand {
+                favoriteStar(slug: result.entityId, slot: slot, visible: showStar)
+            }
+        }
+        .onHover { hovering in
+            hoveredSearchID = hovering ? result.id : (hoveredSearchID == result.id ? nil : hoveredSearchID)
+        }
+        .contextMenu {
+            if isCommand {
+                Button("Move to slot…") { model.beginFavoritePicker(slug: result.entityId) }
+                if slot != nil {
+                    Button("Remove favorite") { model.removeFavorite(slug: result.entityId) }
+                }
+                if model.favoriteSession.canUndo {
+                    Button("Undo favorite change") { model.undoFavoriteLayout() }
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(result.title)
+        .accessibilityValue(slot.map { "Favorite slot \($0)" } ?? (isCommand ? "Not favorited" : result.kind.tag))
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private func favoriteStar(slug: String, slot: Int?, visible: Bool) -> some View {
+        Button {
+            model.beginFavoritePicker(slug: slug)
+        } label: {
+            HStack(spacing: 2) {
+                Image(systemName: slot == nil ? "star" : "star.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(slot == nil ? BridgeTokens.fg4 : BridgeTokens.gold)
+                if let slot {
+                    Text(String(slot))
+                        .font(.system(size: 10, weight: .semibold, design: .rounded).monospacedDigit())
+                        .foregroundStyle(BridgeTokens.fg2)
+                }
+            }
+            .frame(width: 36, height: 46)
             .contentShape(Rectangle())
+            .opacity(visible ? 1 : 0)
+            .accessibilityLabel(slot == nil ? "Add favorite" : "Favorite slot \(slot!)")
         }
         .buttonStyle(.plain)
+        .disabled(!visible)
+        .help(slot == nil ? "Assign a favorite slot" : "Change or remove favorite slot")
+    }
+
+    @ViewBuilder
+    private func favoriteSlotPicker(slug: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Favorite slot for \(model.commandDisplayName(slug))")
+                .font(BridgeTokens.Typeface.meta)
+                .foregroundStyle(BridgeTokens.fg3)
+            HStack(spacing: 4) {
+                ForEach(FavoriteLayout.displayOrder, id: \.self) { slot in
+                    let taken = model.favoriteSession.current.slug(in: slot)
+                    Button {
+                        _ = model.assignFavorite(slug: slug, slot: slot)
+                    } label: {
+                        Text(String(slot))
+                            .font(.system(size: 11, weight: .semibold, design: .rounded).monospacedDigit())
+                            .frame(width: 22, height: 22)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(taken == slug ? BridgeTokens.glassControl : BridgeTokens.wellFill)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .help(taken == nil || taken == slug
+                          ? "Slot \(slot)"
+                          : "Slot \(slot) occupied by \(model.commandDisplayName(taken!))")
+                    .accessibilityLabel(taken == nil || taken == slug
+                                        ? "Favorite slot \(slot)"
+                                        : "Favorite slot \(slot), occupied by \(model.commandDisplayName(taken!))")
+                }
+            }
+        }
+        .padding(BridgeTokens.Space.s3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Choose favorite slot 1 through 0")
+    }
+
+    @ViewBuilder
+    private func favoriteConflictPrompt(_ prompt: FavoriteConflictPrompt) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Assigning \(model.commandDisplayName(prompt.slug)) to slot \(prompt.slot) would displace \(model.commandDisplayName(prompt.occupiedBy)).")
+                .font(BridgeTokens.Typeface.meta)
+                .foregroundStyle(BridgeTokens.fg2)
+            HStack(spacing: 8) {
+                Button("Replace") { model.resolveFavoriteReplace() }
+                if prompt.swap != nil {
+                    Button("Swap") { model.resolveFavoriteSwap() }
+                }
+                Button("Cancel") { model.cancelFavoritePrompt() }
+            }
+        }
+        .padding(BridgeTokens.Space.s3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Replace, swap, or cancel favorite assignment")
     }
 
     /// Selected-row treatment (`.cb-row.on`): faint accent tint + accent hairline
@@ -2190,6 +2440,7 @@ private struct WindowAccessor: NSViewRepresentable {
 /// delegate — see `QueryField.Coordinator`).
 private struct KeyHandler: NSViewRepresentable {
     let onNumber: (Int) -> Void
+    let onOptionNumber: (Int) -> Void
     let onArrowDown: () -> Void
     let onArrowUp: () -> Void
     let onReturn: () -> Void
@@ -2198,6 +2449,7 @@ private struct KeyHandler: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let v = MonitorView()
         v.onNumber = onNumber
+        v.onOptionNumber = onOptionNumber
         v.onArrowDown = onArrowDown
         v.onArrowUp = onArrowUp
         v.onReturn = onReturn
@@ -2205,10 +2457,19 @@ private struct KeyHandler: NSViewRepresentable {
         return v
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let v = nsView as? MonitorView else { return }
+        v.onNumber = onNumber
+        v.onOptionNumber = onOptionNumber
+        v.onArrowDown = onArrowDown
+        v.onArrowUp = onArrowUp
+        v.onReturn = onReturn
+        v.onEscape = onEscape
+    }
 
     final class MonitorView: NSView {
         var onNumber: ((Int) -> Void)?
+        var onOptionNumber: ((Int) -> Void)?
         var onArrowDown: (() -> Void)?
         var onArrowUp: (() -> Void)?
         var onReturn: (() -> Void)?
@@ -2228,18 +2489,13 @@ private struct KeyHandler: NSViewRepresentable {
             guard monitor == nil else { return }
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
                 guard let self else { return event }
-                // Only act when our window is key.
                 guard self.window?.isKeyWindow == true else { return event }
-                // If the focused first responder is the query text view
-                // (i.e. the user is typing), let it have the keystroke
-                // EXCEPT for the bare-number/bare-arrow shortcuts when
-                // the field is empty.
+                if Self.consumeOptionNumber(event, fire: self) { return nil }
                 let isFieldEditor = (self.window?.firstResponder is NSText)
                 if !isFieldEditor || (event.charactersIgnoringModifiers?.isEmpty ?? true) {
                     if Self.consume(event, fire: self) { return nil }
                 } else if let text = self.window?.firstResponder as? NSText,
                           text.string.isEmpty {
-                    // Empty field → bare number keys still fire the slot.
                     if Self.consume(event, fire: self) { return nil }
                 }
                 return event
@@ -2262,6 +2518,20 @@ private struct KeyHandler: NSViewRepresentable {
             // and the cleanup path above is sufficient (the monitor is
             // bound to a window-scoped block that no longer reaches a
             // dead view).
+        }
+
+        static func consumeOptionNumber(_ event: NSEvent, fire v: MonitorView) -> Bool {
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard mods.contains(.option),
+                  !mods.contains(.command),
+                  !mods.contains(.control),
+                  let chars = event.charactersIgnoringModifiers,
+                  chars.count == 1,
+                  let digit = chars.first?.wholeNumberValue,
+                  (0...9).contains(digit)
+            else { return false }
+            v.onOptionNumber?(digit)
+            return true
         }
 
         /// Returns true if the event was handled (swallowed).

--- a/TheBridge/Modules/Commands/CommandCustodyBackend.swift
+++ b/TheBridge/Modules/Commands/CommandCustodyBackend.swift
@@ -241,6 +241,28 @@ final class CommandCustodyBackend: @unchecked Sendable {
         try publishLocked(snapshot)
     }
 
+    func applyFavoriteLayout(slugsBySlot: [Int: String]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var snapshot = try mutableSnapshotLocked()
+        let commands = effectiveCommands(snapshot)
+        var next: [Int: String] = [:]
+        var seen = Set<String>()
+        for (slot, slug) in slugsBySlot {
+            try assertSlot(slot)
+            guard let existing = commands.first(where: { $0.slug == slug }) else {
+                throw CommandStore.StoreError.slugNotFound(slug)
+            }
+            guard seen.insert(existing.id).inserted else {
+                throw CommandStore.StoreError.corruptRevision("duplicate favorite slug \(slug)")
+            }
+            next[slot] = existing.id
+        }
+        snapshot.favorites = next
+        try publishLocked(snapshot)
+    }
+
     func recordUse(slug: String, at date: Date) throws {
         lock.lock()
         defer { lock.unlock() }

--- a/TheBridge/Modules/Commands/CommandStore.swift
+++ b/TheBridge/Modules/Commands/CommandStore.swift
@@ -318,6 +318,22 @@ public final class CommandStore: @unchecked Sendable {
         try custody.setKeySlot(slug: slug, slot: slot)
     }
 
+    /// Current 0…9 favorite map keyed by command slug. Bodies are not included.
+    public func favoriteLayout() throws -> FavoriteLayout {
+        var slots: [Int: String] = [:]
+        for command in try list() {
+            if let slot = command.keySlot {
+                slots[slot] = command.slug
+            }
+        }
+        return FavoriteLayout(slots: slots)
+    }
+
+    /// Replace the entire favorite map in one publish. Does not rewrite bodies.
+    public func applyFavoriteLayout(_ layout: FavoriteLayout) throws {
+        try custody.applyFavoriteLayout(slugsBySlot: layout.slots)
+    }
+
     /// Stamp lastUsedAt to now. Called when the command fires from the popup.
     public func recordUse(slug: String, at when: Date = Date()) throws {
         try custody.recordUse(slug: slug, at: when)

--- a/TheBridge/Modules/Commands/FavoriteLayout.swift
+++ b/TheBridge/Modules/Commands/FavoriteLayout.swift
@@ -1,0 +1,177 @@
+// FavoriteLayout.swift — GitHub #140 C0
+//
+// Pure favorite-map transactions. Slots are CommandStore keys 0…9 (displayed
+// 1…0). One command occupies at most one slot. Layout never carries command
+// bodies — persistence goes through A0's favorite map.
+
+import Foundation
+
+public struct FavoriteLayout: Equatable, Sendable {
+    public static let storeSlots = 0...9
+    public static let displayOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+
+    /// storeSlot → command slug
+    public private(set) var slots: [Int: String]
+
+    public init(slots: [Int: String] = [:]) {
+        var next: [Int: String] = [:]
+        var seen = Set<String>()
+        for slot in Self.storeSlots {
+            guard let slug = slots[slot], !slug.isEmpty, seen.insert(slug).inserted else { continue }
+            next[slot] = slug
+        }
+        self.slots = next
+    }
+
+    public func slug(in slot: Int) -> String? { slots[slot] }
+
+    public func slot(of slug: String) -> Int? {
+        slots.first(where: { $0.value == slug })?.key
+    }
+
+    public enum Assignment: Equatable, Sendable {
+        case applied(FavoriteLayout)
+        /// `swap` is nil when the moving command has no current slot — Replace
+        /// is the only occupancy resolution that can run.
+        case conflict(occupiedBy: String, replace: FavoriteLayout, swap: FavoriteLayout?)
+    }
+
+    public func assigning(slug: String, to slot: Int) -> Assignment? {
+        guard Self.storeSlots.contains(slot), !slug.isEmpty else { return nil }
+        if self.slot(of: slug) == slot {
+            return .applied(self)
+        }
+        guard let occupant = slots[slot], occupant != slug else {
+            return .applied(placing(slug, in: slot, evicting: nil))
+        }
+        let replace = placing(slug, in: slot, evicting: occupant)
+        let swap: FavoriteLayout?
+        if let origin = self.slot(of: slug) {
+            var next = slots
+            next[slot] = slug
+            next[origin] = occupant
+            swap = FavoriteLayout(slots: next)
+        } else {
+            swap = nil
+        }
+        return .conflict(occupiedBy: occupant, replace: replace, swap: swap)
+    }
+
+    public func removing(slug: String) -> FavoriteLayout {
+        FavoriteLayout(slots: slots.filter { $0.value != slug })
+    }
+
+    public func moving(slug: String, to slot: Int) -> FavoriteLayout? {
+        guard case .applied(let next) = assigning(slug: slug, to: slot) else { return nil }
+        return next
+    }
+
+    private func placing(_ slug: String, in slot: Int, evicting: String?) -> FavoriteLayout {
+        var next = slots.filter { $0.value != slug }
+        if let evicting {
+            next = next.filter { $0.value != evicting }
+        }
+        next[slot] = slug
+        return FavoriteLayout(slots: next)
+    }
+}
+
+public struct FavoriteConflictPrompt: Equatable, Sendable {
+    public let slug: String
+    public let slot: Int
+    public let occupiedBy: String
+    public let replace: FavoriteLayout
+    public let swap: FavoriteLayout?
+}
+
+public struct FavoriteLayoutSession: Equatable, Sendable {
+    public var current: FavoriteLayout
+    public var pending: FavoriteConflictPrompt?
+    public var pickerSlug: String?
+    private var undoStack: [FavoriteLayout]
+
+    public init(current: FavoriteLayout = FavoriteLayout()) {
+        self.current = current
+        self.pending = nil
+        self.pickerSlug = nil
+        self.undoStack = []
+    }
+
+    public var canUndo: Bool { !undoStack.isEmpty }
+
+    public mutating func openPicker(slug: String) {
+        pending = nil
+        pickerSlug = slug
+    }
+
+    public mutating func closePicker() {
+        pickerSlug = nil
+        pending = nil
+    }
+
+    /// Returns the layout to persist, or nil when a conflict prompt is now pending.
+    public mutating func chooseSlot(_ slot: Int, for slug: String) -> FavoriteLayout? {
+        guard let assignment = current.assigning(slug: slug, to: slot) else { return nil }
+        switch assignment {
+        case .applied(let next):
+            pending = nil
+            pickerSlug = nil
+            commit(next)
+            return current
+        case .conflict(let occupiedBy, let replace, let swap):
+            pending = FavoriteConflictPrompt(
+                slug: slug,
+                slot: slot,
+                occupiedBy: occupiedBy,
+                replace: replace,
+                swap: swap
+            )
+            return nil
+        }
+    }
+
+    public mutating func resolveReplace() -> FavoriteLayout? {
+        guard let pending else { return nil }
+        commit(pending.replace)
+        self.pending = nil
+        pickerSlug = nil
+        return current
+    }
+
+    public mutating func resolveSwap() -> FavoriteLayout? {
+        guard let pending, let swap = pending.swap else { return nil }
+        commit(swap)
+        self.pending = nil
+        pickerSlug = nil
+        return current
+    }
+
+    public mutating func cancelPrompt() {
+        pending = nil
+    }
+
+    public mutating func remove(slug: String) -> FavoriteLayout {
+        pickerSlug = nil
+        pending = nil
+        commit(current.removing(slug: slug))
+        return current
+    }
+
+    public mutating func undo() -> FavoriteLayout? {
+        guard let previous = undoStack.popLast() else { return nil }
+        current = previous
+        pending = nil
+        pickerSlug = nil
+        return current
+    }
+
+    private mutating func commit(_ next: FavoriteLayout) {
+        if next != current {
+            undoStack.append(current)
+            if undoStack.count > 20 {
+                undoStack.removeFirst()
+            }
+            current = next
+        }
+    }
+}

--- a/TheBridgeTests/CommandFavoriteLayoutTests.swift
+++ b/TheBridgeTests/CommandFavoriteLayoutTests.swift
@@ -1,0 +1,183 @@
+// CommandFavoriteLayoutTests.swift — C0 / GitHub #140
+//
+// Search favorite assignment is a reversible layout transaction. It never
+// mutates or duplicates command bodies. One command occupies at most one slot.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandFavoriteLayoutTests() async {
+    print("\n[Command Search favorites C0 / #140]")
+
+    await test("C0 empty slot assigns without a conflict prompt") {
+        var session = FavoriteLayoutSession()
+        let applied = session.chooseSlot(1, for: "alpha")
+        try expect(applied?.slug(in: 1) == "alpha")
+        try expect(session.pending == nil)
+        try expect(session.current.slot(of: "alpha") == 1)
+    }
+
+    await test("C0 occupied slot prompts Replace and optional Swap") {
+        var session = FavoriteLayoutSession(current: FavoriteLayout(slots: [1: "alpha", 2: "beta"]))
+        try expect(session.chooseSlot(1, for: "beta") == nil)
+        try expect(session.pending?.occupiedBy == "alpha")
+        try expect(session.pending?.swap != nil)
+        let swapped = session.resolveSwap()
+        try expect(swapped?.slug(in: 1) == "beta")
+        try expect(swapped?.slug(in: 2) == "alpha")
+    }
+
+    await test("C0 Replace evicts the occupant and frees the mover's old slot") {
+        var session = FavoriteLayoutSession(current: FavoriteLayout(slots: [1: "alpha", 2: "beta"]))
+        _ = session.chooseSlot(1, for: "beta")
+        let replaced = session.resolveReplace()
+        try expect(replaced?.slug(in: 1) == "beta")
+        try expect(replaced?.slot(of: "alpha") == nil)
+        try expect(replaced?.slug(in: 2) == nil)
+    }
+
+    await test("C0 unfavorited command cannot Swap onto an occupied slot") {
+        var session = FavoriteLayoutSession(current: FavoriteLayout(slots: [1: "alpha"]))
+        _ = session.chooseSlot(1, for: "gamma")
+        try expect(session.pending?.swap == nil)
+        try expect(session.resolveSwap() == nil)
+        let replaced = session.resolveReplace()
+        try expect(replaced?.slug(in: 1) == "gamma")
+        try expect(replaced?.slot(of: "alpha") == nil)
+    }
+
+    await test("C0 Cancel leaves the prior layout intact") {
+        var session = FavoriteLayoutSession(current: FavoriteLayout(slots: [1: "alpha"]))
+        _ = session.chooseSlot(1, for: "beta")
+        session.cancelPrompt()
+        try expect(session.current.slug(in: 1) == "alpha")
+        try expect(session.pending == nil)
+    }
+
+    await test("C0 Remove and Undo restore the prior layout") {
+        var session = FavoriteLayoutSession()
+        _ = session.chooseSlot(3, for: "alpha")
+        _ = session.remove(slug: "alpha")
+        try expect(session.current.slot(of: "alpha") == nil)
+        let undone = session.undo()
+        try expect(undone?.slug(in: 3) == "alpha")
+        try expect(session.canUndo)
+        _ = session.undo()
+        try expect(session.current.slots.isEmpty)
+        try expect(!session.canUndo)
+    }
+
+    await test("C0 one command occupies at most one slot") {
+        let layout = FavoriteLayout(slots: [1: "alpha", 4: "alpha", 0: "beta"])
+        try expect(layout.slot(of: "alpha") == 1)
+        try expect(layout.slug(in: 4) == nil)
+        try expect(layout.slug(in: 0) == "beta")
+    }
+
+    await test("C0 applyFavoriteLayout persists through A0 map without rewriting bodies") {
+        try await withTempHomeC0 { _ in
+            try CommandStore.shared.resetForTesting()
+            let a = try CommandStore.shared.create(name: "Alpha", icon: .emoji("a"), body: "body-a", keySlot: 1)
+            let b = try CommandStore.shared.create(name: "Beta", icon: .emoji("b"), body: "body-b", keySlot: 2)
+            try CommandStore.shared.applyFavoriteLayout(FavoriteLayout(slots: [0: a.slug, 9: b.slug]))
+            try expect(try CommandStore.shared.get(slug: a.slug)?.body == "body-a")
+            try expect(try CommandStore.shared.get(slug: b.slug)?.body == "body-b")
+            try expect(try CommandStore.shared.get(slug: a.slug)?.keySlot == 0)
+            try expect(try CommandStore.shared.get(slug: b.slug)?.keySlot == 9)
+            try expect(try CommandStore.shared.command(forKeySlot: 1) == nil)
+            try expect(try CommandStore.shared.favoriteLayout().slot(of: a.slug) == 0)
+        }
+    }
+
+    await test("C0 setKeySlot still evicts; layout round-trip survives a second apply") {
+        try await withTempHomeC0 { _ in
+            try CommandStore.shared.resetForTesting()
+            _ = try CommandStore.shared.create(name: "Keep", icon: .emoji("k"), body: "keep-body", keySlot: 5)
+            _ = try CommandStore.shared.create(name: "Move", icon: .emoji("m"), body: "move-body")
+            try CommandStore.shared.setKeySlot(slug: "move", slot: 5)
+            try expect(try CommandStore.shared.get(slug: "keep")?.body == "keep-body")
+            try expect(try CommandStore.shared.get(slug: "move")?.keySlot == 5)
+            let layout = try CommandStore.shared.favoriteLayout()
+            try CommandStore.shared.applyFavoriteLayout(layout)
+            try expect(try CommandStore.shared.get(slug: "keep")?.body == "keep-body")
+            try expect(try CommandStore.shared.get(slug: "move")?.body == "move-body")
+            try expect(try CommandStore.shared.get(slug: "move")?.keySlot == 5)
+        }
+    }
+
+    await test("C0 Search digits fire slots until the favorite picker is open") {
+        try await withTempHomeC0 { _ in
+            try CommandStore.shared.resetForTesting()
+            let created = try CommandStore.shared.create(
+                name: "Alpha", icon: .emoji("a"), body: "body-a")
+            let stole = await MainActor.run { () -> Bool in
+                let vm = CommandBridgeViewModel(
+                    store: CommandStore.shared,
+                    recents: CommandBridgeRecents(cap: 1)
+                )
+                return vm.handleFavoriteDigit(1)
+            }
+            try expect(!stole)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.keySlot == nil)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.body == "body-a")
+
+            let assigned = await MainActor.run { () -> Bool in
+                let vm = CommandBridgeViewModel(
+                    store: CommandStore.shared,
+                    recents: CommandBridgeRecents(cap: 1)
+                )
+                vm.beginFavoritePicker(slug: created.slug)
+                return vm.handleFavoriteDigit(3)
+            }
+            try expect(assigned)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.keySlot == 3)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.body == "body-a")
+        }
+    }
+
+    await test("C0 ViewModel Replace names the displaced command and keeps bodies intact") {
+        try await withTempHomeC0 { _ in
+            try CommandStore.shared.resetForTesting()
+            let a = try CommandStore.shared.create(
+                name: "Alpha", icon: .emoji("a"), body: "body-a", keySlot: 1)
+            let b = try CommandStore.shared.create(
+                name: "Beta", icon: .emoji("b"), body: "body-b")
+            let names = await MainActor.run { () -> (String, String, Bool) in
+                let vm = CommandBridgeViewModel(
+                    store: CommandStore.shared,
+                    recents: CommandBridgeRecents(cap: 1)
+                )
+                vm.beginFavoritePicker(slug: b.slug)
+                _ = vm.assignFavorite(slug: b.slug, slot: 1)
+                let occupant = vm.favoriteSession.pending.map {
+                    vm.commandDisplayName($0.occupiedBy)
+                } ?? ""
+                let mover = vm.favoriteSession.pending.map {
+                    vm.commandDisplayName($0.slug)
+                } ?? ""
+                vm.resolveFavoriteReplace()
+                return (mover, occupant, vm.favoriteSession.pending == nil)
+            }
+            try expect(names.0 == "Beta")
+            try expect(names.1 == "Alpha")
+            try expect(names.2)
+            try expect(try CommandStore.shared.get(slug: a.slug)?.body == "body-a")
+            try expect(try CommandStore.shared.get(slug: b.slug)?.body == "body-b")
+            try expect(try CommandStore.shared.get(slug: a.slug)?.keySlot == nil)
+            try expect(try CommandStore.shared.get(slug: b.slug)?.keySlot == 1)
+        }
+    }
+}
+
+private func withTempHomeC0(_ body: (URL) async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("CommandFavoriteLayout-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body(tmp)
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -871,6 +871,10 @@ await runCommandDirectionalCatalogTests()
 // bounded Calibrate report. AI LOG stays telemetry.
 await runCommandGitHubFirstFeedbackTests()
 
+// GitHub #140 C0: Search favorite layout transactions, Replace/Swap/Undo,
+// A0 favorite-map persistence, no command-body mutation.
+await runCommandFavoriteLayoutTests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-search-favorites-c0.md
+++ b/docs/commands-search-favorites-c0.md
@@ -1,0 +1,39 @@
+# Command Search favorites C0
+
+GitHub issue #140, packet C0. Bridge Search can assign, move, swap, replace,
+and undo favorite slots without mutating command bodies. The A0 favorite map
+is the only persistence surface.
+
+## Interaction
+
+Search stays quiet until a command row is hovered, focused, or already
+favorited. Then a star appears. An empty star opens the shared 1–0 picker.
+A filled star plus slot number means the command already occupies that slot.
+
+| Input | Result |
+| --- | --- |
+| Star click / context menu **Move to slot…** | Opens the shared 1–0 picker |
+| Digit 1–0 while picker is open | Assigns that store slot |
+| Option+digit on a selected command | Assigns without opening the picker first |
+| Occupied target, mover already slotted | **Replace**, **Swap**, or **Cancel** |
+| Occupied target, mover unslotted | **Replace** or **Cancel** (Swap is hidden) |
+| Context menu **Remove favorite** | Clears the command's slot |
+| Undo / context menu **Undo favorite change** | Restores the previous layout (20 deep) |
+| Escape | Cancels picker or prompt; otherwise hides Search |
+| Bare digit with picker closed | Still fires the slot, as before |
+
+Replace evicts the occupant. Swap exchanges the two slots. Cancel leaves the
+prior layout. Persistence is one `applyFavoriteLayout` publish, so a swap is
+never two half-states. `setKeySlot` in the editor still evicts atomically.
+
+## Quiet + accessibility
+
+Inactive rows do not show the star. Skills, jobs, and tools never get favorite
+controls. VoiceOver exposes slot value, Move/Remove, and the 1–0 picker.
+Keyboard and pointer reach the same layout transactions.
+
+## Out of scope
+
+No command creation, no editor inside Search, no product publication, no body
+rewrites. Live Search screenshots are a visual-review artifact, not an
+Installed Verified claim.


### PR DESCRIPTION
## Summary
- Bridge Search can assign, move, swap, replace, remove, and undo favorite slots (1–0) without rewriting command bodies.
- Persistence goes through A0's favorite map in one publish (`applyFavoriteLayout`).
- Search stays quiet until hover/focus/favorited. Occupied slots prompt Replace / Swap / Cancel and name the displaced command.
- Interaction spec: `docs/commands-search-favorites-c0.md`.

## Test plan
- [x] Local `TheBridgeTests` on exact SHA `3eb3097`: 3705 passed, 0 failed
- [ ] CI `build-and-test` SUCCESS
- [x] Favorite changes never modify command bodies (unit + ViewModel tests)
- [x] Bare digits still fire slots until the picker is open
- [ ] Live Search screenshots are a visual-review gap (UI-ITER fail-closed; interaction spec is the review artifact)

Closes nothing. GitHub #140 C0 / PKT-1252.