### PR TITLE
C1: explicit Search create and ID-stable command deep links

### DIFF
--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -922,6 +922,9 @@ public final class CommandBridgeController: NSObject {
         model.onFireDestination = { [weak self] dest in self?.fireDestination(dest) }
         model.onEscape   = { [weak self] in self?.hide() }
         model.onSettings = { [weak self] in self?.openCommandsSettings() }
+        model.onEditCommandID = { [weak self] id in
+            self?.navigateSettings(.orders, anchor: CommandSettingsDeepLink.anchor(commandID: id))
+        }
         // (v3.7.6) Dashboard popover presenter. The pill no longer carries a
         // leading bridge-mark (the design `.cb-pill` has none — see `pill`), so
         // this is invoked from the status-bar item path rather than the palette
@@ -992,7 +995,11 @@ public final class CommandBridgeController: NSObject {
                 kind: .command,
                 id: c.slug,
                 title: c.name,
-                subtitle: c.keySlot.map { "slot \($0)" },
+                subtitle: CommandSearchCreate.searchSubtitle(
+                    slot: c.keySlot,
+                    body: c.body,
+                    sensitivePaths: ConfigManager.shared.sensitivePaths
+                ),
                 destination: .command(slug: c.slug),
                 recency: c.lastUsedAt
             ))
@@ -1152,6 +1159,10 @@ public final class CommandBridgeViewModel: ObservableObject {
     @Published public var selectedResultID: String? = nil
     /// C0 Search favorite picker / Replace-Swap-Cancel prompt.
     @Published public var favoriteSession = FavoriteLayoutSession()
+    /// C1 explicit create sheet. Nil means Search is not creating.
+    @Published public var createAssessment: CommandCreateAssessment? = nil
+    @Published public var createDraft = CommandCreateDraft()
+    @Published public var createError: String? = nil
     /// (v3.7.6) Monotonic focus token. The controller bumps this on EVERY
     /// show() (the panel is reused, so `.onAppear` only fires once); the view
     /// observes it and re-claims first responder on the query field.
@@ -1188,6 +1199,8 @@ public final class CommandBridgeViewModel: ObservableObject {
     /// (the design `.cb-pill` has no leading mark); retained for the status-bar
     /// entry point that presents the same Dashboard surface.
     public var onBridgeMark: () -> Void = {}
+    /// C1 Edit/Reveal: Settings deep-link by immutable command ID.
+    public var onEditCommandID: (String) -> Void = { _ in }
 
     private let store: CommandStore
     private let recents: CommandBridgeRecents
@@ -1297,6 +1310,69 @@ public final class CommandBridgeViewModel: ObservableObject {
               result.kind == .command
         else { return nil }
         return result.entityId
+    }
+
+    public func beginCreateFromQuery() {
+        createDraft = CommandSearchCreate.draft(fromSearchText: query)
+        createError = nil
+        refreshCreateAssessment()
+    }
+
+    public func cancelCreate() {
+        createAssessment = nil
+        createError = nil
+    }
+
+    public func refreshCreateAssessment() {
+        let existing = (try? store.list()) ?? []
+        createAssessment = CommandSearchCreate.assess(
+            draft: createDraft,
+            existing: existing,
+            sensitivePaths: ConfigManager.shared.sensitivePaths
+        )
+        createError = nil
+    }
+
+    @discardableResult
+    public func confirmCreate() -> CommandStore.Command? {
+        refreshCreateAssessment()
+        guard let assessment = createAssessment, assessment.canProposeSave else { return nil }
+        do {
+            let created = try store.create(
+                name: assessment.draft.trimmedName,
+                icon: .emoji("✨"),
+                body: assessment.draft.trimmedBody,
+                keySlot: assessment.draft.keySlot
+            )
+            createAssessment = nil
+            createError = nil
+            reload()
+            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                queryDidChange(query)
+            }
+            return created
+        } catch {
+            createError = error.localizedDescription
+            return nil
+        }
+    }
+
+    public func editCommand(slug: String) {
+        guard let command = try? store.get(slug: slug), !command.id.isEmpty else { return }
+        onEditCommandID(command.id)
+    }
+
+    public func duplicateCommand(slug: String) {
+        guard let command = try? store.get(slug: slug) else { return }
+        let names = ((try? store.list()) ?? []).map(\.name)
+        let copy = CommandSearchCreate.duplicateBody(of: command, existingNames: names)
+        createDraft = CommandCreateDraft(name: copy.name, body: copy.body)
+        createError = nil
+        refreshCreateAssessment()
+    }
+
+    public func revealCommand(slug: String) {
+        editCommand(slug: slug)
     }
 
     public func commandDisplayName(_ slug: String) -> String {
@@ -1439,6 +1515,7 @@ public final class CommandBridgeViewModel: ObservableObject {
         searchResults = []
         selectedResultID = nil
         panelMode = .none
+        cancelCreate()
     }
 
     // MARK: Pure builders (unit-tested)
@@ -1550,10 +1627,12 @@ public struct CommandBridgeRootView: View {
         .simultaneousGesture(windowDrag)
         .background(KeyHandler(
             onNumber: { n in
+                if model.createAssessment != nil { return }
                 if model.handleFavoriteDigit(n) { return }
                 model.onFireSlot(n)
             },
             onOptionNumber: { n in
+                if model.createAssessment != nil { return }
                 if let slug = model.selectedCommandSlug() {
                     _ = model.assignFavorite(slug: slug, slot: n)
                 }
@@ -1561,13 +1640,8 @@ public struct CommandBridgeRootView: View {
             onArrowDown: { model.moveSelection(1) },
             onArrowUp: { model.moveSelection(-1) },
             onReturn: { commitTopSelection() },
-            onEscape: {
-                if model.favoriteSession.pickerSlug != nil || model.favoriteSession.pending != nil {
-                    model.cancelFavoritePrompt()
-                } else {
-                    model.onEscape()
-                }
-            }
+            onEscape: { handleSearchEscape() },
+            onCreateShortcut: { model.beginCreateFromQuery() }
         ))
         .onAppear { queryFocused = true }
         // Re-assert field focus whenever the controller bumps the token (the
@@ -1643,6 +1717,17 @@ public struct CommandBridgeRootView: View {
             .buttonStyle(.plain)
             .frame(width: CommandBridgeChrome.tileSize, height: CommandBridgeChrome.tileSize)
             .contentShape(RoundedRectangle(cornerRadius: CommandBridgeChrome.tileCornerRadius, style: .continuous))
+            .contextMenu {
+                Button("Edit") { model.editCommand(slug: cmd.slug) }
+                Button("Duplicate") { model.duplicateCommand(slug: cmd.slug) }
+                Button("Reveal in Settings") { model.revealCommand(slug: cmd.slug) }
+                Divider()
+                Button("Move to slot…") { model.beginFavoritePicker(slug: cmd.slug) }
+                Button("Remove favorite") { model.removeFavorite(slug: cmd.slug) }
+                if model.favoriteSession.canUndo {
+                    Button("Undo favorite change") { model.undoFavoriteLayout() }
+                }
+            }
             // Co-born with bar: opacity only (no under-keycap, no group scale).
             .opacity(model.didOpen ? 1.0 : 0.0)
             .animation(
@@ -1703,13 +1788,8 @@ public struct CommandBridgeRootView: View {
                     onReturn: { commitTopSelection() },
                     onArrowDown: { model.moveSelection(1) },
                     onArrowUp: { model.moveSelection(-1) },
-                    onEscape: {
-                        if model.favoriteSession.pickerSlug != nil || model.favoriteSession.pending != nil {
-                            model.cancelFavoritePrompt()
-                        } else {
-                            model.onEscape()
-                        }
-                    }
+                    onEscape: { handleSearchEscape() },
+                    onCreateShortcut: { model.beginCreateFromQuery() }
                 )
                 .frame(maxWidth: .infinity)
             }
@@ -1808,6 +1888,34 @@ public struct CommandBridgeRootView: View {
                 }
                 if model.searchResults.isEmpty {
                     panelEmptyHint("No match for \"\(q)\".")
+                }
+                if !q.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                   model.createAssessment == nil {
+                    Button {
+                        model.beginCreateFromQuery()
+                    } label: {
+                        HStack(spacing: BridgeTokens.Space.s3) {
+                            Image(systemName: "plus.circle")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(BridgeTokens.fg3)
+                            Text("Create command from this text")
+                                .font(BridgeTokens.Typeface.meta)
+                                .foregroundStyle(BridgeTokens.fg2)
+                            Spacer(minLength: 0)
+                            Text("⌥↩")
+                                .font(BridgeTokens.Typeface.micro)
+                                .foregroundStyle(BridgeTokens.fg5)
+                        }
+                        .padding(.horizontal, BridgeTokens.Space.s3)
+                        .frame(height: 36)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open the create sheet. Ordinary Return never saves.")
+                    .accessibilityLabel("Create command from this text")
+                }
+                if model.createAssessment != nil {
+                    createCommandSheet
                 }
                 if let pickerSlug = model.favoriteSession.pickerSlug,
                    model.favoriteSession.pending == nil {
@@ -1966,6 +2074,10 @@ public struct CommandBridgeRootView: View {
         }
         .contextMenu {
             if isCommand {
+                Button("Edit") { model.editCommand(slug: result.entityId) }
+                Button("Duplicate") { model.duplicateCommand(slug: result.entityId) }
+                Button("Reveal in Settings") { model.revealCommand(slug: result.entityId) }
+                Divider()
                 Button("Move to slot…") { model.beginFavoritePicker(slug: result.entityId) }
                 if slot != nil {
                     Button("Remove favorite") { model.removeFavorite(slug: result.entityId) }
@@ -2062,6 +2174,110 @@ public struct CommandBridgeRootView: View {
         .accessibilityLabel("Replace, swap, or cancel favorite assignment")
     }
 
+    @ViewBuilder
+    private var createCommandSheet: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Create command")
+                .font(BridgeTokens.Typeface.meta)
+                .foregroundStyle(BridgeTokens.fg3)
+            TextField("Name", text: Binding(
+                get: { model.createDraft.name },
+                set: { model.createDraft.name = $0; model.refreshCreateAssessment() }
+            ))
+            .textFieldStyle(.plain)
+            .font(BridgeTokens.Typeface.name)
+            .foregroundStyle(BridgeTokens.fg1)
+            .padding(.horizontal, BridgeTokens.Space.s2)
+            .frame(height: 28)
+            .background(BridgeTokens.wellFill, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            TextEditor(text: Binding(
+                get: { model.createDraft.body },
+                set: { model.createDraft.body = $0; model.refreshCreateAssessment() }
+            ))
+            .font(BridgeTokens.Typeface.meta)
+            .foregroundStyle(BridgeTokens.fg2)
+            .scrollContentBackground(.hidden)
+            .frame(minHeight: 64, maxHeight: 96)
+            .padding(4)
+            .background(BridgeTokens.wellFill, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            Toggle("Treat as sensitive", isOn: Binding(
+                get: { model.createDraft.sensitive },
+                set: { model.createDraft.sensitive = $0; model.refreshCreateAssessment() }
+            ))
+            .font(BridgeTokens.Typeface.meta)
+            .foregroundStyle(BridgeTokens.fg3)
+            .toggleStyle(.checkbox)
+            HStack(spacing: 4) {
+                Text("Slot")
+                    .font(BridgeTokens.Typeface.meta)
+                    .foregroundStyle(BridgeTokens.fg5)
+                ForEach(FavoriteLayout.displayOrder, id: \.self) { slot in
+                    let selected = model.createDraft.keySlot == slot
+                    Button {
+                        model.createDraft.keySlot = selected ? nil : slot
+                        model.refreshCreateAssessment()
+                    } label: {
+                        Text(String(slot))
+                            .font(.system(size: 11, weight: .semibold, design: .rounded).monospacedDigit())
+                            .frame(width: 22, height: 22)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(selected ? BridgeTokens.glassControl : BridgeTokens.wellFill)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Optional favorite slot \(slot)")
+                }
+            }
+            if let assessment = model.createAssessment {
+                ForEach(Array(assessment.duplicates.enumerated()), id: \.offset) { _, dup in
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(duplicateWarning(dup))
+                            .font(BridgeTokens.Typeface.meta)
+                            .foregroundStyle(BridgeTokens.fg2)
+                        if case .exactSlug(let slug) = dup {
+                            Button("Edit existing") { model.editCommand(slug: slug) }
+                        } else if case .exactName(let slug) = dup {
+                            Button("Edit existing") { model.editCommand(slug: slug) }
+                        } else if case .nearName(let slug) = dup {
+                            Button("Open similar") { model.editCommand(slug: slug) }
+                        }
+                    }
+                }
+                if !assessment.sensitiveHits.isEmpty {
+                    Text("Sensitive path warning: \(assessment.sensitiveHits.joined(separator: ", ")). Body previews stay suppressed.")
+                        .font(BridgeTokens.Typeface.meta)
+                        .foregroundStyle(BridgeTokens.fg2)
+                }
+            }
+            if let error = model.createError {
+                Text(error)
+                    .font(BridgeTokens.Typeface.meta)
+                    .foregroundStyle(BridgeTokens.fg2)
+            }
+            HStack(spacing: 8) {
+                Button("Save") { _ = model.confirmCreate() }
+                    .disabled(!(model.createAssessment?.canProposeSave ?? false))
+                Button("Cancel") { model.cancelCreate() }
+            }
+        }
+        .padding(BridgeTokens.Space.s3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Create command sheet")
+    }
+
+    private func duplicateWarning(_ dup: CommandCreateDuplicate) -> String {
+        switch dup {
+        case .exactSlug(let slug):
+            return "A command already uses this identity (\(model.commandDisplayName(slug)))."
+        case .exactName(let slug):
+            return "A command already has this name (\(model.commandDisplayName(slug)))."
+        case .nearName(let slug):
+            return "Similar to \(model.commandDisplayName(slug))."
+        }
+    }
+
     /// Selected-row treatment (`.cb-row.on`): faint accent tint + accent hairline
     /// ring + a 2.5pt accent-strong rail down the leading edge. Unselected is clear.
     @ViewBuilder
@@ -2129,9 +2345,21 @@ public struct CommandBridgeRootView: View {
         return "\(Int(interval / 86_400))d ago"
     }
 
+    /// Fires the keyboard-selected row (↑/↓), falling back to the first.
+    /// Ordinary Return never opens or saves a create sheet.
     private func commitTopSelection() {
-        // Fires the keyboard-selected row (↑/↓), falling back to the first.
+        if model.createAssessment != nil { return }
         model.commitSelected()
+    }
+
+    private func handleSearchEscape() {
+        if model.createAssessment != nil {
+            model.cancelCreate()
+        } else if model.favoriteSession.pickerSlug != nil || model.favoriteSession.pending != nil {
+            model.cancelFavoritePrompt()
+        } else {
+            model.onEscape()
+        }
     }
 }
 
@@ -2258,6 +2486,7 @@ private struct QueryField: NSViewRepresentable {
     var onArrowDown: () -> Void
     var onArrowUp: () -> Void
     var onEscape: () -> Void
+    var onCreateShortcut: () -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -2391,6 +2620,10 @@ private struct QueryField: NSViewRepresentable {
             case #selector(NSResponder.moveUp(_:)):
                 parent.onArrowUp(); return true
             case #selector(NSResponder.insertNewline(_:)):
+                let mods = NSApp.currentEvent?.modifierFlags.intersection(.deviceIndependentFlagsMask) ?? []
+                if mods.contains(.option) || mods.contains(.command) {
+                    parent.onCreateShortcut(); return true
+                }
                 parent.onReturn(); return true
             case #selector(NSResponder.cancelOperation(_:)):
                 parent.onEscape(); return true
@@ -2445,6 +2678,7 @@ private struct KeyHandler: NSViewRepresentable {
     let onArrowUp: () -> Void
     let onReturn: () -> Void
     let onEscape: () -> Void
+    let onCreateShortcut: () -> Void
 
     func makeNSView(context: Context) -> NSView {
         let v = MonitorView()
@@ -2454,6 +2688,7 @@ private struct KeyHandler: NSViewRepresentable {
         v.onArrowUp = onArrowUp
         v.onReturn = onReturn
         v.onEscape = onEscape
+        v.onCreateShortcut = onCreateShortcut
         return v
     }
 
@@ -2465,6 +2700,7 @@ private struct KeyHandler: NSViewRepresentable {
         v.onArrowUp = onArrowUp
         v.onReturn = onReturn
         v.onEscape = onEscape
+        v.onCreateShortcut = onCreateShortcut
     }
 
     final class MonitorView: NSView {
@@ -2474,6 +2710,7 @@ private struct KeyHandler: NSViewRepresentable {
         var onArrowUp: (() -> Void)?
         var onReturn: (() -> Void)?
         var onEscape: (() -> Void)?
+        var onCreateShortcut: (() -> Void)?
         private var monitor: Any?
 
         override func viewDidMoveToWindow() {
@@ -2490,6 +2727,7 @@ private struct KeyHandler: NSViewRepresentable {
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
                 guard let self else { return event }
                 guard self.window?.isKeyWindow == true else { return event }
+                if Self.consumeCreateShortcut(event, fire: self) { return nil }
                 if Self.consumeOptionNumber(event, fire: self) { return nil }
                 let isFieldEditor = (self.window?.firstResponder is NSText)
                 if !isFieldEditor || (event.charactersIgnoringModifiers?.isEmpty ?? true) {
@@ -2518,6 +2756,26 @@ private struct KeyHandler: NSViewRepresentable {
             // and the cleanup path above is sufficient (the monitor is
             // bound to a window-scoped block that no longer reaches a
             // dead view).
+        }
+
+        static func consumeCreateShortcut(_ event: NSEvent, fire v: MonitorView) -> Bool {
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let isReturn = event.keyCode == UInt16(kVK_Return) || event.keyCode == UInt16(kVK_ANSI_KeypadEnter)
+            if isReturn,
+               mods.contains(.option),
+               !mods.contains(.command),
+               !mods.contains(.control) {
+                v.onCreateShortcut?()
+                return true
+            }
+            if mods.contains(.command),
+               !mods.contains(.option),
+               !mods.contains(.control),
+               event.charactersIgnoringModifiers?.lowercased() == "n" {
+                v.onCreateShortcut?()
+                return true
+            }
+            return false
         }
 
         static func consumeOptionNumber(_ event: NSEvent, fire v: MonitorView) -> Bool {

--- a/TheBridge/Modules/Commands/CommandSearchCreate.swift
+++ b/TheBridge/Modules/Commands/CommandSearchCreate.swift
@@ -1,0 +1,179 @@
+// CommandSearchCreate.swift — GitHub #140 C1
+//
+// Search may create a command only through an explicit confirmation. Ordinary
+// Return, empty results, and failed matches never write. Duplicate and
+// sensitive-path warnings are assessed before Save. Edit deep-links by
+// immutable command ID, not display slug.
+
+import Foundation
+
+public struct CommandCreateDraft: Equatable, Sendable {
+    public var name: String
+    public var body: String
+    public var sensitive: Bool
+    public var keySlot: Int?
+
+    public init(name: String = "", body: String = "", sensitive: Bool = false, keySlot: Int? = nil) {
+        self.name = name
+        self.body = body
+        self.sensitive = sensitive
+        self.keySlot = keySlot
+    }
+
+    public var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var trimmedBody: String {
+        body.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+public enum CommandCreateDuplicate: Equatable, Sendable {
+    case exactSlug(String)
+    case exactName(String)
+    case nearName(String)
+}
+
+public struct CommandCreateAssessment: Equatable, Sendable {
+    public var draft: CommandCreateDraft
+    public var duplicates: [CommandCreateDuplicate]
+    public var sensitiveHits: [String]
+    public var requiresConfirmation: Bool { true }
+
+    public var hasExactDuplicate: Bool {
+        duplicates.contains {
+            switch $0 {
+            case .exactSlug, .exactName: return true
+            case .nearName: return false
+            }
+        }
+    }
+
+    public var canProposeSave: Bool {
+        !draft.trimmedName.isEmpty && !hasExactDuplicate
+    }
+}
+
+public enum CommandSettingsDeepLink {
+    public static let prefix = "command-id:"
+
+    public static func anchor(commandID: String) -> String {
+        prefix + commandID
+    }
+
+    public static func commandID(fromAnchor anchor: String?) -> String? {
+        guard let anchor, anchor.hasPrefix(prefix) else { return nil }
+        let id = String(anchor.dropFirst(prefix.count))
+        return id.isEmpty ? nil : id
+    }
+
+    public static func slug(forID id: String, in commands: [CommandStore.Command]) -> String? {
+        commands.first(where: { $0.id == id })?.slug
+    }
+}
+
+public enum CommandSearchCreate {
+    /// Failed searches and ordinary Return never create.
+    public static let returnCreatesCommand = false
+
+    public static func draft(fromSearchText text: String) -> CommandCreateDraft {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let firstLine = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
+        let name = String(firstLine.prefix(80))
+        return CommandCreateDraft(name: name, body: trimmed)
+    }
+
+    public static func assess(
+        draft: CommandCreateDraft,
+        existing: [CommandStore.Command],
+        sensitivePaths: [String]
+    ) -> CommandCreateAssessment {
+        let slug = CommandStore.slugify(draft.trimmedName)
+        var duplicates: [CommandCreateDuplicate] = []
+        var seen = Set<String>()
+        for command in existing {
+            if !slug.isEmpty, command.slug == slug, seen.insert("slug:\(command.slug)").inserted {
+                duplicates.append(.exactSlug(command.slug))
+            } else if command.name.compare(draft.trimmedName, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame,
+                      seen.insert("name:\(command.slug)").inserted {
+                duplicates.append(.exactName(command.slug))
+            } else if isNearDuplicate(draftName: draft.trimmedName, existingName: command.name),
+                      seen.insert("near:\(command.slug)").inserted {
+                duplicates.append(.nearName(command.slug))
+            }
+        }
+        let hits = sensitiveHits(in: draft.body, paths: sensitivePaths)
+        var next = draft
+        next.sensitive = !hits.isEmpty || draft.sensitive
+        return CommandCreateAssessment(draft: next, duplicates: duplicates, sensitiveHits: hits)
+    }
+
+    /// Search never shows command bodies that mention a sensitive path.
+    public static func shouldSuppressBodyPreview(body: String, sensitivePaths: [String]) -> Bool {
+        !sensitiveHits(in: body, paths: sensitivePaths).isEmpty
+    }
+
+    public static func searchSubtitle(slot: Int?, body: String, sensitivePaths: [String]) -> String? {
+        let slotLabel = slot.map { "slot \($0)" }
+        if shouldSuppressBodyPreview(body: body, sensitivePaths: sensitivePaths) {
+            return [slotLabel, "Sensitive"].compactMap { $0 }.joined(separator: " · ")
+        }
+        return slotLabel
+    }
+
+    public static func sensitiveHits(in body: String, paths: [String]) -> [String] {
+        let haystack = body.lowercased()
+        var hits: [String] = []
+        for path in paths {
+            let needle = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !needle.isEmpty else { continue }
+            if haystack.contains(needle.lowercased()) {
+                hits.append(path)
+            }
+        }
+        return hits
+    }
+
+    public static func duplicateBody(of command: CommandStore.Command, existingNames: [String]) -> (name: String, body: String) {
+        var name = "\(command.name) copy"
+        var i = 1
+        let set = Set(existingNames.map { $0.lowercased() })
+        while set.contains(name.lowercased()) {
+            i += 1
+            name = "\(command.name) copy \(i)"
+        }
+        return (name, command.body)
+    }
+
+    private static func isNearDuplicate(draftName: String, existingName: String) -> Bool {
+        let a = normalize(draftName)
+        let b = normalize(existingName)
+        guard !a.isEmpty, !b.isEmpty, a != b else { return false }
+        if a.hasPrefix(b) || b.hasPrefix(a) { return abs(a.count - b.count) <= 4 }
+        return levenshtein(a, b) <= 2 && min(a.count, b.count) >= 4
+    }
+
+    private static func normalize(_ name: String) -> String {
+        name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "", options: .regularExpression)
+    }
+
+    private static func levenshtein(_ a: String, _ b: String) -> Int {
+        let aChars = Array(a)
+        let bChars = Array(b)
+        if aChars.isEmpty { return bChars.count }
+        if bChars.isEmpty { return aChars.count }
+        var prev = Array(0...bChars.count)
+        var cur = Array(repeating: 0, count: bChars.count + 1)
+        for i in 1...aChars.count {
+            cur[0] = i
+            for j in 1...bChars.count {
+                let cost = aChars[i - 1] == bChars[j - 1] ? 0 : 1
+                cur[j] = min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost)
+            }
+            swap(&prev, &cur)
+        }
+        return prev[bChars.count]
+    }
+}

--- a/TheBridge/UI/Sections/CommandsEditorView.swift
+++ b/TheBridge/UI/Sections/CommandsEditorView.swift
@@ -17,6 +17,8 @@ public struct CommandsEditorView: View {
     @Binding private var commands: [CommandStore.Command]
     @Binding private var selectedSlug: String?
 
+    @ObservedObject private var nav = SettingsNavigation.shared
+
     // Adaptive key-cap / tray sheen: the raised "keycap" + tray surfaces used
     // raw Color.white/black literals that wash out on titanium. We compute the
     // sheen + drop-shadow per color-scheme so both themes read correctly (DARK
@@ -77,6 +79,7 @@ public struct CommandsEditorView: View {
         .task { await load() }
         .onAppear { syncAppearanceState() }
         .onChange(of: selectedSlug) { _, _ in syncAppearanceState() }
+        .onChange(of: nav.anchor) { _, _ in applyCommandDeepLink(in: commands) }
         // PKT-879: icon picker sheet
         .sheet(isPresented: $iconPickerPresented) {
             if let cmd = currentCommand {
@@ -790,14 +793,26 @@ public struct CommandsEditorView: View {
             let list = try CommandStore.shared.list()
             await MainActor.run {
                 self.commands = list
-                if self.selectedSlug == nil || !list.contains(where: { $0.slug == self.selectedSlug }) {
-                    self.selectedSlug = self.firstAlphabetical(list)?.slug
+                if !self.applyCommandDeepLink(in: list) {
+                    if self.selectedSlug == nil || !list.contains(where: { $0.slug == self.selectedSlug }) {
+                        self.selectedSlug = self.firstAlphabetical(list)?.slug
+                    }
                 }
                 self.loadError = nil
             }
         } catch {
             await MainActor.run { self.loadError = error.localizedDescription }
         }
+    }
+
+    @discardableResult
+    private func applyCommandDeepLink(in list: [CommandStore.Command]) -> Bool {
+        guard let id = CommandSettingsDeepLink.commandID(fromAnchor: nav.anchor),
+              let slug = CommandSettingsDeepLink.slug(forID: id, in: list)
+        else { return false }
+        selectedSlug = slug
+        nav.anchor = nil
+        return true
     }
 
     private func firstAlphabetical(_ list: [CommandStore.Command]) -> CommandStore.Command? {

--- a/TheBridgeTests/CommandSearchCreateTests.swift
+++ b/TheBridgeTests/CommandSearchCreateTests.swift
@@ -1,0 +1,193 @@
+// CommandSearchCreateTests.swift — C1 / GitHub #140
+//
+// Search creation is explicit. Return never writes. Duplicates and sensitive
+// paths are assessed before Save. Edit deep-links resolve by immutable ID.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandSearchCreateTests() async {
+    print("\n[Command Search create C1 / #140]")
+
+    await test("C1 ordinary Return does not create a command") {
+        try expect(CommandSearchCreate.returnCreatesCommand == false)
+    }
+
+    await test("C1 empty or failed search text still requires an explicit name") {
+        let empty = CommandSearchCreate.assess(
+            draft: CommandCreateDraft(name: "  ", body: "no match for xyz"),
+            existing: [],
+            sensitivePaths: []
+        )
+        try expect(!empty.canProposeSave)
+        let fromQuery = CommandSearchCreate.draft(fromSearchText: "ship the palette")
+        try expect(fromQuery.name == "ship the palette")
+        try expect(fromQuery.body == "ship the palette")
+    }
+
+    await test("C1 exact slug and name duplicates are actionable") {
+        let existing = [
+            CommandStore.Command(id: "id-alpha", slug: "alpha", name: "Alpha", icon: .emoji("a"), body: "body-a")
+        ]
+        let slugHit = CommandSearchCreate.assess(
+            draft: CommandCreateDraft(name: "Alpha", body: "other"),
+            existing: existing,
+            sensitivePaths: []
+        )
+        try expect(slugHit.duplicates.contains(.exactSlug("alpha")))
+        try expect(!slugHit.canProposeSave)
+        let nameHit = CommandSearchCreate.assess(
+            draft: CommandCreateDraft(name: "ALPHA", body: "other"),
+            existing: existing,
+            sensitivePaths: []
+        )
+        try expect(!nameHit.duplicates.isEmpty)
+        try expect(!nameHit.canProposeSave)
+    }
+
+    await test("C1 multiline search text becomes name plus body") {
+        let draft = CommandSearchCreate.draft(fromSearchText: "Ship palette\nkeep the body")
+        try expect(draft.name == "Ship palette")
+        try expect(draft.body == "Ship palette\nkeep the body")
+    }
+
+    await test("C1 near-duplicate names are flagged without blocking the draft") {
+        let existing = [
+            CommandStore.Command(id: "id-close", slug: "close-agent", name: "Close Agent", icon: .emoji("c"), body: "x")
+        ]
+        let near = CommandSearchCreate.assess(
+            draft: CommandCreateDraft(name: "Close Agnt", body: "y"),
+            existing: existing,
+            sensitivePaths: []
+        )
+        try expect(near.canProposeSave)
+        try expect(near.duplicates.contains(.nearName("close-agent")))
+    }
+
+    await test("C1 sensitive path tokens surface a warning and do not enter the assessment as a save") {
+        let assessed = CommandSearchCreate.assess(
+            draft: CommandCreateDraft(name: "Keys", body: "read ~/.ssh/id_ed25519 then continue"),
+            existing: [],
+            sensitivePaths: ["~/.ssh", "~/.aws"]
+        )
+        try expect(assessed.sensitiveHits.contains("~/.ssh"))
+        try expect(assessed.draft.sensitive)
+        try expect(assessed.canProposeSave)
+        try expect(assessed.requiresConfirmation)
+    }
+
+    await test("C1 duplicate copies the body and does not delete the source") {
+        try await withTempHomeC1 { _ in
+            try CommandStore.shared.resetForTesting()
+            let source = try CommandStore.shared.create(
+                name: "Source", icon: .emoji("s"), body: "keep-this-body", keySlot: 2)
+            let copy = CommandSearchCreate.duplicateBody(
+                of: source,
+                existingNames: [source.name]
+            )
+            let created = try CommandStore.shared.create(
+                name: copy.name, icon: .emoji("c"), body: copy.body)
+            try expect(created.body == "keep-this-body")
+            try expect(try CommandStore.shared.get(slug: source.slug)?.body == "keep-this-body")
+            try expect(try CommandStore.shared.get(slug: source.slug)?.keySlot == 2)
+            try expect(created.slug != source.slug)
+            try expect(created.id != source.id)
+        }
+    }
+
+    await test("C1 removing a favorite does not delete the command") {
+        try await withTempHomeC1 { _ in
+            try CommandStore.shared.resetForTesting()
+            let created = try CommandStore.shared.create(
+                name: "Keep", icon: .emoji("k"), body: "alive", keySlot: 4)
+            try CommandStore.shared.setKeySlot(slug: created.slug, slot: nil)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.body == "alive")
+            try expect(try CommandStore.shared.get(slug: created.slug)?.keySlot == nil)
+        }
+    }
+
+    await test("C1 Settings deep link selects by immutable ID not a renamed slug") {
+        let commands = [
+            CommandStore.Command(id: "bridge.command.user.keep", slug: "old-name", name: "New Name", icon: .emoji("n"), body: "x")
+        ]
+        let anchor = CommandSettingsDeepLink.anchor(commandID: "bridge.command.user.keep")
+        try expect(CommandSettingsDeepLink.commandID(fromAnchor: anchor) == "bridge.command.user.keep")
+        try expect(CommandSettingsDeepLink.slug(forID: "bridge.command.user.keep", in: commands) == "old-name")
+        try expect(CommandSettingsDeepLink.commandID(fromAnchor: "job:123") == nil)
+    }
+
+    await test("C1 sensitive body never becomes a Search subtitle") {
+        let subtitle = CommandSearchCreate.searchSubtitle(
+            slot: 3,
+            body: "cat ~/.ssh/id_ed25519",
+            sensitivePaths: ["~/.ssh"]
+        )
+        try expect(subtitle == "slot 3 · Sensitive")
+        try expect(!subtitle!.contains("id_ed25519"))
+        try expect(CommandSearchCreate.shouldSuppressBodyPreview(
+            body: "cat ~/.ssh/id_ed25519",
+            sensitivePaths: ["~/.ssh"]
+        ))
+        let quiet = CommandSearchCreate.searchSubtitle(
+            slot: nil,
+            body: "echo hello",
+            sensitivePaths: ["~/.ssh"]
+        )
+        try expect(quiet == nil)
+    }
+
+    await test("C1 ViewModel ordinary commit does not create") {
+        try await withTempHomeC1 { _ in
+            try CommandStore.shared.resetForTesting()
+            let before = try CommandStore.shared.list().count
+            await MainActor.run {
+                let vm = CommandBridgeViewModel(
+                    store: CommandStore.shared,
+                    recents: CommandBridgeRecents(cap: 1)
+                )
+                vm.queryDidChange("no such command xyzzy-c1")
+                vm.commitSelected()
+            }
+            try expect(try CommandStore.shared.list().count == before)
+        }
+    }
+
+    await test("C1 ViewModel Save after explicit create writes and survives update") {
+        try await withTempHomeC1 { _ in
+            try CommandStore.shared.resetForTesting()
+            let created = await MainActor.run { () -> CommandStore.Command? in
+                let vm = CommandBridgeViewModel(
+                    store: CommandStore.shared,
+                    recents: CommandBridgeRecents(cap: 1)
+                )
+                vm.queryDidChange("Ship palette")
+                vm.beginCreateFromQuery()
+                vm.createDraft.body = "do the thing"
+                vm.refreshCreateAssessment()
+                return vm.confirmCreate()
+            }
+            try expect(created?.name == "Ship palette")
+            try expect(created?.body == "do the thing")
+            guard var live = created else {
+                throw TestError.assertion("expected created command")
+            }
+            live.body = "updated body"
+            let saved = try CommandStore.shared.update(live)
+            try expect(saved.id == live.id)
+            try expect(try CommandStore.shared.get(slug: saved.slug)?.body == "updated body")
+        }
+    }
+}
+
+private func withTempHomeC1(_ body: (URL) async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("CommandSearchCreate-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body(tmp)
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -875,6 +875,10 @@ await runCommandGitHubFirstFeedbackTests()
 // A0 favorite-map persistence, no command-body mutation.
 await runCommandFavoriteLayoutTests()
 
+// GitHub #140 C1: explicit Search create, duplicate/sensitive warnings,
+// Settings deep-link by immutable command ID. Return never writes.
+await runCommandSearchCreateTests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-search-create-c1.md
+++ b/docs/commands-search-create-c1.md
@@ -1,0 +1,39 @@
+# Command Search create C1
+
+GitHub issue #140, packet C1. Bridge Search can create and manage commands
+without accidental saves. Create is explicit. Edit reuses the Settings editor
+through a stable command ID, not a display slug.
+
+## Interaction
+
+Ordinary Return still fires the selected result, or does nothing when Search
+has no match. It never writes a command.
+
+| Input | Result |
+| --- | --- |
+| **Create command from this text** | Opens the compact create sheet from the query |
+| Option+Return or ⌘N | Same explicit create entry |
+| Multiline query / paste | First line becomes the name; full text is the body |
+| Sheet **Save** | Writes through `CommandStore.create` after assessment |
+| Sheet **Cancel** / Escape | Drops the draft; nothing is written |
+| Exact name/slug duplicate | Save stays disabled; **Edit existing** is offered |
+| Near-duplicate name | Warning + **Open similar**; Save remains available |
+| Sensitive path in body | Warning; Search subtitle never includes the body |
+| Context **Edit** / **Reveal** | Settings → Commands, selected by immutable ID |
+| Context **Duplicate** | Opens a create sheet with a copy name and the same body |
+| Context **Move** / **Remove** | Unchanged C0 favorite transactions |
+
+The create sheet is compact: name, body, sensitivity toggle, optional 1–0
+slot, Save, Cancel. It is not a second full editor.
+
+## Quiet + safety
+
+Failed searches stay failed until the operator chooses Create. Duplicate and
+sensitive warnings are shown in the sheet before Save. Removing a favorite
+still only clears the slot. New commands persist through later `update`.
+
+## Out of scope
+
+No save from ordinary Return. No GitHub publication. No automatic deletion.
+Live Search screenshots are a visual-review artifact, not an Installed
+Verified claim.


### PR DESCRIPTION
## Summary
- Search can create a command only through an explicit confirmation sheet (Create from this text, Option+Return, ⌘N). Ordinary Return still never writes.
- Duplicate and sensitive-path warnings are assessed before Save; exact identity collisions stay blocked and offer Edit existing. Edit/Reveal deep-link to Settings by immutable command ID.
- C0 favorite Move/Remove/Undo is preserved. New commands persist through later `update`. No install, tag, or publication.

Closes nothing yet — GitHub #140 program continues through D0–G0.

## Test plan
- [x] Local `TheBridgeTests` on the C1 tree: **3717 passed, 0 failed** (floor 3705 + 12 C1 tests)
- [ ] Reconfirm the same binary on exact SHA `b6feca9` (running)
- [ ] CI `build-and-test` SUCCESS on this PR before merge
- [ ] Failed Search + ordinary Return does not create a command
- [ ] Create sheet Save writes; Cancel/Escape does not
- [ ] Exact duplicate disables Save and offers Edit existing
- [ ] Sensitive body never appears in Search subtitle
- [ ] Edit/Reveal opens Settings → Commands on the same immutable ID after rename
- [ ] Visual review of live Search create sheet (UI-ITER fail-closed; screenshots may be named as a gap)


Made with [Cursor](https://cursor.com)