### PR TITLE
fix: keep Command Bridge create Save/Cancel on-host (v4.0.5 / 94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.0.5 (build 94) — Command Bridge create sheet — 2026-08-18
+
+- **Identity** — Published install after `v4.0.4` / build `93`. Marketing
+  **4.0.5**, build **94**. Sparkle tag `v4.0.5` is this release. Do not reuse 93.
+- **Command Bridge** — Create-command sheet expands the host panel to 480pt
+  so Save/Cancel stay inside the glass. Idle/search host stays 260pt.
+- **UI-ITER** — Whole-chrome Light+Dark audit; CB-1 was the only P0. Search
+  C1 and #129 unchanged (ordinary Return never creates; never NSPasteboard
+  on the insert fire path). Floor remains 3761.
+
 ## v4.0.4 (build 93) — staged install + detached claims — 2026-08-18
 
 - **Identity** — Published install after `v4.0.3` / build `92`. Marketing

--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.4</string>
+	<string>4.0.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>93</string>
+	<string>94</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/App/CommandBridge.swift
+++ b/TheBridge/App/CommandBridge.swift
@@ -212,8 +212,25 @@ public enum CommandBridgeChrome: Sendable {
     public static let tilePitch: CGFloat = 48
     /// Host panel width: bar + horizontal breathing room.
     public static let hostWidth: CGFloat = pillWidth + 24
-    /// Host panel height: content-hug for closed + results room (not 360 empty air).
+    /// Host panel height: content-hug for idle + search results (not 360 empty air).
     public static let hostHeight: CGFloat = 260
+    /// Expanded host when the create sheet is open so Save/Cancel stay inside
+    /// the panel. Idle `hostHeight` stays the content-hug floor (< 360).
+    public static let hostHeightCreateSheet: CGFloat = 480
+
+    public static func hostHeight(createSheetOpen: Bool) -> CGFloat {
+        createSheetOpen ? hostHeightCreateSheet : hostHeight
+    }
+
+    /// Cocoa frame after a host-height change that keeps the **top** edge fixed
+    /// (grow/shrink downward). `current` uses bottom-left origin.
+    public static func frameKeepingTop(current: CGRect, newHeight: CGFloat) -> CGRect {
+        let delta = newHeight - current.height
+        return CGRect(x: current.origin.x,
+                      y: current.origin.y - delta,
+                      width: current.width,
+                      height: newHeight)
+    }
 }
 
 // ============================================================
@@ -959,6 +976,7 @@ public final class CommandBridgeController: NSObject {
         let root = CommandBridgeRootView(model: model)
         let host = NSHostingController(rootView: root)
         host.view.frame = NSRect(origin: .zero, size: Self.panelSize)
+        host.view.autoresizingMask = [.width, .height]
         // Transparent host — the BridgeGlass surfaces draw the backing.
         host.view.wantsLayer = true
         host.view.layer?.backgroundColor = NSColor.clear.cgColor
@@ -1608,8 +1626,25 @@ public struct CommandBridgeRootView: View {
         reduceMotion ? .reduced : .locked
     }
 
+    /// Idle 260; create sheet expands so Save/Cancel are not clipped (CB-1).
+    private var activeHostHeight: CGFloat {
+        CommandBridgeChrome.hostHeight(createSheetOpen: model.createAssessment != nil)
+    }
+
     public init(model: CommandBridgeViewModel) {
         self.model = model
+    }
+
+    /// Grow/shrink the hosting panel downward, keeping the top edge where the
+    /// operator last placed it.
+    private func syncPaletteHostSize() {
+        guard let win = paletteWindow else { return }
+        let target = CommandBridgeChrome.frameKeepingTop(
+            current: win.frame,
+            newHeight: activeHostHeight
+        )
+        guard abs(target.height - win.frame.height) > 0.5 else { return }
+        win.setFrame(target, display: true, animate: false)
     }
 
     public var body: some View {
@@ -1637,8 +1672,14 @@ public struct CommandBridgeRootView: View {
             .animation(.easeOut(duration: anim.recentsSlideDuration), value: panelModeKey)
         }
         .frame(width: CommandBridgeChrome.hostWidth,
-               height: CommandBridgeChrome.hostHeight,
+               height: activeHostHeight,
                alignment: .top)
+        .onChange(of: model.createAssessment != nil) { _, _ in
+            syncPaletteHostSize()
+        }
+        .onChange(of: paletteWindow != nil) { _, _ in
+            syncPaletteHostSize()
+        }
         // (PKT-1006 R4c) Publish the drag state so the legibility halos freeze
         // (rasterize) while the window moves instead of shimmering.
         .environment(\.cbIsDragging, isDraggingWindow)

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "4.0.4"
+    public static let marketing = "4.0.5"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -319,7 +319,9 @@ public enum AppVersion {
     /// mail inbox, registry UUID normalize (#160), and voice-memo residuals.
     /// v4.0.4: 92 -> 93 -- staged-install verify attests STAGED_APP (#177);
     /// detached worktree_claim contract (#178); Commands Search palette hint.
-    public static let build = "93"
+    /// v4.0.5: 93 -> 94 -- Command Bridge create sheet host expands so Save/Cancel
+    /// stay inside the panel (chrome UI-ITER CB-1). 4.0.4/93 stays on the feed.
+    public static let build = "94"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/TheBridgeTests/CommandBridgeControllerTests.swift
+++ b/TheBridgeTests/CommandBridgeControllerTests.swift
@@ -127,6 +127,21 @@ func runCommandBridgeControllerTests() async {
                    "tile is squircle, not full circle")
         try expect(CommandBridgeChrome.hostHeight < 360,
                    "host height content-hug (< legacy 360 plate)")
+        try expect(CommandBridgeChrome.hostHeightCreateSheet > CommandBridgeChrome.hostHeight,
+                   "create sheet must expand the host")
+        try expect(CommandBridgeChrome.hostHeight(createSheetOpen: false) == CommandBridgeChrome.hostHeight,
+                   "idle host height")
+        try expect(CommandBridgeChrome.hostHeight(createSheetOpen: true) == CommandBridgeChrome.hostHeightCreateSheet,
+                   "create-sheet host height")
+        try expect(CommandBridgeChrome.hostHeightCreateSheet >= 440,
+                   "create sheet must fit Save/Cancel (Wave 1 CB-1)")
+        let idle = CGRect(x: 100, y: 200, width: CommandBridgeChrome.hostWidth, height: CommandBridgeChrome.hostHeight)
+        let expanded = CommandBridgeChrome.frameKeepingTop(current: idle, newHeight: CommandBridgeChrome.hostHeightCreateSheet)
+        try expect(expanded.height == CommandBridgeChrome.hostHeightCreateSheet, "expanded height")
+        try expect(abs((expanded.maxY) - idle.maxY) < 0.5, "top edge stays put when expanding")
+        let restored = CommandBridgeChrome.frameKeepingTop(current: expanded, newHeight: CommandBridgeChrome.hostHeight)
+        try expect(abs(restored.maxY - idle.maxY) < 0.5, "top edge stays put when shrinking")
+        try expect(abs(restored.height - CommandBridgeChrome.hostHeight) < 0.5, "idle height restored")
         try expect(CommandBridgeChrome.glassShadowRadius <= 14,
                    "shadow budget — no e2 fog")
     }

--- a/docs/operator/uiiter/bridge-settings-uiiter-log.md
+++ b/docs/operator/uiiter/bridge-settings-uiiter-log.md
@@ -69,3 +69,86 @@ Wave A landed on 3.9.9; operator Ship Gate GO (2026-07-21) cut **v4.0.0** / buil
 | Lost PACKET Priority scores (~60) | Pre-session Notion data loss; not this arc |
 | Incomplete views-write smoke receipt file | Untracked; incomplete; leave or finish later |
 | Shell UI-ITER (Dashboard / Command Bridge / Onboarding) | Explicit Wave A OUT |
+
+---
+
+# v4.0.4 / 93 chrome UI-ITER — Wave 1 board (2026-08-18)
+
+**Baseline:** installed 4.0.4 / build 93 · SHA `f4a7d4ee159a841863df9beffe9b15dc86e1cd03` · dirty false  
+**Feed:** 4.0.4 / 93 Released Verified (do not recut). Next legal identity if this campaign ships: **4.0.5 / 94**.  
+**Worktree:** `feat/v4.0.5-chrome-uiiter` @ `55a5d3c` (origin/main + appcast).  
+**Captures (uncommitted):** `docs/operator/uiiter/captures/v404-chrome/{light,dark}/`  
+**Appearance:** operator Light (`AppleInterfaceStyle` absent). Dark pass via System Events; restored Light in-session (Commands recapture `light/commands-restore.png`).  
+**Onboarding:** `hasCompletedOnboarding = 1`. Wizard **deferred** — restore trap would require relaunch (MCP death) or Advanced Reset; Demo Gate Onboarding deferred with reason.  
+**Skill caveat:** app-dev Testing/Building. No Magic Patterns. Track B not used (finding is clip/height, not an IA fork).
+
+## Operator restore traps
+
+| Flag | Before | After |
+|------|--------|-------|
+| Appearance | Light | Light (proven `commands-restore.png` + `AppleInterfaceStyle` absent) |
+| `hasCompletedOnboarding` | 1 | 1 (untouched) |
+
+## Capture matrix
+
+| Surface | Light | Dark |
+|---------|-------|------|
+| Settings Commands | commands.png | commands.png |
+| Settings Skills | skills.png | skills.png |
+| Settings Jobs | jobs.png | jobs.png |
+| Settings Tools | tools.png | tools.png |
+| Settings Security | security.png | security.png |
+| Settings Connection | connection.png | connection.png |
+| Settings Memory | memory.png | memory.png |
+| Settings Data Sources | data-sources.png | data-sources.png |
+| Settings Advanced | advanced.png | advanced.png |
+| Command Bridge idle | command-bridge-idle.png | command-bridge-idle.png |
+| Command Bridge search no-match | command-bridge-search-nomatch.png | (idle Dark covers chrome; create clip is Light P0) |
+| Command Bridge create sheet | command-bridge-create-sheet.png | — |
+| Dashboard | **deferred** | **deferred** |
+| Onboarding | **deferred** | **deferred** |
+
+Duplicate Settings windows (win 5670 + 5628) during the audit — P3 chrome duplication, not ship-blocking.
+
+## UX interaction audit (fail-closed)
+
+| Check | Result |
+|-------|--------|
+| ⌃⌘B opens palette | **PASS** |
+| Esc dismisses palette | **PASS** (toggle close / hide) |
+| 1–0 fire favorites | **PASS** (slot 1 Initiate fired on probe) |
+| Ordinary Return never creates | **PASS** — Return with no-match query did not open sheet or write |
+| ⌥↩ / Create row opens sheet | **PASS** (Create row click) |
+| Cancel drops draft | **PASS with caveat** — Save/Cancel were off-host (P0); no Save |
+| Settings Tools filter is not Search | **PASS** — family chips + tool filter, not Command Bridge Search |
+| Dashboard deep-links | **deferred** — MenuBarExtra popover not captured via AX; Settings MCP navigate lands on named sections |
+| PKT-1005 harness | **PASS** — `make test-floor` 3761 passed, 0 failed on Wave 3 SHA; SettingsAXIdentifierTests green |
+| #129 clipboard on fire path | not reopened; insert path unchanged |
+
+## Critique board (this campaign)
+
+| ID | Surface | P | Finding | Evidence | Status |
+|----|---------|---|---------|----------|--------|
+| CB-1 | Command Bridge | **P0** | Create sheet clipped by fixed `hostHeight` 260. AX Save/Cancel at y=1318; host bottom y=1218. Primary CTAs not visible / not hittable. Named variable: **host clip vs content-hug when create sheet is open**. | light/command-bridge-create-sheet.png | **fixed in code → F.0 recapture** |
+| CB-2 | Command Bridge | P2 | Create sheet Name + body both echo the query string | light/command-bridge-create-sheet.png | deferred (cheap P2 in same file if loop 1 is open) |
+| SET-DUP | Settings | P3 | Two Settings windows (5670 + 5628) | light/commands-win*.png | deferred |
+| CMD-1 | Commands | P3 | Stats repeated hero + footer | Wave A, still | deferred |
+| SK-2 | Skills | P3 | Tall palette empty-state banner | Wave A, still | deferred |
+| CON-1 | Connection | P3 | Live vs sessions skew | Wave A, still | deferred |
+| CON-2 | Connection | P3 | Runtime meta micro-contrast | Wave A, still | deferred |
+| MEM-1 | Memory | P3 | Empty preview sparse | Wave A, still | deferred |
+| DS-1 | Data Sources | P3 | Last card clip / scroll | Wave A, still | deferred |
+| ADV-1 | Advanced | P3 | Network Save vs field height | Wave A, still | deferred |
+| SEC-2 | Security | P3 | GATES digits unlabeled | Wave A, still | deferred |
+| DARK-TOK | Settings + palette | — | Dark carbon tokens readable on 9 Settings + idle palette | dark/*.png | clean; no new P0 |
+
+**P0:** CB-1. **P1:** none (Dashboard/Onboarding are capture-method deferrals, not proven product hierarchy failures). Empty-release gate: **ship 4.0.5 / 94** for CB-1.
+
+## Track A — loop 1
+
+- **Variable:** host panel height must expand when create sheet is open so Save/Cancel stay inside the host.
+- **Track B:** skipped (not an IA fork).
+- **Loop cap remaining after this loop:** 7.
+- **Code:** idle `hostHeight` stays 260 (`< 360`). `hostHeightCreateSheet` = 480. `CommandBridgeRootView` frames to `hostHeight(createSheetOpen:)` and `setFrame`s the NSPanel with `frameKeepingTop` (grow/shrink downward). Hosting view `autoresizingMask` width+height.
+- **CB-2:** left deferred (`CommandSearchCreate.draft` is a different file).
+- **Last loop id:** Track A loop 1. Recapture + Demo Gate in Wave 4.


### PR DESCRIPTION
## Summary
- Expand the Command Bridge host from 260pt to 480pt while the create-command sheet is open so Save/Cancel stay inside the glass (Wave 1 P0 CB-1). Idle/search height stays 260.
- Record the Light+Dark chrome critique board in the UI-ITER log. Track B skipped (clip/height, not an IA fork). CB-2 and remaining P3s stay deferred.
- Version commit: marketing **4.0.5**, build **94**. Do not reuse 93. `v4.0.4` stays Released Verified on the feed.

## Test plan
- [x] `make test-floor` — 3761 passed, 0 failed (floor unchanged)
- [x] Chrome metrics: create-sheet host > idle; `frameKeepingTop` keeps the top edge
- [x] PKT-1005 Settings AX identifier harness green
- [ ] After merge: F.0 recapture Light+Dark create sheet shows Save/Cancel inside the host
- [ ] Demo Gate: Command Bridge search+create (Cancel, no Save of probe); Settings Commands/Security/Connection/Memory
- [ ] Search C1: ordinary Return never creates; #129: no NSPasteboard on insert fire path
- [ ] Tag `v4.0.5` at merge SHA; wait `release.yml`; `make verify-sparkle-feed` (leave 4.0.4/93 as previous item)


Made with [Cursor](https://cursor.com)