### PR TITLE
fix(ril): treat mac-message as message authority

### DIFF
--- a/TheBridge/Server/RoutingIntegrityLayer.swift
+++ b/TheBridge/Server/RoutingIntegrityLayer.swift
@@ -309,7 +309,8 @@ public enum ToolSkillBindingRegistry {
         let lowered = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased(with: Locale(identifier: "en_US_POSIX"))
         let words = lowered.split { !$0.isLetter && !$0.isNumber }.map(String.init)
-        return words.joined(separator: "-")
+        let normalized = words.joined(separator: "-")
+        return normalized == "mac-message" ? "message" : normalized
     }
 
     public static func callSatisfiesManifestMarker(toolName: String, result: Value) -> Bool {

--- a/TheBridge/Server/ToolRouter.swift
+++ b/TheBridge/Server/ToolRouter.swift
@@ -343,8 +343,13 @@ public actor ToolRouter {
 
     private func hasRouteAcknowledgement(context: ToolDispatchContext, binding: ToolSkillBinding) -> Bool {
         guard let clientKey = context.transportSessionId, !clientKey.isEmpty else { return false }
-        let present = clientRouteAuthorities[clientKey]?[binding.scopeID] ?? []
-        return Set(binding.governingSkills.map(\.slug)).isSubset(of: present)
+        let present = Set((clientRouteAuthorities[clientKey]?[binding.scopeID] ?? []).map {
+            ToolSkillBindingRegistry.normalizeAuthoritySlug($0)
+        })
+        let required = Set(binding.governingSkills.map {
+            ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug)
+        })
+        return required.isSubset(of: present)
     }
 
     private func clientAuthorityDigest(_ context: ToolDispatchContext) -> String {
@@ -388,8 +393,11 @@ public actor ToolRouter {
             authorities.formUnion(receipt.authorityIDs)
             nonces.append(receipt.nonce)
         }
-        let required = Set(binding.governingSkills.map(\.slug))
-        guard required.isSubset(of: authorities) else { return .rejected("incomplete_authorities") }
+        let required = Set(binding.governingSkills.map {
+            ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug)
+        })
+        let presented = Set(authorities.map(ToolSkillBindingRegistry.normalizeAuthoritySlug))
+        guard required.isSubset(of: presented) else { return .rejected("incomplete_authorities") }
         for nonce in nonces { issuedRouteReceipts.removeValue(forKey: nonce) }
         return .accepted
     }
@@ -455,7 +463,9 @@ public actor ToolRouter {
     }
 
     private func fetchedAuthorityIDs(slug: String?, name: String?) -> Set<String> {
-        let known = Set(ToolSkillBindingRegistry.bindings.flatMap { $0.governingSkills.map(\.slug) })
+        let known = Set(ToolSkillBindingRegistry.bindings.flatMap {
+            $0.governingSkills.map { ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug) }
+        })
         let normalizedName = name.map(ToolSkillBindingRegistry.normalizeAuthoritySlug)
         if let slug, !slug.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             let normalizedSlug = ToolSkillBindingRegistry.normalizeAuthoritySlug(slug)
@@ -506,7 +516,9 @@ public actor ToolRouter {
         if toolName == "fetch_skill" {
             let fetched = fetchedAuthorityIDs(slug: routed.slug, name: routed.name)
             for binding in ToolSkillBindingRegistry.bindings {
-                let relevant = Set(binding.governingSkills.map(\.slug)).intersection(fetched)
+                let relevant = Set(binding.governingSkills.map {
+                    ToolSkillBindingRegistry.normalizeAuthoritySlug($0.slug)
+                }).intersection(fetched)
                 if !relevant.isEmpty { byScope[binding.scopeID] = relevant }
             }
         }

--- a/TheBridgeTests/RoutingIntegrityLayerTests.swift
+++ b/TheBridgeTests/RoutingIntegrityLayerTests.swift
@@ -36,6 +36,21 @@ func runRoutingIntegrityLayerTests() async {
         try expect(binding.requiresManifestFetch)
     }
 
+    await test("RIL authority alias: mac-message canonicalizes to message without widening other authorities") {
+        try expect(ToolSkillBindingRegistry.normalizeAuthoritySlug("mac-message") == "message")
+        try expect(ToolSkillBindingRegistry.normalizeAuthoritySlug("message") == "message")
+        try expect(ToolSkillBindingRegistry.normalizeAuthoritySlug("PEOPLE Keepr") == "people-keepr")
+
+        let canonicalScopes = ToolSkillBindingRegistry.scopeIDs(governedBy: "message")
+        let legacyScopes = ToolSkillBindingRegistry.scopeIDs(governedBy: "mac-message")
+        try expect(canonicalScopes == legacyScopes,
+                   "canonical message authority must inherit exactly the legacy mac-message scopes")
+        try expect(canonicalScopes.contains("tool:messages_recent"),
+                   "message authority must govern recent Messages reads")
+        try expect(canonicalScopes.contains("tool:messages_send"),
+                   "message authority must govern exact approved Messages sends")
+    }
+
     await test("RIL discovery: messages_send tool description includes governance") {
         let rendered = MCPToolFactory.tool(for: fakeMessagesSendRegistration()).description ?? ""
         try expect(rendered.contains("Governance:"), "description must include governance annotation: \(rendered)")


### PR DESCRIPTION
## Summary
- Normalize `mac-message` to `message` in RIL authority matching so handshake/route receipts do not reject the canonical keeper slug.
- Tests cover alias equality and that other authorities are not widened.

## Test plan
- [x] `make test` — 3804 passed, 0 failed (includes new RIL alias test)


Made with [Cursor](https://cursor.com)