### PR TITLE
Attach command-insert unicode only to keyUp

### DIFF
--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -368,27 +368,39 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
     /// Unicode CGEvent typing — no pasteboard. Last-resort when AX set
     /// fails but the focused element still looks like an editor.
     ///
-    /// Unicode is attached **only** to keyDown. Chromium markdown editors
-    /// (Cursor Agents composer) treat keyDown unicode as live typing
-    /// (input rules eat `**` and drop letters) and insert the same chunk
-    /// again on keyUp — garbled copy then a clean duplicate.
+    /// Unicode is attached **only** to keyUp. Cursor's markdown composer
+    /// treats keyDown unicode as live typing (`**` eaten, letters dropped).
+    /// `virtualKey` 0 is kVK_ANSI_A — leaving keyUp unset posts `"a"`.
+    /// Carrier 0xFFFF plus an explicit empty unicode payload on keyDown
+    /// avoids both the markdown chew and the A-key leak.
     private func postUnicode(_ text: String, interChunkDelay: TimeInterval = 0) throws {
         guard let src = CGEventSource(stateID: .hidSystemState) else {
             throw CommandInsertSynthError.source
         }
         let chunks = CommandInsertUnicodeTyping.utf16Chunks(text)
+        let vk = CommandInsertUnicodeTyping.carrierKeyCode
         for (i, chunk) in chunks.enumerated() {
-            guard let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true),
-                  let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+            guard let down = CGEvent(keyboardEventSource: src, virtualKey: vk, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: src, virtualKey: vk, keyDown: false)
             else { throw CommandInsertSynthError.event }
-            chunk.withUnsafeBufferPointer { buf in
-                down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: buf.baseAddress)
-            }
+            setUnicode(down, CommandInsertUnicodeTyping.unicodeUnits(forKeyDown: chunk))
+            setUnicode(up, CommandInsertUnicodeTyping.unicodeUnits(forKeyUp: chunk))
             down.post(tap: .cghidEventTap)
             up.post(tap: .cghidEventTap)
             if interChunkDelay > 0, i + 1 < chunks.count {
                 Thread.sleep(forTimeInterval: interChunkDelay)
             }
+        }
+    }
+
+    private func setUnicode(_ event: CGEvent, _ units: [UInt16]) {
+        if units.isEmpty {
+            var zero: UniChar = 0
+            event.keyboardSetUnicodeString(stringLength: 0, unicodeString: &zero)
+            return
+        }
+        units.withUnsafeBufferPointer { buf in
+            event.keyboardSetUnicodeString(stringLength: units.count, unicodeString: buf.baseAddress)
         }
     }
 }
@@ -458,17 +470,29 @@ public enum CommandInsertPointerFocus {
     }
 }
 
-/// UTF-16 chunking + keyDown-only unicode policy for synthetic insert.
+/// UTF-16 chunking + keyUp-only unicode policy for synthetic insert.
 /// CGEvent `keyboardSetUnicodeString` caps at ~20 UTF-16 units; surrogate
-/// pairs must not be split across chunks.
+/// pairs and markdown `**` markers must not be split across chunks.
 public enum CommandInsertUnicodeTyping {
     public static let maxUTF16PerChunk = 20
-    /// Chromium contenteditable inserts keyUp unicode as a second copy.
-    public static let attachUnicodeToKeyUp = false
+    /// kVK_ANSI_A. An unset keyUp on this code posts `"a"`.
+    public static let ansiAKeyCode: CGKeyCode = 0
+    /// Non-character carrier so an empty unicode payload types nothing.
+    public static let carrierKeyCode: CGKeyCode = 0xFFFF
+    public static let attachUnicodeToKeyDown = false
+    public static let attachUnicodeToKeyUp = true
     public static let webLikeInterChunkDelay: TimeInterval = 0.008
 
     public static func interChunkDelay(role: String) -> TimeInterval {
         CommandInsertPointerFocus.isWebLike(role) ? webLikeInterChunkDelay : 0
+    }
+
+    public static func unicodeUnits(forKeyDown chunk: [UInt16]) -> [UInt16] {
+        attachUnicodeToKeyDown ? chunk : []
+    }
+
+    public static func unicodeUnits(forKeyUp chunk: [UInt16]) -> [UInt16] {
+        attachUnicodeToKeyUp ? chunk : []
     }
 
     public static func utf16Chunks(_ text: String, maxUTF16: Int = maxUTF16PerChunk) -> [[UInt16]] {
@@ -481,6 +505,16 @@ public enum CommandInsertUnicodeTyping {
             var end = min(idx + cap, units.count)
             if end < units.count, isHighSurrogate(units[end - 1]) {
                 end -= 1
+            }
+            // Don't split a `**` pair across chunks.
+            if end < units.count, end > idx, units[end - 1] == 0x2A, units[end] == 0x2A {
+                end -= 1
+            }
+            // Don't end a chunk with `**` when more text follows — keep the
+            // marker with the next header (`**Use when:**`, not `**` + `Use when:**`).
+            if end < units.count, end - idx >= 2,
+               units[end - 2] == 0x2A, units[end - 1] == 0x2A {
+                end -= 2
             }
             if end <= idx {
                 end = idx + 1

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -155,10 +155,34 @@ func runCommandCursorInsertTests() async {
         try expect(joined == text, "got \(joined)")
     }
 
-    await test("UnicodeTyping: keyUp must not carry unicode; web-like delay is 8ms") {
-        try expect(!CommandInsertUnicodeTyping.attachUnicodeToKeyUp, "keyUp unicode duplicates in Chromium")
+    await test("UnicodeTyping: keyUp carries unicode; keyDown is empty; carrier is not A") {
+        let chunk: [UInt16] = Array("ab".utf16)
+        try expect(CommandInsertUnicodeTyping.attachUnicodeToKeyUp)
+        try expect(!CommandInsertUnicodeTyping.attachUnicodeToKeyDown)
+        try expect(CommandInsertUnicodeTyping.carrierKeyCode != CommandInsertUnicodeTyping.ansiAKeyCode)
+        try expect(CommandInsertUnicodeTyping.unicodeUnits(forKeyDown: chunk).isEmpty)
+        try expect(CommandInsertUnicodeTyping.unicodeUnits(forKeyUp: chunk) == chunk)
         try expect(CommandInsertUnicodeTyping.interChunkDelay(role: "AXWebArea") == 0.008, "got \(CommandInsertUnicodeTyping.interChunkDelay(role: "AXWebArea"))")
         try expect(CommandInsertUnicodeTyping.interChunkDelay(role: "AXTextArea") == 0, "native fields need no delay")
+    }
+
+    await test("UnicodeTyping: does not end a chunk with ** when a header follows") {
+        let text = "aping or acting.\n\n**Use when:** important"
+        let chunks = CommandInsertUnicodeTyping.utf16Chunks(text)
+        let decoded = chunks.map { String(utf16CodeUnits: $0, count: $0.count) }
+        try expect(!decoded.dropLast().contains(where: { $0.hasSuffix("**") }), "got \(decoded)")
+        try expect(decoded.contains(where: { $0.contains("**Use when:**") }), "got \(decoded)")
+        let joined = String(utf16CodeUnits: chunks.flatMap { $0 }, count: text.utf16.count)
+        try expect(joined == text, "got \(joined)")
+    }
+
+    await test("UnicodeTyping: does not split a ** pair across chunks") {
+        let text = String(repeating: "x", count: 19) + "**"
+        let chunks = CommandInsertUnicodeTyping.utf16Chunks(text)
+        let decoded = chunks.map { String(utf16CodeUnits: $0, count: $0.count) }
+        try expect(!decoded.contains(where: { $0.hasSuffix("*") && !$0.hasSuffix("**") && $0 != "*" }), "split pair: \(decoded)")
+        let joined = String(utf16CodeUnits: chunks.flatMap { $0 }, count: text.utf16.count)
+        try expect(joined == text, "got \(joined)")
     }
 
     await test("AXVerify: splice match counts as landed") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -61,7 +61,11 @@
 # 2026-08-17: 3754 → 3757 (+3) — unicode attach only on keyDown;
 #   Chromium markdown composers duplicate keyUp chunks. Measured
 #   3757 passed, 0 failed on feat/command-insert-unicode-keydown.
-FLOOR="${BRIDGE_TEST_FLOOR:-3757}"
+# 2026-08-18: 3757 → 3759 (+2) — unicode attach only on keyUp; carrier
+#   0xFFFF so unset events are not kVK_ANSI_A; don't split markdown **.
+#   Measured 3759 passed, 0 failed on
+#   fix/command-insert-keyup-unicode.
+FLOOR="${BRIDGE_TEST_FLOOR:-3759}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- Runtime tap of a live Recon insert showed **keyDown carrying each 20-unit chunk** (Cursor markdown chews `**` / drops letters) and **keyUp of virtualKey 0 posting `"a"`** (kVK_ANSI_A). PR #174 never cleared keyUp unicode, so the A-key leak remained.
- Attach unicode **only to keyUp**, post an explicit empty unicode payload on keyDown, and use carrier keycode `0xFFFF` so empty events type nothing.
- Keep markdown `**` with the following header instead of ending a 20-unit chunk on `**` (`**Use when:**`, not `**` + `Use when:**`).
- Floor 3757 → 3759. Measured 3759 passed, 0 failed.

## Test plan
- [ ] Click the Cursor composer, Control-Command-B, Recon (slot 2) once
- [ ] Inserted body matches `commands_get recon` (no `iestigation`, no `Use when:**`, no second copy, no `nwh -oDeySe*O**nv`)
- [ ] Clipboard unchanged
- [ ] No Return / send


Made with [Cursor](https://cursor.com)