### PR TITLE
release(v4.0.4): assign marketing 4.0.4 and build 93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v4.0.4 (build 93) — staged install + detached claims — 2026-08-18
+
+- **Identity** — Published install after `v4.0.3` / build `92`. Marketing
+  **4.0.4**, build **93**. Sparkle tag `v4.0.4` is this release.
+- **Staged install (#177)** — `install-copy-staged` verifies the staged
+  candidate's version and SPM bundle, not primary `.build/TheBridge.app`.
+- **Detached worktree claims (#178)** — `worktree_claim` documents and tests
+  `branch: "(detached)"` with `baseSHA = HEAD`. Named-branch claims on
+  detached HEAD still fail `worktree_identity_changed`.
+- **Commands Search G0** — Settings → Commands points Search, favorites, and
+  create at the Command Bridge palette. Ordinary Return still never creates.
+- **Audit** — Security review of the 4.0.3 delta plus this branch vs `main`:
+  no open P0/P1. Floor 3759 → 3761.
+
 ## v4.0.3 (build 92) — Command system v2 + post-4.0.2 main — 2026-08-18
 
 - **Identity** — First published install after `v4.0.2` / build `91`. Marketing

--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.3</string>
+	<string>4.0.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>92</string>
+	<string>93</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "4.0.3"
+    public static let marketing = "4.0.4"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -317,7 +317,9 @@ public enum AppVersion {
     /// v4.0.3: 91 -> 92 -- first published install after v4.0.2. Ships command
     /// system v2 (#140 A0–G0), command-insert Chromium/keyUp path (#171–#175),
     /// mail inbox, registry UUID normalize (#160), and voice-memo residuals.
-    public static let build = "92"
+    /// v4.0.4: 92 -> 93 -- staged-install verify attests STAGED_APP (#177);
+    /// detached worktree_claim contract (#178); Commands Search palette hint.
+    public static let build = "93"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## Summary
- One version commit: marketing **4.0.4**, build **93**, CHANGELOG entry.
- Hardening already on `main` via [#179](https://github.com/KUP-IP/the-bridge/pull/179) (CI green, 3761 floor).
- Tag `v4.0.4` comes after Installed Verified, not in this PR.

## Test plan
- [x] Hardening SHA `066c87b` CI build-and-test SUCCESS
- [ ] This PR CI green
- [ ] After merge: FF primary `main`; Sparkle sign/stage/promote separately
