### PR TITLE
Bridge v4.1 capability truth (PKT-1305 / 1196 / 1296)

### DIFF
--- a/TheBridge/Modules/ProcessLifecycleTruth.swift
+++ b/TheBridge/Modules/ProcessLifecycleTruth.swift
@@ -1,0 +1,266 @@
+// ProcessLifecycleTruth.swift — PKT-1196
+// TheBridge · Modules
+//
+// Residual process-lifecycle contract on top of already-shipped process-group
+// ownership (BgProcessRuntime posix_spawn SETPGROUP + SIGTERM→SIGKILL
+// killpg). This file does not reimplement group identity or bg_kill. It
+// classifies terminal truth, timeout outcomes, and descendant-cleanup evidence
+// so receipts cannot report stillRunning=false while a requested workload
+// remains alive.
+
+import CryptoKit
+import Darwin
+import Foundation
+
+public enum ProcessLifecycleState: String, Codable, Sendable, Equatable {
+    case starting
+    case running
+    case exited
+    case signaled
+    case launchFailed = "launch_failed"
+    case orphaned
+}
+
+public enum TimeoutOutcome: String, Codable, Sendable, Equatable {
+    /// Request window elapsed; the requested workload is still alive.
+    case requestTimeoutWorkloadContinuing = "request_timeout_workload_continuing"
+    /// Request window elapsed and the process group is proven gone.
+    case verifiedGroupTermination = "verified_group_termination"
+    /// Request window elapsed; wrapper vs descendants cannot be reconciled.
+    case ambiguous = "timeout_ambiguous"
+}
+
+public enum DescendantCleanupEvidence: String, Codable, Sendable, Equatable {
+    case verified
+    case incomplete
+    case notApplicable = "not_applicable"
+}
+
+public struct ProcessLifecycleReceipt: Sendable, Equatable {
+    public let state: ProcessLifecycleState
+    public let exitCode: Int32?
+    public let signal: Int32?
+    public let launchError: String?
+    public let orphanReason: String?
+    public let commandHash: String
+    public let startedAt: Date
+    public let endedAt: Date?
+    public let supervisorPid: Int32
+    public let rootPid: Int32?
+    public let pgid: Int32?
+    public let logPath: String?
+    public let terminalReceiptPath: String?
+    public let observedAt: Date
+    public let timeoutOutcome: TimeoutOutcome?
+    public let stillRunning: Bool
+    public let descendantCleanup: DescendantCleanupEvidence
+
+    public init(
+        state: ProcessLifecycleState,
+        exitCode: Int32?,
+        signal: Int32?,
+        launchError: String?,
+        orphanReason: String?,
+        commandHash: String,
+        startedAt: Date,
+        endedAt: Date?,
+        supervisorPid: Int32,
+        rootPid: Int32?,
+        pgid: Int32?,
+        logPath: String?,
+        terminalReceiptPath: String?,
+        observedAt: Date,
+        timeoutOutcome: TimeoutOutcome?,
+        stillRunning: Bool,
+        descendantCleanup: DescendantCleanupEvidence
+    ) {
+        self.state = state
+        self.exitCode = exitCode
+        self.signal = signal
+        self.launchError = launchError
+        self.orphanReason = orphanReason
+        self.commandHash = commandHash
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.supervisorPid = supervisorPid
+        self.rootPid = rootPid
+        self.pgid = pgid
+        self.logPath = logPath
+        self.terminalReceiptPath = terminalReceiptPath
+        self.observedAt = observedAt
+        self.timeoutOutcome = timeoutOutcome
+        self.stillRunning = stillRunning
+        self.descendantCleanup = descendantCleanup
+    }
+}
+
+public enum ProcessLifecycleTruth {
+    public static func commandHash(_ command: String) -> String {
+        SHA256.hash(data: Data(command.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Invariant: stillRunning is true whenever the requested pid OR its
+    /// process group still answers kill(…, 0). Callers must not report a
+    /// finished receipt while this is true.
+    public static func stillRunning(pidAlive: Bool, processGroupAlive: Bool) -> Bool {
+        pidAlive || processGroupAlive
+    }
+
+    public static func descendantCleanup(pidAlive: Bool, processGroupAlive: Bool) -> DescendantCleanupEvidence {
+        if pidAlive { return .incomplete }
+        if processGroupAlive { return .incomplete }
+        return .verified
+    }
+
+    public static func classifyTimeout(
+        requestTimedOut: Bool,
+        pidAlive: Bool,
+        processGroupAlive: Bool
+    ) -> TimeoutOutcome? {
+        guard requestTimedOut else { return nil }
+        let workloadAlive = stillRunning(pidAlive: pidAlive, processGroupAlive: processGroupAlive)
+        if workloadAlive && pidAlive { return .requestTimeoutWorkloadContinuing }
+        if workloadAlive { return .ambiguous }
+        return .verifiedGroupTermination
+    }
+
+    public static func classifyTerminal(
+        launchFailed: Bool,
+        launchError: String?,
+        pidAssigned: Bool,
+        pidAlive: Bool,
+        processGroupAlive: Bool,
+        exitCode: Int32?,
+        signal: Int32?,
+        missedWait: Bool
+    ) -> ProcessLifecycleState {
+        if launchFailed || (!pidAssigned && launchError != nil) { return .launchFailed }
+        if stillRunning(pidAlive: pidAlive, processGroupAlive: processGroupAlive) {
+            return pidAssigned ? .running : .starting
+        }
+        if missedWait { return .orphaned }
+        if signal != nil { return .signaled }
+        if exitCode != nil { return .exited }
+        if !pidAssigned { return .starting }
+        return .orphaned
+    }
+
+    /// Map shipped `BgProcessStatus` without replacing it. Residual truth lives
+    /// on the receipt; runtime status values stay as they are.
+    public static func classifyBgJob(
+        status: BgProcessStatus,
+        pidAlive: Bool,
+        processGroupAlive: Bool,
+        exitCode: Int32?,
+        killSignal: Int32?,
+        note: String?,
+        command: String,
+        pid: Int32,
+        pgid: Int32,
+        startedAt: Date,
+        endedAt: Date?,
+        logPath: String?,
+        now: Date
+    ) -> ProcessLifecycleReceipt {
+        let workloadAlive = stillRunning(pidAlive: pidAlive, processGroupAlive: processGroupAlive)
+        let state: ProcessLifecycleState
+        switch status {
+        case .running:
+            state = workloadAlive ? .running : .orphaned
+        case .done:
+            state = .exited
+        case .failed:
+            state = killSignal != nil ? .signaled : .exited
+        case .killed:
+            state = .signaled
+        case .unknown:
+            state = .orphaned
+        }
+        let cleanup: DescendantCleanupEvidence
+        if status == .running && workloadAlive {
+            cleanup = .notApplicable
+        } else {
+            cleanup = descendantCleanup(pidAlive: pidAlive, processGroupAlive: processGroupAlive)
+        }
+        return ProcessLifecycleReceipt(
+            state: state,
+            exitCode: exitCode,
+            signal: killSignal,
+            launchError: nil,
+            orphanReason: state == .orphaned ? (note ?? "pid absent or wait missed") : nil,
+            commandHash: commandHash(command),
+            startedAt: startedAt,
+            endedAt: endedAt,
+            supervisorPid: getpid(),
+            rootPid: pid,
+            pgid: pgid,
+            logPath: logPath,
+            terminalReceiptPath: logPath,
+            observedAt: now,
+            timeoutOutcome: nil,
+            stillRunning: workloadAlive,
+            descendantCleanup: cleanup
+        )
+    }
+
+    public static func classifyShell(
+        command: String,
+        timedOut: Bool,
+        pid: Int32,
+        pidAlive: Bool,
+        processGroupAlive: Bool,
+        exitCode: Int32,
+        signaled: Int32?,
+        launchError: String?,
+        startedAt: Date,
+        endedAt: Date,
+        now: Date
+    ) -> ProcessLifecycleReceipt {
+        let state = classifyTerminal(
+            launchFailed: launchError != nil,
+            launchError: launchError,
+            pidAssigned: pid > 0,
+            pidAlive: pidAlive,
+            processGroupAlive: processGroupAlive,
+            exitCode: launchError == nil ? exitCode : nil,
+            signal: signaled,
+            missedWait: false
+        )
+        let workloadAlive = stillRunning(pidAlive: pidAlive, processGroupAlive: processGroupAlive)
+        return ProcessLifecycleReceipt(
+            state: state,
+            exitCode: launchError == nil ? exitCode : nil,
+            signal: signaled,
+            launchError: launchError,
+            orphanReason: nil,
+            commandHash: commandHash(command),
+            startedAt: startedAt,
+            endedAt: endedAt,
+            supervisorPid: getpid(),
+            rootPid: pid > 0 ? pid : nil,
+            pgid: pid > 0 ? pid : nil,
+            logPath: nil,
+            terminalReceiptPath: nil,
+            observedAt: now,
+            timeoutOutcome: classifyTimeout(
+                requestTimedOut: timedOut,
+                pidAlive: pidAlive,
+                processGroupAlive: processGroupAlive
+            ),
+            stillRunning: workloadAlive,
+            descendantCleanup: timedOut || signaled != nil
+                ? descendantCleanup(pidAlive: pidAlive, processGroupAlive: processGroupAlive)
+                : .notApplicable
+        )
+    }
+
+    public static func processAlive(_ pid: Int32) -> Bool {
+        guard pid > 0 else { return false }
+        return Darwin.kill(pid, 0) == 0
+    }
+
+    public static func processGroupAlive(_ pgid: Int32) -> Bool {
+        guard pgid > 0 else { return false }
+        return Darwin.kill(-pgid, 0) == 0
+    }
+}

--- a/TheBridge/Modules/ShellModule.swift
+++ b/TheBridge/Modules/ShellModule.swift
@@ -4,6 +4,7 @@
 // Two tools: shell_exec (request), run_script (request).
 // Auto-escalation and forbidden path enforcement handled by SecurityGate.
 
+import Darwin
 import Foundation
 import MCP
 
@@ -159,17 +160,57 @@ public enum ShellModule {
                 process.standardOutput = stdoutPipe
                 process.standardError = stderrPipe
 
+                let startedAt = Date()
                 let startTime = ContinuousClock.now
                 let timeoutFlag = TimeoutFlag()
 
-                try process.run()
+                do {
+                    try process.run()
+                } catch {
+                    let receipt = ProcessLifecycleTruth.classifyShell(
+                        command: command,
+                        timedOut: false,
+                        pid: 0,
+                        pidAlive: false,
+                        processGroupAlive: false,
+                        exitCode: -1,
+                        signaled: nil,
+                        launchError: error.localizedDescription,
+                        startedAt: startedAt,
+                        endedAt: Date(),
+                        now: Date()
+                    )
+                    return Self.lifecycleValue(
+                        receipt: receipt,
+                        stdout: "",
+                        stderr: error.localizedDescription,
+                        success: false,
+                        status: "launch_failed",
+                        timedOut: false,
+                        timeoutSeconds: timeout,
+                        terminationReason: "launch_failed",
+                        durationSec: 0,
+                        isBackground: isBackground,
+                        stdoutLineCount: 0,
+                        stderrLineCount: 1,
+                        stdoutTruncated: false,
+                        stderrTruncated: false
+                    )
+                }
 
-                // Timeout enforcement — terminate process if it exceeds the limit. The response explicitly
-                // reports timeout state so agents can distinguish killed work from ordinary non-zero exits.
+                // Timeout: SIGTERM then, if still running after 1s, SIGKILL on the
+                // requested pid. Process-group ownership stays with BgProcessRuntime;
+                // this is residual request-window truth for shell_exec only.
                 let timeoutItem = DispatchWorkItem {
                     if process.isRunning {
                         timeoutFlag.value = true
+                        let pid = process.processIdentifier
                         process.terminate()
+                        DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+                            if process.isRunning {
+                                _ = Darwin.kill(pid, SIGKILL)
+                            }
+                        }
                     }
                 }
                 DispatchQueue.global().asyncAfter(
@@ -198,30 +239,71 @@ public enum ShellModule {
                     head: Self.valueToInt(args["stderrHeadLines"]),
                     tail: Self.valueToInt(args["stderrTailLines"])
                 )
-                let exitCode = Int(process.terminationStatus)
+                let pid = process.processIdentifier
+                let signaled: Int32? = process.terminationReason == .uncaughtSignal
+                    ? process.terminationStatus : nil
+                let pidAlive = ProcessLifecycleTruth.processAlive(pid)
+                let pgid = pid > 0 ? getpgid(pid) : Int32(-1)
+                let groupAlive = ProcessLifecycleTruth.processGroupAlive(pgid > 0 ? pgid : pid)
                 let timedOut = timeoutFlag.value
-                let success = exitCode == 0 && !timedOut
-                let terminationReason: String = timedOut
-                    ? "timeout_killed"
-                    : (success ? "exited" : "non_zero_exit")
+                let receipt = ProcessLifecycleTruth.classifyShell(
+                    command: command,
+                    timedOut: timedOut,
+                    pid: pid,
+                    pidAlive: pidAlive,
+                    processGroupAlive: groupAlive,
+                    exitCode: process.terminationStatus,
+                    signaled: signaled,
+                    launchError: nil,
+                    startedAt: startedAt,
+                    endedAt: Date(),
+                    now: Date()
+                )
+                let success = process.terminationStatus == 0 && !timedOut && !receipt.stillRunning
+                let terminationReason: String
+                if let outcome = receipt.timeoutOutcome {
+                    switch outcome {
+                    case .verifiedGroupTermination:
+                        terminationReason = "timeout_killed"
+                    case .requestTimeoutWorkloadContinuing, .ambiguous:
+                        terminationReason = outcome.rawValue
+                    }
+                } else if success {
+                    terminationReason = "exited"
+                } else if signaled != nil {
+                    terminationReason = "signaled"
+                } else {
+                    terminationReason = "non_zero_exit"
+                }
+                // Compat: verified timeout kill keeps the historical timeout_killed token
+                // in `status` while `terminationReason` carries the classified outcome.
+                let statusToken: String
+                if success {
+                    statusToken = "success"
+                } else if timedOut {
+                    statusToken = receipt.stillRunning ? "timed_out_still_running" : "timed_out"
+                } else if receipt.state == .launchFailed {
+                    statusToken = "launch_failed"
+                } else {
+                    statusToken = "failed"
+                }
 
-                return .object([
-                    "stdout": .string(stdoutSummary.text),
-                    "stderr": .string(stderrSummary.text),
-                    "exitCode": .int(exitCode),
-                    "success": .bool(success),
-                    "status": .string(success ? "success" : (timedOut ? "timed_out" : "failed")),
-                    "timedOut": .bool(timedOut),
-                    "timeoutSeconds": .int(timeout),
-                    "terminationReason": .string(terminationReason),
-                    "duration": .double(durationSec),
-                    "backgroundCommand": .bool(isBackground),
-                    "recoveryHint": .string(isBackground ? "Background commands (trailing &) are capped at 5s by the MCP request. For work that must outlive the request, use bg_run (detached, returns immediately) and poll it with bg_poll." : "For long-running work, increase timeout — or use bg_run to launch it detached (returns a jobId immediately) and poll with bg_poll / stop with bg_kill."),
-                    "stdoutLineCount": .int(stdoutSummary.lineCount),
-                    "stderrLineCount": .int(stderrSummary.lineCount),
-                    "stdoutTruncated": .bool(stdoutSummary.truncated),
-                    "stderrTruncated": .bool(stderrSummary.truncated)
-                ])
+                return Self.lifecycleValue(
+                    receipt: receipt,
+                    stdout: stdoutSummary.text,
+                    stderr: stderrSummary.text,
+                    success: success,
+                    status: statusToken,
+                    timedOut: timedOut,
+                    timeoutSeconds: timeout,
+                    terminationReason: terminationReason,
+                    durationSec: durationSec,
+                    isBackground: isBackground,
+                    stdoutLineCount: stdoutSummary.lineCount,
+                    stderrLineCount: stderrSummary.lineCount,
+                    stdoutTruncated: stdoutSummary.truncated,
+                    stderrTruncated: stderrSummary.truncated
+                )
             }
         ))
 
@@ -355,5 +437,64 @@ public enum ShellModule {
                 ])
             }
         ))
+    }
+
+    private static func lifecycleValue(
+        receipt: ProcessLifecycleReceipt,
+        stdout: String,
+        stderr: String,
+        success: Bool,
+        status: String,
+        timedOut: Bool,
+        timeoutSeconds: Int,
+        terminationReason: String,
+        durationSec: Double,
+        isBackground: Bool,
+        stdoutLineCount: Int,
+        stderrLineCount: Int,
+        stdoutTruncated: Bool,
+        stderrTruncated: Bool
+    ) -> Value {
+        var obj: [String: Value] = [
+            "stdout": .string(stdout),
+            "stderr": .string(stderr),
+            "exitCode": .int(Int(receipt.exitCode ?? -1)),
+            "success": .bool(success),
+            "status": .string(status),
+            "timedOut": .bool(timedOut),
+            "timeoutSeconds": .int(timeoutSeconds),
+            "terminationReason": .string(terminationReason),
+            "duration": .double(durationSec),
+            "backgroundCommand": .bool(isBackground),
+            "recoveryHint": .string(isBackground
+                ? "Background commands (trailing &) are capped at 5s by the MCP request. For work that must outlive the request, use bg_run (detached, returns immediately) and poll it with bg_poll."
+                : "For long-running work, increase timeout — or use bg_run to launch it detached (returns a jobId immediately) and poll with bg_poll / stop with bg_kill."),
+            "stdoutLineCount": .int(stdoutLineCount),
+            "stderrLineCount": .int(stderrLineCount),
+            "stdoutTruncated": .bool(stdoutTruncated),
+            "stderrTruncated": .bool(stderrTruncated),
+            "terminalState": .string(receipt.state.rawValue),
+            "stillRunning": .bool(receipt.stillRunning),
+            "descendantCleanup": .string(receipt.descendantCleanup.rawValue),
+            "commandHash": .string(receipt.commandHash),
+            "supervisorPid": .int(Int(receipt.supervisorPid)),
+            "observedAt": .double(receipt.observedAt.timeIntervalSince1970)
+        ]
+        if let outcome = receipt.timeoutOutcome {
+            obj["timeoutOutcome"] = .string(outcome.rawValue)
+        }
+        if let signal = receipt.signal {
+            obj["signal"] = .int(Int(signal))
+        }
+        if let launchError = receipt.launchError {
+            obj["launchError"] = .string(launchError)
+        }
+        if let pid = receipt.rootPid {
+            obj["rootPid"] = .int(Int(pid))
+        }
+        if let pgid = receipt.pgid {
+            obj["pgid"] = .int(Int(pgid))
+        }
+        return .object(obj)
     }
 }

--- a/TheBridge/Modules/StandingOrders/LaunchReadiness.swift
+++ b/TheBridge/Modules/StandingOrders/LaunchReadiness.swift
@@ -1,0 +1,308 @@
+// LaunchReadiness.swift — PKT-1305
+// TheBridge · Modules · StandingOrders
+//
+// Provider-neutral execution-preflight contract. Distinct from PKT-1065C
+// intent-sensitive capability probes (declared capability) and from transport
+// reachability: those axes must not be conflated with live launch readiness.
+//
+// Every named check returns exactly one of:
+//   PASS              — prerequisite proven ready with evidence
+//   BLOCKED           — prerequisite deterministically unavailable/invalid
+//   TRANSPORT_UNKNOWN — the evidence path itself is unavailable; product
+//                       readiness cannot be concluded (never a false BLOCKED)
+//
+// `safeToLaunch` is true only when every required check is PASS.
+// Probes are injectable seams so fixtures can be hermetic; no live credential
+// mutation, no new MCP product surface.
+
+import Foundation
+
+// MARK: - Verdict
+
+public enum LaunchReadinessVerdict: String, Codable, Sendable, Equatable {
+    case pass = "PASS"
+    case blocked = "BLOCKED"
+    case transportUnknown = "TRANSPORT_UNKNOWN"
+}
+
+// MARK: - Check + report
+
+public struct LaunchReadinessCheck: Sendable, Equatable, Codable {
+    public let name: String
+    public let required: Bool
+    public let verdict: LaunchReadinessVerdict
+    public let evidence: String
+
+    public init(name: String, required: Bool, verdict: LaunchReadinessVerdict, evidence: String) {
+        self.name = name
+        self.required = required
+        self.verdict = verdict
+        self.evidence = evidence
+    }
+}
+
+public struct LaunchReadinessReport: Sendable, Equatable {
+    public let checkedAt: Date
+    public let checks: [LaunchReadinessCheck]
+
+    public var safeToLaunch: Bool {
+        checks.filter(\.required).allSatisfy { $0.verdict == .pass }
+    }
+
+    public init(checkedAt: Date, checks: [LaunchReadinessCheck]) {
+        self.checkedAt = checkedAt
+        self.checks = checks
+    }
+}
+
+// MARK: - Observation seam
+
+/// One observation of a named prerequisite. The evaluator never infers
+/// BLOCKED from a transport failure — that mapping is forbidden.
+public enum LaunchReadinessObservation: Sendable, Equatable {
+    case ready(evidence: String)
+    case unavailable(evidence: String)
+    case transportUnknown(evidence: String)
+
+    public var verdict: LaunchReadinessVerdict {
+        switch self {
+        case .ready: return .pass
+        case .unavailable: return .blocked
+        case .transportUnknown: return .transportUnknown
+        }
+    }
+
+    public var evidence: String {
+        switch self {
+        case .ready(let evidence), .unavailable(let evidence), .transportUnknown(let evidence):
+            return evidence
+        }
+    }
+}
+
+public protocol LaunchReadinessSeam: Sendable {
+    func observe() async -> LaunchReadinessObservation
+}
+
+public protocol LaunchReadinessProbe: Sendable {
+    var name: String { get }
+    var required: Bool { get }
+    func probe() async -> LaunchReadinessCheck
+}
+
+public struct NamedLaunchReadinessProbe: LaunchReadinessProbe {
+    public let name: String
+    public let required: Bool
+    private let seam: LaunchReadinessSeam
+
+    public init(name: String, required: Bool = true, seam: LaunchReadinessSeam) {
+        self.name = name
+        self.required = required
+        self.seam = seam
+    }
+
+    public func probe() async -> LaunchReadinessCheck {
+        let observation = await seam.observe()
+        return LaunchReadinessCheck(
+            name: name,
+            required: required,
+            verdict: observation.verdict,
+            evidence: observation.evidence
+        )
+    }
+}
+
+// MARK: - Contract evaluator
+
+public enum LaunchReadinessContract {
+    public static let commandAuthCheck = "command.auth"
+    public static let registryConsumerCheck = "registry.consumer"
+    public static let runtimeBrowserCheck = "runtime.browser"
+    public static let storageWriteCheck = "storage.write"
+    public static let implementationCoverageCheck = "implementation.coverage"
+
+    /// Canonical five-check launch set. Callers inject seams; the names and
+    /// required-ness are part of the v4.1 contract.
+    public static func standardProbes(
+        commandAuth: LaunchReadinessSeam,
+        registryConsumer: LaunchReadinessSeam,
+        runtimeBrowser: LaunchReadinessSeam,
+        storageWrite: LaunchReadinessSeam,
+        implementationCoverage: LaunchReadinessSeam
+    ) -> [LaunchReadinessProbe] {
+        [
+            NamedLaunchReadinessProbe(name: commandAuthCheck, seam: commandAuth),
+            NamedLaunchReadinessProbe(name: registryConsumerCheck, seam: registryConsumer),
+            NamedLaunchReadinessProbe(name: runtimeBrowserCheck, seam: runtimeBrowser),
+            NamedLaunchReadinessProbe(name: storageWriteCheck, seam: storageWrite),
+            NamedLaunchReadinessProbe(name: implementationCoverageCheck, seam: implementationCoverage),
+        ]
+    }
+
+    public static func evaluate(
+        probes: [LaunchReadinessProbe],
+        now: Date = Date()
+    ) async -> LaunchReadinessReport {
+        var checks: [LaunchReadinessCheck] = []
+        checks.reserveCapacity(probes.count)
+        for probe in probes {
+            checks.append(await probe.probe())
+        }
+        return LaunchReadinessReport(checkedAt: now, checks: checks)
+    }
+}
+
+// MARK: - Fixture / injectable seams (hermetic; no live credentials)
+
+/// Deterministic seam used by tests and by Packet Runner fixtures when a live
+/// provider is unavailable. Never mutates credentials or accounts.
+public struct FixedLaunchReadinessSeam: LaunchReadinessSeam {
+    private let observation: LaunchReadinessObservation
+
+    public init(_ observation: LaunchReadinessObservation) {
+        self.observation = observation
+    }
+
+    public func observe() async -> LaunchReadinessObservation { observation }
+}
+
+/// Command/tool availability + authentication readiness.
+/// Unauthenticated or missing tool → BLOCKED. Evidence-path failure → TRANSPORT_UNKNOWN.
+public struct CommandAuthReadinessSeam: LaunchReadinessSeam {
+    public enum AuthState: Sendable, Equatable {
+        case authenticated(tool: String)
+        case unauthenticated(tool: String)
+        case missing(tool: String)
+        case evidenceUnavailable(reason: String)
+    }
+
+    private let state: AuthState
+
+    public init(_ state: AuthState) {
+        self.state = state
+    }
+
+    public func observe() async -> LaunchReadinessObservation {
+        switch state {
+        case .authenticated(let tool):
+            return .ready(evidence: "tool \(tool) present and authenticated")
+        case .unauthenticated(let tool):
+            return .unavailable(evidence: "tool \(tool) present but unauthenticated")
+        case .missing(let tool):
+            return .unavailable(evidence: "tool \(tool) not registered")
+        case .evidenceUnavailable(let reason):
+            return .transportUnknown(evidence: reason)
+        }
+    }
+}
+
+/// Registry consumer-contract readiness. Wraps the existing read-only
+/// `PacketRegistryPreflight` evaluator. Schema-read failure is TRANSPORT_UNKNOWN,
+/// not product BLOCKED.
+public struct RegistryConsumerReadinessSeam: LaunchReadinessSeam {
+    public enum Input: Sendable {
+        case evidenceUnavailable(reason: String)
+        case snapshot(config: RegistryConfig, schema: DataSourceSchema)
+    }
+
+    private let input: Input
+
+    public init(_ input: Input) {
+        self.input = input
+    }
+
+    public func observe() async -> LaunchReadinessObservation {
+        switch input {
+        case .evidenceUnavailable(let reason):
+            return .transportUnknown(evidence: reason)
+        case .snapshot(let config, let schema):
+            let report = PacketRegistryPreflight.evaluate(config: config, schema: schema)
+            if report.passes {
+                return .ready(evidence:
+                    "\(report.contractVersion) PASS classified=\(report.classifiedColumnCount) live=\(report.liveColumnCount)")
+            }
+            let codes = report.defects.map(\.code).joined(separator: ",")
+            return .unavailable(evidence: "\(report.contractVersion) DRIFT codes=\(codes)")
+        }
+    }
+}
+
+/// Browser/runtime availability through a pluggable seam.
+public struct RuntimeAvailabilitySeam: LaunchReadinessSeam {
+    public enum State: Sendable, Equatable {
+        case available(runtime: String)
+        case missing(runtime: String)
+        case evidenceUnavailable(reason: String)
+    }
+
+    private let state: State
+
+    public init(_ state: State) {
+        self.state = state
+    }
+
+    public func observe() async -> LaunchReadinessObservation {
+        switch state {
+        case .available(let runtime):
+            return .ready(evidence: "runtime \(runtime) reachable")
+        case .missing(let runtime):
+            return .unavailable(evidence: "runtime \(runtime) missing")
+        case .evidenceUnavailable(let reason):
+            return .transportUnknown(evidence: reason)
+        }
+    }
+}
+
+/// Storage/writeability readiness through a pluggable seam.
+public struct StorageWriteabilitySeam: LaunchReadinessSeam {
+    public enum State: Sendable, Equatable {
+        case writable(path: String)
+        case unavailable(path: String, reason: String)
+        case evidenceUnavailable(reason: String)
+    }
+
+    private let state: State
+
+    public init(_ state: State) {
+        self.state = state
+    }
+
+    public func observe() async -> LaunchReadinessObservation {
+        switch state {
+        case .writable(let path):
+            return .ready(evidence: "path \(path) writable")
+        case .unavailable(let path, let reason):
+            return .unavailable(evidence: "path \(path) not writable: \(reason)")
+        case .evidenceUnavailable(let reason):
+            return .transportUnknown(evidence: reason)
+        }
+    }
+}
+
+/// Implementation-coverage evidence bound to an inspectable artifact, code
+/// path, workflow, or SHA. Missing proof is BLOCKED. Unreadable locator is
+/// TRANSPORT_UNKNOWN.
+public struct ImplementationCoverageSeam: LaunchReadinessSeam {
+    public enum State: Sendable, Equatable {
+        case proven(locator: String)
+        case missing(expected: String)
+        case evidenceUnavailable(reason: String)
+    }
+
+    private let state: State
+
+    public init(_ state: State) {
+        self.state = state
+    }
+
+    public func observe() async -> LaunchReadinessObservation {
+        switch state {
+        case .proven(let locator):
+            return .ready(evidence: "coverage proven at \(locator)")
+        case .missing(let expected):
+            return .unavailable(evidence: "coverage proof missing: \(expected)")
+        case .evidenceUnavailable(let reason):
+            return .transportUnknown(evidence: reason)
+        }
+    }
+}

--- a/TheBridge/Server/ConnectorContinuity.swift
+++ b/TheBridge/Server/ConnectorContinuity.swift
@@ -1,0 +1,285 @@
+// ConnectorContinuity.swift — PKT-1296
+// TheBridge · Server
+//
+// Connector delivery observation + governed per-session serialization.
+// Root-cause companion: SSEHTTPHandler used to overwrite an in-flight HTTP/1.1
+// assembly and launch overlapping response writers on one channel — parallel
+// remote POSTs could vanish before audit ingestion. This type classifies
+// executed=true|false|unknown without leaking auth material.
+
+import Foundation
+
+public enum ConnectorExecuted: String, Codable, Sendable, Equatable {
+    case `true` = "true"
+    case `false` = "false"
+    case unknown = "unknown"
+}
+
+public enum ConnectorOutcome: String, Codable, Sendable, Equatable {
+    case success
+    case preDispatchLeaseExpiry
+    case transportOutage
+    case handlerFailure
+    case generationChange
+    case responseLoss
+}
+
+public enum ConnectorRetryDisposition: String, Codable, Sendable, Equatable {
+    case none
+    case queued
+    case serialized
+}
+
+public struct ConnectorLease: Sendable, Equatable, Codable {
+    public let id: String
+    public let expiresAt: Date
+
+    public init(id: String = UUID().uuidString, expiresAt: Date) {
+        self.id = id
+        self.expiresAt = expiresAt
+    }
+
+    public func isExpired(at now: Date) -> Bool { expiresAt <= now }
+}
+
+public struct ConnectorCallReceipt: Sendable, Equatable, Codable {
+    public let schemaVersion: String
+    public let connectorGeneration: String
+    public let leaseId: String
+    public let leaseExpiresAt: Date
+    public let dispatchId: String
+    public let retryDisposition: ConnectorRetryDisposition
+    public let executed: ConnectorExecuted
+    public let outcome: ConnectorOutcome
+    public let toolName: String
+
+    public init(
+        schemaVersion: String,
+        connectorGeneration: String,
+        leaseId: String,
+        leaseExpiresAt: Date,
+        dispatchId: String,
+        retryDisposition: ConnectorRetryDisposition,
+        executed: ConnectorExecuted,
+        outcome: ConnectorOutcome,
+        toolName: String
+    ) {
+        self.schemaVersion = schemaVersion
+        self.connectorGeneration = connectorGeneration
+        self.leaseId = leaseId
+        self.leaseExpiresAt = leaseExpiresAt
+        self.dispatchId = dispatchId
+        self.retryDisposition = retryDisposition
+        self.executed = executed
+        self.outcome = outcome
+        self.toolName = toolName
+    }
+
+    /// Machine-readable `_meta` payload. No tokens, subjects, or raw headers.
+    public var observationDictionary: [String: Any] {
+        [
+            "schemaVersion": schemaVersion,
+            "connectorGeneration": connectorGeneration,
+            "leaseId": leaseId,
+            "leaseExpiresAt": ISO8601DateFormatter().string(from: leaseExpiresAt),
+            "dispatchId": dispatchId,
+            "retryDisposition": retryDisposition.rawValue,
+            "executed": executed.rawValue,
+            "outcome": outcome.rawValue,
+            "toolName": toolName
+        ]
+    }
+}
+
+public enum ConnectorDeliveryError: Sendable, Equatable, Error {
+    case transport
+    case handler
+    case responseLost
+    case generationChanged
+}
+
+public enum ConnectorAuthHealth: String, Codable, Sendable, Equatable {
+    case oauthReady
+    case oauthInactive
+    case tokenMismatch
+    case loopbackExempt
+}
+
+public enum ConnectorContinuity {
+    public static let schemaVersion = "4.1.0"
+
+    /// Auth-mode truth for health/audit. Remote OAuth and local loopback stay
+    /// distinct; a transport or token mismatch never reports as ready.
+    public static func classifyAuthHealth(
+        remote: Bool,
+        oauthConfigured: Bool,
+        tokenValid: Bool,
+        tokenMatchesSession: Bool
+    ) -> ConnectorAuthHealth {
+        if !remote { return .loopbackExempt }
+        if !oauthConfigured { return .oauthInactive }
+        if !tokenValid || !tokenMatchesSession { return .tokenMismatch }
+        return .oauthReady
+    }
+
+    /// Classify execution disposition. Handler failure means the handler ran
+    /// (`executed=true`) and must not disable sibling tools. Pre-dispatch
+    /// refusal is `executed=false`. A successful mutation whose response was
+    /// lost is `executed=unknown`.
+    public static func classify(
+        leaseExpiredBeforeDispatch: Bool,
+        generationChanged: Bool,
+        dispatched: Bool,
+        handlerFailed: Bool,
+        transportFailed: Bool,
+        responseLost: Bool
+    ) -> (executed: ConnectorExecuted, outcome: ConnectorOutcome) {
+        if leaseExpiredBeforeDispatch {
+            return (.false, .preDispatchLeaseExpiry)
+        }
+        if generationChanged && !dispatched {
+            return (.false, .generationChange)
+        }
+        if transportFailed && !dispatched {
+            return (.false, .transportOutage)
+        }
+        if dispatched && responseLost {
+            return (.unknown, .responseLoss)
+        }
+        if dispatched && handlerFailed {
+            return (.true, .handlerFailure)
+        }
+        if dispatched {
+            return (.true, .success)
+        }
+        return (.unknown, .responseLoss)
+    }
+}
+
+/// Per-session serial queue for remote connector `tools/call`. Concurrent
+/// callers wait; none are dropped. Actor isolation is the governed serialize
+/// mitigation that proves 4-parallel batches deliver with zero unexplained loss
+/// at the Bridge boundary.
+public actor ConnectorCallQueue {
+    public static let shared = ConnectorCallQueue()
+
+    public let connectorGeneration: String
+    private var leases: [String: ConnectorLease] = [:]
+    private let leaseTTL: TimeInterval
+
+    public init(
+        connectorGeneration: String = UUID().uuidString,
+        leaseTTL: TimeInterval = 86_400
+    ) {
+        self.connectorGeneration = connectorGeneration
+        self.leaseTTL = leaseTTL
+    }
+
+    public func lease(for sessionKey: String, now: Date = Date()) -> ConnectorLease {
+        if let existing = leases[sessionKey] {
+            return existing
+        }
+        let minted = ConnectorLease(expiresAt: now.addingTimeInterval(leaseTTL))
+        leases[sessionKey] = minted
+        return minted
+    }
+
+    public func expireLease(for sessionKey: String, at now: Date) {
+        leases[sessionKey] = ConnectorLease(expiresAt: now.addingTimeInterval(-1))
+    }
+
+    public func runSerialized<T: Sendable>(
+        sessionKey: String,
+        toolName: String,
+        now: Date = Date(),
+        queued: Bool = false,
+        operation: @Sendable () async -> Result<T, ConnectorDeliveryError>
+    ) async -> (value: T?, receipt: ConnectorCallReceipt) {
+        let activeLease = lease(for: sessionKey, now: now)
+        let dispatchId = UUID().uuidString
+        let retry: ConnectorRetryDisposition = queued ? .serialized : .none
+
+        func receipt(
+            executed: ConnectorExecuted,
+            outcome: ConnectorOutcome
+        ) -> ConnectorCallReceipt {
+            ConnectorCallReceipt(
+                schemaVersion: ConnectorContinuity.schemaVersion,
+                connectorGeneration: connectorGeneration,
+                leaseId: activeLease.id,
+                leaseExpiresAt: activeLease.expiresAt,
+                dispatchId: dispatchId,
+                retryDisposition: retry,
+                executed: executed,
+                outcome: outcome,
+                toolName: toolName
+            )
+        }
+
+        if activeLease.isExpired(at: now) {
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: true,
+                generationChanged: false,
+                dispatched: false,
+                handlerFailed: false,
+                transportFailed: false,
+                responseLost: false
+            )
+            return (nil, receipt(executed: classified.executed, outcome: classified.outcome))
+        }
+
+        let result = await operation()
+        switch result {
+        case .success(let value):
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: false,
+                generationChanged: false,
+                dispatched: true,
+                handlerFailed: false,
+                transportFailed: false,
+                responseLost: false
+            )
+            return (value, receipt(executed: classified.executed, outcome: classified.outcome))
+        case .failure(.handler):
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: false,
+                generationChanged: false,
+                dispatched: true,
+                handlerFailed: true,
+                transportFailed: false,
+                responseLost: false
+            )
+            return (nil, receipt(executed: classified.executed, outcome: classified.outcome))
+        case .failure(.transport):
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: false,
+                generationChanged: false,
+                dispatched: false,
+                handlerFailed: false,
+                transportFailed: true,
+                responseLost: false
+            )
+            return (nil, receipt(executed: classified.executed, outcome: classified.outcome))
+        case .failure(.responseLost):
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: false,
+                generationChanged: false,
+                dispatched: true,
+                handlerFailed: false,
+                transportFailed: false,
+                responseLost: true
+            )
+            return (nil, receipt(executed: classified.executed, outcome: classified.outcome))
+        case .failure(.generationChanged):
+            let classified = ConnectorContinuity.classify(
+                leaseExpiredBeforeDispatch: false,
+                generationChanged: true,
+                dispatched: false,
+                handlerFailed: false,
+                transportFailed: false,
+                responseLost: false
+            )
+            return (nil, receipt(executed: classified.executed, outcome: classified.outcome))
+        }
+    }
+}

--- a/TheBridge/Server/SSETransport.swift
+++ b/TheBridge/Server/SSETransport.swift
@@ -1095,22 +1095,34 @@ public actor SSEServer {
             } else {
                 argsValue = .object([:])
             }
-            let (text, isError) = await router.dispatchFormatted(
+            let queued = origin == .remote
+            let (payload, receipt) = await ConnectorCallQueue.shared.runSerialized(
+                sessionKey: brokerSessionID,
                 toolName: name,
-                arguments: argsValue,
-                context: ToolDispatchContext(
-                    transportSessionId: brokerSessionID,
-                    origin: origin,
-                    client: origin == .remote ? "remote-connector" : nil,
-                    governancePrincipal: principal,
-                    routeAcknowledgementMode: origin == .remote ? .explicitReceipt : .transportSession
+                queued: queued
+            ) { () -> Result<(text: String, isError: Bool), ConnectorDeliveryError> in
+                let (text, isError) = await router.dispatchFormatted(
+                    toolName: name,
+                    arguments: argsValue,
+                    context: ToolDispatchContext(
+                        transportSessionId: brokerSessionID,
+                        origin: origin,
+                        client: origin == .remote ? "remote-connector" : nil,
+                        governancePrincipal: principal,
+                        routeAcknowledgementMode: origin == .remote ? .explicitReceipt : .transportSession
+                    )
                 )
-            )
-            if !isError { await MainActor.run { onToolCall() } }
-            let data = buildRPCResponse(id: requestId, result: [
+                return .success((text: text, isError: isError))
+            }
+            let text = payload?.text ?? "Error: connector dispatch did not execute"
+            let isError = payload?.isError ?? true
+            if payload != nil && !isError { await MainActor.run { onToolCall() } }
+            var result: [String: Any] = [
                 "content": [["type": "text", "text": text] as [String: Any]],
                 "isError": isError
-            ] as [String: Any]) ?? Data()
+            ]
+            result["_meta"] = ["connectorObservation": receipt.observationDictionary]
+            let data = buildRPCResponse(id: requestId, result: result) ?? Data()
             return .data(data, headers: headers)
 
         case "ping":
@@ -1879,7 +1891,10 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         var bodyBuffer: ByteBuffer
     }
 
-    private var pending: PendingRequest?
+    private var assemblies: [PendingRequest] = []
+    private var completed: [(head: HTTPRequestHead, body: Data?)] = []
+    private var drainTask: Task<Void, Never>?
+    private let assemblyLock = NSLock()
     private var legacySessionID: String?
 
     init(
@@ -1904,28 +1919,90 @@ private final class SSEHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let part = unwrapInboundIn(data)
+        ingest(unwrapInboundIn(data), context: context)
+    }
+
+    /// PKT-1296: assemble HTTP/1.1 requests in FIFO order and drain them
+    /// serially so overlapping keepalive POSTs cannot clobber each other or
+    /// interleave response writers on one channel.
+    fileprivate func ingest(_ part: HTTPServerRequestPart, context: ChannelHandlerContext) {
         switch part {
         case .head(let head):
-            pending = PendingRequest(
-                head: head,
-                bodyBuffer: context.channel.allocator.buffer(capacity: 0)
-            )
-        case .body(var buffer):
-            pending?.bodyBuffer.writeBuffer(&buffer)
-        case .end:
-            guard let req = pending else { return }
-            pending = nil
-            
-            let head = req.head
-            let bodyData: Data? = req.bodyBuffer.readableBytes > 0 
-                ? req.bodyBuffer.getBytes(at: 0, length: req.bodyBuffer.readableBytes).map { Data($0) }
-                : nil
-            
-            nonisolated(unsafe) let ctx = context
-            Task {
-                await self.processRequest(head: head, body: bodyData, context: ctx)
+            withAssemblyLock {
+                assemblies.append(PendingRequest(
+                    head: head,
+                    bodyBuffer: context.channel.allocator.buffer(capacity: 0)
+                ))
             }
+        case .body(var buffer):
+            withAssemblyLock {
+                if !assemblies.isEmpty {
+                    assemblies[assemblies.count - 1].bodyBuffer.writeBuffer(&buffer)
+                }
+            }
+        case .end:
+            withAssemblyLock {
+                let req: PendingRequest? = assemblies.isEmpty ? nil : assemblies.removeFirst()
+                if let req {
+                    completed.append(Self.completedTuple(req))
+                }
+            }
+            startDrain(context: context)
+        }
+    }
+
+    private static func completedTuple(_ req: PendingRequest) -> (head: HTTPRequestHead, body: Data?) {
+        let bodyData: Data? = req.bodyBuffer.readableBytes > 0
+            ? req.bodyBuffer.getBytes(at: 0, length: req.bodyBuffer.readableBytes).map { Data($0) }
+            : nil
+        return (req.head, bodyData)
+    }
+
+    nonisolated private func withAssemblyLock(_ body: () -> Void) {
+        assemblyLock.lock()
+        defer { assemblyLock.unlock() }
+        body()
+    }
+
+    nonisolated private func takeNextCompleted() -> (head: HTTPRequestHead, body: Data?)? {
+        assemblyLock.lock()
+        defer { assemblyLock.unlock() }
+        guard !completed.isEmpty else {
+            drainTask = nil
+            return nil
+        }
+        return completed.removeFirst()
+    }
+
+    nonisolated private func snapshotDrainState() -> (task: Task<Void, Never>?, remaining: Int) {
+        assemblyLock.lock()
+        defer { assemblyLock.unlock() }
+        return (drainTask, completed.count)
+    }
+
+    private func startDrain(context: ChannelHandlerContext) {
+        assemblyLock.lock()
+        if drainTask == nil {
+            nonisolated(unsafe) let ctx = context
+            drainTask = Task { [weak self] in
+                await self?.drainQueue(context: ctx)
+            }
+        }
+        assemblyLock.unlock()
+    }
+
+    private func drainQueue(context: ChannelHandlerContext) async {
+        while true {
+            guard let next = takeNextCompleted() else { return }
+            await processRequest(head: next.head, body: next.body, context: context)
+        }
+    }
+
+    fileprivate func waitUntilIdleForTesting() async {
+        while true {
+            let snapshot = snapshotDrainState()
+            if snapshot.task == nil && snapshot.remaining == 0 { return }
+            await snapshot.task?.value
         }
     }
 
@@ -2313,5 +2390,28 @@ extension SSEServer {
         try await channel.pipeline.addHandler(handler).get()
         let context = try await channel.pipeline.context(handler: handler).get()
         await handler.processRequest(head: head, body: body, context: context)
+    }
+
+    /// PKT-1296 test seam: feed raw HTTP/1.1 parts (including overlapping
+    /// heads) through the live assembler + serial drain.
+    public static func ingestHTTPPartsForTesting(
+        on channel: Channel,
+        parts: [HTTPServerRequestPart]
+    ) async throws {
+        let handler = SSEHTTPHandler(
+            legacyBridge: LegacySSEBridge(),
+            endpoint: "/mcp",
+            rpcHandler: { _, _ in nil },
+            httpRequestHandler: { _ in .ok() },
+            healthHandler: { Data("{\"ok\":true}".utf8) },
+            jobsCallbackHandler: { _ in Data() },
+            onClientDisconnected: { _ in }
+        )
+        try await channel.pipeline.addHandler(handler).get()
+        let context = try await channel.pipeline.context(handler: handler).get()
+        for part in parts {
+            handler.ingest(part, context: context)
+        }
+        await handler.waitUntilIdleForTesting()
     }
 }

--- a/TheBridgeTests/ConnectorContinuityTests.swift
+++ b/TheBridgeTests/ConnectorContinuityTests.swift
@@ -1,0 +1,175 @@
+// ConnectorContinuityTests.swift — PKT-1296
+// Connector execution receipts, governed serialize queue, HTTP/1.1 overlap drain.
+
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import TheBridgeLib
+
+private final class ContinuityFlag: @unchecked Sendable {
+    var ran = false
+    var names = ["alpha", "beta"]
+}
+
+func runConnectorContinuityTests() async {
+    print("\n🔌 ConnectorContinuity (PKT-1296 · delivery + executed truth)")
+
+    await test("Continuity: pre-dispatch lease expiry is executed=false") {
+        let classified = ConnectorContinuity.classify(
+            leaseExpiredBeforeDispatch: true,
+            generationChanged: false,
+            dispatched: false,
+            handlerFailed: false,
+            transportFailed: false,
+            responseLost: false
+        )
+        try expect(classified.executed == .false)
+        try expect(classified.outcome == .preDispatchLeaseExpiry)
+    }
+
+    await test("Continuity: response-loss after dispatch is executed=unknown") {
+        let classified = ConnectorContinuity.classify(
+            leaseExpiredBeforeDispatch: false,
+            generationChanged: false,
+            dispatched: true,
+            handlerFailed: false,
+            transportFailed: false,
+            responseLost: true
+        )
+        try expect(classified.executed == .unknown)
+        try expect(classified.outcome == .responseLoss)
+    }
+
+    await test("Continuity: handler failure is executed=true and does not classify as transport") {
+        let classified = ConnectorContinuity.classify(
+            leaseExpiredBeforeDispatch: false,
+            generationChanged: false,
+            dispatched: true,
+            handlerFailed: true,
+            transportFailed: false,
+            responseLost: false
+        )
+        try expect(classified.executed == .true, "handler ran ⇒ executed=true")
+        try expect(classified.outcome == .handlerFailure)
+    }
+
+    await test("Continuity: auth health keeps oauth-ready, inactive, mismatch, and loopback distinct") {
+        try expect(ConnectorContinuity.classifyAuthHealth(
+            remote: true, oauthConfigured: true, tokenValid: true, tokenMatchesSession: true
+        ) == .oauthReady)
+        try expect(ConnectorContinuity.classifyAuthHealth(
+            remote: true, oauthConfigured: false, tokenValid: false, tokenMatchesSession: false
+        ) == .oauthInactive)
+        try expect(ConnectorContinuity.classifyAuthHealth(
+            remote: true, oauthConfigured: true, tokenValid: true, tokenMatchesSession: false
+        ) == .tokenMismatch)
+        try expect(ConnectorContinuity.classifyAuthHealth(
+            remote: false, oauthConfigured: false, tokenValid: false, tokenMatchesSession: false
+        ) == .loopbackExempt)
+    }
+
+    await test("Continuity: expired lease proves executed=false without running the operation") {
+        let queue = ConnectorCallQueue(connectorGeneration: "gen-test", leaseTTL: 60)
+        await queue.expireLease(for: "sess-1", at: Date())
+        let flag = ContinuityFlag()
+        let (_, receipt) = await queue.runSerialized(sessionKey: "sess-1", toolName: "ping") {
+            () -> Result<String, ConnectorDeliveryError> in
+            flag.ran = true
+            return .success("should-not-run")
+        }
+        try expect(!flag.ran, "pre-dispatch expiry must not invoke the handler")
+        try expect(receipt.executed == .false)
+        try expect(receipt.outcome == .preDispatchLeaseExpiry)
+        try expect(receipt.schemaVersion == ConnectorContinuity.schemaVersion)
+        try expect(receipt.connectorGeneration == "gen-test")
+    }
+
+    await test("Continuity: handler failure leaves a sibling tool executable") {
+        let queue = ConnectorCallQueue(connectorGeneration: "gen-iso")
+        let tools = ContinuityFlag()
+        let (_, failed) = await queue.runSerialized(sessionKey: "iso", toolName: "alpha") {
+            () -> Result<String, ConnectorDeliveryError> in
+            tools.names.removeAll { $0 == "alpha" }
+            return .failure(.handler)
+        }
+        try expect(failed.executed == .true)
+        try expect(failed.outcome == .handlerFailure)
+        try expect(tools.names.contains("beta"), "sibling tool must remain available")
+        let (ok, okReceipt) = await queue.runSerialized(sessionKey: "iso", toolName: "beta") {
+            () -> Result<String, ConnectorDeliveryError> in
+            .success("beta-ok")
+        }
+        try expect(ok == "beta-ok")
+        try expect(okReceipt.executed == .true)
+        try expect(okReceipt.outcome == .success)
+    }
+
+    await test("Continuity: 4-parallel ×3 consecutive runs have zero unexplained drops") {
+        let queue = ConnectorCallQueue(connectorGeneration: "gen-parallel")
+        for round in 1...3 {
+            let results = await withTaskGroup(
+                of: ConnectorCallReceipt.self,
+                returning: [ConnectorCallReceipt].self
+            ) { group in
+                for i in 1...4 {
+                    group.addTask {
+                        let (_, receipt) = await queue.runSerialized(
+                            sessionKey: "parallel",
+                            toolName: "ping-\(round)-\(i)",
+                            queued: true
+                        ) {
+                            () -> Result<Int, ConnectorDeliveryError> in
+                            try? await Task.sleep(nanoseconds: 2_000_000)
+                            return .success(i)
+                        }
+                        return receipt
+                    }
+                }
+                var collected: [ConnectorCallReceipt] = []
+                for await receipt in group { collected.append(receipt) }
+                return collected
+            }
+            try expect(results.count == 4, "round \(round) dropped calls: \(results.count)")
+            for receipt in results {
+                try expect(receipt.executed == .true, "round \(round) unexplained drop: \(receipt.outcome.rawValue)")
+                try expect(receipt.retryDisposition == .serialized)
+            }
+        }
+    }
+
+    await test("Continuity: overlapping HTTP/1.1 heads do not drop a sibling /health") {
+        func decodeHead(_ raw: String) throws -> HTTPRequestHead {
+            let channel = EmbeddedChannel()
+            try channel.pipeline.configureHTTPServerPipeline().wait()
+            var buf = channel.allocator.buffer(capacity: raw.utf8.count)
+            buf.writeString(raw)
+            try channel.writeInbound(buf)
+            defer { _ = try? channel.finish() }
+            guard let part = try channel.readInbound(as: HTTPServerRequestPart.self),
+                  case .head(let head) = part else {
+                throw TestError.assertion("expected a decoded .head")
+            }
+            return head
+        }
+
+        let raw = "GET /health HTTP/1.1\r\nHost: 127.0.0.1:9700\r\n\r\n"
+        let headA = try decodeHead(raw)
+        let headB = try decodeHead(raw)
+        let channel = EmbeddedChannel()
+        try await SSEServer.ingestHTTPPartsForTesting(on: channel, parts: [
+            .head(headA),
+            .head(headB),
+            .end(nil),
+            .end(nil)
+        ])
+        (channel.eventLoop as! EmbeddedEventLoop).run()
+        var statuses: [Int] = []
+        while let out = try? channel.readOutbound(as: HTTPServerResponsePart.self) {
+            if case .head(let h) = out { statuses.append(Int(h.status.code)) }
+        }
+        _ = try? channel.finish()
+        try expect(statuses.count == 2, "overlapping heads must emit two responses, got \(statuses)")
+        try expect(statuses.allSatisfy { $0 == 200 }, "both /health responses must be 200, got \(statuses)")
+    }
+}

--- a/TheBridgeTests/LaunchReadinessTests.swift
+++ b/TheBridgeTests/LaunchReadinessTests.swift
@@ -1,0 +1,195 @@
+// LaunchReadinessTests.swift — PKT-1305
+// TheBridge · Tests
+//
+// Hermetic fixtures for the provider-neutral launch-readiness contract.
+// No live credentials, no provider-account mutation, no new MCP surface.
+
+import Foundation
+import TheBridgeLib
+
+func runLaunchReadinessTests() async {
+    print("\n🛫 LaunchReadiness (PKT-1305 · provider-neutral preflight + safeToLaunch)")
+
+    let checkedAt = Date(timeIntervalSince1970: 1_777_200_000)
+
+    func packetProperty(_ field: PacketRegistryContract.Field) -> RegistryProperty {
+        RegistryProperty(
+            key: field.key,
+            notionName: field.notionName,
+            notionPropertyId: "id_\(field.key)",
+            type: field.type
+        )
+    }
+
+    func passingPacketConfig() -> RegistryConfig {
+        let packet = RegistryEntity(
+            key: "packet",
+            displayName: "PACKETS",
+            dataSourceId: "packets-ds",
+            properties: PacketRegistryContract.fields
+                .filter(\.registryBindingRequired)
+                .map(packetProperty),
+            cacheTTLSeconds: 300,
+            hasBody: true
+        )
+        let project = RegistryEntity(key: "project", displayName: "Projects", dataSourceId: "projects-ds", properties: [], cacheTTLSeconds: 300)
+        let skill = RegistryEntity(key: "skill", displayName: "Skills", dataSourceId: "skills-ds", properties: [], cacheTTLSeconds: 300)
+        let telemetry = RegistryEntity(key: "telemetry", displayName: "Telemetry", dataSourceId: "telemetry-ds", properties: [], cacheTTLSeconds: 300)
+        let schedule = RegistryEntity(key: "schedule", displayName: "Schedule", dataSourceId: "schedule-ds", properties: [], cacheTTLSeconds: 300)
+        let client = RegistryEntity(key: "client", displayName: "Clients", dataSourceId: "clients-ds", properties: [], cacheTTLSeconds: 300)
+        return RegistryConfig(entities: [packet, project, skill, telemetry, schedule, client])
+    }
+
+    func passingPacketSchema() -> DataSourceSchema {
+        var columns: [String: DataSourceSchema.Column] = [:]
+        for field in PacketRegistryContract.fields {
+            let target: String?
+            switch field.relationTargetEntity {
+            case "packet": target = "packets-ds"
+            case "project": target = "projects-ds"
+            case "skill": target = "skills-ds"
+            case "telemetry": target = "telemetry-ds"
+            case "schedule": target = "schedule-ds"
+            case "client": target = "clients-ds"
+            default: target = nil
+            }
+            columns[field.notionName] = .init(
+                id: "id_\(field.key)",
+                type: field.type,
+                options: field.expectedOptions.sorted(),
+                relationDataSourceId: target
+            )
+        }
+        return DataSourceSchema(columnsByName: columns)
+    }
+
+    func greenProbes(
+        commandAuth: LaunchReadinessSeam = CommandAuthReadinessSeam(.authenticated(tool: "notion_page_read")),
+        registry: LaunchReadinessSeam? = nil,
+        runtime: LaunchReadinessSeam = RuntimeAvailabilitySeam(.available(runtime: "chrome")),
+        storage: LaunchReadinessSeam = StorageWriteabilitySeam(.writable(path: "/tmp/bridge-worktree")),
+        coverage: LaunchReadinessSeam = ImplementationCoverageSeam(.proven(locator: "sha:48d6f8fe"))
+    ) -> [LaunchReadinessProbe] {
+        LaunchReadinessContract.standardProbes(
+            commandAuth: commandAuth,
+            registryConsumer: registry ?? RegistryConsumerReadinessSeam(.snapshot(
+                config: passingPacketConfig(), schema: passingPacketSchema())),
+            runtimeBrowser: runtime,
+            storageWrite: storage,
+            implementationCoverage: coverage
+        )
+    }
+
+    func check(_ report: LaunchReadinessReport, _ name: String) -> LaunchReadinessCheck? {
+        report.checks.first { $0.name == name }
+    }
+
+    await test("LaunchReadiness: unauthenticated command/tool fixture returns BLOCKED with evidence") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(commandAuth: CommandAuthReadinessSeam(.unauthenticated(tool: "notion_page_update"))),
+            now: checkedAt
+        )
+        let auth = check(report, LaunchReadinessContract.commandAuthCheck)
+        try expect(auth?.verdict == .blocked, "expected BLOCKED, got \(auth?.verdict.rawValue ?? "nil")")
+        try expect(auth?.evidence.contains("unauthenticated") == true, "evidence must name unauthenticated: \(auth?.evidence ?? "")")
+        try expect(!report.safeToLaunch, "any required BLOCKED forbids launch")
+        try expect(report.checkedAt == checkedAt)
+    }
+
+    await test("LaunchReadiness: missing browser/runtime fixture returns BLOCKED") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(runtime: RuntimeAvailabilitySeam(.missing(runtime: "chrome"))),
+            now: checkedAt
+        )
+        let runtime = check(report, LaunchReadinessContract.runtimeBrowserCheck)
+        try expect(runtime?.verdict == .blocked)
+        try expect(runtime?.evidence.contains("missing") == true)
+        try expect(!report.safeToLaunch)
+    }
+
+    await test("LaunchReadiness: unavailable storage/write path returns BLOCKED") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(storage: StorageWriteabilitySeam(
+                .unavailable(path: "/tmp/bridge-worktree", reason: "permission denied"))),
+            now: checkedAt
+        )
+        let storage = check(report, LaunchReadinessContract.storageWriteCheck)
+        try expect(storage?.verdict == .blocked)
+        try expect(storage?.evidence.contains("not writable") == true)
+        try expect(!report.safeToLaunch)
+    }
+
+    await test("LaunchReadiness: missing implementation-coverage proof returns BLOCKED") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(coverage: ImplementationCoverageSeam(
+                .missing(expected: "workflow:pkt-1305-tests"))),
+            now: checkedAt
+        )
+        let coverage = check(report, LaunchReadinessContract.implementationCoverageCheck)
+        try expect(coverage?.verdict == .blocked)
+        try expect(coverage?.evidence.contains("coverage proof missing") == true)
+        try expect(!report.safeToLaunch)
+    }
+
+    await test("LaunchReadiness: failed evidence transport returns TRANSPORT_UNKNOWN, never false BLOCKED") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(registry: RegistryConsumerReadinessSeam(
+                .evidenceUnavailable(reason: "tunnel drop: failed to connect to MCP server"))),
+            now: checkedAt
+        )
+        let registry = check(report, LaunchReadinessContract.registryConsumerCheck)
+        try expect(registry?.verdict == .transportUnknown,
+                   "transport failure must not collapse to BLOCKED, got \(registry?.verdict.rawValue ?? "nil")")
+        try expect(registry?.verdict != .blocked, "false BLOCKED is a contract violation")
+        try expect(registry?.evidence.contains("failed to connect") == true)
+        try expect(!report.safeToLaunch, "TRANSPORT_UNKNOWN on a required check is not safeToLaunch")
+    }
+
+    await test("LaunchReadiness: command auth evidence-path failure is TRANSPORT_UNKNOWN not BLOCKED") {
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(commandAuth: CommandAuthReadinessSeam(
+                .evidenceUnavailable(reason: "TCC probe timed out"))),
+            now: checkedAt
+        )
+        try expect(check(report, LaunchReadinessContract.commandAuthCheck)?.verdict == .transportUnknown)
+        try expect(!report.safeToLaunch)
+    }
+
+    await test("LaunchReadiness: all-green fixture returns PASS for every check and safeToLaunch=true") {
+        let report = await LaunchReadinessContract.evaluate(probes: greenProbes(), now: checkedAt)
+        try expect(report.checks.count == 5)
+        for item in report.checks {
+            try expect(item.verdict == .pass, "\(item.name) expected PASS, got \(item.verdict.rawValue)")
+            try expect(item.required, "canonical checks are required")
+            try expect(!item.evidence.isEmpty, "\(item.name) must carry evidence")
+        }
+        try expect(report.safeToLaunch, "all required PASS → safeToLaunch")
+        try expect(report.checkedAt == checkedAt)
+    }
+
+    await test("LaunchReadiness: registry consumer DRIFT is product BLOCKED, not transport") {
+        let emptyConfig = RegistryConfig(entities: [])
+        let report = await LaunchReadinessContract.evaluate(
+            probes: greenProbes(registry: RegistryConsumerReadinessSeam(
+                .snapshot(config: emptyConfig, schema: passingPacketSchema()))),
+            now: checkedAt
+        )
+        let registry = check(report, LaunchReadinessContract.registryConsumerCheck)
+        try expect(registry?.verdict == .blocked, "known contract drift is BLOCKED")
+        try expect(registry?.evidence.contains("DRIFT") == true)
+        try expect(!report.safeToLaunch)
+    }
+
+    await test("LaunchReadiness: optional TRANSPORT_UNKNOWN does not veto safeToLaunch") {
+        let probes: [LaunchReadinessProbe] = greenProbes() + [
+            NamedLaunchReadinessProbe(
+                name: "optional.telemetry",
+                required: false,
+                seam: FixedLaunchReadinessSeam(.transportUnknown(evidence: "audit log unreachable"))
+            )
+        ]
+        let report = await LaunchReadinessContract.evaluate(probes: probes, now: checkedAt)
+        try expect(report.safeToLaunch, "optional unknown transport must not veto launch")
+        try expect(check(report, "optional.telemetry")?.verdict == .transportUnknown)
+    }
+}

--- a/TheBridgeTests/ProcessLifecycleTruthTests.swift
+++ b/TheBridgeTests/ProcessLifecycleTruthTests.swift
@@ -1,0 +1,140 @@
+// ProcessLifecycleTruthTests.swift — PKT-1196
+// Residual terminal-state / timeout / descendant-cleanup contract.
+// Does not reimplement BgProcessRuntime process-group ownership.
+
+import Darwin
+import Foundation
+import TheBridgeLib
+
+func runProcessLifecycleTruthTests() async {
+    print("\n📟 ProcessLifecycleTruth (PKT-1196 · residual terminal receipt)")
+
+    let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+    let t1 = Date(timeIntervalSince1970: 1_700_000_010)
+
+    await test("Lifecycle: stillRunning cannot be false while pid or group is alive") {
+        try expect(ProcessLifecycleTruth.stillRunning(pidAlive: true, processGroupAlive: false))
+        try expect(ProcessLifecycleTruth.stillRunning(pidAlive: false, processGroupAlive: true))
+        try expect(!ProcessLifecycleTruth.stillRunning(pidAlive: false, processGroupAlive: false))
+    }
+
+    await test("Lifecycle: descendant cleanup is incomplete while any requested workload lives") {
+        try expect(ProcessLifecycleTruth.descendantCleanup(pidAlive: false, processGroupAlive: true) == .incomplete)
+        try expect(ProcessLifecycleTruth.descendantCleanup(pidAlive: false, processGroupAlive: false) == .verified)
+    }
+
+    await test("Lifecycle: timeout receipts distinguish continuation, verified termination, and ambiguous") {
+        try expect(ProcessLifecycleTruth.classifyTimeout(requestTimedOut: true, pidAlive: true, processGroupAlive: true)
+                   == .requestTimeoutWorkloadContinuing)
+        try expect(ProcessLifecycleTruth.classifyTimeout(requestTimedOut: true, pidAlive: false, processGroupAlive: false)
+                   == .verifiedGroupTermination)
+        try expect(ProcessLifecycleTruth.classifyTimeout(requestTimedOut: true, pidAlive: false, processGroupAlive: true)
+                   == .ambiguous)
+        try expect(ProcessLifecycleTruth.classifyTimeout(requestTimedOut: false, pidAlive: false, processGroupAlive: false) == nil)
+    }
+
+    await test("Lifecycle: no terminal fixture remains unclassified") {
+        let cases: [(ProcessLifecycleState, () -> ProcessLifecycleState)] = [
+            (.launchFailed, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: true, launchError: "posix_spawn", pidAssigned: false,
+                pidAlive: false, processGroupAlive: false, exitCode: nil, signal: nil, missedWait: false) }),
+            (.starting, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: false, launchError: nil, pidAssigned: false,
+                pidAlive: false, processGroupAlive: false, exitCode: nil, signal: nil, missedWait: false) }),
+            (.running, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: false, launchError: nil, pidAssigned: true,
+                pidAlive: true, processGroupAlive: true, exitCode: nil, signal: nil, missedWait: false) }),
+            (.exited, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: false, launchError: nil, pidAssigned: true,
+                pidAlive: false, processGroupAlive: false, exitCode: 0, signal: nil, missedWait: false) }),
+            (.signaled, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: false, launchError: nil, pidAssigned: true,
+                pidAlive: false, processGroupAlive: false, exitCode: -1, signal: SIGTERM, missedWait: false) }),
+            (.orphaned, { ProcessLifecycleTruth.classifyTerminal(
+                launchFailed: false, launchError: nil, pidAssigned: true,
+                pidAlive: false, processGroupAlive: false, exitCode: nil, signal: nil, missedWait: true) }),
+        ]
+        for (expected, classify) in cases {
+            try expect(classify() == expected, "expected \(expected.rawValue), got \(classify().rawValue)")
+        }
+    }
+
+    await test("Lifecycle: wrapper exit with live descendants is ambiguous and stillRunning") {
+        let receipt = ProcessLifecycleTruth.classifyShell(
+            command: "wrapper",
+            timedOut: true,
+            pid: 42,
+            pidAlive: false,
+            processGroupAlive: true,
+            exitCode: 0,
+            signaled: nil,
+            launchError: nil,
+            startedAt: t0,
+            endedAt: t1,
+            now: t1
+        )
+        try expect(receipt.timeoutOutcome == .ambiguous)
+        try expect(receipt.stillRunning, "descendants alive ⇒ stillRunning must stay true")
+        try expect(receipt.descendantCleanup == .incomplete)
+        try expect(receipt.state == .running)
+    }
+
+    await test("Lifecycle: shipped bg unknown maps to orphaned without replacing BgProcessStatus") {
+        let receipt = ProcessLifecycleTruth.classifyBgJob(
+            status: .unknown,
+            pidAlive: false,
+            processGroupAlive: false,
+            exitCode: nil,
+            killSignal: nil,
+            note: "orphan reconciled on relaunch — pid 9 absent",
+            command: "sleep 9",
+            pid: 9,
+            pgid: 9,
+            startedAt: t0,
+            endedAt: t1,
+            logPath: "/tmp/job/stdout",
+            now: t1
+        )
+        try expect(receipt.state == .orphaned)
+        try expect(receipt.orphanReason?.contains("absent") == true)
+        try expect(!receipt.stillRunning)
+        try expect(BgProcessStatus.unknown.rawValue == "unknown", "shipped status enum must remain")
+    }
+
+    await test("Lifecycle: bg killed maps to signaled; incomplete cleanup is a failure state") {
+        let dirty = ProcessLifecycleTruth.classifyBgJob(
+            status: .killed,
+            pidAlive: false,
+            processGroupAlive: true,
+            exitCode: -1,
+            killSignal: SIGKILL,
+            note: nil,
+            command: "sleep 99",
+            pid: 11,
+            pgid: 11,
+            startedAt: t0,
+            endedAt: t1,
+            logPath: nil,
+            now: t1
+        )
+        try expect(dirty.state == .signaled)
+        try expect(dirty.descendantCleanup == .incomplete)
+        try expect(dirty.stillRunning, "group still alive is unreported workload")
+    }
+
+    await test("Lifecycle: nonzero empty-output exit and zero exit are both exited") {
+        let zero = ProcessLifecycleTruth.classifyTerminal(
+            launchFailed: false, launchError: nil, pidAssigned: true,
+            pidAlive: false, processGroupAlive: false, exitCode: 0, signal: nil, missedWait: false)
+        let nonzero = ProcessLifecycleTruth.classifyTerminal(
+            launchFailed: false, launchError: nil, pidAssigned: true,
+            pidAlive: false, processGroupAlive: false, exitCode: 1, signal: nil, missedWait: false)
+        try expect(zero == .exited && nonzero == .exited)
+    }
+
+    await test("Lifecycle: command hash is durable and command-sensitive") {
+        let a = ProcessLifecycleTruth.commandHash("echo hi")
+        let b = ProcessLifecycleTruth.commandHash("echo ho")
+        try expect(a.count == 64 && a != b)
+    }
+}

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -819,6 +819,7 @@ await runRemoteOAuthBearerTests()   // PKT-800 (S2): JWTKit bearer + ScopeGate +
 await runRemoteOAuthHardeningTests() // PKT-800 (S3): step-up + confused-deputy + leak-sweep + gating
 await runRemoteOAuthHardeningS4Tests() // PKT-800 (S4): contacts.read split + TransportRouter seam + step-up scope-only
 await runRemoteOAuthOriginGatingTests() // PKT-810 R5: origin split — loopback token-free, tunnel OAuth-gated
+await runConnectorContinuityTests()    // PKT-1296: connector continuity + executed truth + HTTP overlap drain
 await runBridgeFeatureFlagsTests()  // PKT-798 (v2.3 · WS-C): fail-closed capability gates
 await runBridgeModuleRegistryTests() // PKT v3.0·0.4: single-source module registrar
 await runMCPToolFactoryTests()       // PKT v3.0·0.5: metadata contract + unified Tool factory

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -669,6 +669,7 @@ await test("AuditEntry is Codable (JSON round-trip)") {
 // SKIPPED: checkAll() hangs in CLI — NSAppleScript probes need AppKit run loop
 // await runPermissionManagerTests()
 await runShellModuleTests()
+await runProcessLifecycleTruthTests() // PKT-1196: residual terminal / timeout / descendant-cleanup truth
 await runNodeTestModuleTests() // U2: owner-bound foreground Node test runner
 await runBgProcessModuleTests()   // Tool-Dev (PRJCT-2754): bg_run/bg_poll/bg_kill detached background execution (registration/tier/annotation + LIVE run→poll→exit round-trip + bg_kill SIGTERM)
 await runBgProcessRuntimeTests()  // v4 audit #3: BgProcessRuntime actor — kill cascade SIGTERM→SIGKILL, reconcileOrphans (dead→unknown / live-reattach / TTL sweep), finalizeExit signaled-not-killed, concurrency-safe start

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -781,6 +781,7 @@ await runGovernancePropagationTests() // PKT-1124 W2C: real Streamable-HTTP gove
 await runRemoteGovernanceContinuityTests() // principal-keyed remote governance + routing-manifest continuity across session churn
 await runRoutingCustodyStoreTests() // WU2: atomic durable routing bootstrap + checksum recovery
 await runCapabilityPreflightTests() // PKT-1065C: intent-sensitive capability preflight + Reminders adapter
+await runLaunchReadinessTests() // PKT-1305: provider-neutral PASS/BLOCKED/TRANSPORT_UNKNOWN + safeToLaunch
 await runShortcutsModuleTests()   // PKT-959 (v3.7·F): shortcuts_* MCP tools (mock CLI seam)
 await runCommandsDataTests()      // cmd-w2: Commands data layer (CommandsManager + MentionResolver + cache)
 await runFetchSkillMarkdownTests() // cmd-w4: fetch_skill /markdown + shared MentionResolver


### PR DESCRIPTION
## Summary
- Land Bridge v4.1 capability truth onto `main`: launch-readiness contract (PKT-1305), process-lifecycle terminal receipt classification (PKT-1196), and connector HTTP/1.1 serialized delivery with executed-truth classification (PKT-1296).
- Integration SHA `030d03887650dce5b2898cb9d8de231b43fecedd` is a clean cherry-pick stack of those three packets onto current `origin/main` (`48d6f8fe`). Floor 3830/0. Local install already verified at this SHA.
- Does **not** include `feat/notion-view-delete` (view-delete / database-delete / protected trash).

## Test plan
- [x] Isolated lane suites + integration `make test-floor` at `030d0388` (3830 passed / 0 failed, floor ≥3790)
- [ ] CI checks on this PR
- [ ] After merge: confirm `origin/main` contains `030d0388` (merge commit, not squash)
- [ ] After merge: prune only clean v4.1 packet worktrees fully represented on `main`; keep `feat/notion-view-delete`