### PR TITLE
Harden command preservation with an adversarial F0 rehearsal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased — Commands #140 hardening
+
+- **Command system F0 adversarial rehearsal** — Forward-update, interrupt,
+  corrupt-revision, tombstone, favorite undo, compatibility-required, and
+  publication-privacy cases stay on one SHA. Signed candidate may be built;
+  promoted install remains the G0 Ship Gate. See `docs/commands-f0-hardening.md`.
+
 ## Unreleased — Commands #140 integration
 
 - **Command system A0–D0 on one review candidate** — Durable custody,

--- a/TheBridgeTests/CommandGitHubFirstFeedbackTests.swift
+++ b/TheBridgeTests/CommandGitHubFirstFeedbackTests.swift
@@ -140,6 +140,7 @@ private enum CommandFeedbackScan {
         let skipNames: Set<String> = [
             "CommandGitHubFirstFeedbackTests.swift",
             "CommandIntegrationE0Tests.swift",
+            "CommandHardeningF0Tests.swift",
             "CommandCalibrateReport.swift",
             "CHANGELOG.md",
             "test-floor-gate-history.md",

--- a/TheBridgeTests/CommandHardeningF0Tests.swift
+++ b/TheBridgeTests/CommandHardeningF0Tests.swift
@@ -1,0 +1,188 @@
+// CommandHardeningF0Tests.swift — F0 / GitHub #140
+//
+// Adversarial rehearsal of the integrated command system. No promoted install.
+
+import Foundation
+import TheBridgeLib
+
+func runCommandHardeningF0Tests() async {
+    print("\n[Command hardening F0 / #140]")
+
+    await test("F0 two forward catalog updates keep the local override") {
+        try await withHardeningStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommandF0(store, slug: "initiate")
+            local.body = "f0-override-v1\nexact"
+            _ = try store.update(local)
+            var first = CommandStore.defaultProductCatalog
+            first[0].body = "incoming-forward-1"
+            let afterFirst = CommandStore(storageRoot: root, productDefaults: first)
+            try expect(try requireCommandF0(afterFirst, slug: "initiate").body == "f0-override-v1\nexact")
+            var second = first
+            second[0].body = "incoming-forward-2"
+            let afterSecond = CommandStore(storageRoot: root, productDefaults: second)
+            let kept = try requireCommandF0(afterSecond, slug: "initiate")
+            try expect(kept.body == "f0-override-v1\nexact")
+            let rec = try requireReconciliationF0(afterSecond, slug: "initiate")
+            try expect(rec.local?.body == "f0-override-v1\nexact")
+            try expect(rec.incoming.body == "incoming-forward-2")
+        }
+    }
+
+    await test("F0 interrupted write and corrupt revision do not lose the prior body") {
+        try await withHardeningStore { store, root in
+            let stable = try store.create(name: "F0 Stable", icon: .emoji("s"), body: "f0-prior-valid")
+            store.setFaultPointForTesting(.beforeActivation)
+            var threwInterrupt = false
+            do {
+                _ = try store.create(name: "F0 Interrupted", icon: .emoji("x"), body: "must not activate")
+            } catch CommandStore.StoreError.injectedFailure(.beforeActivation) {
+                threwInterrupt = true
+            }
+            store.setFaultPointForTesting(nil)
+            try expect(threwInterrupt)
+            try expect(try store.get(slug: stable.slug)?.body == "f0-prior-valid")
+            try expect(try store.get(slug: "f0-interrupted") == nil)
+
+            var revisionTwo = stable
+            revisionTwo.body = "f0-should-not-win"
+            _ = try store.update(revisionTwo)
+            try store.corruptActiveBodyForTesting(commandID: stable.id)
+            let reopened = CommandStore(storageRoot: root)
+            try expect(try reopened.get(slug: stable.slug)?.body == "f0-prior-valid")
+            try reopened.setKeySlot(slug: stable.slug, slot: nil)
+            try expect(try reopened.get(slug: stable.slug)?.body == "f0-prior-valid")
+        }
+    }
+
+    await test("F0 tombstone, favorite undo, and Search collision stay coherent") {
+        try await withHardeningStore { store, _ in
+            try store.seedIfEmpty()
+            let before = try requireCommandF0(store, slug: "review")
+            try store.delete(slug: "review")
+            try expect(try store.get(slug: "review") == nil)
+            try store.seedIfEmpty()
+            try expect(try store.get(slug: "review") == nil, "hidden default resurrected")
+            try expect(before.body.isEmpty == false)
+
+            var session = FavoriteLayoutSession(current: FavoriteLayout(slots: [1: "initiate", 2: "execute"]))
+            _ = session.chooseSlot(1, for: "execute")
+            let replaced = session.resolveReplace()
+            try expect(replaced?.slug(in: 1) == "execute")
+            try expect(replaced?.slot(of: "initiate") == nil)
+            let undone = session.undo()
+            try expect(undone?.slug(in: 1) == "initiate")
+            try expect(undone?.slug(in: 2) == "execute")
+
+            let existing = try store.list()
+            let collision = CommandSearchCreate.assess(
+                draft: CommandCreateDraft(name: "Initiate", body: "other"),
+                existing: existing,
+                sensitivePaths: []
+            )
+            try expect(!collision.canProposeSave)
+            try expect(CommandSearchCreate.returnCreatesCommand == false)
+        }
+    }
+
+    await test("F0 compatibility-required is a true positive; editorial stays executable") {
+        try await withHardeningStore { store, root in
+            try store.seedIfEmpty()
+            var local = try requireCommandF0(store, slug: "initiate")
+            local.body = "f0-local"
+            _ = try store.update(local)
+
+            var editorial = CommandStore.defaultProductCatalog
+            editorial[0].body = "wording-only"
+            let editorialStore = CommandStore(storageRoot: root, productDefaults: editorial)
+            let editorialState = try requireReconciliationF0(editorialStore, slug: "initiate")
+            try expect(editorialState.classification == .editorial)
+            try expect(editorialState.executionGate == .open)
+            try expect(try editorialStore.get(slug: "initiate")?.body == "f0-local")
+
+            var incompatible = editorial
+            incompatible[0].schemaVersion = 2
+            incompatible[0].requiredCapabilities = ["commands.hardening.v2"]
+            let gated = CommandStore(storageRoot: root, productDefaults: incompatible)
+            let gatedState = try requireReconciliationF0(gated, slug: "initiate")
+            try expect(gatedState.classification == .compatibilityRequired)
+            guard case .compatibilityRequired(let evidence) = gatedState.executionGate else {
+                throw TestError.assertion("expected compatibility-required gate")
+            }
+            try expect(evidence.contains("schemaVersion"))
+            try expect(try gated.get(slug: "initiate")?.body == "f0-local")
+        }
+    }
+
+    await test("F0 publication privacy and Calibrate still refuse silent ship") {
+        var proposal = CommandProductPublication.draft(
+            command: CommandStore.Command(
+                id: "bridge.command.user.f0",
+                slug: "f0-ship",
+                name: "F0 Ship",
+                icon: .emoji("f"),
+                body: "read ~/.ssh/id_ed25519"
+            ),
+            baseBody: "product default",
+            intendedProductOutcome: "Harden publication",
+            sensitivePaths: ["~/.ssh"]
+        )
+        proposal.issueNumber = 140
+        proposal.branch = "feat/issue-140-f0-hardening"
+        try expect(CommandProductPublication.developerControlsVisible(developerMode: false) == false)
+        try expect(CommandProductPublication.privacyBlocks(proposal))
+        try expect(CommandProductPublication.canBecomeReady(proposal, developerMode: true) == false)
+        proposal.approvals.privacyAcknowledged = true
+        try expect(CommandProductPublication.canBecomeReady(proposal, developerMode: true))
+        try expect(CommandProductPublication.intendedGitAction(
+            proposal, developerMode: false, hasRepo: true, repoIdentity: "/tmp/repo"
+        ) == nil)
+
+        let report = try CommandCalibrate.make(
+            identity: .init(
+                sourceSHA: "5bf864b86e017f3d89510f818ede8d41ee5ebda1",
+                sourceBranch: "main",
+                sourceDirty: false,
+                installedSHA: nil,
+                installedPath: nil,
+                identitiesMatch: false
+            ),
+            github: .init(openIssues: ["#140"], openPullRequests: [], ciConclusion: "success"),
+            workspace: .init(branches: ["main"], worktrees: []),
+            release: .init(installAllowed: false, reason: "F0 may sign a candidate; G0 owns promoted install"),
+            coherenceNotes: ["E0 is on the integration line"],
+            sprintOutcomes: ["E0", "F0 hardening"]
+        )
+        try expect(report.isBounded)
+        try expect(!report.release.installAllowed)
+        try expect(CommandFeedbackLedger.activeWriterHits(in: report.render()).isEmpty)
+    }
+}
+
+private func withHardeningStore(
+    _ body: (CommandStore, URL) async throws -> Void
+) async throws {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory
+        .appendingPathComponent("CommandHardening-F0-\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: root) }
+    try await body(CommandStore(storageRoot: root), root)
+}
+
+private func requireCommandF0(_ store: CommandStore, slug: String) throws -> CommandStore.Command {
+    guard let command = try store.get(slug: slug) else {
+        throw TestError.assertion("missing command \(slug)")
+    }
+    return command
+}
+
+private func requireReconciliationF0(
+    _ store: CommandStore,
+    slug: String
+) throws -> CommandStore.CommandReconciliation {
+    guard let state = try store.reconciliation(slug: slug) else {
+        throw TestError.assertion("missing reconciliation for \(slug)")
+    }
+    return state
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -885,6 +885,9 @@ await runCommandProductPublicationTests()
 // GitHub #140 E0: A0–D0 coexist; no promoted install; no AGENT_FEEDBACK writer.
 await runCommandIntegrationE0Tests()
 
+// GitHub #140 F0: adversarial preservation matrix. No promoted install.
+await runCommandHardeningF0Tests()
+
 // PKT-876 (v3.6.1): Settings sections Liquid Glass reskin.
 await runSettingsSectionsLGTests()
 

--- a/docs/commands-f0-hardening.md
+++ b/docs/commands-f0-hardening.md
@@ -1,0 +1,30 @@
+# Command hardening F0
+
+GitHub issue #140, packet F0. E0 is merged. This packet hardens the integrated
+command system and may produce a signed candidate. It does not install, tag,
+or close the issue.
+
+## Preservation matrix (source)
+
+| Rehearsal | Expected |
+| --- | --- |
+| Two forward catalog updates | Local override body stays byte-for-byte |
+| Interrupted revision write | Prior revision stays active |
+| Corrupt new revision | Reads stay on the last valid body; mutation recovers |
+| Product-default hide | Tombstone does not resurrect the default |
+| Favorite replace + undo | Layout restores; command bodies unchanged |
+| Compatibility-required incoming | Execution gate closes with schema evidence |
+| Editorial incoming | Execution gate stays open (false-positive refusal) |
+| Search create | Ordinary Return never writes; exact name collision blocks Save |
+| Developer publication | Secrets block Ready until acknowledged; standard mode has no Git |
+| Calibrate | Bounded; `installAllowed` stays false |
+
+## Out of scope
+
+Promoted install (`make install-copy`), tags, Sparkle, and closing #140.
+G0 owns `/Applications`.
+
+## Visual / UX
+
+UI-ITER is fail-closed. Live Search/Settings screenshots are a named gap
+unless captured in the same SHA receipt.


### PR DESCRIPTION
## Summary
- Adds an F0 preservation-matrix rehearsal: two forward catalog updates, interrupt/corrupt recovery, tombstone hide, favorite undo, Search collision, compatibility-required vs editorial, publication privacy, and Calibrate still refusing promoted install.
- Docs: `docs/commands-f0-hardening.md`. No `install-copy`, tag, or close of #140. G0 still owns `/Applications`.
- Source tests on feature SHA `956fc70` (TheBridgeTests 3733 passed locally before/at commit). Signed-candidate receipt follows separately if `make sign` succeeds in the F0 worktree.

## Test plan
- [x] `swift build -c debug --product TheBridgeTests` then run the binary
- [ ] Rebind the same suite to exact SHA `956fc70` on a clean tree
- [ ] CI `build-and-test` SUCCESS
- [ ] `make sign` candidate (no `install-copy`)
- [ ] Manual Search/Settings smoke (UI-ITER fail-closed unless screenshots land)

Closes nothing. Issue #140 stays open until G0.


Made with [Cursor](https://cursor.com)