### PR TITLE
Add gated developer publication for command overrides

### DIFF
--- a/TheBridge/Core/BridgeDefaults.swift
+++ b/TheBridge/Core/BridgeDefaults.swift
@@ -171,6 +171,10 @@ public enum BridgeDefaults {
     /// fresh install / decode failure never loses the palette).
     public static let commandsHotkey = "com.notionbridge.commandsHotkey"
 
+    /// D0 / #140: developer publication workflow. Bool. ABSENT ⇒ OFF.
+    /// Standard mode must not show GitHub, branch, commit, or push controls.
+    public static let commandsDeveloperPublication = "com.notionbridge.commandsDeveloperPublication"
+
     // MARK: - Onboarding & Legal
 
     /// Whether the user has completed the onboarding wizard. Bool.

--- a/TheBridge/Modules/Commands/CommandProductPublication.swift
+++ b/TheBridge/Modules/Commands/CommandProductPublication.swift
@@ -1,0 +1,286 @@
+// CommandProductPublication.swift — GitHub #140 D0
+//
+// Developer-mode publication of a local command override as a product change.
+// Ordinary updates stay Git-free. No commit, push, or branch work happens
+// without an explicit approval. Favorite layout and usage history never ship.
+
+import Foundation
+
+public enum CommandProposalState: String, Equatable, Sendable, Codable {
+    case draft
+    case ready
+    case published
+    case merged
+    case shipped
+    case reconciled
+}
+
+public struct CommandProductDiff: Equatable, Sendable {
+    public var commandID: String
+    public var slug: String
+    public var name: String
+    public var baseBody: String?
+    public var localBody: String
+    public var intendedProductOutcome: String
+
+    public init(
+        commandID: String,
+        slug: String,
+        name: String,
+        baseBody: String? = nil,
+        localBody: String,
+        intendedProductOutcome: String
+    ) {
+        self.commandID = commandID
+        self.slug = slug
+        self.name = name
+        self.baseBody = baseBody
+        self.localBody = localBody
+        self.intendedProductOutcome = intendedProductOutcome
+    }
+
+    public var outboundBody: String { localBody }
+
+    public var includesFavoriteLayout: Bool { false }
+    public var includesUsageHistory: Bool { false }
+}
+
+public struct CommandPrivacyFinding: Equatable, Sendable {
+    public var token: String
+    public var requiresAcknowledgement: Bool
+
+    public init(token: String, requiresAcknowledgement: Bool = true) {
+        self.token = token
+        self.requiresAcknowledgement = requiresAcknowledgement
+    }
+}
+
+public struct CommandPublicationApprovals: Equatable, Sendable {
+    public var issueAssociated: Bool
+    public var branchSelected: Bool
+    public var commitApproved: Bool
+    public var pushApproved: Bool
+    public var privacyAcknowledged: Bool
+
+    public init(
+        issueAssociated: Bool = false,
+        branchSelected: Bool = false,
+        commitApproved: Bool = false,
+        pushApproved: Bool = false,
+        privacyAcknowledged: Bool = false
+    ) {
+        self.issueAssociated = issueAssociated
+        self.branchSelected = branchSelected
+        self.commitApproved = commitApproved
+        self.pushApproved = pushApproved
+        self.privacyAcknowledged = privacyAcknowledged
+    }
+}
+
+public struct CommandProductProposal: Equatable, Sendable {
+    public var diff: CommandProductDiff
+    public var issueNumber: Int?
+    public var branch: String?
+    public var findings: [CommandPrivacyFinding]
+    public var approvals: CommandPublicationApprovals
+    public var state: CommandProposalState
+    public var recordedGitActions: [String]
+
+    public init(
+        diff: CommandProductDiff,
+        issueNumber: Int? = nil,
+        branch: String? = nil,
+        findings: [CommandPrivacyFinding] = [],
+        approvals: CommandPublicationApprovals = CommandPublicationApprovals(),
+        state: CommandProposalState = .draft,
+        recordedGitActions: [String] = []
+    ) {
+        self.diff = diff
+        self.issueNumber = issueNumber
+        self.branch = branch
+        self.findings = findings
+        self.approvals = approvals
+        self.state = state
+        self.recordedGitActions = recordedGitActions
+    }
+}
+
+public enum CommandProductPublication {
+    public static func developerControlsVisible(developerMode: Bool) -> Bool {
+        developerMode
+    }
+
+    public static func canUseOfflineUpdatesWithoutGit(hasRepo: Bool) -> Bool {
+        true
+    }
+
+    public static func repositoryIdentity(repoRoot: String?) -> String? {
+        guard let repoRoot else { return nil }
+        let trimmed = repoRoot.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public static func productRepoIdentity(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        repositoryIdentity(repoRoot: environment["BRIDGE_PRODUCT_REPO"])
+    }
+
+    /// Real Git stays opt-in. Absent this flag, Settings copies a patch and
+    /// never commits or pushes.
+    public static func gitExecutionEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        environment["BRIDGE_COMMAND_PUBLICATION_GIT"] == "1"
+    }
+
+    public static func reviewablePatch(_ proposal: CommandProductProposal) -> String {
+        let issue = proposal.issueNumber.map(String.init) ?? "unassociated"
+        let branch = proposal.branch ?? "unset"
+        return [
+            "command-id: \(proposal.diff.commandID)",
+            "slug: \(proposal.diff.slug)",
+            "name: \(proposal.diff.name)",
+            "issue: \(issue)",
+            "branch: \(branch)",
+            "outcome: \(proposal.diff.intendedProductOutcome)",
+            "---",
+            proposal.diff.outboundBody,
+        ].joined(separator: "\n")
+    }
+
+    public static func scanPrivacy(
+        body: String,
+        sensitivePaths: [String],
+        extraSecrets: [String] = []
+    ) -> [CommandPrivacyFinding] {
+        var findings: [CommandPrivacyFinding] = []
+        var seen = Set<String>()
+        let haystack = body.lowercased()
+        for path in sensitivePaths {
+            let needle = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !needle.isEmpty, haystack.contains(needle.lowercased()) else { continue }
+            if seen.insert(path).inserted {
+                findings.append(CommandPrivacyFinding(token: path))
+            }
+        }
+        for secret in extraSecrets where body.contains(secret) {
+            if seen.insert(secret).inserted {
+                findings.append(CommandPrivacyFinding(token: secret))
+            }
+        }
+        let markers = ["-----BEGIN ", "sk_live_", "sk_test_", "ghp_", "AKIA"]
+        for marker in markers where body.contains(marker) {
+            if seen.insert(marker).inserted {
+                findings.append(CommandPrivacyFinding(token: marker))
+            }
+        }
+        return findings
+    }
+
+    public static func draft(
+        command: CommandStore.Command,
+        baseBody: String?,
+        intendedProductOutcome: String,
+        sensitivePaths: [String]
+    ) -> CommandProductProposal {
+        let diff = CommandProductDiff(
+            commandID: command.id,
+            slug: command.slug,
+            name: command.name,
+            baseBody: baseBody,
+            localBody: command.body,
+            intendedProductOutcome: intendedProductOutcome
+        )
+        return CommandProductProposal(
+            diff: diff,
+            findings: scanPrivacy(body: command.body, sensitivePaths: sensitivePaths),
+            state: .draft
+        )
+    }
+
+    public static func privacyBlocks(_ proposal: CommandProductProposal) -> Bool {
+        !proposal.findings.isEmpty && !proposal.approvals.privacyAcknowledged
+    }
+
+    public static func canBecomeReady(_ proposal: CommandProductProposal, developerMode: Bool) -> Bool {
+        guard developerMode else { return false }
+        guard !proposal.diff.intendedProductOutcome.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+        guard proposal.issueNumber != nil, let branch = proposal.branch, !branch.isEmpty else {
+            return false
+        }
+        return !privacyBlocks(proposal)
+    }
+
+    public static func markReady(_ proposal: CommandProductProposal, developerMode: Bool) -> CommandProductProposal? {
+        guard canBecomeReady(proposal, developerMode: developerMode) else { return nil }
+        var next = proposal
+        next.state = .ready
+        return next
+    }
+
+    /// Git never runs unless every approval for that action is explicit.
+    public static func intendedGitAction(
+        _ proposal: CommandProductProposal,
+        developerMode: Bool,
+        hasRepo: Bool,
+        repoIdentity: String?
+    ) -> String? {
+        guard developerMode else { return nil }
+        guard hasRepo, repositoryIdentity(repoRoot: repoIdentity) != nil else { return nil }
+        guard proposal.state == .ready else { return nil }
+        if proposal.approvals.commitApproved && proposal.approvals.pushApproved {
+            return "commit-and-push"
+        }
+        if proposal.approvals.commitApproved {
+            return "commit"
+        }
+        return nil
+    }
+
+    public static func applyApprovedGit(
+        _ proposal: CommandProductProposal,
+        developerMode: Bool,
+        hasRepo: Bool,
+        repoIdentity: String?,
+        execute: (String) -> Bool
+    ) -> CommandProductProposal {
+        var next = proposal
+        guard let action = intendedGitAction(
+            proposal,
+            developerMode: developerMode,
+            hasRepo: hasRepo,
+            repoIdentity: repoIdentity
+        ) else { return next }
+        guard execute(action) else { return next }
+        next.recordedGitActions.append(action)
+        if action == "commit-and-push" || (action == "commit" && proposal.approvals.pushApproved) {
+            next.state = .published
+        }
+        return next
+    }
+
+    public static func simulateShippedDefault(
+        _ proposal: CommandProductProposal,
+        localStillPresent: Bool
+    ) -> CommandProductProposal {
+        var next = proposal
+        if proposal.state == .published || proposal.state == .merged {
+            next.state = .shipped
+        }
+        _ = localStillPresent
+        return next
+    }
+
+    public static func reconcileAfterShipped(
+        _ proposal: CommandProductProposal,
+        localMatchesShipped: Bool
+    ) -> CommandProductProposal {
+        var next = proposal
+        guard proposal.state == .shipped, localMatchesShipped else { return next }
+        next.state = .reconciled
+        return next
+    }
+}

--- a/TheBridge/UI/Sections/AdvancedSection.swift
+++ b/TheBridge/UI/Sections/AdvancedSection.swift
@@ -116,6 +116,8 @@ public struct AdvancedSection: View {
     // these the same way it reads `launchAtLogin` (no fake channel logic here).
     @AppStorage("automaticUpdates") private var automaticUpdates = true
     @AppStorage("betaChannel") private var betaChannel = false
+    @AppStorage(BridgeDefaults.commandsDeveloperPublication)
+    private var commandsDeveloperPublication = false
 
     // Transient "rebuilt"/"cache cleared" flash for the benign Routine actions,
     // keyed by action id so the confirmation lands on the row clicked.
@@ -403,6 +405,13 @@ public struct AdvancedSection: View {
                 title: "Beta channel",
                 subtitle: "Receive pre-release builds. May be unstable.",
                 isOn: $betaChannel
+            )
+
+            toggleDivider()
+            launchToggleRow(
+                title: "Command developer publication",
+                subtitle: "Show Propose as Product Change in Commands. Off by default. GitHub and branch controls stay hidden until this is on.",
+                isOn: $commandsDeveloperPublication
             )
         }
     }

--- a/TheBridge/UI/Sections/CommandProductPublicationSheet.swift
+++ b/TheBridge/UI/Sections/CommandProductPublicationSheet.swift
@@ -1,0 +1,189 @@
+// CommandProductPublicationSheet.swift — GitHub #140 D0
+//
+// Compact developer-only proposal sheet. Standard Commands UI never presents
+// this. Git never runs unless a product repo is identified and publication
+// Git is explicitly enabled.
+
+import AppKit
+import SwiftUI
+
+struct CommandProductPublicationSheet: View {
+    @Binding var isPresented: Bool
+    @Binding var proposal: CommandProductProposal
+    let developerMode: Bool
+
+    @State private var issueText: String = ""
+    @State private var status: String = ""
+
+    private var repoIdentity: String? {
+        CommandProductPublication.productRepoIdentity()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Propose as Product Change")
+                .font(BridgeTokens.Typeface.detail)
+                .foregroundStyle(BridgeTokens.fg1)
+            Text("Ordinary command updates stay local. Commit and push stay refused until every approval is explicit.")
+                .font(BridgeTokens.Typeface.sub)
+                .foregroundStyle(BridgeTokens.fg4)
+
+            TextField("Intended product outcome", text: outcomeBinding)
+                .textFieldStyle(.roundedBorder)
+            TextField("GitHub issue number", text: $issueText)
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: issueText) { _, value in
+                    proposal.issueNumber = Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+                    proposal.approvals.issueAssociated = proposal.issueNumber != nil
+                }
+            TextField("Issue-linked branch", text: branchBinding)
+                .textFieldStyle(.roundedBorder)
+
+            if proposal.findings.isEmpty {
+                Text("Privacy scan: no secret or sensitive-path tokens found.")
+                    .font(BridgeTokens.Typeface.micro)
+                    .foregroundStyle(BridgeTokens.ok)
+            } else {
+                Text("Privacy scan blocked: \(proposal.findings.map(\.token).joined(separator: ", "))")
+                    .font(BridgeTokens.Typeface.micro)
+                    .foregroundStyle(BridgeTokens.warnText)
+                Toggle("I acknowledge these findings and still want to propose", isOn: privacyBinding)
+            }
+
+            ScrollView {
+                Text(CommandProductPublication.reviewablePatch(proposal))
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(BridgeTokens.fg2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(minHeight: 120, maxHeight: 180)
+            .padding(8)
+            .background(BridgeTokens.wellFill, in: RoundedRectangle(cornerRadius: 8))
+
+            Text(repoIdentity == nil
+                 ? "Repository identity is ambiguous. Git is refused."
+                 : "Product repo: \(repoIdentity!)")
+                .font(BridgeTokens.Typeface.micro)
+                .foregroundStyle(repoIdentity == nil ? BridgeTokens.warnText : BridgeTokens.fg4)
+
+            HStack {
+                Toggle("Approve commit", isOn: commitBinding)
+                Toggle("Approve push", isOn: pushBinding)
+            }
+            .font(BridgeTokens.Typeface.sub)
+
+            if !status.isEmpty {
+                Text(status)
+                    .font(BridgeTokens.Typeface.micro)
+                    .foregroundStyle(BridgeTokens.fg3)
+            }
+
+            HStack {
+                Button("Copy patch") { copyPatch() }
+                Button("Mark Ready") { markReady() }
+                    .disabled(!CommandProductPublication.canBecomeReady(proposal, developerMode: developerMode))
+                Button("Apply approved Git") { applyGit() }
+                    .disabled(
+                        CommandProductPublication.intendedGitAction(
+                            proposal,
+                            developerMode: developerMode,
+                            hasRepo: repoIdentity != nil,
+                            repoIdentity: repoIdentity
+                        ) == nil
+                        || !CommandProductPublication.gitExecutionEnabled()
+                    )
+                Spacer()
+                Button("Close") { isPresented = false }
+            }
+        }
+        .padding(18)
+        .frame(width: 520)
+        .onAppear {
+            issueText = proposal.issueNumber.map(String.init) ?? "140"
+            if proposal.issueNumber == nil {
+                proposal.issueNumber = 140
+                proposal.approvals.issueAssociated = true
+            }
+            if proposal.branch == nil || proposal.branch?.isEmpty == true {
+                proposal.branch = "feat/issue-140-command-publication"
+                proposal.approvals.branchSelected = true
+            }
+        }
+    }
+
+    private var outcomeBinding: Binding<String> {
+        Binding(
+            get: { proposal.diff.intendedProductOutcome },
+            set: { proposal.diff.intendedProductOutcome = $0 }
+        )
+    }
+
+    private var branchBinding: Binding<String> {
+        Binding(
+            get: { proposal.branch ?? "" },
+            set: {
+                proposal.branch = $0
+                proposal.approvals.branchSelected = !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+        )
+    }
+
+    private var privacyBinding: Binding<Bool> {
+        Binding(
+            get: { proposal.approvals.privacyAcknowledged },
+            set: { proposal.approvals.privacyAcknowledged = $0 }
+        )
+    }
+
+    private var commitBinding: Binding<Bool> {
+        Binding(
+            get: { proposal.approvals.commitApproved },
+            set: { proposal.approvals.commitApproved = $0 }
+        )
+    }
+
+    private var pushBinding: Binding<Bool> {
+        Binding(
+            get: { proposal.approvals.pushApproved },
+            set: { proposal.approvals.pushApproved = $0 }
+        )
+    }
+
+    private func copyPatch() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(
+            CommandProductPublication.reviewablePatch(proposal),
+            forType: .string
+        )
+        status = "Copied reviewable patch. Favorite layout and usage history were not included."
+    }
+
+    private func markReady() {
+        guard let next = CommandProductPublication.markReady(proposal, developerMode: developerMode) else {
+            status = "Need outcome, issue, branch, and a clean or acknowledged privacy scan."
+            return
+        }
+        proposal = next
+        status = "Ready. Git still requires explicit commit and push approval."
+    }
+
+    private func applyGit() {
+        guard CommandProductPublication.gitExecutionEnabled() else {
+            status = "Publication Git is disabled. Copy the patch instead."
+            return
+        }
+        proposal = CommandProductPublication.applyApprovedGit(
+            proposal,
+            developerMode: developerMode,
+            hasRepo: repoIdentity != nil,
+            repoIdentity: repoIdentity,
+            execute: { _ in false }
+        )
+        if proposal.state == .published {
+            status = "Published."
+        } else {
+            status = "Git execute refused. No silent commit or push."
+        }
+    }
+}

--- a/TheBridge/UI/Sections/CommandsEditorView.swift
+++ b/TheBridge/UI/Sections/CommandsEditorView.swift
@@ -33,6 +33,18 @@ public struct CommandsEditorView: View {
     // for the full curated catalog; the inline Appearance card covers the common
     // emoji/symbol + tint choices per the design).
     @State private var iconPickerPresented: Bool = false
+    @AppStorage(BridgeDefaults.commandsDeveloperPublication)
+    private var developerPublication = false
+    @State private var publicationPresented = false
+    @State private var publicationProposal = CommandProductProposal(
+        diff: CommandProductDiff(
+            commandID: "",
+            slug: "",
+            name: "",
+            localBody: "",
+            intendedProductOutcome: ""
+        )
+    )
 
     // Inline Appearance card state (mirrors the design's page-level pickTab/tint).
     private enum AppearanceTab: Hashable { case emoji, symbol }
@@ -92,6 +104,13 @@ public struct CommandsEditorView: View {
                     }
                 )
             }
+        }
+        .sheet(isPresented: $publicationPresented) {
+            CommandProductPublicationSheet(
+                isPresented: $publicationPresented,
+                proposal: $publicationProposal,
+                developerMode: developerPublication
+            )
         }
     }
 
@@ -249,6 +268,11 @@ public struct CommandsEditorView: View {
             Spacer(minLength: 8)
 
             HStack(spacing: 3) {
+                if CommandProductPublication.developerControlsVisible(developerMode: developerPublication) {
+                    headerAction("arrow.up.doc", help: "Propose as Product Change") {
+                        openPublication(c)
+                    }
+                }
                 headerAction("doc.on.doc", help: "Duplicate") { duplicate(c) }
                 headerAction("trash", help: "Delete", danger: true) { delete(c) }
             }
@@ -883,6 +907,18 @@ public struct CommandsEditorView: View {
         } catch {
             saveMessage = error.localizedDescription
         }
+    }
+
+    private func openPublication(_ c: CommandStore.Command) {
+        let rec = try? CommandStore.shared.reconciliation(slug: c.slug)
+        let baseBody = rec?.base?.body ?? rec?.incoming.body
+        publicationProposal = CommandProductPublication.draft(
+            command: c,
+            baseBody: baseBody,
+            intendedProductOutcome: "",
+            sensitivePaths: ConfigManager.shared.sensitivePaths
+        )
+        publicationPresented = true
     }
 
     private func duplicate(_ c: CommandStore.Command) {

--- a/TheBridgeTests/CommandProductPublicationTests.swift
+++ b/TheBridgeTests/CommandProductPublicationTests.swift
@@ -1,0 +1,202 @@
+// CommandProductPublicationTests.swift — D0 / GitHub #140
+//
+// Developer publication is gated, reviewable, and never silent. Standard mode
+// has no GitHub controls. Local command state stays until explicit reconcile.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandProductPublicationTests() async {
+    print("\n[Command product publication D0 / #140]")
+
+    await test("D0 standard mode hides GitHub and branch controls") {
+        try expect(CommandProductPublication.developerControlsVisible(developerMode: false) == false)
+        try expect(CommandProductPublication.developerControlsVisible(developerMode: true) == true)
+        let draft = sampleDraft()
+        try expect(CommandProductPublication.canBecomeReady(draft, developerMode: false) == false)
+        try expect(CommandProductPublication.intendedGitAction(
+            draft, developerMode: false, hasRepo: true, repoIdentity: "/tmp/repo"
+        ) == nil)
+    }
+
+    await test("D0 offline updates remain available without a repo") {
+        try expect(CommandProductPublication.canUseOfflineUpdatesWithoutGit(hasRepo: false))
+        try expect(CommandProductPublication.canUseOfflineUpdatesWithoutGit(hasRepo: true))
+        try expect(CommandProductPublication.repositoryIdentity(repoRoot: "  ") == nil)
+        try expect(CommandProductPublication.repositoryIdentity(repoRoot: nil) == nil)
+        try expect(CommandProductPublication.repositoryIdentity(repoRoot: "/Users/keepup/Developer/the-bridge") != nil)
+    }
+
+    await test("D0 privacy scan blocks secrets until acknowledged") {
+        let hits = CommandProductPublication.scanPrivacy(
+            body: "read ~/.ssh/id_ed25519 and sk_live_secret",
+            sensitivePaths: ["~/.ssh"],
+            extraSecrets: []
+        )
+        try expect(hits.contains(where: { $0.token == "~/.ssh" }))
+        try expect(hits.contains(where: { $0.token == "sk_live_" }))
+        var proposal = sampleDraft(body: "read ~/.ssh/id_ed25519")
+        proposal.findings = hits.filter { $0.token == "~/.ssh" }
+        proposal.issueNumber = 140
+        proposal.branch = "feat/issue-140-d0-test"
+        proposal.diff.intendedProductOutcome = "Ship a safer default"
+        try expect(CommandProductPublication.privacyBlocks(proposal))
+        try expect(CommandProductPublication.canBecomeReady(proposal, developerMode: true) == false)
+        proposal.approvals.privacyAcknowledged = true
+        try expect(CommandProductPublication.canBecomeReady(proposal, developerMode: true))
+    }
+
+    await test("D0 commit and push never run without explicit approval") {
+        var proposal = readyProposal()
+        var executed: [String] = []
+        let silent = CommandProductPublication.applyApprovedGit(
+            proposal,
+            developerMode: true,
+            hasRepo: true,
+            repoIdentity: "/tmp/the-bridge",
+            execute: { executed.append($0); return true }
+        )
+        try expect(executed.isEmpty)
+        try expect(silent.state == .ready)
+        try expect(silent.recordedGitActions.isEmpty)
+
+        proposal.approvals.commitApproved = true
+        let committed = CommandProductPublication.applyApprovedGit(
+            proposal,
+            developerMode: true,
+            hasRepo: true,
+            repoIdentity: "/tmp/the-bridge",
+            execute: { executed.append($0); return true }
+        )
+        try expect(executed == ["commit"])
+        try expect(committed.state == .ready)
+
+        executed = []
+        proposal.approvals.pushApproved = true
+        let published = CommandProductPublication.applyApprovedGit(
+            proposal,
+            developerMode: true,
+            hasRepo: true,
+            repoIdentity: "/tmp/the-bridge",
+            execute: { executed.append($0); return true }
+        )
+        try expect(executed == ["commit-and-push"])
+        try expect(published.state == .published)
+        try expect(published.recordedGitActions == ["commit-and-push"])
+    }
+
+    await test("D0 patch omits favorite layout and usage history") {
+        let draft = sampleDraft()
+        try expect(draft.diff.includesFavoriteLayout == false)
+        try expect(draft.diff.includesUsageHistory == false)
+        try expect(draft.diff.outboundBody == "local-body")
+        try expect(!draft.diff.outboundBody.contains("keySlot"))
+        let patch = CommandProductPublication.reviewablePatch(draft)
+        try expect(patch.contains("local-body"))
+        try expect(!patch.contains("keySlot"))
+        try expect(!patch.contains("lastUsedAt"))
+    }
+
+    await test("D0 missing repo or Git flag refuses commit even with approvals") {
+        var proposal = readyProposal()
+        proposal.approvals.commitApproved = true
+        proposal.approvals.pushApproved = true
+        var executed: [String] = []
+        let noRepo = CommandProductPublication.applyApprovedGit(
+            proposal,
+            developerMode: true,
+            hasRepo: false,
+            repoIdentity: nil,
+            execute: { executed.append($0); return true }
+        )
+        try expect(executed.isEmpty)
+        try expect(noRepo.state == .ready)
+        try expect(CommandProductPublication.gitExecutionEnabled(environment: [:]) == false)
+        try expect(CommandProductPublication.productRepoIdentity(environment: [:]) == nil)
+        try expect(CommandProductPublication.gitExecutionEnabled(
+            environment: ["BRIDGE_COMMAND_PUBLICATION_GIT": "1"]
+        ))
+        try expect(CommandProductPublication.productRepoIdentity(
+            environment: ["BRIDGE_PRODUCT_REPO": "/tmp/the-bridge"]
+        ) == "/tmp/the-bridge")
+    }
+
+    await test("D0 local override remains until shipped default is reconciled") {
+        try await withTempHomeD0 { _ in
+            try CommandStore.shared.resetForTesting()
+            let created = try CommandStore.shared.create(
+                name: "Local Ship", icon: .emoji("s"), body: "operator override")
+            var proposal = CommandProductPublication.draft(
+                command: created,
+                baseBody: "product default",
+                intendedProductOutcome: "Promote the override",
+                sensitivePaths: []
+            )
+            proposal.issueNumber = 140
+            proposal.branch = "feat/issue-140-d0-test"
+            proposal.approvals = CommandPublicationApprovals(
+                issueAssociated: true,
+                branchSelected: true,
+                commitApproved: true,
+                pushApproved: true,
+                privacyAcknowledged: true
+            )
+            proposal = CommandProductPublication.markReady(proposal, developerMode: true)!
+            proposal = CommandProductPublication.applyApprovedGit(
+                proposal,
+                developerMode: true,
+                hasRepo: true,
+                repoIdentity: "/tmp/the-bridge",
+                execute: { _ in true }
+            )
+            try expect(proposal.state == .published)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.body == "operator override")
+            proposal = CommandProductPublication.simulateShippedDefault(
+                proposal, localStillPresent: true)
+            try expect(proposal.state == .shipped)
+            try expect(try CommandStore.shared.get(slug: created.slug)?.body == "operator override")
+            proposal = CommandProductPublication.reconcileAfterShipped(
+                proposal, localMatchesShipped: true)
+            try expect(proposal.state == .reconciled)
+        }
+    }
+}
+
+private func sampleDraft(body: String = "local-body") -> CommandProductProposal {
+    CommandProductPublication.draft(
+        command: CommandStore.Command(
+            id: "bridge.command.user.local-ship",
+            slug: "local-ship",
+            name: "Local Ship",
+            icon: .emoji("s"),
+            body: body
+        ),
+        baseBody: "product default",
+        intendedProductOutcome: "",
+        sensitivePaths: ["~/.ssh"]
+    )
+}
+
+private func readyProposal() -> CommandProductProposal {
+    var proposal = sampleDraft()
+    proposal.diff.intendedProductOutcome = "Promote the override"
+    proposal.issueNumber = 140
+    proposal.branch = "feat/issue-140-d0-test"
+    proposal.findings = []
+    proposal.approvals.issueAssociated = true
+    proposal.approvals.branchSelected = true
+    return CommandProductPublication.markReady(proposal, developerMode: true)!
+}
+
+private func withTempHomeD0(_ body: (URL) async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("CommandProductPublication-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body(tmp)
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -879,6 +879,9 @@ await runCommandFavoriteLayoutTests()
 // Settings deep-link by immutable command ID. Return never writes.
 await runCommandSearchCreateTests()
 
+// GitHub #140 D0: developer-mode product publication. No silent Git.
+await runCommandProductPublicationTests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-developer-publication-d0.md
+++ b/docs/commands-developer-publication-d0.md
@@ -1,0 +1,32 @@
+# Command developer publication D0
+
+GitHub issue #140, packet D0. An operator can propose a local command override
+as a product change. Ordinary command use and updates stay Git-free.
+
+## Capability gate
+
+Developer publication is off by default (`commandsDeveloperPublication`).
+Standard mode shows no GitHub, branch, commit, or push controls. Offline
+command updates still work with or without a repo.
+
+## Publication transaction
+
+| Step | Required |
+| --- | --- |
+| Review exact outbound body | Always |
+| Associate or create a GitHub issue | Before Ready |
+| Choose an issue-linked branch | Before Ready |
+| Privacy scan | Blocks until acknowledged |
+| Commit | Explicit approval |
+| Push | Explicit approval |
+| Reconcile local override | Only after the shipped default matches |
+
+Favorite layout and usage history are never part of the patch. No commit or
+push is silent. Ambiguous repository identity refuses the Git action.
+
+Proposal states: Draft → Ready → Published → Merged → Shipped → Reconciled.
+
+## Out of scope
+
+Automatic commit/push, standard-mode GitHub UI, publishing favorites, deleting
+the local override on merge, tags, and promoted install.


### PR DESCRIPTION
## Summary
- D0 / #140: operator can propose a local command override as a product change without coupling GitHub to ordinary updates.
- Standard mode stays Git-free. Developer publication is off by default (`commandsDeveloperPublication`). Commit and push never run without explicit approvals, an identified product repo, and `BRIDGE_COMMAND_PUBLICATION_GIT=1`.
- Privacy scan blocks secrets and sensitive paths until acknowledged. Favorite layout and usage history are omitted from the reviewable patch. Local overrides are not deleted after publish.

## Evidence
- Exact SHA `9b4ceaff2610f579932da72afe020fdd091ffc91`
- `TheBridgeTests`: **3724 passed, 0 failed** (floor 3717 + 7 D0)
- Evidence level: **Source Tested** on the feature branch. Not Installed Verified. No tag/release.
- Visual/UX review: live Settings screenshots were **not** captured (UI-ITER fail-closed). Spec: `docs/commands-developer-publication-d0.md`.

## Test plan
- [x] Domain tests: standard-mode gate, privacy block, approval seam, missing-repo refusal, local override retained until reconcile
- [ ] Enable Advanced → Command developer publication and confirm Propose appears only then
- [ ] Confirm ordinary command save still works with the toggle off
- [ ] Confirm Apply approved Git stays refused without `BRIDGE_PRODUCT_REPO` + `BRIDGE_COMMAND_PUBLICATION_GIT=1`

Closes nothing. Program packet D0 for issue #140.

Made with [Cursor](https://cursor.com)