### PR TITLE
Write Memory action items as checkboxes and attach unique 2-token project prefixes

### DIFF
--- a/TheBridge/Modules/VoiceMemo/VoiceMemoMemoryRelationMatcher.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoMemoryRelationMatcher.swift
@@ -1,9 +1,10 @@
 // VoiceMemoMemoryRelationMatcher.swift — cache-only Memory relation attach
 // TheBridge · Modules · VoiceMemo
 //
-// Conservative matcher for memory_keep: unique contacts, distinctive
-// project/doc phrases (including unique 2-token prefixes), exact-title
-// blocks. Never creates PEOPLE rows.
+// Conservative matcher for memory_keep: unique 2+ token contact titles
+// or aliases only (1-token names never attach), distinctive project/doc
+// phrases (including unique 2-token prefixes), exact-title blocks.
+// Never creates PEOPLE rows.
 // Dual-sided Notion reverse-fill is accepted; we only write the Memory side.
 
 import Foundation
@@ -73,17 +74,24 @@ public struct VoiceMemoRelationCatalog: Sendable, Equatable {
     private static func strings(from value: Value?) -> [String] {
         switch value {
         case .string(let s):
-            let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
-            return t.isEmpty ? [] : [t]
+            return splitNewlines(s)
         case .array(let arr):
-            return arr.compactMap { item -> String? in
-                guard case .string(let s) = item else { return nil }
-                let t = s.trimmingCharacters(in: .whitespacesAndNewlines)
-                return t.isEmpty ? nil : t
+            return arr.flatMap { item -> [String] in
+                guard case .string(let s) = item else { return [] }
+                return splitNewlines(s)
             }
         default:
             return []
         }
+    }
+
+    /// Notion Alias often stores one blob with newline-separated phrases.
+    /// Index each line on its own so a shared pair on one line cannot be
+    /// glued to the rest of the blob.
+    static func splitNewlines(_ raw: String) -> [String] {
+        raw.split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 }
 
@@ -122,16 +130,25 @@ public enum VoiceMemoMemoryRelationMatcher {
         guard !hay.isEmpty, !catalog.isEmpty else { return VoiceMemoRelationMatch() }
 
         let contacts = matchContacts(hay: hay, entries: catalog.contacts)
+        // Projects and docs share distinctive-token/pair uniqueness so a
+        // geographic alias on a doc can block the same pair on a project.
+        let distinctiveEntries = catalog.projects + catalog.docs
+        let tokenOwners = distinctiveTokenIndex(distinctiveEntries)
+        let pairOwners = distinctivePairIndex(distinctiveEntries)
         return VoiceMemoRelationMatch(
             contactIds: contacts.ids,
-            projectIds: matchDistinctive(hay: hay, entries: catalog.projects),
-            docIds: matchDistinctive(hay: hay, entries: catalog.docs),
+            projectIds: matchDistinctive(
+                hay: hay, entries: catalog.projects, tokenOwners: tokenOwners, pairOwners: pairOwners
+            ),
+            docIds: matchDistinctive(
+                hay: hay, entries: catalog.docs, tokenOwners: tokenOwners, pairOwners: pairOwners
+            ),
             blockIds: matchExactTitles(hay: hay, entries: catalog.blocks, requireTwoTokens: true),
             notes: contacts.notes
         )
     }
 
-    // MARK: - Contacts (unique only; collisions listed, never attached)
+    // MARK: - Contacts (unique 2+ token title/alias only; first-name collisions noted)
 
     private static func matchContacts(
         hay: String,
@@ -141,32 +158,49 @@ public enum VoiceMemoMemoryRelationMatcher {
         var notes: [String] = []
         var attachedIds = Set<String>()
 
-        let byFull = Dictionary(grouping: entries) { normalize($0.title) }
-        for (full, group) in byFull where !full.isEmpty {
-            guard containsPhrase(hay, full) else { continue }
-            if group.count == 1, let only = group.first, attachedIds.insert(only.id).inserted {
+        var phraseOwners: [String: [VoiceMemoCacheEntry]] = [:]
+        for entry in entries {
+            for phrase in multiTokenPhrases(entry) {
+                phraseOwners[phrase, default: []].append(entry)
+            }
+        }
+        for (phrase, group) in phraseOwners {
+            guard containsPhrase(hay, phrase) else { continue }
+            let uniqueIds = Set(group.map(\.id))
+            if uniqueIds.count == 1, let only = group.first, attachedIds.insert(only.id).inserted {
                 attached.append(only.id)
-            } else if group.count >= 2 {
+            } else if uniqueIds.count >= 2 {
                 notes.append(collisionNote(label: group[0].title, entries: group))
             }
         }
 
+        // First-name hits are notes only when two or more contacts share the
+        // token and none of them already attached via a full name. Unique
+        // first names never attach (PEOPLE: full_name_only).
         let byFirst = Dictionary(grouping: entries) { firstToken(normalize($0.title)) }
         for (first, group) in byFirst where !first.isEmpty && first.count >= 2 {
             guard containsPhrase(hay, first) else { continue }
             let uniqueIds = Set(group.map(\.id))
-            if uniqueIds.count == 1, let only = group.first {
-                if attachedIds.insert(only.id).inserted {
-                    attached.append(only.id)
-                }
-            } else if uniqueIds.count >= 2 {
-                let already = group.contains { attachedIds.contains($0.id) }
-                if !already {
-                    notes.append(collisionNote(label: first.capitalized, entries: group))
-                }
+            guard uniqueIds.count >= 2 else { continue }
+            let already = group.contains { attachedIds.contains($0.id) }
+            if !already {
+                notes.append(collisionNote(label: first.capitalized, entries: group))
             }
         }
         return (attached, notes)
+    }
+
+    /// Titles and aliases with two or more tokens. 1-token names never attach.
+    private static func multiTokenPhrases(_ entry: VoiceMemoCacheEntry) -> [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for raw in sourcePhrases(entry) {
+            let phrase = normalize(raw)
+            let tokens = phrase.split(separator: " ")
+            guard tokens.count >= 2, seen.insert(phrase).inserted else { continue }
+            out.append(phrase)
+        }
+        return out
     }
 
     private static func collisionNote(label: String, entries: [VoiceMemoCacheEntry]) -> String {
@@ -178,9 +212,12 @@ public enum VoiceMemoMemoryRelationMatcher {
 
     // MARK: - Projects / docs (exact title/alias, unique 2-token prefix, or unique token)
 
-    private static func matchDistinctive(hay: String, entries: [VoiceMemoCacheEntry]) -> [String] {
-        let tokenOwners = distinctiveTokenIndex(entries)
-        let pairOwners = distinctivePairIndex(entries)
+    private static func matchDistinctive(
+        hay: String,
+        entries: [VoiceMemoCacheEntry],
+        tokenOwners: [String: Set<String>],
+        pairOwners: [String: Set<String>]
+    ) -> [String] {
         var ids: [String] = []
         var seen = Set<String>()
         for entry in entries {
@@ -198,7 +235,7 @@ public enum VoiceMemoMemoryRelationMatcher {
         tokenOwners: [String: Set<String>],
         pairOwners: [String: Set<String>]
     ) -> Bool {
-        let phrases = ([entry.title] + entry.aliases)
+        let phrases = sourcePhrases(entry)
             .map(normalize)
             .filter { !$0.isEmpty }
         for phrase in phrases {
@@ -228,7 +265,7 @@ public enum VoiceMemoMemoryRelationMatcher {
     private static func distinctiveTokenIndex(_ entries: [VoiceMemoCacheEntry]) -> [String: Set<String>] {
         var index: [String: Set<String>] = [:]
         for entry in entries {
-            let phrases = ([entry.title] + entry.aliases).map(normalize)
+            let phrases = sourcePhrases(entry).map(normalize)
             var tokens = Set<String>()
             for phrase in phrases {
                 for token in phrase.split(separator: " ").map(String.init) where !stoplist.contains(token) && token.count >= 3 {
@@ -247,7 +284,7 @@ public enum VoiceMemoMemoryRelationMatcher {
     private static func distinctivePairIndex(_ entries: [VoiceMemoCacheEntry]) -> [String: Set<String>] {
         var index: [String: Set<String>] = [:]
         for entry in entries {
-            for phrase in ([entry.title] + entry.aliases).map(normalize) {
+            for phrase in sourcePhrases(entry).map(normalize) {
                 let distinctive = phrase.split(separator: " ").map(String.init)
                     .filter { !stoplist.contains($0) && $0.count >= 3 }
                 guard distinctive.count >= 2 else { continue }
@@ -281,6 +318,10 @@ public enum VoiceMemoMemoryRelationMatcher {
     }
 
     // MARK: - Normalize / phrase
+
+    private static func sourcePhrases(_ entry: VoiceMemoCacheEntry) -> [String] {
+        ([entry.title] + entry.aliases).flatMap(VoiceMemoRelationCatalog.splitNewlines)
+    }
 
     public static func normalize(_ raw: String) -> String {
         var out = ""

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoMemoryRelationMatcher.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoMemoryRelationMatcher.swift
@@ -2,7 +2,8 @@
 // TheBridge · Modules · VoiceMemo
 //
 // Conservative matcher for memory_keep: unique contacts, distinctive
-// project/doc phrases, exact-title blocks. Never creates PEOPLE rows.
+// project/doc phrases (including unique 2-token prefixes), exact-title
+// blocks. Never creates PEOPLE rows.
 // Dual-sided Notion reverse-fill is accepted; we only write the Memory side.
 
 import Foundation
@@ -175,14 +176,17 @@ public enum VoiceMemoMemoryRelationMatcher {
         return "Skipped “\(label)” — \(names.count) contacts (\(shown)\(extra))"
     }
 
-    // MARK: - Projects / docs (exact title/alias, or distinctive ≥2-token phrase)
+    // MARK: - Projects / docs (exact title/alias, unique 2-token prefix, or unique token)
 
     private static func matchDistinctive(hay: String, entries: [VoiceMemoCacheEntry]) -> [String] {
         let tokenOwners = distinctiveTokenIndex(entries)
+        let pairOwners = distinctivePairIndex(entries)
         var ids: [String] = []
         var seen = Set<String>()
         for entry in entries {
-            guard matchProjectOrDoc(hay: hay, entry: entry, tokenOwners: tokenOwners) else { continue }
+            guard matchProjectOrDoc(
+                hay: hay, entry: entry, tokenOwners: tokenOwners, pairOwners: pairOwners
+            ) else { continue }
             if seen.insert(entry.id).inserted { ids.append(entry.id) }
         }
         return ids
@@ -191,7 +195,8 @@ public enum VoiceMemoMemoryRelationMatcher {
     private static func matchProjectOrDoc(
         hay: String,
         entry: VoiceMemoCacheEntry,
-        tokenOwners: [String: Set<String>]
+        tokenOwners: [String: Set<String>],
+        pairOwners: [String: Set<String>]
     ) -> Bool {
         let phrases = ([entry.title] + entry.aliases)
             .map(normalize)
@@ -203,6 +208,14 @@ public enum VoiceMemoMemoryRelationMatcher {
             if containsPhrase(hay, phrase) { return true }
             if distinctive.count >= 2, containsPhrase(hay, distinctive.joined(separator: " ")) {
                 return true
+            }
+            let pairTokens = distinctive.filter { $0.count >= 3 }
+            if pairTokens.count >= 2 {
+                for i in 0..<(pairTokens.count - 1) {
+                    let pair = pairTokens[i] + " " + pairTokens[i + 1]
+                    let owners = pairOwners[pair] ?? []
+                    if owners.count == 1, containsPhrase(hay, pair) { return true }
+                }
             }
             if distinctive.count == 1, let token = distinctive.first, token.count >= 3 {
                 let owners = tokenOwners[token] ?? []
@@ -224,6 +237,24 @@ public enum VoiceMemoMemoryRelationMatcher {
             }
             for token in tokens {
                 index[token, default: []].insert(entry.id)
+            }
+        }
+        return index
+    }
+
+    /// Consecutive distinctive ≥3-char token pairs, e.g. "emmiwood obk" from
+    /// "Emmiwood / OBK Website + Booking System". Shared pairs never attach.
+    private static func distinctivePairIndex(_ entries: [VoiceMemoCacheEntry]) -> [String: Set<String>] {
+        var index: [String: Set<String>] = [:]
+        for entry in entries {
+            for phrase in ([entry.title] + entry.aliases).map(normalize) {
+                let distinctive = phrase.split(separator: " ").map(String.init)
+                    .filter { !stoplist.contains($0) && $0.count >= 3 }
+                guard distinctive.count >= 2 else { continue }
+                for i in 0..<(distinctive.count - 1) {
+                    let pair = distinctive[i] + " " + distinctive[i + 1]
+                    index[pair, default: []].insert(entry.id)
+                }
             }
         }
         return index

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
@@ -634,7 +634,7 @@ public enum VoiceMemoModule {
                     ]),
                     "title": .object([
                         "type": .string("string"),
-                        "description": .string("Reminder title override; also the comment text fallback when body is unset."),
+                        "description": .string("Memory title for intentKind=memory_keep (wins over fields.title). Reminder title override; also the comment text fallback when body is unset."),
                     ]),
                     "body": .object([
                         "type": .string("string"),

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -966,12 +966,42 @@ public enum VoiceMemoProcessor {
     }
 
     static func resolvedMemoryKeepFields(intent: VoiceMemoIntent, plan: VoiceMemoPlan) -> [String: String] {
-        if !intent.fields.isEmpty { return intent.fields }
-        return VoiceMemoParser.memoryKeepFields(
-            title: intent.title ?? plan.generatedTitle,
-            summary: plan.summary,
-            actions: plan.actions
+        let overrideTitle = intent.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if intent.fields.isEmpty {
+            return VoiceMemoParser.memoryKeepFields(
+                title: overrideTitle.isEmpty ? plan.generatedTitle : overrideTitle,
+                summary: plan.summary,
+                actions: plan.actions
+            )
+        }
+
+        var fields = intent.fields
+        if !overrideTitle.isEmpty {
+            fields["title"] = overrideTitle
+            return fields
+        }
+
+        let existingTitle = fields["title"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !existingTitle.isEmpty {
+            return fields
+        }
+
+        let semantic = [
+            fields["summary"],
+            intent.body,
+            plan.summary,
+        ]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty } ?? ""
+        let fromSummary = VoiceMemoParser.sanitizeTitle(
+            nil,
+            fallback: VoiceMemoParser.firstSentencePublic(in: semantic, maxLen: 72)
         )
+        if !fromSummary.isEmpty {
+            fields["title"] = fromSummary
+        }
+        return fields
     }
 
     static func skipNoTranscript(
@@ -1108,13 +1138,14 @@ public enum VoiceMemoProcessor {
     /// Never invent "Follow up."
     static func memoryKeepActionItems(plan: VoiceMemoPlan, summaryText: String) -> [String] {
         let fromPlan = plan.actions
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .map { stripLeadingNextLabel($0) }
             .filter { !$0.isEmpty && !isFollowUpFiller($0) }
         if !fromPlan.isEmpty { return Array(fromPlan.prefix(12)) }
 
         var fromProse = proseActionSentences(from: summaryText)
         if fromProse.isEmpty {
             fromProse = VoiceMemoDegradedPreviewBuilder.build(from: summaryText).actions
+                .map { stripLeadingNextLabel($0) }
                 .filter { !isFollowUpFiller($0) }
         }
         return Array(fromProse.prefix(12))
@@ -1123,6 +1154,19 @@ public enum VoiceMemoProcessor {
     private static func isFollowUpFiller(_ text: String) -> Bool {
         let lower = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return lower == "follow up" || lower == "follow up." || lower == "follow-up" || lower == "follow-up."
+    }
+
+    /// Lifted checkboxes should not keep the "Next:" label in the to-do text.
+    private static func stripLeadingNextLabel(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        for prefix in ["next:", "next —", "next –", "next -"] {
+            if lower.hasPrefix(prefix) {
+                return String(trimmed.dropFirst(prefix.count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        return trimmed
     }
 
     private static func proseActionSentences(from text: String) -> [String] {
@@ -1138,7 +1182,10 @@ public enum VoiceMemoProcessor {
                 || lower.hasPrefix("i need to")
                 || lower.hasPrefix("i'll ")
                 || lower.hasPrefix("i will ")
-            if isAction { out.append(sentence) }
+            guard isAction else { continue }
+            let cleaned = stripLeadingNextLabel(sentence)
+            guard cleaned.count >= 12, !isFollowUpFiller(cleaned) else { continue }
+            out.append(cleaned)
         }
         return out
     }

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoProcessor.swift
@@ -1058,7 +1058,8 @@ public enum VoiceMemoProcessor {
                 ],
             ])
         }
-        if !plan.actions.isEmpty {
+        let actions = memoryKeepActionItems(plan: plan, summaryText: trimmed)
+        if !actions.isEmpty {
             children.append([
                 "object": "block",
                 "type": "heading_3",
@@ -1066,11 +1067,12 @@ public enum VoiceMemoProcessor {
                     "rich_text": [["type": "text", "text": ["content": "Action items"]]],
                 ],
             ])
-            for action in plan.actions.prefix(12) {
+            for action in actions.prefix(12) {
                 children.append([
                     "object": "block",
-                    "type": "bulleted_list_item",
-                    "bulleted_list_item": [
+                    "type": "to_do",
+                    "to_do": [
+                        "checked": false,
                         "rich_text": [["type": "text", "text": ["content": String(action.prefix(1900))]]],
                     ],
                 ])
@@ -1100,6 +1102,45 @@ public enum VoiceMemoProcessor {
             "blockId": .string(pageId),
             "children": .string(json),
         ]))
+    }
+
+    /// Plan actions first; otherwise lift "Next:" / "I need to" prose from the summary.
+    /// Never invent "Follow up."
+    static func memoryKeepActionItems(plan: VoiceMemoPlan, summaryText: String) -> [String] {
+        let fromPlan = plan.actions
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && !isFollowUpFiller($0) }
+        if !fromPlan.isEmpty { return Array(fromPlan.prefix(12)) }
+
+        var fromProse = proseActionSentences(from: summaryText)
+        if fromProse.isEmpty {
+            fromProse = VoiceMemoDegradedPreviewBuilder.build(from: summaryText).actions
+                .filter { !isFollowUpFiller($0) }
+        }
+        return Array(fromProse.prefix(12))
+    }
+
+    private static func isFollowUpFiller(_ text: String) -> Bool {
+        let lower = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lower == "follow up" || lower == "follow up." || lower == "follow-up" || lower == "follow-up."
+    }
+
+    private static func proseActionSentences(from text: String) -> [String] {
+        let parts = text
+            .replacingOccurrences(of: "\n", with: ". ")
+            .components(separatedBy: CharacterSet(charactersIn: ".!?"))
+        var out: [String] = []
+        for raw in parts {
+            let sentence = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard sentence.count >= 12, !isFollowUpFiller(sentence) else { continue }
+            let lower = sentence.lowercased()
+            let isAction = lower.hasPrefix("next")
+                || lower.hasPrefix("i need to")
+                || lower.hasPrefix("i'll ")
+                || lower.hasPrefix("i will ")
+            if isAction { out.append(sentence) }
+        }
+        return out
     }
 
     /// Legacy transcript append — retained for explicit opt-in callers only.

--- a/TheBridgeTests/VoiceMemoMemoryRelationMatcherTests.swift
+++ b/TheBridgeTests/VoiceMemoMemoryRelationMatcherTests.swift
@@ -1,9 +1,10 @@
 // VoiceMemoMemoryRelationMatcherTests.swift — cache-only Memory relation attach
 // TheBridge · Tests
 //
-// Unique contacts attach; first-name collisions are listed and never written.
-// Distinctive project/doc tokens attach; stoplist tokens do not. Blocks require
-// a two-token exact title. executeMemoryKeep writes bound relation keys only.
+// Unique 2+ token contacts attach; 1-token names never attach. First-name
+// collisions are listed and never written. Distinctive project/doc tokens
+// attach; stoplist tokens do not. Blocks require a two-token exact title.
+// executeMemoryKeep writes bound relation keys only.
 
 import Foundation
 import MCP
@@ -18,6 +19,13 @@ private let kFBD = "eeeeeeee-1111-2222-3333-444444444444"
 private let kWalk = "ffffffff-1111-2222-3333-444444444441"
 private let kDeepWork = "ffffffff-1111-2222-3333-444444444442"
 private let kIsaiahPlayerId = "dc8e8f3f-e607-4b5d-809e-ae289574f40c"
+private let kWill = "11111111-1111-2222-3333-444444444441"
+private let kLong = "11111111-1111-2222-3333-444444444442"
+private let kNewPerson = "11111111-1111-2222-3333-444444444443"
+private let kFairmont = "11111111-1111-2222-3333-444444444444"
+private let kBarro = "11111111-1111-2222-3333-444444444445"
+private let kConnector = "22222222-1111-2222-3333-444444444441"
+private let k605 = "22222222-1111-2222-3333-444444444442"
 
 private func sampleCatalog() -> VoiceMemoRelationCatalog {
     VoiceMemoRelationCatalog(
@@ -124,15 +132,21 @@ private func installRelationStubs(on router: ToolRouter, state: RelationStubStat
 }
 
 func runVoiceMemoMemoryRelationMatcherTests() async {
-    print("\n\u{1F517} Memory relation matcher — unique contacts + distinctive projects")
+    print("\n\u{1F517} Memory relation matcher — full-name contacts + distinctive projects")
 
-    await test("matcher: unique full name and unique first name attach") {
-        let match = VoiceMemoMemoryRelationMatcher.match(
+    await test("matcher: unique full name attaches; unique first name does not") {
+        let full = VoiceMemoMemoryRelationMatcher.match(
             haystack: "Talked to Andrew Moeller about the lake gathering.",
             catalog: sampleCatalog()
         )
-        try expect(match.contactIds == [kAndrew], "Andrew Moeller is unique, got \(match.contactIds)")
-        try expect(match.notes.isEmpty, "unique contact must not emit a collision note, got \(match.notes)")
+        try expect(full.contactIds == [kAndrew], "Andrew Moeller is unique, got \(full.contactIds)")
+        try expect(full.notes.isEmpty, "unique contact must not emit a collision note, got \(full.notes)")
+
+        let firstOnly = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Talked to Andrew about the lake gathering.",
+            catalog: sampleCatalog()
+        )
+        try expect(firstOnly.contactIds.isEmpty, "unique first name must not attach, got \(firstOnly.contactIds)")
     }
 
     await test("matcher: first-name collision lists names and attaches none") {
@@ -274,6 +288,11 @@ func runVoiceMemoMemoryRelationMatcherTests() async {
         try expect(appended.contains("\"to_do\""), "Next: prose must become a checkbox, got \(appended)")
         try expect(appended.contains("booking-flow screenshots") || appended.contains("booking flow screenshots"),
                    "checkbox must carry the physical next step, got \(appended)")
+        if let range = appended.range(of: "\"to_do\"") {
+            let todoSlice = String(appended[range.lowerBound...])
+            try expect(!todoSlice.lowercased().contains("next:"),
+                       "checkbox text must strip leading Next:, got \(todoSlice)")
+        }
         try expect(!appended.contains("Follow up"), "must not invent Follow up")
         let fields = await state.createdFields
         try expect(fields["projects"] == .string(kEmmiwood), "Emmiwood / OBK prefix must attach, got \(String(describing: fields["projects"]))")
@@ -310,5 +329,141 @@ func runVoiceMemoMemoryRelationMatcherTests() async {
         try expect(fields["contacts"] == nil, "unbound CONTACTS must not be written, got \(fields)")
         try expect(fields["players"] == .string(kIsaiahPlayerId), "PLAYERS must still attach")
         try expect(fields["projects"] == nil, "no project mention in this memo")
+    }
+
+    await test("matcher: ordinary 1-token words do not attach Will/Long/New/Fairmont") {
+        let catalog = VoiceMemoRelationCatalog(
+            contacts: [
+                VoiceMemoCacheEntry(id: kWill, title: "Will Cruz"),
+                VoiceMemoCacheEntry(id: kLong, title: "Long"),
+                VoiceMemoCacheEntry(id: kNewPerson, title: "New Person"),
+                VoiceMemoCacheEntry(id: kFairmont, title: "Fairmont Bus"),
+            ]
+        )
+        let match = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "It will take a long time for the new fairmont schedule.",
+            catalog: catalog
+        )
+        try expect(match.contactIds.isEmpty, "1-token titles and unique first names must not attach, got \(match.contactIds)")
+    }
+
+    await test("matcher: 1-token alias never attaches; 2-token title does") {
+        let catalog = VoiceMemoRelationCatalog(
+            contacts: [VoiceMemoCacheEntry(id: kBarro, title: "Barro Kannah", aliases: ["Barro"])]
+        )
+        let aliasOnly = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Talked to Barro about the lake gathering.",
+            catalog: catalog
+        )
+        try expect(aliasOnly.contactIds.isEmpty, "1-token alias must not attach, got \(aliasOnly.contactIds)")
+
+        let full = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Talked to Barro Kannah about the lake gathering.",
+            catalog: catalog
+        )
+        try expect(full.contactIds == [kBarro], "2-token title must attach, got \(full.contactIds)")
+    }
+
+    await test("matcher: shared Sioux Falls pair attaches none; unique geography still attaches") {
+        let shared = VoiceMemoRelationCatalog(
+            projects: [
+                VoiceMemoCacheEntry(id: kConnector, title: "Sioux Falls Connector Network"),
+            ],
+            docs: [
+                VoiceMemoCacheEntry(
+                    id: k605,
+                    title: "605 Good Dog PRD",
+                    aliases: ["Sioux Falls dog care\n605 good dog"]
+                ),
+            ]
+        )
+        let miss = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Driving just north of Sioux Falls this afternoon.",
+            catalog: shared
+        )
+        try expect(miss.projectIds.isEmpty, "shared Sioux Falls pair must not attach a project, got \(miss.projectIds)")
+        try expect(miss.docIds.isEmpty, "shared Sioux Falls pair must not attach a doc, got \(miss.docIds)")
+
+        let unique = VoiceMemoRelationCatalog(
+            projects: [
+                VoiceMemoCacheEntry(id: kConnector, title: "Sioux Falls Connector Network"),
+            ]
+        )
+        let residual = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Driving just north of Sioux Falls this afternoon.",
+            catalog: unique
+        )
+        try expect(residual.projectIds == [kConnector],
+                   "honesty: unique Sioux Falls project still attaches from geography, got \(residual.projectIds)")
+    }
+
+    await test("executeMemoryKeep: intent.title wins over missing fields.title") {
+        let router = ToolRouter(securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()), auditLog: AuditLog())
+        let state = RelationStubState()
+        await installRelationStubs(on: router, state: state, pageId: "page-title-from-intent")
+
+        _ = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: VoiceMemoIntent(
+                kind: .memoryKeep,
+                confidence: 0.95,
+                entityKey: "memory",
+                title: "Judah condolence letters",
+                fields: [
+                    "summary": "Barro wants the booking-flow screenshots before Friday go-live.",
+                ]
+            ),
+            plan: VoiceMemoPlan(
+                generatedTitle: "Lake gathering",
+                skipMemoryKeep: false,
+                summary: "Barro wants the booking-flow screenshots before Friday go-live.",
+                actions: [],
+                intents: []
+            ),
+            transcript: "Memory keep. I talked with Barro about the booking flow screenshots for Friday.",
+            router: router,
+            entity: memoryEntityWithRelations(),
+            catalog: sampleCatalog()
+        )
+
+        let fields = await state.createdFields
+        try expect(fields["title"] == .string("Judah condolence letters"),
+                   "intent.title must become Memory title, got \(String(describing: fields["title"]))")
+        try expect(fields["summary"] == nil, "Relevant select must not receive prose, got \(String(describing: fields["summary"]))")
+    }
+
+    await test("executeMemoryKeep: intent.title wins over stale fields.title") {
+        let router = ToolRouter(securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()), auditLog: AuditLog())
+        let state = RelationStubState()
+        await installRelationStubs(on: router, state: state, pageId: "page-title-override")
+
+        _ = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: VoiceMemoIntent(
+                kind: .memoryKeep,
+                confidence: 0.95,
+                entityKey: "memory",
+                title: "Judah condolence letters",
+                fields: [
+                    "title": "Sally Smith",
+                    "summary": "Barro wants the booking-flow screenshots before Friday go-live.",
+                ]
+            ),
+            plan: VoiceMemoPlan(
+                generatedTitle: "Sally Smith",
+                skipMemoryKeep: false,
+                summary: "Barro wants the booking-flow screenshots before Friday go-live.",
+                actions: [],
+                intents: []
+            ),
+            transcript: "Memory keep. I talked with Barro about the booking flow screenshots for Friday.",
+            router: router,
+            entity: memoryEntityWithRelations(),
+            catalog: sampleCatalog()
+        )
+
+        let fields = await state.createdFields
+        try expect(fields["title"] == .string("Judah condolence letters"),
+                   "commit/intent title must win over fields.title, got \(String(describing: fields["title"]))")
     }
 }

--- a/TheBridgeTests/VoiceMemoMemoryRelationMatcherTests.swift
+++ b/TheBridgeTests/VoiceMemoMemoryRelationMatcherTests.swift
@@ -220,6 +220,63 @@ func runVoiceMemoMemoryRelationMatcherTests() async {
         try expect(appended.contains("Hannah"), "Hannah collision must be listed in the body, got \(appended)")
         try expect(appended.contains("Isaiah will text Andrew Moeller"),
                    "action items must copy onto the body, got \(appended)")
+        try expect(appended.contains("\"to_do\""), "action items must be Notion checkboxes, got \(appended)")
+    }
+
+    await test("matcher: unique 2-token prefix attaches when emmiwood alone collides") {
+        let catalog = VoiceMemoRelationCatalog(
+            projects: [
+                VoiceMemoCacheEntry(id: kEmmiwood, title: "Emmiwood / OBK Website + Booking System"),
+                VoiceMemoCacheEntry(id: kFBD, title: "Emmiwood — Go Live Prep"),
+            ]
+        )
+        let miss = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Review Emmiwood before Friday.",
+            catalog: catalog
+        )
+        try expect(miss.projectIds.isEmpty, "shared Emmiwood token must not attach, got \(miss.projectIds)")
+
+        let hit = VoiceMemoMemoryRelationMatcher.match(
+            haystack: "Talked with Barro about Emmiwood / OBK.",
+            catalog: catalog
+        )
+        try expect(hit.projectIds == [kEmmiwood], "unique emmiwood obk prefix must attach, got \(hit.projectIds)")
+    }
+
+    await test("executeMemoryKeep: Next: prose becomes a to_do when plan.actions is empty") {
+        let router = ToolRouter(securityGate: SecurityGate(approvalProvider: TestSecurityApprovalProvider()), auditLog: AuditLog())
+        let state = RelationStubState()
+        await installRelationStubs(on: router, state: state, pageId: "page-next-todo")
+
+        _ = try await VoiceMemoProcessor.executeMemoryKeep(
+            entityKey: "memory",
+            intent: VoiceMemoIntent(
+                kind: .memoryKeep,
+                confidence: 0.95,
+                entityKey: "memory",
+                title: "Barro screenshots",
+                fields: [:]
+            ),
+            plan: VoiceMemoPlan(
+                generatedTitle: "Barro screenshots",
+                skipMemoryKeep: false,
+                summary: "Talked with Barro about Emmiwood / OBK. Next: send him the booking-flow screenshots so he can confirm the go-live checklist.",
+                actions: [],
+                intents: []
+            ),
+            transcript: "Memory keep. I talked with Barro about Emmiwood / OBK. Next, I need to send him the booking flow screenshots.",
+            router: router,
+            entity: memoryEntityWithRelations(),
+            catalog: sampleCatalog()
+        )
+
+        let appended = await state.appendedChildrenJSON
+        try expect(appended.contains("\"to_do\""), "Next: prose must become a checkbox, got \(appended)")
+        try expect(appended.contains("booking-flow screenshots") || appended.contains("booking flow screenshots"),
+                   "checkbox must carry the physical next step, got \(appended)")
+        try expect(!appended.contains("Follow up"), "must not invent Follow up")
+        let fields = await state.createdFields
+        try expect(fields["projects"] == .string(kEmmiwood), "Emmiwood / OBK prefix must attach, got \(String(describing: fields["projects"]))")
     }
 
     await test("executeMemoryKeep: unbound CONTACTS is skipped, PLAYERS still writes") {


### PR DESCRIPTION
## Summary
- Memory `executeMemoryKeep` now appends action items as Notion `to_do` checkboxes. When `plan.actions` is empty, it lifts “Next:” / “I need to” / “I’ll” / “I will” from the summary and never invents “Follow up.”
- Projects/docs attach on a unique consecutive ≥3-char 2-token prefix (e.g. `emmiwood obk`) when a shared single token would otherwise miss. Shared pairs still attach none.
- BLOCKS stay exact-title. TIME/EVENT matching, old-memo reprocess, Sparkle, and version bump stay out.

## Test plan
- [ ] `TheBridgeTests` green (measured 3696 passed / 0 failed before merging main #162)
- [ ] Unique 2-token prefix attaches Emmiwood/OBK when `emmiwood` collides; `Emmiwood` alone attaches none
- [ ] Empty `plan.actions` + “Next: send him the booking-flow…” becomes a checkbox
- [ ] After install, record a **new** memo (not the existing Barro row, not the 195 backlog): checkbox + Emmiwood/OBK project attach; unique-contact Barro behavior unchanged


Made with [Cursor](https://cursor.com)