### PR TITLE
Attach command-insert unicode only to keyDown

### DIFF
--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -248,7 +248,10 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
             restoreFocus(focused, pid: pid)
             clickForPointerFocus(focused, role: role)
             do {
-                try postUnicode(text)
+                try postUnicode(
+                    text,
+                    interChunkDelay: CommandInsertUnicodeTyping.interChunkDelay(role: role)
+                )
                 return .inserted(replacedSelection: replaced, characters: text.count)
             } catch {
                 return .insertFailed(reason: "synthetic typing failed")
@@ -364,26 +367,28 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
 
     /// Unicode CGEvent typing — no pasteboard. Last-resort when AX set
     /// fails but the focused element still looks like an editor.
-    private func postUnicode(_ text: String) throws {
+    ///
+    /// Unicode is attached **only** to keyDown. Chromium markdown editors
+    /// (Cursor Agents composer) treat keyDown unicode as live typing
+    /// (input rules eat `**` and drop letters) and insert the same chunk
+    /// again on keyUp — garbled copy then a clean duplicate.
+    private func postUnicode(_ text: String, interChunkDelay: TimeInterval = 0) throws {
         guard let src = CGEventSource(stateID: .hidSystemState) else {
             throw CommandInsertSynthError.source
         }
-        let utf16 = Array(text.utf16)
-        let chunkSize = 20
-        var idx = 0
-        while idx < utf16.count {
-            let end = min(idx + chunkSize, utf16.count)
-            let chunk = Array(utf16[idx..<end])
+        let chunks = CommandInsertUnicodeTyping.utf16Chunks(text)
+        for (i, chunk) in chunks.enumerated() {
             guard let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true),
                   let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
             else { throw CommandInsertSynthError.event }
             chunk.withUnsafeBufferPointer { buf in
                 down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: buf.baseAddress)
-                up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: buf.baseAddress)
             }
             down.post(tap: .cghidEventTap)
             up.post(tap: .cghidEventTap)
-            idx = end
+            if interChunkDelay > 0, i + 1 < chunks.count {
+                Thread.sleep(forTimeInterval: interChunkDelay)
+            }
         }
     }
 }
@@ -450,5 +455,43 @@ public enum CommandInsertPointerFocus {
             return CGPoint(x: frame.midX, y: frame.maxY - inset)
         }
         return CGPoint(x: frame.midX, y: frame.midY)
+    }
+}
+
+/// UTF-16 chunking + keyDown-only unicode policy for synthetic insert.
+/// CGEvent `keyboardSetUnicodeString` caps at ~20 UTF-16 units; surrogate
+/// pairs must not be split across chunks.
+public enum CommandInsertUnicodeTyping {
+    public static let maxUTF16PerChunk = 20
+    /// Chromium contenteditable inserts keyUp unicode as a second copy.
+    public static let attachUnicodeToKeyUp = false
+    public static let webLikeInterChunkDelay: TimeInterval = 0.008
+
+    public static func interChunkDelay(role: String) -> TimeInterval {
+        CommandInsertPointerFocus.isWebLike(role) ? webLikeInterChunkDelay : 0
+    }
+
+    public static func utf16Chunks(_ text: String, maxUTF16: Int = maxUTF16PerChunk) -> [[UInt16]] {
+        let units = Array(text.utf16)
+        guard !units.isEmpty else { return [] }
+        let cap = max(1, maxUTF16)
+        var chunks: [[UInt16]] = []
+        var idx = 0
+        while idx < units.count {
+            var end = min(idx + cap, units.count)
+            if end < units.count, isHighSurrogate(units[end - 1]) {
+                end -= 1
+            }
+            if end <= idx {
+                end = idx + 1
+            }
+            chunks.append(Array(units[idx..<end]))
+            idx = end
+        }
+        return chunks
+    }
+
+    private static func isHighSurrogate(_ u: UInt16) -> Bool {
+        u >= 0xD800 && u <= 0xDBFF
     }
 }

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -133,6 +133,34 @@ func runCommandCursorInsertTests() async {
         ))
     }
 
+    await test("UnicodeTyping: 20 UTF-16 stay one chunk; 21 split 20+1") {
+        let twenty = String(repeating: "a", count: 20)
+        let twentyOne = twenty + "b"
+        let one = CommandInsertUnicodeTyping.utf16Chunks(twenty)
+        let two = CommandInsertUnicodeTyping.utf16Chunks(twentyOne)
+        try expect(one.count == 1, "got \(one.count)")
+        try expect(one[0].count == 20, "got \(one[0].count)")
+        try expect(two.count == 2, "got \(two.count)")
+        try expect(two[0].count == 20 && two[1].count == 1, "got \(two.map(\.count))")
+        try expect(String(utf16CodeUnits: two.flatMap { $0 }, count: 21) == twentyOne, "join must reconstruct")
+    }
+
+    await test("UnicodeTyping: does not split a surrogate pair at the chunk boundary") {
+        let text = String(repeating: "a", count: 19) + "👍"
+        let chunks = CommandInsertUnicodeTyping.utf16Chunks(text)
+        try expect(chunks.count == 2, "got \(chunks.count)")
+        try expect(chunks[0].count == 19, "would have taken high surrogate, got \(chunks[0].count)")
+        try expect(chunks[1].count == 2, "emoji is one surrogate pair, got \(chunks[1].count)")
+        let joined = String(utf16CodeUnits: chunks.flatMap { $0 }, count: text.utf16.count)
+        try expect(joined == text, "got \(joined)")
+    }
+
+    await test("UnicodeTyping: keyUp must not carry unicode; web-like delay is 8ms") {
+        try expect(!CommandInsertUnicodeTyping.attachUnicodeToKeyUp, "keyUp unicode duplicates in Chromium")
+        try expect(CommandInsertUnicodeTyping.interChunkDelay(role: "AXWebArea") == 0.008, "got \(CommandInsertUnicodeTyping.interChunkDelay(role: "AXWebArea"))")
+        try expect(CommandInsertUnicodeTyping.interChunkDelay(role: "AXTextArea") == 0, "native fields need no delay")
+    }
+
     await test("AXVerify: splice match counts as landed") {
         let landed = CommandInsertAXVerify.landed(
             before: "ab",

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -58,7 +58,10 @@
 #   clears the 24px follow-up strip; skip AX set on AXWebArea.
 #   Measured 3754 passed, 0 failed on
 #   feat/command-insert-chromium-composer.
-FLOOR="${BRIDGE_TEST_FLOOR:-3754}"
+# 2026-08-17: 3754 → 3757 (+3) — unicode attach only on keyDown;
+#   Chromium markdown composers duplicate keyUp chunks. Measured
+#   3757 passed, 0 failed on feat/command-insert-unicode-keydown.
+FLOOR="${BRIDGE_TEST_FLOOR:-3757}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Chromium markdown composers (Cursor Agents) treated unicode on both keyDown and keyUp: keyDown ran live markdown input rules (garbled `**`, dropped letters), then keyUp inserted the same chunks as a clean second copy. Stored Recon was never the problem; `commands_get recon` matches the second copy in the paste.
- Attach unicode **only** to keyDown, keep an empty keyUp, avoid splitting UTF-16 surrogate pairs across the 20-unit CGEvent cap, and add an 8ms inter-chunk delay for web-like roles. Clipboard is still never written (#129).
- Floor 3754 → 3757. Local `make test-floor`: **3757 passed, 0 failed**.

## Test plan
- [ ] CI `build-and-test` green
- [ ] After merge + operator **GO** (do not install from this branch): `⌃⌘B` slot 2 (Recon) into this composer produces **one** clean body matching `commands_get recon`
- [ ] Clipboard unchanged; do not press Return during insert
- [ ] If focus is on Send follow-up, click the composer first

Merge with **merge commit**, not squash (same as #172/#173). No version bump, Sparkle, or #140 close.