### PR TITLE
docs: reconcile current release and config paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 ## Project Overview
 
-TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.0** (build **82**). It registers **205 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **31 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
+TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.5** (build **94**). It registers **223 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **32 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
 
 Bundle ID: `kup.solutions.the-bridge` (legacy: `kup.solutions.notion-bridge`, `solutions.kup.keepr`)
 
@@ -94,7 +94,7 @@ tools or a separately reviewed target contract instead.
 Set the Notion API token (resolution priority order):
 1. `NOTION_API_TOKEN` environment variable
 2. `NOTION_API_KEY` environment variable (legacy)
-3. `~/.config/notion-bridge/config.json` — key: `notion_api_token`
+3. `~/.config/the-bridge/config.json` — key: `notion_api_token` (the legacy `~/.config/notion-bridge/config.json` path is migration input only)
 
 **Cursor MCP (avoid duplicates):** use a **single** global MCP entry in `~/.cursor/mcp.json` named **`Bridge MCP`** (JSON key), pointing at your Streamable HTTP URL (and `Authorization: Bearer` when required). Do **not** add a workspace-scoped duplicate — remove it under Cursor **Settings → MCP** if present, then restart Cursor.
 
@@ -120,7 +120,7 @@ Trunk = `origin/main`. Branches are short-lived and **rebased onto current main 
 
 ### Release flow (the v3.7.x → 3.8.x pattern)
 
-**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `3.8.9 → 3.9.0`, `3.9.9 → 4.0.0`). From the current `3.9.9`, **the next published version is `4.0.0`**, the sale-ready "V4" destination. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
+**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `4.0.9 → 4.1.0`, `4.9.9 → 5.0.0`). From the current `4.0.5`, **the next published version is `4.0.6`**. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
 
 1. `git switch -c release/vX.Y.Z origin/main` (off current main).
 2. One atomic version commit: `Version.swift` (marketing + build) **and** root `Info.plist` (`CFBundleShortVersionString` + `CFBundleVersion`) in the SAME commit (see `### Version surfaces`), plus the `CHANGELOG.md` entry.
@@ -203,7 +203,7 @@ Enable **Keychain credentials** in Settings to expose the `credential_*` MCP too
 
 ### Notion Token Configuration
 
-`NotionTokenResolver` (`TheBridge/Notion/NotionClient.swift`) handles token resolution at runtime. To update the token from the UI, call `NotionTokenResolver.writeToken(_:)` (writes to `~/.config/notion-bridge/config.json`) and post `Notification.Name.notionTokenDidChange` to trigger re-validation. Token format must start with `ntn_` or `secret_` and be ≥20 characters.
+`NotionTokenResolver` (`TheBridge/Notion/NotionClient.swift`) handles token resolution at runtime. To update the token from the UI, call `NotionTokenResolver.writeToken(_:)` (writes to `~/.config/the-bridge/config.json`) and post `Notification.Name.notionTokenDidChange` to trigger re-validation. Token format must start with `ntn_` or `secret_` and be ≥20 characters.
 
 ### Swift 6 Concurrency Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A macOS menu-bar app that exposes the Mac + a Notion workspace to AI agents over
   executable wraps it. Tests are a custom harness (`TheBridgeTests`), NOT XCTest.
 - **MCP server:** `Server/SSEServer` (`SSETransport.swift`) serves `/mcp`, `/sse`,
   `/health`, job callbacks. Tools register via `Server/BridgeModuleRegistry.swift`
-  (205 static feature-module tools across 31 families; conditional tools are counted
+  (223 static feature-module tools across 32 families; conditional tools are counted
   separately) → `ToolRouter` → `MCPToolFactory`.
 - **Tools:** `ToolRegistration {name, module, tier, inputSchema (MCP Value), handler}`.
   Every live tool MUST have a `ToolAnnotationCatalog` entry — `ToolAnnotationAuditTests`
@@ -22,7 +22,8 @@ A macOS menu-bar app that exposes the Mac + a Notion workspace to AI agents over
   drain on launch/wake/cloud-online) — the reuse template for any offline outbox.
 - **Paths/config:** `Core/BridgePaths` (`~/Library/Application Support/The Bridge/…`,
   `overrideHomeForTesting` for hermetic tests), `Config/ConfigManager`
-  (`~/.config/notion-bridge/config.json`), `Core/BridgeDefaults` (UserDefaults keys).
+  (`~/.config/the-bridge/config.json`; the prior path is migration input only),
+  `Core/BridgeDefaults` (UserDefaults keys).
 - **UI:** SwiftUI Settings under `UI/Sections/*`, `SettingsSection` enum in
   `UI/SettingsWindow.swift`, design tokens in `UI/BridgeTokens.swift`.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -126,7 +126,7 @@ If you are located in the European Economic Area (EEA), the following applies un
 
 - **Right of access** — We hold no personal data about you. Your purchase data is held by Lemon Squeezy (our Merchant of Record) under their own privacy policy.
 - **Right to erasure** — Uninstalling The Bridge removes all locally stored configuration, audit logs, and cached data. No data persists on our servers because we operate none.
-- **Right to data portability** — Your configuration file (`~/.config/notion-bridge/config.json`) and audit logs are stored in standard formats on your Mac and are fully portable.
+- **Right to data portability** — Your configuration file (`~/.config/the-bridge/config.json`) and audit logs are stored in standard formats on your Mac and are fully portable. The prior `~/.config/notion-bridge/config.json` location is retained only as migration input.
 - **Right to object** — You can disable Sparkle auto-update checks in Settings to stop the only outbound connection initiated by the Software itself.
 - **Right to lodge a complaint** — You may contact your local Data Protection Authority.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 The Bridge exposes your local Mac and connected services as Model Context Protocol (MCP) tools over **Streamable HTTP**, **legacy SSE**, and **stdio** — locally on `127.0.0.1` for clients like Claude Code, Cursor, and Notion agents, and **securely from the cloud** (claude.ai and ChatGPT custom connectors) through a customer-owned Cloudflare Tunnel with OAuth. Built in Swift 6.2 for macOS 26+ on Apple Silicon, it is designed to be always-on, auto-launched, and safe enough for daily operator use.
 
-**205 static feature-module tools** across **31 module families** · **3 transports + cloud connector** (Claude web · ChatGPT) · **3-tier security model** with on-device approvals · **Liquid Glass UI**
+**223 static feature-module tools** across **32 module families** · **3 transports + cloud connector** (Claude web · ChatGPT) · **3-tier security model** with on-device approvals · **Liquid Glass UI**
 
-**Latest published release:** [v4.0.0](https://github.com/KUP-IP/the-bridge/releases/tag/v4.0.0) (July 2026). The current source version is 4.0.0 (build 82). Existing installs auto-update via Sparkle.
+**Latest published release:** [v4.0.5](https://github.com/KUP-IP/the-bridge/releases/tag/v4.0.5) (August 2026). The current source version is 4.0.5 (build 94). Existing installs auto-update via Sparkle.
 
 **Product page:** https://kup.solutions/notion-bridge
 
@@ -29,7 +29,7 @@ Current commercial posture:
 
 ## Current product surface
 
-The Bridge registers **205 static feature-module tools across 31 module families**, surfaced collapsibly in **Settings → Tools**. Conditional tools such as cloud status are outside that static count, and the displayed list can be smaller when a feature group is disabled. Highlights below; the full live registry is in-app.
+The Bridge registers **223 static feature-module tools across 32 module families**, surfaced collapsibly in **Settings → Tools**. Conditional tools such as cloud status are outside that static count, and the displayed list can be smaller when a feature group is disabled. Highlights below; the full live registry is in-app.
 
 | Module | Tools | Notes |
 |---|---:|---|
@@ -46,7 +46,7 @@ The Bridge registers **205 static feature-module tools across 31 module families
 | CredentialModule | 4 | Keychain-backed credential storage |
 | SkillsModule | 3 | `fetch_skill`, `list_routing_skills`, `manage_skill` |
 | ConnectionsModule | 5 | connection inventory, health, validation |
-| **Total** | **205 static** | Across 31 feature-module families. The former builtin `echo` and Stripe/payment surfaces are removed; conditional tools are counted separately. The table highlights selected families, while **Settings → Tools** shows the full live registry. |
+| **Total** | **223 static** | Across 32 feature-module families. The former builtin `echo` and Stripe/payment surfaces are removed; conditional tools are counted separately. The table highlights selected families, while **Settings → Tools** shows the full live registry. |
 
 Core product traits:
 - Native macOS menu-bar app with onboarding, settings, and a status popover
@@ -74,7 +74,7 @@ Core product traits:
 
 ```bash
 git clone https://github.com/KUP-IP/the-bridge.git
-cd Notion-bridge
+cd the-bridge
 make app
 ```
 
@@ -101,8 +101,10 @@ The app bundle is written to `.build/TheBridge.app`.
 Primary configuration path:
 
 ```text
-~/.config/notion-bridge/config.json
+~/.config/the-bridge/config.json
 ```
+
+The legacy `~/.config/notion-bridge/config.json` location is read only as migration input.
 
 The Bridge supports:
 - Notion workspace connections
@@ -151,7 +153,7 @@ Use stdio when connecting local clients such as Claude Code or Cursor directly t
 
 #### Using Bridge with Antigravity
 
-Google Antigravity enforces a strict 100-tool limit per MCP server, whereas The Bridge registers 205 static feature-module tools. To use Bridge with Antigravity, we have curated a subset of ~84 tools to stay under the limit.
+Google Antigravity enforces a strict 100-tool limit per MCP server, whereas The Bridge registers 223 static feature-module tools. To use Bridge with Antigravity, we have curated a subset of ~84 tools to stay under the limit.
 
 You can launch the Bridge process with a `--multi-instance` flag (bypasses single-instance GUI guard) and `--allow-tools` flag pointing to the Antigravity allowlist:
 

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -7,9 +7,9 @@
 //
 // VERSIONING (operator rule, 2026-06-15): +1 patch per PUBLISHED INSTALL
 // (release), NOT per branch — several task branches can merge to main and ship
-// together as one install increment. Single-digit segments roll at 9 (3.8.9→
-// 3.9.0, 3.9.9→4.0.0), never double digits. THIS install is 3.8.0; next is 3.8.1 (3.7.10–3.7.12
-// were pre-rule legacy). 4.0.0 = sale-ready "V4", reached incrementally. Build
+// together as one install increment. Single-digit segments roll at 9 (4.0.9→
+// 4.1.0, 4.9.9→5.0.0), never double digits. This source is 4.0.5; the next
+// published install is 4.0.6. The 3.7.10–3.7.12 releases were pre-rule legacy. Build
 // (CFBundleVersion) monotonic +1. See AGENTS.md "Release flow" + versioning memory.
 
 import Foundation


### PR DESCRIPTION
## Summary

- align public and agent-facing version/tool-family documentation with source v4.0.5 build 94
- make ~/.config/the-bridge/config.json the documented primary path while retaining the legacy path as migration input
- refresh the current release link and checkout directory

## Verification

- git diff --check
- source constants verified: 4.0.5 / build 94 / 223 static tools / 32 families
- GitHub latest release verified as v4.0.5

This PR is part of the branch-reconciliation closeout and intentionally contains no runtime behavior change.