### PR TITLE
feat(skills): runtime cache refresh + lean handshake init

### DIFF
--- a/TheBridge/Modules/Skills/SkillExposureRuntime.swift
+++ b/TheBridge/Modules/Skills/SkillExposureRuntime.swift
@@ -4,6 +4,21 @@
 import Foundation
 import MCP
 
+/// Persisted freshness lease for an active Runtime Exposure generation.
+/// Independent of `latest-receipt.json`, which remains the audit of the last
+/// reconciliation *attempt* (including failed/blocked/changed shadows).
+public struct SkillFreshnessLease: Codable, Sendable, Equatable {
+    public let generationID: String
+    public let renewedAt: Date
+    public let receiptID: String
+
+    public init(generationID: String, renewedAt: Date, receiptID: String) {
+        self.generationID = generationID
+        self.renewedAt = renewedAt
+        self.receiptID = receiptID
+    }
+}
+
 public struct SkillExposureReconciliationReceipt: Codable, Sendable, Equatable {
     public enum Mode: String, Codable, Sendable { case shadow, publish }
     public enum Outcome: String, Codable, Sendable { case blocked, shadowReady, published, failed }
@@ -45,6 +60,9 @@ public actor SkillRuntimeGenerationStore {
     private var generationsDir: URL { root.appendingPathComponent("generations", isDirectory: true) }
     private var receiptsDir: URL { root.appendingPathComponent("receipts", isDirectory: true) }
     private var pointerURL: URL { root.appendingPathComponent("active.json") }
+    private var leaseURL: URL { root.appendingPathComponent("freshness-lease.json") }
+    /// One-shot upgrade seed per store instance when the lease file is absent.
+    private var didAttemptLeaseSeed = false
 
     public func activeGenerationID() -> String? {
         guard let data = try? Data(contentsOf: pointerURL),
@@ -75,7 +93,7 @@ public actor SkillRuntimeGenerationStore {
         return .init(
             generation: generation,
             emergencyDenylist: emergencyDenylist(),
-            freshnessRenewedAt: unchangedShadowRenewal(for: generation)
+            freshnessRenewedAt: freshnessRenewedAt(for: generation)
         )
     }
 
@@ -91,7 +109,7 @@ public actor SkillRuntimeGenerationStore {
         return .active(.init(
             generation: generation,
             emergencyDenylist: emergencyDenylist(),
-            freshnessRenewedAt: unchangedShadowRenewal(for: generation)
+            freshnessRenewedAt: freshnessRenewedAt(for: generation)
         ))
     }
 
@@ -124,6 +142,17 @@ public actor SkillRuntimeGenerationStore {
         let url = receiptsDir.appendingPathComponent("\(receipt.receiptID).json")
         try atomicWrite(receipt, to: url)
         try atomicWrite(receipt, to: root.appendingPathComponent("latest-receipt.json"))
+        if Self.receiptQualifiesAsUnchangedShadow(receipt),
+           let generationID = receipt.activeGenerationID, !generationID.isEmpty {
+            try atomicWrite(
+                SkillFreshnessLease(
+                    generationID: generationID,
+                    renewedAt: receipt.attemptedAt,
+                    receiptID: receipt.receiptID
+                ),
+                to: leaseURL
+            )
+        }
     }
 
     public func latestReceipt() -> SkillExposureReconciliationReceipt? {
@@ -131,7 +160,15 @@ public actor SkillRuntimeGenerationStore {
         return try? decoder().decode(SkillExposureReconciliationReceipt.self, from: data)
     }
 
+    public func freshnessLease() -> SkillFreshnessLease? {
+        readLease()
+    }
+
     /// An unchanged shadow renews the active generation's freshness window.
+    ///
+    /// The lease is a separate pointer from `latest-receipt.json`. Failed,
+    /// blocked, and changed shadows still overwrite the latest-attempt audit
+    /// but must not erase a prior good lease for this generation.
     ///
     /// Key off empty exposure `changes` + the receipt's `activeGenerationID`,
     /// not `snapshotID` equality. The registry snapshot hash includes
@@ -140,15 +177,59 @@ public actor SkillRuntimeGenerationStore {
     /// (`changes == []`). Requiring snapshot equality left cold starts stuck
     /// on `runtime_exposure_freshness_expired` after a successful shadowReady
     /// (build 89 local pilot, 2026-08-03).
-    private func unchangedShadowRenewal(for generation: SkillRuntimeGeneration) -> Date? {
-        guard let receipt = latestReceipt(),
-              receipt.mode == .shadow,
-              receipt.outcome == .shadowReady,
-              receipt.errors.isEmpty,
-              receipt.changes.isEmpty,
-              receipt.activeGenerationID == generation.generationID
-        else { return nil }
-        return receipt.attemptedAt
+    private func freshnessRenewedAt(for generation: SkillRuntimeGeneration) -> Date? {
+        if let lease = readLease(), lease.generationID == generation.generationID {
+            return lease.renewedAt
+        }
+        guard !didAttemptLeaseSeed else { return nil }
+        didAttemptLeaseSeed = true
+        guard let seeded = newestQualifyingLease(for: generation.generationID) else { return nil }
+        try? atomicWrite(seeded, to: leaseURL)
+        return seeded.renewedAt
+    }
+
+    private func readLease() -> SkillFreshnessLease? {
+        guard let data = try? Data(contentsOf: leaseURL) else { return nil }
+        return try? decoder().decode(SkillFreshnessLease.self, from: data)
+    }
+
+    private static func receiptQualifiesAsUnchangedShadow(
+        _ receipt: SkillExposureReconciliationReceipt
+    ) -> Bool {
+        receipt.mode == .shadow
+            && receipt.outcome == .shadowReady
+            && receipt.errors.isEmpty
+            && receipt.changes.isEmpty
+            && !(receipt.activeGenerationID ?? "").isEmpty
+    }
+
+    private func newestQualifyingLease(for generationID: String) -> SkillFreshnessLease? {
+        let names: [String]
+        do {
+            names = try FileManager.default.contentsOfDirectory(atPath: receiptsDir.path)
+        } catch {
+            return nil
+        }
+        var best: SkillExposureReconciliationReceipt?
+        for name in names where name.hasSuffix(".json") {
+            let url = receiptsDir.appendingPathComponent(name)
+            guard let data = try? Data(contentsOf: url),
+                  let receipt = try? decoder().decode(SkillExposureReconciliationReceipt.self, from: data),
+                  Self.receiptQualifiesAsUnchangedShadow(receipt),
+                  receipt.activeGenerationID == generationID
+            else { continue }
+            if let current = best {
+                if receipt.attemptedAt > current.attemptedAt { best = receipt }
+            } else {
+                best = receipt
+            }
+        }
+        guard let receipt = best, let gid = receipt.activeGenerationID else { return nil }
+        return SkillFreshnessLease(
+            generationID: gid,
+            renewedAt: receipt.attemptedAt,
+            receiptID: receipt.receiptID
+        )
     }
 
     public func emergencyDenylist() -> Set<String> {
@@ -359,6 +440,9 @@ public struct SkillExposureReconciler: Sendable {
                     throw ReconcileError.publicationVerificationFailed
                 }
                 await SkillRuntimeCachePruner.prune(using: .init(generation: candidate, emergencyDenylist: denylist))
+                // Prune only filters existing cache children. Enrollment
+                // expansions (new Standard specialists) need a live re-enumeration.
+                await SkillRuntimeCachePruner.refreshRouting()
             } catch {
                 SkillRuntimeProjectionPublisher.rollback(backup)
                 try? await generationStore.restoreActiveGeneration(id: previousID)
@@ -435,6 +519,9 @@ public struct SkillExposureReconciler: Sendable {
 
 public enum SkillRuntimeCachePruner {
     public static func prune(using gate: SkillRuntimeExposureGate, now: Date = Date()) async {
+        // Memory keys are name+params+meta, not page id — selective evict is
+        // not possible. Full clear matches SkillBodyCacheEviction.
+        await SkillCache.shared.clear()
         for body in await SkillBodyCacheStore.shared.readAll()
             where !gate.allows(pageID: body.pageId, surface: .bodyCache, now: now) {
             await SkillBodyCacheStore.shared.evict(pageId: body.pageId)
@@ -451,6 +538,33 @@ public enum SkillRuntimeCachePruner {
                     parentTitle: parent.parentTitle, children: children))
             }
         }
+    }
+
+    /// Re-enumerate Specialist-relation children after a generation change.
+    /// `prune` cannot add newly allowed children; handshake lists stay stale
+    /// until this refresh (or Settings → Refresh routing cache).
+    @discardableResult
+    public static func refreshRouting(
+        source: SkillsCacheWriter.ParentSource,
+        enumerator: SkillsCacheWriter.ChildEnumerator,
+        ttlHours: Int = BridgeDefaults.skillsCacheTTLHoursEffective,
+        now: Date = Date()
+    ) async -> Int {
+        await SkillsCacheWriter.shared.refreshAll(
+            source: source, enumerator: enumerator, ttlHours: ttlHours, now: now
+        )
+    }
+
+    @discardableResult
+    public static func refreshRouting() async -> Int {
+        guard let client = try? NotionClient() else {
+            NSLog("[SkillRuntimeCachePruner] routing refresh skipped — no Notion token")
+            return 0
+        }
+        let source = await MainActor.run {
+            SkillsCacheWriter.ParentSource.fromSkillsManager(SkillsManager())
+        }
+        return await refreshRouting(source: source, enumerator: .live(client: client))
     }
 }
 

--- a/TheBridge/Modules/Skills/SkillsModuleConfiguration.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleConfiguration.swift
@@ -397,9 +397,9 @@ extension SkillsModule {
             try c.encode(platform, forKey: .platform)
         }
 
-        /// Stable token for `fetch_skill` cache invalidation when metadata changes.
+        /// Stable token for `fetch_skill` cache invalidation when metadata or page identity changes.
         var metadataCacheToken: String {
-            let raw = "\(summary)\u{1e}\(triggerPhrases.joined(separator: "\u{1f}"))\u{1e}\(antiTriggerPhrases.joined(separator: "\u{1f}"))"
+            let raw = "\(notionPageId)\u{1e}\(summary)\u{1e}\(triggerPhrases.joined(separator: "\u{1f}"))\u{1e}\(antiTriggerPhrases.joined(separator: "\u{1f}"))"
             var h: UInt64 = 14695981039346656037
             for b in raw.utf8 {
                 h ^= UInt64(b)

--- a/TheBridge/Modules/Skills/SkillsModuleExposureRegistration.swift
+++ b/TheBridge/Modules/Skills/SkillsModuleExposureRegistration.swift
@@ -13,7 +13,7 @@ extension SkillsModule {
             name: "skills_exposure_status",
             module: moduleName,
             tier: .open,
-            description: "Read Runtime Exposure state: active verified generation, latest reconciliation receipt, enabled migration baseline, degraded status, and emergency denylist. Read-only.",
+            description: "Read Runtime Exposure state: active verified generation, freshness lease, latest reconciliation receipt (last attempt — may disagree with the lease after failed/blocked/changed shadows), enabled migration baseline, degraded status, and emergency denylist. Read-only.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),
@@ -24,6 +24,7 @@ extension SkillsModule {
                 let active = await store.activeGeneration()
                 let gate = await store.gate()
                 let latest = await store.latestReceipt()
+                let lease = await store.freshnessLease()
                 let denylist = await store.emergencyDenylist().sorted()
                 let baseline = await MainActor.run {
                     SkillExposureBaselineEntry.fromSkillsManager(SkillsManager())
@@ -43,7 +44,14 @@ extension SkillsModule {
                     "enabledBaselineCount": .int(baseline.count),
                     "emergencyDenylist": .array(denylist.map(Value.string)),
                     "emergencyDenylistCount": .int(denylist.count),
-                    "latestReceipt": latest.map(Self.exposureReceiptValue) ?? .null
+                    "latestReceipt": latest.map(Self.exposureReceiptValue) ?? .null,
+                    "freshnessLease": lease.map { lease in
+                        .object([
+                            "generationId": .string(lease.generationID),
+                            "renewedAt": .string(Self.exposureISO8601(lease.renewedAt)),
+                            "receiptId": .string(lease.receiptID)
+                        ])
+                    } ?? .null
                 ]
                 if let active {
                     var counts: [String: Int] = [:]
@@ -204,6 +212,7 @@ extension SkillsModule {
                 await store.setEmergencyDenylist(ids)
                 if let gate = await store.gate() {
                     await SkillRuntimeCachePruner.prune(using: gate)
+                    await SkillRuntimeCachePruner.refreshRouting()
                 }
                 return .object([
                     "action": .string(action),

--- a/TheBridge/Modules/SkillsModule.swift
+++ b/TheBridge/Modules/SkillsModule.swift
@@ -21,11 +21,14 @@ struct CachedSkill: Sendable {
 }
 
 /// Thread-safe actor cache for fetched skill content.
-actor SkillCache {
-    static let shared = SkillCache()
+@_spi(Testing)
+public actor SkillCache {
+    public static let shared = SkillCache()
     private var cache: [String: CachedSkill] = [:]
 
-    func get(_ key: String) -> Value? {
+    public init() {}
+
+    public func get(_ key: String) -> Value? {
         guard let entry = cache[key], !entry.isExpired else {
             cache.removeValue(forKey: key)
             return nil
@@ -33,12 +36,56 @@ actor SkillCache {
         return entry.content
     }
 
-    func set(_ key: String, content: Value) {
+    public func set(_ key: String, content: Value) {
         cache[key] = CachedSkill(content: content, fetchedAt: Date())
     }
 
-    func clear() {
+    public func clear() {
         cache.removeAll()
+    }
+}
+
+extension SkillsModule {
+    /// Policy-then-memory decision used by `fetch_skill`. Tests seed `cache`
+    /// and call this function so a helper cannot stay cache-first while the
+    /// handler stays wrong.
+    @_spi(Testing)
+    public enum FetchMemoryResult: Sendable {
+        case disabled
+        case invalidPageId
+        case unpublished
+        case cached(Value)
+        case miss
+    }
+
+    @_spi(Testing)
+    public static func fetchMemoryResult(
+        enabled: Bool,
+        pageId: String,
+        cacheKey: String,
+        cache: SkillCache,
+        gate: SkillRuntimeExposureGate?,
+        skipMemoryCache: Bool = false
+    ) async -> FetchMemoryResult {
+        guard enabled else { return .disabled }
+        let trimmed = pageId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard NotionPageRef.isValidStoredPageId(trimmed) else { return .invalidPageId }
+        if let gate, !gate.allows(pageID: trimmed, surface: .exactFetch) {
+            return .unpublished
+        }
+        if skipMemoryCache { return .miss }
+        if let cached = await cache.get(cacheKey) { return .cached(cached) }
+        return .miss
+    }
+
+    static func cachedSpecialistPageID(parentPageID: String, childTitle: String) async -> String? {
+        let wanted = childTitle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !wanted.isEmpty else { return nil }
+        guard let parent = await SkillsCacheReader.shared.read(parentId: parentPageID) else { return nil }
+        return parent.children.first { child in
+            child.title.lowercased() == wanted
+                || child.aliases.contains { $0.lowercased() == wanted }
+        }?.id
     }
 }
 
@@ -411,37 +458,57 @@ public enum SkillsModule {
                 let sectionKey = sectionArg.map { "|s=\($0.lowercased())" } ?? ""
                 let cacheKey = "\(name.lowercased())|n=\(includeNested)|mb=\(maxBlocks)|md=\(maxDepth)|meta=\(skillConfig.metadataCacheToken)\(pathSelectorKey)\(sectionKey)"
 
-                if let cached = await cache.get(cacheKey) {
+                let parentPageId = skillConfig.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
+                var fetchPageId = parentPageId
+                var skipMemoryCache = false
+                if let child = parsedPath.child {
+                    if let childId = await Self.cachedSpecialistPageID(
+                        parentPageID: parentPageId, childTitle: child
+                    ) {
+                        fetchPageId = childId
+                    } else {
+                        skipMemoryCache = true
+                    }
+                } else if intentArg != nil {
+                    skipMemoryCache = true
+                }
+
+                let exposureGate = await SkillRuntimeGenerationStore.shared.gate()
+                switch await Self.fetchMemoryResult(
+                    enabled: skillConfig.enabled,
+                    pageId: fetchPageId,
+                    cacheKey: cacheKey,
+                    cache: cache,
+                    gate: exposureGate,
+                    skipMemoryCache: skipMemoryCache
+                ) {
+                case .disabled:
+                    return .object([
+                        "error": .string("Skill '\(name)' is disabled."),
+                        "hint": .string("Enable it in Settings \u{2192} Skills tab.")
+                    ])
+                case .invalidPageId:
+                    return .object([
+                        "error": .string("Invalid Notion page ID for skill '\(name)'."),
+                        "hint": .string("Update the page URL or ID in Settings \u{2192} Skills to a valid Notion page (32 hex digits or a notion.so / notion.site link).")
+                    ])
+                case .unpublished:
+                    return .object([
+                        "error": .string("Skill '\(name)' is not published in the active runtime generation."),
+                        "hint": .string("Review Runtime Exposure and the latest reconciliation receipt in Settings → Skills.")
+                    ])
+                case .cached(let cached):
                     let cachedResult = await MemoryRoutingAppendix.attach(
                         to: cached,
                         parent: name,
                         intent: intentArg
                     )
                     return Self.projectSkillResult(cachedResult, fields: fieldsArg)
+                case .miss:
+                    break
                 }
 
-                guard skillConfig.enabled else {
-                    return .object([
-                        "error": .string("Skill '\(name)' is disabled."),
-                        "hint": .string("Enable it in Settings \u{2192} Skills tab.")
-                    ])
-                }
-
-                let pageIdRaw = skillConfig.notionPageId.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard NotionPageRef.isValidStoredPageId(pageIdRaw) else {
-                    return .object([
-                        "error": .string("Invalid Notion page ID for skill '\(name)'."),
-                        "hint": .string("Update the page URL or ID in Settings \u{2192} Skills to a valid Notion page (32 hex digits or a notion.so / notion.site link).")
-                    ])
-                }
-
-                if let exposureGate = await SkillRuntimeGenerationStore.shared.gate(),
-                   !exposureGate.allows(pageID: pageIdRaw, surface: .exactFetch) {
-                    return .object([
-                        "error": .string("Skill '\(name)' is not published in the active runtime generation."),
-                        "hint": .string("Review Runtime Exposure and the latest reconciliation receipt in Settings → Skills.")
-                    ])
-                }
+                let pageIdRaw = parentPageId
 
                 // cmd-w4: includeNested / maxBlocks / maxDepth are retained
                 // for input-schema + cache-key stability (existing callers

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeModule.swift
@@ -150,7 +150,7 @@ public enum BridgeInitializeModule {
                     ]),
                     "includeConstitution": .object([
                         "type": .string("boolean"),
-                        "description": .string("When true or omitted, include the W1 constitution bundle in the receipt.")
+                        "description": .string("When true, include the constitution bundle (doctrine + command index + routing roster + supplemental order bodies). Defaults to false — lean receipt. Prefer false unless you need constitution.orders.")
                     ])
                 ]),
                 "required": .array([])
@@ -193,9 +193,9 @@ public enum BridgeInitializeModule {
                 let includeConstitution: Bool = {
                     guard case .object(let a) = arguments,
                           let raw = a["includeConstitution"]
-                    else { return true }
+                    else { return false }
                     if case .bool(let value) = raw { return value }
-                    return true
+                    return false
                 }()
                 let context = await contextProvider(client)
                 let routingSnapshot = await routingSnapshotProvider(context.now)

--- a/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
+++ b/TheBridge/Modules/StandingOrders/BridgeInitializeService.swift
@@ -379,7 +379,7 @@ public enum BridgeInitializeService {
     public static func run(
         context: BridgeInitializeContext,
         mode: BrokerSessionMode = .general,
-        includeConstitution: Bool = true,
+        includeConstitution: Bool = false,
         sessionRegistry: SessionRegistry = .shared,
         store: StandingOrdersRecordStore = .shared,
         receiptStore: HandshakeReceiptStore = .shared,

--- a/TheBridge/Modules/StandingOrders/StandingOrdersStore.swift
+++ b/TheBridge/Modules/StandingOrders/StandingOrdersStore.swift
@@ -541,13 +541,7 @@ public final class StandingOrdersStore: @unchecked Sendable {
                 )
             ),
             initializationSequence: [
-                "bridge_status",
-                "load_manifest",
-                "load_handshake_doctrine",
-                "verify_metadata_and_hash",
-                "skills_routing_list",
-                "standing_orders_list",
-                "emit_completion_receipt",
+                "bridge_initialize",
             ],
             completionReceiptFields: [
                 "bridgeState",

--- a/TheBridge/Resources/standing-orders/orders.md
+++ b/TheBridge/Resources/standing-orders/orders.md
@@ -3,7 +3,7 @@
 > **Where this doctrine lives.** You're reading the **on-disk mirror** of the Keepr root constitution, served by The Bridge at MCP handshake.
 > - **SSOT (authoritative):** https://www.notion.so/28acbb58889e80d5b111ed23b996c304 — fetch when anything here is unclear or appears stale.
 > - **This file** — curated condensation in plain markdown; serves non-Notion clients (Claude Code, Cursor, Raycast, ChatGPT, Claude.ai). Principles match SSOT; Notion-specific mechanisms are footnoted with `Notion implementation:` so they activate only when the Notion connector is loaded.
-> - **Amendment record:** v7.0.2 (PUBLISHED 2026-06-26) — prune stale inline routing catalog; document handshake stack; consequence-governed routing; dynamic Bridge version via `bridge_status`. Full evolution history remains on the SSOT.
+> - **Amendment record:** v7.3.0 (PUBLISHED 2026-08-25) — init is the `bridge_initialize` receipt (prefer lean constitution); forced one-line fences (precedence, hygiene, skill-routing, turn-end, context-pressure, registry-find). Carries v7.2.0 (evidence class + L2 transport). Full evolution history remains on the SSOT.
 > - **Decision Log:** https://www.notion.so/c99d0a57d994449fa66b16233e392dbc — architectural trade-offs and walk-backs.
 >
 > If any surface conflicts: SSOT wins. The Bridge serves this preamble verbatim in `InitializeResult.instructions` at session start; edits here apply on the next handshake after a Bridge restart.
@@ -24,17 +24,21 @@ Compose `bridge-keepr` with your host identity (Claude Code, Cursor, Raycast, Ch
 
 ### Bridge initialization contract
 
-Initialization is evidence-backed and fail-closed. Resolve source roles from `standing-orders/manifest.json`; do not treat a single registry lookup as the entire standing-orders system.
+Call `bridge_initialize` (optional: client, mode, intent). Prefer `includeConstitution:false` so the receipt stays small. Treat the tool receipt as SSOT for: bridge/connection state · doctrine version + integrity · doctrineFreshness · routing roster · supplementalOrderCounts · capabilityState · finalState (`COMPLETE` | `DEGRADED` | `INCOMPLETE`).
 
-Required sequence:
-1. Confirm `bridge_status` is online or degraded with Mac tools available.
-2. Load this required handshake doctrine (`standing-orders/orders.md`).
-3. Verify `metadata.json` version and doctrine hash against the source manifest.
-4. Load `skills_routing_list` as the active routing roster.
-5. Query `standing_orders_list` for supplemental orders only.
-6. Emit a completion receipt containing Bridge state, doctrine version, routing-roster state, supplemental-order count, and final initialization state.
+A supplemental count of zero means no supplemental overlays — never "no standing orders." Do not reconstruct a parallel receipt that ignores `bridge_initialize` fields. Do not run a multi-tool init ceremony in place of the tool.
 
-A supplemental count of zero means **no supplemental orders**; it never means no standing orders. Missing or unreadable doctrine, metadata mismatch, or routing failure must report `DEGRADED` or `INCOMPLETE`, never `complete`.
+If `finalState` is `DEGRADED` solely for `doctrineFreshness=stale` and capability is `FULL`: report `DEGRADED` truthfully. Remediation is operator-approved `doctrine_sync`, never silent.
+
+### Forced fences
+
+Always-on. Matched per-context > matched per-skill/per-tool > remaining global supplemental orders > this doctrine. Remaining global orders still win until archived.
+
+- **Hygiene.** The standing-order registry is a quarantine for time-bounded overlays and scoped constants. Procedures belong in skills; identifiers in config. Review-by or fold; do not mint a global order as the default home for a new rule.
+- **Skill routing.** Creating, renaming, restructuring, or retiring a skill, command, or routing surface routes through skill-keepr. Using an existing capability does not.
+- **Turn-end.** Every action this turn announced, prepared, or was holding as pending is completed or explicitly declared outstanding with a reason and next step. A new message does not clear that obligation.
+- **Context pressure.** Under compaction or drift, re-anchor on the active contract, pending actions, the active telemetry id, and unclosed loops — recover those four, do not guess.
+- **Registry reads.** `registry_get` by id is authoritative for one row. Do not trust `registry_find` / `registry_list` for completeness-critical sets.
 
 **Personality modes** — apply the one the work needs.
 - **Builder** (encouraging, action-oriented) → execution, shipping, momentum.
@@ -84,13 +88,13 @@ Maturity scales enforcement: new / unproven flows enforce all four; stable flows
 
 ### Platform hazards
 
-Tool calls intermittently fail (the Notion API is the canonical example). **Never accept a first failure as final.** Escalation: retry → variation → check Troubleshooting registry → creative alternative → web research → BLOCK with an explicit signal.
+Tool calls intermittently fail (the Notion API is the canonical example). **Never accept a first failure as final.** First, name the layer: a connect-level failure (timeout, tunnel drop, "failed to connect") is **L2 transport** and earns **one immediate retry** before any L1 product conclusion is drawn — report the layer explicitly in your status line. Escalation: one immediate retry → variation → check Troubleshooting registry → creative alternative → web research → BLOCK with an explicit signal. Never batch more than one host-steering operation per call — batched loops time out, and the timeout then reads as a product defect. Do not trust `registry_find` / `registry_list` for completeness-critical sets; `registry_get` by id is authoritative for a single row.
 
 ---
 
 ## 3. Communication
 
-Succinct but complete. Educational when it helps (examples, parallels). Tasteful humor when it fits.
+Succinct but complete. Educational when it helps (examples, parallels). Tasteful humor when it fits. Warnings get a **bold lead-in** in plain markdown — no decorative callout blocks.
 
 **Raw output mode** — when generating text destined for another entity (agent, contact, external tool), output **only** the raw text. No preamble, no closing commentary.
 
@@ -106,6 +110,16 @@ Succinct but complete. Educational when it helps (examples, parallels). Tasteful
 4. **Consequence** — classify forks by impact, not a numeric score. Irreversible, destructive, customer-facing, strategic, credential-changing, or underdetermined → stop at the approval/review gate and ask. Low-consequence read-only or clearly idempotent work proceeds. When the consequence class is unclear, ask one precise question — do not guess or invent a confidence number.
 5. **Execute** — Universal Execution Protocol: context gathering → task decomposition → wave execution → final checkpoint → closeout. Direct → execute with native tools. Beyond your boundary → write a packet.
 6. **Learn** — novel pattern / error fix / insight → capture per §6. Nothing new → skip. No forced learning.
+
+### Relation-First Initiation (RFI)
+
+When initiating any hub surface (a governing page, contact, project, event, or equivalent), load **relation context before deep content**: enumerate its relations, fetch the top 5 most-recently-touched entries per relation — properties/metadata only — and deep-fetch bodies only when the session actually needs them. Cap unbounded relations; never bulk-fetch. Surface-specific protocols run after RFI, not instead of it. Prefer surfaces whose relations link their own skills/tools, so RFI surfaces the working stack automatically.
+
+Notion implementation: after `loadPage`, query related rows capped at 5 per relation by Last Edit DESC, properties only. Hosts without relations: approximate with the nearest linked index or recent-file list, still capped and properties-first.
+
+### Evidence class
+
+Before concluding that something is dead, absent, unused, or proven, name the edge types your method can see and the edge types it cannot. If any consumer class is invisible to it — human-, button-, automation-, or runtime-configuration-mediated — the correct output is **hold**, not cut. Absence of an edge in a partial graph is not evidence of absence. And never assert from a label, a step name, or your own summary when the underlying structure is in reach — derive from the structure.
 
 ### Maturity → activation
 

--- a/TheBridgeTests/BridgeInitializeTests.swift
+++ b/TheBridgeTests/BridgeInitializeTests.swift
@@ -391,6 +391,7 @@ func runBridgeInitializeTests() async {
 
             let receipt = await BridgeInitializeService.run(
                 context: ctx(),
+                includeConstitution: true,
                 store: supplementalStore,
                 receiptStore: receiptStore,
                 commandStore: commandStore

--- a/TheBridgeTests/SkillExposureAuthorityTests.swift
+++ b/TheBridgeTests/SkillExposureAuthorityTests.swift
@@ -65,9 +65,10 @@ private func compile(
 private func publishedGeneration(
     exposure: SkillRuntimeExposure = .routing,
     compiledAt: Date = exposureNow,
-    id: String = exposureUUIDA
+    id: String = exposureUUIDA,
+    generationID: String = "generation-1"
 ) -> SkillRuntimeGeneration {
-    .init(generationID: "generation-1", snapshotID: "snapshot-1",
+    .init(generationID: generationID, snapshotID: "snapshot-1",
           compilerVersion: "1.0.0", compiledAt: compiledAt,
           entries: [.init(notionPageUUID: id, displayName: "Alpha", slug: "alpha",
                           desiredExposure: exposure, publishedExposure: exposure,
@@ -312,6 +313,134 @@ func runSkillExposureAuthorityTests() async {
         try expect(gate.isDegraded(now: exposureNow), "a changed shadow must not renew active policy")
         try expect(gate.freshnessRenewedAt == nil)
         try expect(await store.activeGenerationID() == staleGeneration.generationID)
+    }
+
+    await test("failed shadow after a renewing lease keeps freshness and latestReceipt splits") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-lease-failed-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady, attemptedAt: exposureNow,
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [], warnings: [], changes: []
+        ))
+        let failedAt = exposureNow.addingTimeInterval(60)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .failed, attemptedAt: failedAt,
+            snapshotID: nil, candidateGenerationID: nil,
+            activeGenerationID: staleGeneration.generationID,
+            errors: ["reconciliation_failed:offline"], warnings: [], changes: []
+        ))
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(!gate.isDegraded(now: exposureNow.addingTimeInterval(120)),
+                   "a later failed shadow must not erase a good lease")
+        try expect(gate.freshnessRenewedAt == exposureNow)
+        let latest = await store.latestReceipt()
+        try expect(latest?.outcome == .failed, "latestReceipt must remain the last attempt")
+        let lease = await store.freshnessLease()
+        try expect(lease?.generationID == staleGeneration.generationID)
+        try expect(lease?.renewedAt == exposureNow)
+    }
+
+    await test("changed shadow after a renewing lease does not delete the lease") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-lease-changed-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady, attemptedAt: exposureNow,
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [], warnings: [], changes: []
+        ))
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady,
+            attemptedAt: exposureNow.addingTimeInterval(30),
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "changed-unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [], warnings: [], changes: ["exposure:Alpha:Routing->Standard"]
+        ))
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(gate.freshnessRenewedAt == exposureNow, "changed shadow must not update or delete the lease")
+        try expect(await store.latestReceipt()?.changes == ["exposure:Alpha:Routing->Standard"])
+    }
+
+    await test("freshness lease is generation-keyed across promote") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-lease-gen-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let genA = publishedGeneration(
+            compiledAt: exposureNow.addingTimeInterval(-48 * 3600),
+            generationID: "generation-a"
+        )
+        let genB = publishedGeneration(
+            compiledAt: exposureNow.addingTimeInterval(-48 * 3600),
+            generationID: "generation-b"
+        )
+        _ = try await store.stage(genA)
+        _ = try await store.promote(generationID: genA.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady, attemptedAt: exposureNow,
+            snapshotID: genA.snapshotID, candidateGenerationID: "cand-a",
+            activeGenerationID: genA.generationID,
+            errors: [], warnings: [], changes: []
+        ))
+        _ = try await store.stage(genB)
+        _ = try await store.promote(generationID: genB.generationID)
+        guard case .active(let gate) = await store.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(gate.freshnessRenewedAt == nil, "gen B must ignore gen A's lease")
+        try expect(gate.isDegraded(now: exposureNow), "stale gen B without its own lease must degrade")
+    }
+
+    await test("upgrade seeds lease from receipts when the lease file is missing") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bridge-exposure-lease-seed-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = SkillRuntimeGenerationStore(baseDirectory: root)
+        let staleGeneration = publishedGeneration(compiledAt: exposureNow.addingTimeInterval(-48 * 3600))
+        _ = try await store.stage(staleGeneration)
+        _ = try await store.promote(generationID: staleGeneration.generationID)
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .shadowReady, attemptedAt: exposureNow,
+            snapshotID: staleGeneration.snapshotID,
+            candidateGenerationID: "unpublished-candidate",
+            activeGenerationID: staleGeneration.generationID,
+            errors: [], warnings: [], changes: []
+        ))
+        try await store.writeReceipt(.init(
+            mode: .shadow, outcome: .failed, attemptedAt: exposureNow.addingTimeInterval(90),
+            snapshotID: nil, candidateGenerationID: nil,
+            activeGenerationID: staleGeneration.generationID,
+            errors: ["reconciliation_failed:offline"], warnings: [], changes: []
+        ))
+        let leaseURL = root.appendingPathComponent("freshness-lease.json")
+        try FileManager.default.removeItem(at: leaseURL)
+        let reloaded = SkillRuntimeGenerationStore(baseDirectory: root)
+        guard case .active(let gate) = await reloaded.routingAuthority() else {
+            throw TestError.assertion("expected active routing authority")
+        }
+        try expect(gate.freshnessRenewedAt == exposureNow,
+                   "upgrade must seed from the newest qualifying receipt, not failed latest-receipt")
+        try expect(await reloaded.latestReceipt()?.outcome == .failed)
+        try expect(await reloaded.freshnessLease()?.renewedAt == exposureNow)
     }
 
     await test("corrupt active generation pointer is explicit missing authority, never legacy fallback") {

--- a/TheBridgeTests/SkillFetchMemoryTests.swift
+++ b/TheBridgeTests/SkillFetchMemoryTests.swift
@@ -1,0 +1,121 @@
+// SkillFetchMemoryTests.swift — policy-then-memory fetch_skill seam
+// TheBridge · Tests
+
+@_spi(Testing) import TheBridgeLib
+import Foundation
+import MCP
+
+private let fetchNow = Date(timeIntervalSince1970: 1_785_196_800)
+private let fetchPageA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+private let fetchPageB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+private func fetchGeneration(id: String = fetchPageA) -> SkillRuntimeGeneration {
+    .init(generationID: "generation-1", snapshotID: "snapshot-1",
+          compilerVersion: "1.0.0", compiledAt: fetchNow,
+          entries: [.init(notionPageUUID: id, displayName: "Alpha", slug: "alpha",
+                          desiredExposure: .standard, publishedExposure: .standard,
+                          lifecycleOverrideReason: nil, approvalID: "approval-1",
+                          notionLastEditedTime: "2026-07-28T00:00:00.000Z",
+                          url: "https://www.notion.so/\(id)")])
+}
+
+func runSkillFetchMemoryTests() async {
+    print("\n🧠 fetch_skill policy-then-memory")
+
+    await test("disabled skill is denied even when memory cache is warm") {
+        let cache = SkillCache()
+        let key = "alpha|meta=warm"
+        await cache.set(key, content: .object(["content": .string("stale-body")]))
+        let gate = SkillRuntimeExposureGate(generation: fetchGeneration())
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: false, pageId: fetchPageA, cacheKey: key,
+            cache: cache, gate: gate
+        )
+        guard case .disabled = result else {
+            throw TestError.assertion("disabled must beat a warm cache, got \(result)")
+        }
+    }
+
+    await test("unpublished page is denied even when memory cache is warm") {
+        let cache = SkillCache()
+        let key = "alpha|meta=warm"
+        await cache.set(key, content: .object(["content": .string("stale-body")]))
+        let gate = SkillRuntimeExposureGate(generation: fetchGeneration(id: fetchPageA))
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: true, pageId: fetchPageB, cacheKey: key,
+            cache: cache, gate: gate
+        )
+        guard case .unpublished = result else {
+            throw TestError.assertion("unpublished must beat a warm cache, got \(result)")
+        }
+    }
+
+    await test("denylisted page is denied even when memory cache is warm") {
+        let cache = SkillCache()
+        let key = "alpha|meta=warm"
+        await cache.set(key, content: .object(["content": .string("stale-body")]))
+        let gate = SkillRuntimeExposureGate(
+            generation: fetchGeneration(),
+            emergencyDenylist: [fetchPageA]
+        )
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: true, pageId: fetchPageA, cacheKey: key,
+            cache: cache, gate: gate
+        )
+        guard case .unpublished = result else {
+            throw TestError.assertion("denylist must beat a warm cache, got \(result)")
+        }
+    }
+
+    await test("allowed skill may serve memory cache after policy") {
+        let cache = SkillCache()
+        let key = "alpha|meta=warm"
+        await cache.set(key, content: .object(["content": .string("fresh-body")]))
+        let gate = SkillRuntimeExposureGate(generation: fetchGeneration())
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: true, pageId: fetchPageA, cacheKey: key,
+            cache: cache, gate: gate
+        )
+        guard case .cached(let value) = result,
+              case .object(let obj) = value,
+              case .string(let body) = obj["content"],
+              body == "fresh-body" else {
+            throw TestError.assertion("policy pass must serve memory, got \(result)")
+        }
+    }
+
+    await test("URL identity change misses memory when the cache key includes page id") {
+        let cache = SkillCache()
+        let oldKey = "alpha|meta=old-page"
+        await cache.set(oldKey, content: .object(["content": .string("old-body")]))
+        let gate = SkillRuntimeExposureGate(generation: fetchGeneration())
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: true, pageId: fetchPageA, cacheKey: "alpha|meta=new-page",
+            cache: cache, gate: gate
+        )
+        guard case .miss = result else {
+            throw TestError.assertion("page-id token change must miss, got \(result)")
+        }
+    }
+
+    await test("unresolved child or intent skips memory even when a parent key is warm") {
+        let cache = SkillCache()
+        let key = "alpha|p=executor|meta=warm"
+        await cache.set(key, content: .object(["content": .string("child-body")]))
+        let gate = SkillRuntimeExposureGate(generation: fetchGeneration())
+        let result = await SkillsModule.fetchMemoryResult(
+            enabled: true, pageId: fetchPageA, cacheKey: key,
+            cache: cache, gate: gate, skipMemoryCache: true
+        )
+        guard case .miss = result else {
+            throw TestError.assertion("unresolved selector must not serve memory, got \(result)")
+        }
+    }
+
+    await test("SkillCache.clear drops seeded entries") {
+        let cache = SkillCache()
+        await cache.set("k", content: .string("v"))
+        await cache.clear()
+        try expect(await cache.get("k") == nil, "clear must drop entries")
+    }
+}

--- a/TheBridgeTests/SkillsCacheTests.swift
+++ b/TheBridgeTests/SkillsCacheTests.swift
@@ -435,4 +435,65 @@ func runSkillsCacheTests() async {
                        "children not deterministically sorted: \(got.children.map(\.title))")
         }
     }
+
+    // -----------------------------------------------------------------
+    // 13. Publish prune is filter-only; enrollment expansions require
+    //     refreshRouting() after prune (handshake specialist-list lag).
+    // -----------------------------------------------------------------
+    await test("prune does not add newly allowed specialists; refreshRouting does") {
+        try await withTempHome { _ in
+            let parentId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            let oldChild = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            let newChild = "cccccccccccccccccccccccccccccccc"
+            let now = Date()
+            try await SkillsCacheWriter.shared.write(parent: CachedParent(
+                writtenAt: now, ttlHours: 24, parentId: parentId,
+                parentTitle: "Parent",
+                children: [CachedSpecialist(id: oldChild, title: "Old", summary: "old")]
+            ))
+
+            let generation = SkillRuntimeGeneration(
+                generationID: "generation-1", snapshotID: "snapshot-1",
+                compilerVersion: "1.0.0", compiledAt: now,
+                entries: [
+                    .init(notionPageUUID: parentId, displayName: "Parent", slug: "parent",
+                          desiredExposure: .routing, publishedExposure: .routing,
+                          lifecycleOverrideReason: nil, approvalID: "approval-1",
+                          notionLastEditedTime: "2026-07-28T00:00:00.000Z",
+                          url: "https://www.notion.so/\(parentId)"),
+                    .init(notionPageUUID: oldChild, displayName: "Old", slug: "old",
+                          desiredExposure: .standard, publishedExposure: .standard,
+                          lifecycleOverrideReason: nil, approvalID: "approval-1",
+                          notionLastEditedTime: "2026-07-28T00:00:00.000Z",
+                          url: "https://www.notion.so/\(oldChild)"),
+                    .init(notionPageUUID: newChild, displayName: "New", slug: "new",
+                          desiredExposure: .standard, publishedExposure: .standard,
+                          lifecycleOverrideReason: nil, approvalID: "approval-1",
+                          notionLastEditedTime: "2026-07-28T00:00:00.000Z",
+                          url: "https://www.notion.so/\(newChild)"),
+                ]
+            )
+            await SkillRuntimeCachePruner.prune(using: .init(generation: generation), now: now)
+            let afterPrune = await SkillsCacheReader.shared.read(parentId: parentId)
+            try expect(afterPrune?.children.map(\.id) == [oldChild],
+                       "prune must keep existing allowed children only, got \(afterPrune?.children.map(\.id) ?? [])")
+
+            let source = SkillsCacheWriter.ParentSource(load: {
+                [SkillsCacheWriter.ParentSource.Parent(id: parentId, title: "Parent")]
+            })
+            let enumerator = SkillsCacheWriter.ChildEnumerator(listChildren: { _ in
+                [
+                    CachedSpecialist(id: oldChild, title: "Old", summary: "old"),
+                    CachedSpecialist(id: newChild, title: "New", summary: "new"),
+                ]
+            })
+            let refreshed = await SkillRuntimeCachePruner.refreshRouting(
+                source: source, enumerator: enumerator, ttlHours: 24, now: now
+            )
+            try expect(refreshed == 1, "refreshRouting must report 1 parent, got \(refreshed)")
+            let afterRefresh = await SkillsCacheReader.shared.read(parentId: parentId)
+            try expect(afterRefresh?.children.map(\.id) == [oldChild, newChild].sorted(),
+                       "refreshRouting must enumerate newly allowed specialists, got \(afterRefresh?.children.map(\.id) ?? [])")
+        }
+    }
 }

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -947,6 +947,7 @@ await runSkillsCacheTests()
 // envelope-equivalence between the cache-hit and network paths.
 await runSkillBodyCacheTests()
 await runSkillExposureAuthorityTests() // Runtime Exposure authority, lifecycle, authorization, generations
+await runSkillFetchMemoryTests() // fetch_skill policy-then-memory + SkillCache.clear
 await runSkillBodyCacheEvictionTests()
 await runSkillMutationTargetResolverTests()
 await runToolRouterListToolsReadyTests()

--- a/TheBridgeTests/Wave1BrokerTests.swift
+++ b/TheBridgeTests/Wave1BrokerTests.swift
@@ -126,7 +126,7 @@ func runWave1BrokerTests() async {
         }
     }
 
-    await test("W1 bridge_initialize v2: writes session and returns constitution by default") {
+    await test("W1 bridge_initialize v2: writes session and returns constitution when includeConstitution is true") {
         try await withWave1TempHome { tmp in
             try StandingOrdersStore.shared.resetForTesting()
             _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v8.0.1\n\nRoot doctrine.")
@@ -159,6 +159,37 @@ func runWave1BrokerTests() async {
             try expect(receipt.session?.governed == true)
             try expect(receipt.constitution?.doctrineVersion == "v8.0.1")
             try expect(try await registry.current(transportSessionId: "http-session-2")?.sessionId == receipt.session?.sessionId)
+        }
+    }
+
+    await test("W1 bridge_initialize v2: omitted includeConstitution is lean (no constitution bundle)") {
+        try await withWave1TempHome { tmp in
+            try StandingOrdersStore.shared.resetForTesting()
+            _ = try StandingOrdersStore.shared.write("# Orders\n\n> **Amendment record:** v8.0.1\n\nRoot doctrine.")
+            let registry = SessionRegistry(path: tmp.appendingPathComponent("sessions.sqlite"))
+            try await registry.resetForTesting()
+            let receiptStore = HandshakeReceiptStore(baseDir: tmp.appendingPathComponent("handshakes", isDirectory: true))
+            receiptStore.resetForTesting()
+
+            let receipt = await ToolDispatchContext.$current.withValue(
+                .init(transportSessionId: "http-session-lean", origin: .local, client: "codex")
+            ) {
+                await BridgeInitializeService.run(
+                    context: BridgeInitializeContext(
+                        client: "codex",
+                        connectionState: "local",
+                        macToolsAvailable: true,
+                        bridgeState: "running",
+                        now: Date(timeIntervalSince1970: 1_800_000_011)
+                    ),
+                    mode: .execute,
+                    sessionRegistry: registry,
+                    receiptStore: receiptStore
+                )
+            }
+
+            try expect(receipt.constitution == nil, "lean init must not inject constitution.orders")
+            try expect(receipt.session?.transportSessionId == "http-session-lean")
         }
     }
 


### PR DESCRIPTION
## Summary
- Runtime Exposure: cache-before-policy fetch, freshness-lease isolation, prune-clears-memory, publish-time routing-cache refresh (`e123efb`).
- Handshake: lean init default, standing-orders v7.3.0, `bridge_initialize` seed (`4fe6f66`).

## Test plan
- [x] `make test` on `4fe6f66` — 3803 passed, 0 failed
- [x] `make test` on `e123efb` — 3802 passed, 0 failed
- [ ] post-merge `make test` on `main`
- Local install of `e123efb` already verified; post-merge install-copy from `main` follows this PR.