### PR TITLE
Integrate command streams A0–D0 into one #140 review candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased — Commands #140 integration
+
+- **Command system A0–D0 on one review candidate** — Durable custody,
+  directional defaults, GitHub-first feedback, Search favorites/create, and
+  gated developer publication land together. Ordinary updates stay Git-free.
+  No `AGENT_FEEDBACK.md` writer. Promoted install remains the G0 Ship Gate.
+  See `docs/commands-e0-integration.md`.
+
 ## Unreleased — Mail inbox management
 
 - **Mail organize surface** — Extends the Apple Mail family with identity-safe

--- a/TheBridgeTests/CommandGitHubFirstFeedbackTests.swift
+++ b/TheBridgeTests/CommandGitHubFirstFeedbackTests.swift
@@ -139,6 +139,7 @@ private enum CommandFeedbackScan {
     static func activeWriterFiles(under root: URL) throws -> [(path: String, match: String)] {
         let skipNames: Set<String> = [
             "CommandGitHubFirstFeedbackTests.swift",
+            "CommandIntegrationE0Tests.swift",
             "CommandCalibrateReport.swift",
             "CHANGELOG.md",
             "test-floor-gate-history.md",

--- a/TheBridgeTests/CommandIntegrationE0Tests.swift
+++ b/TheBridgeTests/CommandIntegrationE0Tests.swift
@@ -1,0 +1,117 @@
+// CommandIntegrationE0Tests.swift — E0 / GitHub #140
+//
+// A0–D0 coexist on one SHA. Standard mode stays Git-free. Favorite layout
+// never enters a publication patch. Promoted install is still G0.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandIntegrationE0Tests() async {
+    print("\n[Command integration E0 / #140]")
+
+    await test("E0 standard mode, Search Return, and publication stay uncoupled") {
+        try expect(CommandProductPublication.developerControlsVisible(developerMode: false) == false)
+        try expect(CommandSearchCreate.returnCreatesCommand == false)
+        try expect(CommandProductPublication.canUseOfflineUpdatesWithoutGit(hasRepo: false))
+        let draft = CommandProductPublication.draft(
+            command: CommandStore.Command(
+                id: "bridge.command.user.e0",
+                slug: "e0-ship",
+                name: "E0 Ship",
+                icon: .emoji("e"),
+                keySlot: 3,
+                lastUsedAt: Date(),
+                body: "operator override"
+            ),
+            baseBody: "product default",
+            intendedProductOutcome: "Keep the override local until Ready",
+            sensitivePaths: []
+        )
+        try expect(draft.diff.includesFavoriteLayout == false)
+        try expect(draft.diff.includesUsageHistory == false)
+        let patch = CommandProductPublication.reviewablePatch(draft)
+        try expect(patch.contains("operator override"))
+        try expect(!patch.contains("keySlot"))
+        try expect(!patch.contains("lastUsedAt"))
+    }
+
+    await test("E0 local override, favorite slot, and catalog default coexist") {
+        try await withTempHomeE0 { _ in
+            try CommandStore.shared.resetForTesting()
+            try CommandStore.shared.seedIfEmpty()
+            var local = try CommandStore.shared.get(slug: "initiate")
+            try expect(local != nil, "seeded catalog missing initiate")
+            local!.body = "e0-local-override"
+            _ = try CommandStore.shared.update(local!)
+            try CommandStore.shared.setKeySlot(slug: "initiate", slot: 4)
+            let rec = try CommandStore.shared.reconciliation(slug: "initiate")
+            try expect(rec?.local?.body == "e0-local-override")
+            let current = try CommandStore.shared.get(slug: "initiate")
+            try expect(current?.body == "e0-local-override")
+            try expect(current?.keySlot == 4)
+            let draft = CommandProductPublication.draft(
+                command: current!,
+                baseBody: rec?.base?.body,
+                intendedProductOutcome: "Keep the override local",
+                sensitivePaths: []
+            )
+            try expect(draft.diff.includesFavoriteLayout == false)
+            try expect(!CommandProductPublication.reviewablePatch(draft).contains("keySlot"))
+            let close = CommandStore.defaultProductCatalog.first { $0.slug == "close-agent" }
+            try expect(close != nil)
+            try expect(CommandProductCatalog.validate(close!).isEmpty)
+        }
+    }
+
+    await test("E0 live fixture store migrates without rewriting the override") {
+        try await withTempHomeE0 { tmp in
+            let root = tmp.appendingPathComponent("commands-e0-fixture", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let store = CommandStore(storageRoot: root)
+            var fixture = CommandStore.currentLegacyProductionFixture
+            guard let executeIndex = fixture.firstIndex(where: { $0.slug == "execute" }) else {
+                throw TestError.assertion("fixture missing Execute")
+            }
+            fixture[executeIndex].body = "e0-legacy-override\r\nexact"
+            try store.installLegacyFixtureForTesting(fixture)
+            try store.setKeySlot(slug: "execute", slot: fixture[executeIndex].keySlot)
+            try expect(try store.get(slug: "execute")?.body == "e0-legacy-override\r\nexact")
+            let state = try store.reconciliation(slug: "execute")
+            try expect(state?.local?.body == "e0-legacy-override\r\nexact")
+            try expect(try store.get(slug: "execute")?.keySlot == fixture[executeIndex].keySlot)
+        }
+    }
+
+    await test("E0 Calibrate still refuses promoted install") {
+        let report = try CommandCalibrate.make(
+            identity: .init(
+                sourceSHA: "34a9ce010f75d7b475d4b4535a0f0d4be7fc0f2e",
+                sourceBranch: "main",
+                sourceDirty: false,
+                installedSHA: nil,
+                installedPath: nil,
+                identitiesMatch: false
+            ),
+            github: .init(openIssues: ["#140"], openPullRequests: [], ciConclusion: "success"),
+            workspace: .init(branches: ["main"], worktrees: []),
+            release: .init(installAllowed: false, reason: "E0 is a review candidate; G0 owns promoted install"),
+            coherenceNotes: ["A0–D0 are on the integration line"],
+            sprintOutcomes: ["A0", "A1", "B0", "B1", "C0"]
+        )
+        try expect(!report.release.installAllowed)
+        try expect(!report.render().contains("AGENT_FEEDBACK.md"))
+    }
+}
+
+private func withTempHomeE0(_ body: (URL) async throws -> Void) async throws {
+    let fm = FileManager.default
+    let tmp = fm.temporaryDirectory
+        .appendingPathComponent("CommandIntegrationE0-test-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+    BridgePaths.overrideHomeForTesting(tmp)
+    defer {
+        BridgePaths.overrideHomeForTesting(nil)
+        try? fm.removeItem(at: tmp)
+    }
+    try await body(tmp)
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -882,6 +882,9 @@ await runCommandSearchCreateTests()
 // GitHub #140 D0: developer-mode product publication. No silent Git.
 await runCommandProductPublicationTests()
 
+// GitHub #140 E0: A0–D0 coexist; no promoted install; no AGENT_FEEDBACK writer.
+await runCommandIntegrationE0Tests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-e0-integration.md
+++ b/docs/commands-e0-integration.md
@@ -1,0 +1,28 @@
+# Command integration E0
+
+GitHub issue #140, packet E0. A0–D0 are on one integration SHA. This packet
+does not install, tag, or close the issue.
+
+## Integrated streams
+
+| Packet | Contract kept |
+| --- | --- |
+| A0 / A1 | Durable custody and explicit reconciliation. Local overrides stay until adopted. |
+| B0 | Directional catalog defaults. Local overrides are never written from the catalog. |
+| B1 | GitHub Issues is the feedback ledger. No `AGENT_FEEDBACK.md` writer. |
+| C0 | Search favorite slots are reversible and do not mutate command bodies. |
+| C1 | Ordinary Return never creates. Edit deep-links by immutable command ID. |
+| D0 | Developer publication is off by default. No silent Git. |
+
+Issue #129 cursor-insert coverage stays hooked (`CommandCursorInsertTests`).
+Promoted install remains G0.
+
+## Installed-store meaning
+
+“Installed-store” here is the local command custody store (revisioned
+overrides + adopted bases), not `/Applications/The Bridge.app`. Replacing
+the application bundle must not rewrite operator overrides.
+
+## Out of scope
+
+Promoted install, tags, Sparkle, and closing issue #140.


### PR DESCRIPTION
## Summary
- Lands A0–D0 on one review candidate: custody, directional defaults, GitHub-first feedback, Search favorites/create, and gated developer publication.
- Adds `docs/commands-e0-integration.md`, an Unreleased CHANGELOG note, and coexistence/migration tests. Ordinary updates stay Git-free. No `AGENT_FEEDBACK.md` writer. Promoted install remains G0.
- Source Tested on feature SHA `07df0c0` (TheBridgeTests 3728 passed, floor 3724 + 4 E0). Not Installed Verified. No tag or `install-copy`.

## Test plan
- [x] `swift build -c debug --product TheBridgeTests` then `.build/arm64-apple-macosx/debug/TheBridgeTests` on exact SHA `07df0c0`
- [x] E0 coexistence: standard mode hides Git; Search Return never creates; publication patch omits favorite layout
- [x] Live fixture store migrates without rewriting the local override
- [x] Calibrate still refuses promoted install
- [ ] CI `build-and-test` SUCCESS
- [ ] Manual Search/Settings smoke (UI-ITER fail-closed: live screenshots not captured this pass)

Closes nothing. Issue #140 stays open until G0.


Made with [Cursor](https://cursor.com)