### PR TITLE
Aim Chromium command insert above the follow-up strip

### DIFF
--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -199,8 +199,10 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
         let len = selectedRange?.length ?? 0
         let replaced = len > 0
         let before = stringAttr(focused, kAXValueAttribute as String)
+        let frame = axFrame(focused)
+        let trustAX = CommandInsertPointerFocus.trustsAXSet(role: role, frame: frame)
 
-        if isSettable(focused, kAXSelectedTextAttribute as String) {
+        if trustAX, isSettable(focused, kAXSelectedTextAttribute as String) {
             let setErr = AXUIElementSetAttributeValue(
                 focused, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
             if setErr == .success {
@@ -219,7 +221,7 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
             }
         }
 
-        if isSettable(focused, kAXValueAttribute as String),
+        if trustAX, isSettable(focused, kAXValueAttribute as String),
            let current = before ?? stringAttr(focused, kAXValueAttribute as String),
            let range = selectedRange {
             let spliced = CommandTextSplicer.splice(
@@ -299,7 +301,8 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
         ) else { return }
         down.post(tap: .cghidEventTap)
         up.post(tap: .cghidEventTap)
-        _ = CFRunLoopRunInMode(CFRunLoopMode.defaultMode, 0.04, false)
+        let settle = CommandInsertPointerFocus.isWebLike(role) ? 0.08 : 0.04
+        _ = CFRunLoopRunInMode(CFRunLoopMode.defaultMode, settle, false)
     }
 
     private func axFrame(_ el: AXUIElement) -> CGRect? {
@@ -417,10 +420,33 @@ public enum CommandInsertAXVerify {
 /// Pure click-target math for the Chromium fallback. Native AX fields
 /// use the control center; web areas put the composer at the bottom.
 public enum CommandInsertPointerFocus {
+    public static let webLikeRoles: Set<String> = ["AXWebArea", "AXGroup", "AXUnknown"]
+    public static let tallWebAreaThreshold: CGFloat = 120
+
+    public static func isWebLike(_ role: String) -> Bool {
+        webLikeRoles.contains(role)
+    }
+
+    /// Chromium `AXWebArea` (and page-sized groups) report settable AXValue
+    /// without mutating the DOM. Native fields still use AX set + read-back.
+    public static func trustsAXSet(role: String, frame: CGRect?) -> Bool {
+        if role == "AXWebArea" { return false }
+        if isWebLike(role), let frame, frame.height >= tallWebAreaThreshold {
+            return false
+        }
+        return true
+    }
+
     public static func point(role: String, frame: CGRect) -> CGPoint {
-        let webLike: Set<String> = ["AXWebArea", "AXGroup", "AXUnknown"]
-        if webLike.contains(role) {
-            let inset = min(28, max(8, frame.height * 0.12))
+        if isWebLike(role) {
+            let inset: CGFloat
+            if frame.height >= tallWebAreaThreshold {
+                // Page-sized Cursor Agents web area is ~1387px; a 28px
+                // cap lands in the 24px "Send follow-up" strip.
+                inset = min(120, max(48, frame.height * 0.08))
+            } else {
+                inset = min(28, max(8, frame.height * 0.12))
+            }
             return CGPoint(x: frame.midX, y: frame.maxY - inset)
         }
         return CGPoint(x: frame.midX, y: frame.midY)

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -100,9 +100,37 @@ func runCommandCursorInsertTests() async {
         let frame = CGRect(x: 0, y: 0, width: 400, height: 800)
         let p = CommandInsertPointerFocus.point(role: "AXWebArea", frame: frame)
         try expect(p.x == 200, "got \(p.x)")
-        try expect(p.y == 772, "got \(p.y)")
+        try expect(p.y == 736, "got \(p.y)")
         let group = CommandInsertPointerFocus.point(role: "AXGroup", frame: frame)
         try expect(group == p, "AXGroup must share the web-area heuristic")
+    }
+
+    await test("PointerFocus: short web-like control keeps a small inset") {
+        let frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        let p = CommandInsertPointerFocus.point(role: "AXWebArea", frame: frame)
+        try expect(p.x == 60, "got \(p.x)")
+        try expect(p.y == 52, "got \(p.y)")
+    }
+
+    await test("PointerFocus: page-sized Agents web area clears the follow-up strip") {
+        let frame = CGRect(x: 251, y: 30, width: 2030, height: 1387)
+        let p = CommandInsertPointerFocus.point(role: "AXWebArea", frame: frame)
+        let inset = min(120 as CGFloat, max(48, frame.height * 0.08))
+        try expect(p.x == frame.midX, "got \(p.x)")
+        try expect(p.y == frame.maxY - inset, "got \(p.y)")
+        try expect(inset > 28, "28px cap lands in the 24px follow-up strip, got \(inset)")
+        try expect(inset >= 48, "got \(inset)")
+    }
+
+    await test("AXSet: AXWebArea is untrusted even when AXValue looks settable") {
+        let frame = CGRect(x: 251, y: 30, width: 2030, height: 1387)
+        try expect(!CommandInsertPointerFocus.trustsAXSet(role: "AXWebArea", frame: frame))
+        try expect(!CommandInsertPointerFocus.trustsAXSet(role: "AXGroup", frame: frame))
+        try expect(CommandInsertPointerFocus.trustsAXSet(role: "AXTextArea", frame: frame))
+        try expect(CommandInsertPointerFocus.trustsAXSet(
+            role: "AXGroup",
+            frame: CGRect(x: 0, y: 0, width: 200, height: 40)
+        ))
     }
 
     await test("AXVerify: splice match counts as landed") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -54,7 +54,11 @@
 #   read AXValue back; Chromium false success falls through to
 #   click-then-type. Measured 3751 passed, 0 failed on
 #   feat/command-insert-ax-readback.
-FLOOR="${BRIDGE_TEST_FLOOR:-3751}"
+# 2026-08-17: 3751 → 3754 (+3) — tall Chromium web area click inset
+#   clears the 24px follow-up strip; skip AX set on AXWebArea.
+#   Measured 3754 passed, 0 failed on
+#   feat/command-insert-chromium-composer.
+FLOOR="${BRIDGE_TEST_FLOOR:-3754}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Installed #172 still typed into Cursor's 24px **Send follow-up** strip: the focused node is a page-sized `AXWebArea` (~1387px) and the click inset was capped at 28px.
- Skip AX set on `AXWebArea` / tall web-like frames. Chromium reports settable + success while `AXValue` stays empty.
- Tall web-area click inset is now ~8% of height (min 48, max 120), so a 1387px Agents composer is clicked ~111px from the bottom — above the follow-up chrome.

## Test plan
- [x] Local `make test-floor`: **3754 passed, 0 failed** (`/tmp/bridge-test-floor-chromium-composer.log`)
- [ ] After merge + **GO** `install-copy-staged`: ⌃⌘B in this Cursor Agents composer, slot 1/2
- [ ] Body lands in the composer, not Monaco; clipboard unchanged; do not press Return
- [ ] If focus is on **Send follow-up**, click the real composer first, then retry

Do not bump version. Do not tag / Sparkle. Leave #140 open.
