### PR TITLE
Restore command insert at the pre-palette caret

### DIFF
--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -601,13 +601,11 @@ public final class CommandBridgeController: NSObject {
         // Cancel any in-flight close so re-hotkey mid-fade doesn't orderOut.
         dismissGeneration &+= 1
 
-        // (v3.7.6) Capture the frontmost app BEFORE we order the panel front,
-        // so paste-into-app can re-activate it on commit. The panel is a
-        // `.nonactivatingPanel`, so the prior app normally stays frontmost —
-        // but we record it explicitly to be robust across Spaces / ⌘-Tab.
-        let me = NSRunningApplication.current
-        let front = NSWorkspace.shared.frontmostApplication
-        priorApp = (front?.processIdentifier == me.processIdentifier) ? nil : front
+        // Snapshot the destination caret BEFORE the palette becomes key.
+        // `makeKeyAndOrderFront` below focuses the query field and clears
+        // the prior app's AX focused element — insert must use this snapshot
+        // (issue #129 live miss: clipboard gone, nothing landed at cursor).
+        snapshotInsertDestination(frontmost: NSWorkspace.shared.frontmostApplication)
 
         let panel = self.panel ?? makePanel()
         self.panel = panel
@@ -676,11 +674,22 @@ public final class CommandBridgeController: NSObject {
         }
     }
 
+    /// Snapshot the app + focused AX element that should receive the
+    /// command body. Called from `show()` before the palette becomes key.
+    /// Tests call this with `NSRunningApplication.current` (self → no target).
+    public func snapshotInsertDestination(frontmost: NSRunningApplication?) {
+        let me = NSRunningApplication.current.processIdentifier
+        priorApp = (frontmost?.processIdentifier == me) ? nil : frontmost
+        inserter.captureFocusedElement(of: insertTargetPID(priorApp))
+    }
+
     /// Public entrypoint mirroring the legacy `dismissOnEscape()` —
     /// closes the popup without writing anything.
     /// Visual-pass: animate close (didOpen→false) then `orderOut` only after
     /// `closeDuration` so dismiss is never a hard cut (Red Team DoD).
-    public func hide() {
+    /// Pass `immediate: true` on the fire path so CGEvent typing cannot
+    /// land in the palette query field.
+    public func hide(immediate: Bool = false) {
         guard lifecycle == .open || lifecycle == .opening else { return }
         lifecycle = .closing
         removeFocusLossObserver()
@@ -689,6 +698,12 @@ public final class CommandBridgeController: NSObject {
         removeDidMoveObserver()
         model?.didOpen = false
         dismissGeneration &+= 1
+        if immediate {
+            panel?.orderOut(nil)
+            model?.resetToTray()
+            lifecycle = .closed
+            return
+        }
         let gen = dismissGeneration
         let reduce = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
         let delay = reduce ? 0 : CommandBridgeAnimation.locked.closeDuration
@@ -827,8 +842,9 @@ public final class CommandBridgeController: NSObject {
 
     /// Shared fire path for `fireSlot` / `fireSlug`. Inserts the body at
     /// the prior app's focused editable control (issue #129). Never
-    /// copies to the clipboard. On failure, records a status and still
-    /// closes the palette so the operator is not stuck in the overlay.
+    /// copies to the clipboard. Dismisses the palette *before* insert so
+    /// synthetic typing cannot land in the query field; the focused
+    /// element was snapshotted at `show()`.
     /// Compatibility-required commands fail closed: no insert, no fire.
     private func commitBody(_ body: String, slug: String) {
         let gate: CommandStore.ExecutionGate
@@ -848,16 +864,18 @@ public final class CommandBridgeController: NSObject {
         }
         let target = priorApp
         let pid = insertTargetPID(target)
+        // Resign key before AX / CGEvent insert. The destination caret was
+        // captured in `snapshotInsertDestination` while the palette was
+        // still not key.
+        hide(immediate: true)
+        if let target,
+           target.processIdentifier != NSRunningApplication.current.processIdentifier {
+            target.activate()
+        }
         let outcome = applyCommit(.paste(body), intoProcess: pid)
         if outcome?.succeeded == true {
             try? store.recordUse(slug: slug)
             recents.record(slug)
-        }
-        hide()
-        if outcome?.succeeded == true,
-           let target,
-           target.processIdentifier != NSRunningApplication.current.processIdentifier {
-            target.activate(options: [])
         }
         if let outcome, !outcome.succeeded {
             print("[CommandBridge] \(outcome.userMessage)")

--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -9,8 +9,10 @@
 //   • CommandTextSplicer — pure UTF-16 splice (caret insert / selection
 //     replace). Headlessly testable with no Accessibility grant.
 //   • CommandTextInserting — injectable delivery seam. Production is
-//     AccessibilityCommandInserter (AX focused element). Tests inject
-//     RecordingTextInserter so the suite never types into the host.
+//     AccessibilityCommandInserter. It snapshots the focused AX element
+//     *before* the palette becomes key (the query field otherwise clears
+//     the destination caret). Tests inject RecordingTextInserter so the
+//     suite never types into the host.
 
 import Foundation
 import AppKit
@@ -105,6 +107,12 @@ public enum CommandTextSplicer {
 // ============================================================
 
 public protocol CommandTextInserting: AnyObject, Sendable {
+    /// Snapshot the focused AX element of `pid` *before* the command
+    /// palette becomes key. The palette's query field steals AX focus;
+    /// insert uses this snapshot instead of re-querying the live tree.
+    @MainActor
+    func captureFocusedElement(of pid: pid_t?)
+
     /// Insert `text` into the focused editable control of `pid` (the
     /// previously-frontmost app). `pid == nil` means "no destination" —
     /// production fails closed; the recording double still records.
@@ -115,12 +123,18 @@ public protocol CommandTextInserting: AnyObject, Sendable {
 /// Test double. Never touches NSPasteboard or the live AX tree.
 public final class RecordingTextInserter: CommandTextInserting, @unchecked Sendable {
     public private(set) var inserts: [(text: String, pid: pid_t?)] = []
+    public private(set) var capturedFocusPIDs: [pid_t?] = []
     /// Forced outcome for the next (and subsequent) inserts. `.inserted`
     /// character counts are rewritten from the actual payload.
     public var forcedOutcome: CommandInsertOutcome
 
     public init(forcedOutcome: CommandInsertOutcome = .inserted(replacedSelection: false, characters: 0)) {
         self.forcedOutcome = forcedOutcome
+    }
+
+    @MainActor
+    public func captureFocusedElement(of pid: pid_t?) {
+        capturedFocusPIDs.append(pid)
     }
 
     @MainActor
@@ -142,7 +156,21 @@ public final class RecordingTextInserter: CommandTextInserting, @unchecked Senda
 /// Never reads or writes `NSPasteboard`. Fail-closed: missing grant or
 /// missing editable target returns a status outcome, not a clipboard copy.
 public final class AccessibilityCommandInserter: CommandTextInserting, @unchecked Sendable {
+    /// Focused element of the destination app, captured before the
+    /// palette becomes key. AXUIElement is not Sendable; this class is
+    /// already `@unchecked Sendable` and only touched on the main actor.
+    private var capturedElement: AXUIElement?
+    private var capturedPID: pid_t?
+
     public init() {}
+
+    @MainActor
+    public func captureFocusedElement(of pid: pid_t?) {
+        capturedElement = nil
+        capturedPID = pid
+        guard AXIsProcessTrusted(), let pid, pid > 0 else { return }
+        capturedElement = copyFocusedElement(of: pid)
+    }
 
     @MainActor
     public func insert(_ text: String, intoProcess pid: pid_t?) -> CommandInsertOutcome {
@@ -157,14 +185,9 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
 
         guard let pid, pid > 0 else { return .noEditableTarget }
 
-        let appEl = AXUIElementCreateApplication(pid)
-        var focusedRef: CFTypeRef?
-        let focusErr = AXUIElementCopyAttributeValue(
-            appEl, kAXFocusedUIElementAttribute as CFString, &focusedRef)
-        guard focusErr == .success, let focusedRef else {
-            return .noEditableTarget
-        }
-        let focused = focusedRef as! AXUIElement
+        let usedCapture = (capturedPID == pid && capturedElement != nil)
+        let focused = usedCapture ? capturedElement : copyFocusedElement(of: pid)
+        guard let focused else { return .noEditableTarget }
 
         let role = stringAttr(focused, kAXRoleAttribute as String) ?? ""
         if role == "AXSecureTextField" {
@@ -200,7 +223,11 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
             }
         }
 
-        if looksEditable(role: role, element: focused) {
+        // A captured element had the caret when the operator invoked the
+        // palette — try synthetic typing even when Chromium reports a
+        // generic role (AXWebArea / AXGroup) instead of AXTextArea.
+        if usedCapture || looksEditable(role: role, element: focused) {
+            restoreFocus(focused, pid: pid)
             do {
                 try postUnicode(text)
                 return .inserted(replacedSelection: replaced, characters: text.count)
@@ -210,6 +237,28 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
         }
 
         return .noEditableTarget
+    }
+
+    @MainActor
+    private func copyFocusedElement(of pid: pid_t) -> AXUIElement? {
+        let appEl = AXUIElementCreateApplication(pid)
+        var focusedRef: CFTypeRef?
+        let focusErr = AXUIElementCopyAttributeValue(
+            appEl, kAXFocusedUIElementAttribute as CFString, &focusedRef)
+        guard focusErr == .success, let focusedRef else { return nil }
+        return (focusedRef as! AXUIElement)
+    }
+
+    /// Put the caret back on `element` so CGEvent unicode typing lands
+    /// there instead of the (now dismissed) palette query field.
+    @MainActor
+    private func restoreFocus(_ element: AXUIElement, pid: pid_t) {
+        if let app = NSRunningApplication(processIdentifier: pid) {
+            app.activate()
+        }
+        AXUIElementPerformAction(element, kAXRaiseAction as CFString)
+        AXUIElementSetAttributeValue(
+            element, kAXFocusedAttribute as CFString, kCFBooleanTrue)
     }
 
     // MARK: AX helpers

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -12,6 +12,7 @@
 // the operator smoke ceiling (docs/operator/command-bridge-smoke-checklist.md).
 
 import Foundation
+import AppKit
 import TheBridgeLib
 
 func runCommandCursorInsertTests() async {
@@ -204,6 +205,27 @@ func runCommandCursorInsertTests() async {
             throw TestError.assertion("expected inserted, got \(String(describing: outcome))")
         }
         try expect(replaced, "forced replace flag must round-trip")
+        try expect(cb.writeCount == 0)
+    }
+
+    await test("snapshotInsertDestination: frontmost=self captures nil pid (never insert into us)") {
+        let cb = InMemoryClipboard(initial: "prior")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        await ctrl.snapshotInsertDestination(frontmost: NSRunningApplication.current)
+        try expect(ins.capturedFocusPIDs.count == 1, "show-path must snapshot before key, got \(ins.capturedFocusPIDs.count)")
+        try expect(ins.capturedFocusPIDs[0] == nil, "self as frontmost must not be an insert target")
+        try expect(cb.writeCount == 0)
+    }
+
+    await test("snapshotInsertDestination then applyCommit still never writes the clipboard") {
+        let cb = InMemoryClipboard(initial: "user-prior-clip")
+        let ins = RecordingTextInserter()
+        let ctrl = await CommandBridgeController(clipboard: cb, inserter: ins, coordinator: coord())
+        await ctrl.snapshotInsertDestination(frontmost: NSRunningApplication.current)
+        await ctrl.applyCommit(.paste("after-snapshot"))
+        try expect(ins.inserts.map(\.text) == ["after-snapshot"])
+        try expect(cb.readString() == "user-prior-clip")
         try expect(cb.writeCount == 0)
     }
 }


### PR DESCRIPTION
## Summary
- Command activation already stopped writing the clipboard (#129 / F0), but insert looked up AX focus *after* the palette became key, so the destination caret was gone and nothing landed.
- Snapshot the focused element before `makeKeyAndOrderFront`, dismiss the palette, reactivate the destination app, then insert into that snapshot.

## Test plan
- [x] `TheBridgeTests` 3735 passed / 0 failed on this change (pre-rebase)
- [ ] Place caret in Notes or Cursor, invoke a Bridge command, confirm the body inserts at the caret
- [ ] `pbpaste` still matches the pre-fire clipboard
- [ ] Password fields still refuse insert (no clipboard fallback)


Made with [Cursor](https://cursor.com)