### PR TITLE
PJT-2770: binding vs consumer preflight, mission revision, LaunchReadiness attach

### DIFF
--- a/TheBridge/Modules/Registry/PacketMissionRevision.swift
+++ b/TheBridge/Modules/Registry/PacketMissionRevision.swift
@@ -1,0 +1,223 @@
+// PacketMissionRevision.swift — PJT-2770 DoD 4
+// TheBridge · Modules · Registry
+//
+// Governed packet mission/dependency revision. Apply is one transaction:
+// either the next revision+hash is produced, or the call returns
+// `partial_ambiguous` / `blocked` and writes nothing.
+//
+// Hash membership follows A0: operator-owned mission fields only. Controller
+// mutable fields (Status, Packet Output, timestamps, tokens, …) are excluded.
+
+import Foundation
+
+public enum PacketMissionRevision {
+    public static let contractVersion = "packet-mission-revision-v1"
+
+    public enum Outcome: String, Sendable, Equatable {
+        case applied
+        case partialAmbiguous = "partial_ambiguous"
+        case blocked
+    }
+
+    public struct Mission: Sendable, Equatable {
+        public var name: String
+        public var title: String
+        public var objective: String
+        public var sourceOfTruth: String
+        public var executionClass: String
+        public var projectIds: [String]
+        public var skillIds: [String]
+        public var blockedByIds: [String]
+        public var bodyCanonical: String
+
+        public init(
+            name: String,
+            title: String,
+            objective: String,
+            sourceOfTruth: String,
+            executionClass: String,
+            projectIds: [String],
+            skillIds: [String],
+            blockedByIds: [String],
+            bodyCanonical: String
+        ) {
+            self.name = name
+            self.title = title
+            self.objective = objective
+            self.sourceOfTruth = sourceOfTruth
+            self.executionClass = executionClass
+            self.projectIds = projectIds
+            self.skillIds = skillIds
+            self.blockedByIds = blockedByIds
+            self.bodyCanonical = bodyCanonical
+        }
+    }
+
+    public struct State: Sendable, Equatable {
+        public var packetId: String
+        public var mission: Mission
+        public var revision: Int
+        public var hash: String
+
+        public init(packetId: String, mission: Mission, revision: Int, hash: String) {
+            self.packetId = packetId
+            self.mission = mission
+            self.revision = revision
+            self.hash = hash
+        }
+
+        public static func hashed(packetId: String, mission: Mission, revision: Int) -> State {
+            State(packetId: packetId, mission: mission, revision: revision, hash: PacketMissionRevision.hash(mission))
+        }
+    }
+
+    public struct Request: Sendable {
+        public var current: State
+        public var proposed: Mission
+        public var expectedHash: String
+        public var expectedRevision: Int
+        /// False when Blocked-by changed but the reciprocal Blocking graph
+        /// cannot be read in the same transaction.
+        public var reciprocalBlockingKnown: Bool
+        public var reciprocalBlockingConsistent: Bool
+
+        public init(
+            current: State,
+            proposed: Mission,
+            expectedHash: String,
+            expectedRevision: Int,
+            reciprocalBlockingKnown: Bool = true,
+            reciprocalBlockingConsistent: Bool = true
+        ) {
+            self.current = current
+            self.proposed = proposed
+            self.expectedHash = expectedHash
+            self.expectedRevision = expectedRevision
+            self.reciprocalBlockingKnown = reciprocalBlockingKnown
+            self.reciprocalBlockingConsistent = reciprocalBlockingConsistent
+        }
+    }
+
+    public struct Result: Sendable, Equatable {
+        public var outcome: Outcome
+        public var reason: String
+        public var state: State
+        public var appliedWrites: Bool
+
+        public init(outcome: Outcome, reason: String, state: State, appliedWrites: Bool) {
+            self.outcome = outcome
+            self.reason = reason
+            self.state = state
+            self.appliedWrites = appliedWrites
+        }
+    }
+
+    public static func hash(_ mission: Mission) -> String {
+        CalendarRegistryDigest.sha256(canonicalJSON(mission))
+    }
+
+    public static func apply(_ request: Request) -> Result {
+        if request.expectedHash != request.current.hash {
+            return Result(
+                outcome: .partialAmbiguous,
+                reason: "expectedHash does not match current.hash",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+        if request.expectedRevision != request.current.revision {
+            return Result(
+                outcome: .partialAmbiguous,
+                reason: "expectedRevision does not match current.revision",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+        if request.proposed.blockedByIds.contains(request.current.packetId) {
+            return Result(
+                outcome: .blocked,
+                reason: "blockedBy contains self",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+        let blockedByChanged = normalized(request.proposed.blockedByIds)
+            != normalized(request.current.mission.blockedByIds)
+        if blockedByChanged && !request.reciprocalBlockingKnown {
+            return Result(
+                outcome: .partialAmbiguous,
+                reason: "blockedBy changed but reciprocal Blocking graph is unknown",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+        if blockedByChanged && !request.reciprocalBlockingConsistent {
+            return Result(
+                outcome: .blocked,
+                reason: "blockedBy change is not reciprocal with Blocking",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+
+        let proposed = normalized(request.proposed)
+        if proposed == normalized(request.current.mission) {
+            return Result(
+                outcome: .applied,
+                reason: "idempotent",
+                state: request.current,
+                appliedWrites: false
+            )
+        }
+
+        let next = State(
+            packetId: request.current.packetId,
+            mission: proposed,
+            revision: request.current.revision + 1,
+            hash: hash(proposed)
+        )
+        return Result(
+            outcome: .applied,
+            reason: "mission revised",
+            state: next,
+            appliedWrites: true
+        )
+    }
+
+    private static func normalized(_ ids: [String]) -> [String] {
+        Array(Set(ids.filter { !$0.isEmpty })).sorted()
+    }
+
+    private static func normalized(_ mission: Mission) -> Mission {
+        Mission(
+            name: mission.name,
+            title: mission.title,
+            objective: mission.objective,
+            sourceOfTruth: mission.sourceOfTruth,
+            executionClass: mission.executionClass,
+            projectIds: normalized(mission.projectIds),
+            skillIds: normalized(mission.skillIds),
+            blockedByIds: normalized(mission.blockedByIds),
+            bodyCanonical: mission.bodyCanonical
+        )
+    }
+
+    private static func canonicalJSON(_ mission: Mission) -> String {
+        let object: [String: Any] = [
+            "bodyCanonical": mission.bodyCanonical,
+            "blockedByIds": normalized(mission.blockedByIds),
+            "executionClass": mission.executionClass,
+            "name": mission.name,
+            "objective": mission.objective,
+            "projectIds": normalized(mission.projectIds),
+            "skillIds": normalized(mission.skillIds),
+            "sourceOfTruth": mission.sourceOfTruth,
+            "title": mission.title,
+        ]
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys]
+        ) else { return "" }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/TheBridge/Modules/Registry/PacketRegistryContract.swift
+++ b/TheBridge/Modules/Registry/PacketRegistryContract.swift
@@ -161,6 +161,11 @@ public enum PacketRegistryContract {
 }
 
 public enum PacketRegistryPreflight {
+    public enum Axis: String, Sendable, Equatable {
+        case binding
+        case consumer
+    }
+
     public struct Defect: Sendable, Equatable {
         public let code: String
         public let field: String
@@ -173,6 +178,25 @@ public enum PacketRegistryPreflight {
             self.expected = expected
             self.actual = actual
         }
+
+        /// Configured-binding defects describe registry.json identity and
+        /// property-id maps. Consumer-contract defects describe live schema
+        /// completeness against the classified PACKETS contract.
+        public var axis: Axis {
+            Self.bindingCodes.contains(code) ? .binding : .consumer
+        }
+
+        private static let bindingCodes: Set<String> = [
+            "BINDING_MISSING",
+            "DUPLICATE_BINDING",
+            "LEGACY_BINDING_ALIAS",
+            "UNCLASSIFIED_BINDING",
+            "DUPLICATE_FIELD_BINDING",
+            "UNBOUND_FIELD",
+            "BINDING_CONTRACT_MISMATCH",
+            "BINDING_ID_MISMATCH",
+            "RELATION_TARGET_UNRESOLVED",
+        ]
     }
 
     public struct Report: Sendable, Equatable {
@@ -183,20 +207,29 @@ public enum PacketRegistryPreflight {
         public let liveColumnCount: Int
         public let defects: [Defect]
 
+        public var bindingDefects: [Defect] { defects.filter { $0.axis == .binding } }
+        public var consumerDefects: [Defect] { defects.filter { $0.axis == .consumer } }
+        public var bindingPasses: Bool { bindingDefects.isEmpty }
+        public var consumerPasses: Bool { consumerDefects.isEmpty }
         public var passes: Bool { defects.isEmpty }
 
         public var value: Value {
             .object([
                 "result": .string(passes ? "PASS" : "DRIFT"),
+                "bindingResult": .string(bindingPasses ? "PASS" : "DRIFT"),
+                "consumerResult": .string(consumerPasses ? "PASS" : "DRIFT"),
                 "contractVersion": .string(contractVersion),
                 "canonicalEntity": .string(canonicalEntity),
                 "bindingCandidates": .array(bindingCandidates.map(Value.string)),
                 "classifiedColumnCount": .int(classifiedColumnCount),
                 "liveColumnCount": .int(liveColumnCount),
                 "defectCount": .int(defects.count),
+                "bindingDefectCount": .int(bindingDefects.count),
+                "consumerDefectCount": .int(consumerDefects.count),
                 "defects": .array(defects.map { defect in
                     .object([
                         "code": .string(defect.code),
+                        "axis": .string(defect.axis.rawValue),
                         "field": .string(defect.field),
                         "expected": .string(defect.expected),
                         "actual": .string(defect.actual),

--- a/TheBridge/Modules/Registry/RegistryModule.swift
+++ b/TheBridge/Modules/Registry/RegistryModule.swift
@@ -232,13 +232,13 @@ public enum RegistryModule {
     public static func makeEntities() -> ToolRegistration {
         ToolRegistration(
             name: "registry_entities", module: moduleName, tier: .open,
-            description: "List the configured data-source registry entities (entity → Notion data source + property map), including per-property binding status. Read-only. Pass includePacketPreflight:true to also read the live PACKETS schema and report canonical-binding/schema drift without persisting or repairing anything.",
+            description: "List the configured data-source registry entities (entity → Notion data source + property map), including per-property binding status. Read-only. Pass includePacketPreflight:true to also read the live PACKETS schema and report canonical-binding vs consumer-contract drift plus LaunchReadiness (PASS/BLOCKED/TRANSPORT_UNKNOWN) without persisting or repairing anything. No new MCP product surface.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "includePacketPreflight": .object([
                         "type": .string("boolean"),
-                        "description": .string("Optional. Read the live PACKETS schema and include the read-only canonical identity/execution-schema preflight report. Never mutates registry config, cache, or Notion."),
+                        "description": .string("Optional. Read the live PACKETS schema and include packetPreflight (binding vs consumer axes) plus launchReadiness. Never mutates registry config, cache, or Notion."),
                     ]),
                 ]),
             ]),
@@ -250,24 +250,53 @@ public enum RegistryModule {
                 ]
                 if case .object(let object) = args,
                    case .bool(true)? = object["includePacketPreflight"] {
-                    guard let packet = PacketRegistryContract.preferredStoredEntity(in: config) else {
-                        result["packetPreflight"] = PacketRegistryPreflight.evaluate(
-                            config: config,
-                            schema: DataSourceSchema(columnsByName: [:])
-                        ).value
-                        return .object(result)
-                    }
-                    let schema = try await gateway().schema(
-                        dataSourceId: packet.dataSourceId,
-                        workspace: packet.workspace
-                    )
-                    result["packetPreflight"] = PacketRegistryPreflight.evaluate(
-                        config: config,
-                        schema: schema
-                    ).value
+                    let readiness = await packetReadiness(config: config)
+                    result["packetPreflight"] = readiness.preflight
+                    result["launchReadiness"] = readiness.launch
                 }
                 return .object(result)
             })
+    }
+
+    /// Read-only PACKETS preflight + LaunchReadiness attach. Schema-read
+    /// failure is TRANSPORT_UNKNOWN, never a false product DRIFT/BLOCKED.
+    private static func packetReadiness(config: RegistryConfig) async -> (preflight: Value, launch: Value) {
+        guard let packet = PacketRegistryContract.preferredStoredEntity(in: config) else {
+            let schema = DataSourceSchema(columnsByName: [:])
+            let preflight = PacketRegistryPreflight.evaluate(config: config, schema: schema)
+            let launch = await LaunchReadinessContract.evaluate(
+                probes: LaunchReadinessLive.registryEntitiesProbes(
+                    config: config, schema: schema, schemaError: nil)
+            )
+            return (preflight.value, launch.value)
+        }
+        do {
+            let schema = try await gateway().schema(
+                dataSourceId: packet.dataSourceId,
+                workspace: packet.workspace
+            )
+            let preflight = PacketRegistryPreflight.evaluate(config: config, schema: schema)
+            let launch = await LaunchReadinessContract.evaluate(
+                probes: LaunchReadinessLive.registryEntitiesProbes(
+                    config: config, schema: schema, schemaError: nil)
+            )
+            return (preflight.value, launch.value)
+        } catch {
+            let reason = error.localizedDescription
+            let preflight: Value = .object([
+                "result": .string("TRANSPORT_UNKNOWN"),
+                "bindingResult": .string("TRANSPORT_UNKNOWN"),
+                "consumerResult": .string("TRANSPORT_UNKNOWN"),
+                "contractVersion": .string(PacketRegistryContract.version),
+                "canonicalEntity": .string("packet"),
+                "reason": .string(reason),
+            ])
+            let launch = await LaunchReadinessContract.evaluate(
+                probes: LaunchReadinessLive.registryEntitiesProbes(
+                    config: config, schema: nil, schemaError: reason)
+            )
+            return (preflight, launch.value)
+        }
     }
 
     // MARK: - registry_add_entity

--- a/TheBridge/Modules/StandingOrders/LaunchReadiness.swift
+++ b/TheBridge/Modules/StandingOrders/LaunchReadiness.swift
@@ -16,6 +16,7 @@
 // mutation, no new MCP product surface.
 
 import Foundation
+import MCP
 
 // MARK: - Verdict
 
@@ -217,12 +218,15 @@ public struct RegistryConsumerReadinessSeam: LaunchReadinessSeam {
             return .transportUnknown(evidence: reason)
         case .snapshot(let config, let schema):
             let report = PacketRegistryPreflight.evaluate(config: config, schema: schema)
+            let binding = report.bindingPasses ? "PASS" : "DRIFT"
+            let consumer = report.consumerPasses ? "PASS" : "DRIFT"
             if report.passes {
                 return .ready(evidence:
-                    "\(report.contractVersion) PASS classified=\(report.classifiedColumnCount) live=\(report.liveColumnCount)")
+                    "\(report.contractVersion) PASS binding=\(binding) consumer=\(consumer) classified=\(report.classifiedColumnCount) live=\(report.liveColumnCount)")
             }
             let codes = report.defects.map(\.code).joined(separator: ",")
-            return .unavailable(evidence: "\(report.contractVersion) DRIFT codes=\(codes)")
+            return .unavailable(evidence:
+                "\(report.contractVersion) DRIFT binding=\(binding) consumer=\(consumer) codes=\(codes)")
         }
     }
 }
@@ -304,5 +308,75 @@ public struct ImplementationCoverageSeam: LaunchReadinessSeam {
         case .evidenceUnavailable(let reason):
             return .transportUnknown(evidence: reason)
         }
+    }
+}
+
+extension LaunchReadinessReport {
+    public var value: Value {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return .object([
+            "safeToLaunch": .bool(safeToLaunch),
+            "checkedAt": .string(formatter.string(from: checkedAt)),
+            "checks": .array(checks.map { check in
+                .object([
+                    "name": .string(check.name),
+                    "required": .bool(check.required),
+                    "verdict": .string(check.verdict.rawValue),
+                    "evidence": .string(check.evidence),
+                ])
+            }),
+        ])
+    }
+}
+
+/// Live (non-fixture) probe assembly for existing MCP surfaces.
+/// No new product tool: `registry_entities(includePacketPreflight:true)` is the
+/// attach point. `runtime.browser` stays a required check and is honestly
+/// TRANSPORT_UNKNOWN here — Packet Runner dispatch wiring is residual.
+public enum LaunchReadinessLive {
+    public static func registryEntitiesProbes(
+        config: RegistryConfig,
+        schema: DataSourceSchema?,
+        schemaError: String?,
+        storagePath: String = NSTemporaryDirectory(),
+        coverageLocator: String? = Bundle.main.object(forInfoDictionaryKey: "BridgeGitSHA") as? String
+    ) -> [LaunchReadinessProbe] {
+        let commandAuth: LaunchReadinessSeam
+        let registry: LaunchReadinessSeam
+        if let schemaError {
+            commandAuth = CommandAuthReadinessSeam(.evidenceUnavailable(reason: schemaError))
+            registry = RegistryConsumerReadinessSeam(.evidenceUnavailable(reason: schemaError))
+        } else if let schema {
+            commandAuth = CommandAuthReadinessSeam(.authenticated(tool: "registry_entities"))
+            registry = RegistryConsumerReadinessSeam(.snapshot(config: config, schema: schema))
+        } else {
+            commandAuth = CommandAuthReadinessSeam(.missing(tool: "packet"))
+            registry = RegistryConsumerReadinessSeam(.snapshot(
+                config: config, schema: DataSourceSchema(columnsByName: [:])))
+        }
+
+        let storage: LaunchReadinessSeam
+        if FileManager.default.isWritableFile(atPath: storagePath) {
+            storage = StorageWriteabilitySeam(.writable(path: storagePath))
+        } else {
+            storage = StorageWriteabilitySeam(.unavailable(path: storagePath, reason: "not writable"))
+        }
+
+        let trimmed = coverageLocator?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let coverage: LaunchReadinessSeam = trimmed.isEmpty
+            ? ImplementationCoverageSeam(.evidenceUnavailable(reason: "BridgeGitSHA not readable in this process"))
+            : ImplementationCoverageSeam(.proven(locator: "sha:\(trimmed)"))
+
+        let runtime = RuntimeAvailabilitySeam(.evidenceUnavailable(
+            reason: "runtime.browser not probed on registry_entities; Packet Runner dispatch residual"))
+
+        return LaunchReadinessContract.standardProbes(
+            commandAuth: commandAuth,
+            registryConsumer: registry,
+            runtimeBrowser: runtime,
+            storageWrite: storage,
+            implementationCoverage: coverage
+        )
     }
 }

--- a/TheBridgeTests/LaunchReadinessTests.swift
+++ b/TheBridgeTests/LaunchReadinessTests.swift
@@ -192,4 +192,29 @@ func runLaunchReadinessTests() async {
         try expect(report.safeToLaunch, "optional unknown transport must not veto launch")
         try expect(check(report, "optional.telemetry")?.verdict == .transportUnknown)
     }
+
+    await test("LaunchReadiness live attach: runtime residual is TRANSPORT_UNKNOWN, axes distinguished") {
+        var config = passingPacketConfig()
+        var packet = config.entities[0]
+        packet.properties.removeAll { $0.key == "objective" }
+        config.entities[0] = packet
+        let probes = LaunchReadinessLive.registryEntitiesProbes(
+            config: config,
+            schema: passingPacketSchema(),
+            schemaError: nil,
+            storagePath: NSTemporaryDirectory(),
+            coverageLocator: "030d03887650dce5b2898cb9d8de231b43fecedd"
+        )
+        let report = await LaunchReadinessContract.evaluate(probes: probes, now: checkedAt)
+        try expect(check(report, LaunchReadinessContract.commandAuthCheck)?.verdict == .pass)
+        let registry = check(report, LaunchReadinessContract.registryConsumerCheck)
+        try expect(registry?.verdict == .blocked)
+        try expect(registry?.evidence.contains("binding=DRIFT") == true)
+        try expect(registry?.evidence.contains("consumer=PASS") == true)
+        try expect(check(report, LaunchReadinessContract.runtimeBrowserCheck)?.verdict == .transportUnknown)
+        try expect(check(report, LaunchReadinessContract.storageWriteCheck)?.verdict == .pass)
+        try expect(check(report, LaunchReadinessContract.implementationCoverageCheck)?.verdict == .pass)
+        try expect(!report.safeToLaunch)
+        try expect(report.value != .null)
+    }
 }

--- a/TheBridgeTests/PacketMissionRevisionTests.swift
+++ b/TheBridgeTests/PacketMissionRevisionTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import TheBridgeLib
+
+func runPacketMissionRevisionTests() async {
+    print("\n📜 PacketMissionRevision (PJT-2770 · governed transaction / partial_ambiguous)")
+
+    func sampleMission(
+        objective: String = "Ship the floor",
+        blockedByIds: [String] = []
+    ) -> PacketMissionRevision.Mission {
+        PacketMissionRevision.Mission(
+            name: "PKT-1234",
+            title: "Integration",
+            objective: objective,
+            sourceOfTruth: "hub",
+            executionClass: "REVIEW-FIRST",
+            projectIds: ["proj-1"],
+            skillIds: ["skill-1"],
+            blockedByIds: blockedByIds,
+            bodyCanonical: "## Objective\nShip the floor"
+        )
+    }
+
+    await test("Mission revision: idempotent apply writes nothing") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 3)
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: mission,
+            expectedHash: current.hash, expectedRevision: 3
+        ))
+        try expect(result.outcome == .applied)
+        try expect(result.reason == "idempotent")
+        try expect(!result.appliedWrites)
+        try expect(result.state.revision == 3)
+        try expect(result.state.hash == current.hash)
+    }
+
+    await test("Mission revision: stale hash returns partial_ambiguous and keeps current state") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 3)
+        var proposed = mission
+        proposed.objective = "Different"
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: proposed,
+            expectedHash: "stale", expectedRevision: 3
+        ))
+        try expect(result.outcome == .partialAmbiguous)
+        try expect(!result.appliedWrites)
+        try expect(result.state == current)
+    }
+
+    await test("Mission revision: self blockedBy is blocked") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 1)
+        var proposed = mission
+        proposed.blockedByIds = ["pkt-1"]
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: proposed,
+            expectedHash: current.hash, expectedRevision: 1,
+            reciprocalBlockingKnown: true, reciprocalBlockingConsistent: true
+        ))
+        try expect(result.outcome == .blocked)
+        try expect(!result.appliedWrites)
+        try expect(result.reason.contains("self"))
+    }
+
+    await test("Mission revision: unknown reciprocal Blocking is partial_ambiguous") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 1)
+        var proposed = mission
+        proposed.blockedByIds = ["pkt-2"]
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: proposed,
+            expectedHash: current.hash, expectedRevision: 1,
+            reciprocalBlockingKnown: false, reciprocalBlockingConsistent: false
+        ))
+        try expect(result.outcome == .partialAmbiguous)
+        try expect(!result.appliedWrites)
+        try expect(result.reason.contains("reciprocal"))
+    }
+
+    await test("Mission revision: inconsistent reciprocal Blocking is blocked") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 1)
+        var proposed = mission
+        proposed.blockedByIds = ["pkt-2"]
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: proposed,
+            expectedHash: current.hash, expectedRevision: 1,
+            reciprocalBlockingKnown: true, reciprocalBlockingConsistent: false
+        ))
+        try expect(result.outcome == .blocked)
+        try expect(!result.appliedWrites)
+    }
+
+    await test("Mission revision: objective change applies as one revision+hash write") {
+        let mission = sampleMission()
+        let current = PacketMissionRevision.State.hashed(packetId: "pkt-1", mission: mission, revision: 4)
+        var proposed = mission
+        proposed.objective = "Close PJT-2770"
+        let result = PacketMissionRevision.apply(.init(
+            current: current, proposed: proposed,
+            expectedHash: current.hash, expectedRevision: 4
+        ))
+        try expect(result.outcome == .applied)
+        try expect(result.appliedWrites)
+        try expect(result.state.revision == 5)
+        try expect(result.state.hash == PacketMissionRevision.hash(proposed))
+        try expect(result.state.hash != current.hash)
+        try expect(result.state.mission.objective == "Close PJT-2770")
+    }
+}

--- a/TheBridgeTests/PacketRegistryPreflightTests.swift
+++ b/TheBridgeTests/PacketRegistryPreflightTests.swift
@@ -153,4 +153,37 @@ func runPacketRegistryPreflightTests() async {
         try expect(schema.column(named: "PROJECT")?.relationDataSourceId == "projects-ds")
         try expect(schema.column(withID: "project-id")?.name == "PROJECT")
     }
+
+    await test("Packet preflight: binding DRIFT can leave consumer PASS") {
+        var config = packetConfig()
+        var packet = config.entities[0]
+        packet.properties.removeAll { $0.key == "objective" }
+        config.entities[0] = packet
+        let report = PacketRegistryPreflight.evaluate(config: config, schema: packetSchema())
+        try expect(!report.bindingPasses)
+        try expect(report.consumerPasses, "live schema is still complete: \(report.consumerDefects)")
+        try expect(codes(report).contains("UNBOUND_FIELD"))
+        try expect(report.defects.contains { $0.axis == .binding && $0.code == "UNBOUND_FIELD" })
+        guard case .object(let value) = report.value else {
+            throw TestError.assertion("report.value not object")
+        }
+        try expect(value["bindingResult"] == .string("DRIFT"))
+        try expect(value["consumerResult"] == .string("PASS"))
+    }
+
+    await test("Packet preflight: consumer DRIFT can leave binding PASS") {
+        var columns = packetSchema().columnsByName
+        columns["Surprise"] = .init(id: "surprise", type: "rich_text")
+        let report = PacketRegistryPreflight.evaluate(
+            config: packetConfig(), schema: DataSourceSchema(columnsByName: columns)
+        )
+        try expect(report.bindingPasses, "bindings still match classified columns: \(report.bindingDefects)")
+        try expect(!report.consumerPasses)
+        try expect(report.defects.contains { $0.axis == .consumer && $0.code == "UNCLASSIFIED_COLUMN" })
+        guard case .object(let value) = report.value else {
+            throw TestError.assertion("report.value not object")
+        }
+        try expect(value["bindingResult"] == .string("PASS"))
+        try expect(value["consumerResult"] == .string("DRIFT"))
+    }
 }

--- a/TheBridgeTests/RegistryModuleTests.swift
+++ b/TheBridgeTests/RegistryModuleTests.swift
@@ -245,6 +245,25 @@ func runRegistryModuleTests() async {
             try expect(preflight["contractVersion"] == .string(PacketRegistryContract.version))
             try expect(preflight["canonicalEntity"] == .string("packet"))
             try expect(preflight["result"] == .string("DRIFT"), "three-column fixture must report the missing classified columns")
+            try expect(preflight["bindingResult"] != nil, "binding vs consumer axes must be distinguished")
+            try expect(preflight["consumerResult"] == .string("DRIFT"))
+
+            guard case .object(let launch)? = obj(out)["launchReadiness"] else {
+                throw TestError.assertion("launchReadiness missing from includePacketPreflight")
+            }
+            try expect(launch["safeToLaunch"] == .bool(false), "runtime.browser residual is TRANSPORT_UNKNOWN")
+            guard case .array(let checks)? = launch["checks"] else {
+                throw TestError.assertion("launchReadiness.checks missing")
+            }
+            let names = Set(checks.compactMap { obj($0)["name"] }.compactMap { if case .string(let n) = $0 { return n } else { return nil } })
+            try expect(names.isSuperset(of: [
+                LaunchReadinessContract.commandAuthCheck,
+                LaunchReadinessContract.registryConsumerCheck,
+                LaunchReadinessContract.runtimeBrowserCheck,
+            ]))
+            let runtime = checks.first { obj($0)["name"] == .string(LaunchReadinessContract.runtimeBrowserCheck) }
+            try expect(obj(runtime ?? .null)["verdict"] == .string("TRANSPORT_UNKNOWN"),
+                       "Packet Runner residual must not collapse to BLOCKED")
 
             let after = try Data(contentsOf: storeURL)
             try expect(after == before, "read-only preflight must not rewrite registry.json")

--- a/TheBridgeTests/TestRunner.swift
+++ b/TheBridgeTests/TestRunner.swift
@@ -678,6 +678,7 @@ await runSessionModuleTests()
 await runSessionPersistenceTests()   // ITEM [session]: MCP session durability across restart/install (persist + clean-shutdown marker + resumable reconnect)
 await runRegistryConfigTests()       // Data-Source Registry W1: config model + store (Skills = entity #1, bind-by-property-id)
 await runPacketRegistryPreflightTests() // A1: canonical PACKETS identity + read-only 34-column schema preflight
+await runPacketMissionRevisionTests() // PJT-2770: mission/dependency revision as one transaction or partial_ambiguous
 await runRegistryRowCacheTests()     // Data-Source Registry W1: generalized per-entity read-through row cache (stale-while-revalidate + offline)
 await runRegistryPropertyCodecTests() // Data-Source Registry W2: Notion property codec (typed Value ↔ Notion JSON, decode/encode/isWritable)
 await runPageUpdateApplicationTests()  // issue #138: updatePage applied vs canonicalized vs rejected

--- a/docs/evidence/pjt-2770-ship-gate-2026-08-27.md
+++ b/docs/evidence/pjt-2770-ship-gate-2026-08-27.md
@@ -1,0 +1,63 @@
+# PJT-2770 — Ship-gate / compatibility / residual-risk / rollback
+
+**Project:** Bridge v4.1 Hardening (`3accbb58-889e-8192-9e2c-d36bd8dfcf23`)  
+**Evidence time:** 2026-08-27 10:17 CT  
+**Evidence class:** Source Tested (code SHA below). Installed Verified is a predecessor SHA. Released is not proven.
+
+## Identities (live readback)
+
+| Surface | Value |
+|---|---|
+| `origin/main` | `fb66c7cb7125550a6c65a8282ec8f57d690bbd3a` (contains `030d0388`) |
+| DoD-axes candidate | `5f97af50fd21dea2fa2675ab0ed840a649dfe594` (`feat/pjt-2770-dod-axes`, 1 commit ahead of main) |
+| Isolated floor | 3839 passed / 0 failed on the candidate tree before that commit’s docs-only follow-up; code SHA `5f97af5` |
+| Installed `/Applications/The Bridge.app` | marketing **4.0.5** / build **94** / `BridgeGitSHA=030d03887650dce5b2898cb9d8de231b43fecedd` / dirty **false** |
+| Last published tag | `v4.0.5` (no `v4.0.6` / `v4.0.8` tag) |
+| Next published install | **4.0.6** / build **95** (monotonic +1 from 94). Local-only 4.0.8/97 on view-delete is residue, not a tag. |
+
+Do not Check-for-Updates / Sparkle-overwrite the installed `030d0388` copy until the published candidate contains that SHA or a successor (`5f97af5` after merge is a successor).
+
+Rollback for the current install: `/Users/keepup/Developer/the-bridge-rollbacks/The-Bridge-4.0.8-97-c58215dd.app`.
+
+## Merge / release gate (exact)
+
+1. Merge `feat/pjt-2770-dod-axes` to `origin/main` (merge commit, not squash) after CI green. No force-push.
+2. One-commit version identity on a release branch off that main: `Version.swift` + root `Info.plist` + `CHANGELOG.md` → marketing **4.0.6**, build **95**, `BridgeGitSHA` of that commit.
+3. Notarized candidate → `install-copy` only after SHA bind. Installed readback must equal tag.
+4. Tag `v4.0.6` and Sparkle promote only as Ship Gate G of this project. Then verify installed SHA == tag == appcast.
+
+## Hub DoD vs evidence
+
+| # | Requirement | Evidence | Status |
+|---|---|---|---|
+| 1 | Capability preflight PASS / BLOCKED / TRANSPORT_UNKNOWN | `LaunchReadiness` contract + live attach on `registry_entities(includePacketPreflight:true)`. Packet Runner dispatch still residual: `runtime.browser` = TRANSPORT_UNKNOWN | Contract + attach **proven**. Packet Runner wiring **residual** (owner: Isaiah). |
+| 2 | Shell/bg never report terminal failure while workload runs | `ProcessLifecycleTruth` used from `ShellModule` (`terminalState`) on main (`55f0f08`) | **Proven** in product path. |
+| 3 | Registry distinguishes configured bindings from consumer-contract completeness | `PacketRegistryPreflight` `bindingResult` / `consumerResult` on `5f97af5` | **Proven** (evaluator). PKT-1298 fleet mirror sweep still HOLD. |
+| 4 | Mission/dependency revision is one transaction or `partial_ambiguous` | `PacketMissionRevision.apply` on `5f97af5` | **Proven** (pure transaction). Notion mission-hash **writer** still residual. |
+| 5 | Tool discovery/invocation failures return stable disposition without disabling unrelated tools | `ConnectorContinuity` + `_meta` observation on main (`030d0388`) | **Proven** for connector path. |
+| 6 | Isolated floor green on the release SHA | 3839/0 on candidate `5f97af5` tree; CI still required after PR | **Source Tested**. Not yet the tagged release SHA. |
+| 7 | This artifact | this file | **Exists**. Does not by itself make Released true. |
+
+DoD checkboxes stay **unchecked** until the matching evidence is on the Released identity. Do not close-project on this artifact.
+
+## Compatibility
+
+- Additive MCP JSON on existing `registry_entities` (`bindingResult`, `consumerResult`, `launchReadiness`). No new static feature-module tool. E2E counts unchanged.
+- Mission revision is in-process only until a writer is wired; existing PACKETS rows are unchanged.
+
+## Explicit deferrals (owner: Isaiah)
+
+### `feat/notion-view-delete` @ `c58215dd`
+
+**Deferred from PJT-2770 / 4.0.6.** Not merged. Product-surface OUT of v4.1 hardening. Five unique commits (view-delete, E2E bump, Allow/Deny, `notion_database_delete`, protected trash) also carry local-only **4.0.8 / 97** identity that must not land on the 4.0.6 line. Branch preserved; do not prune. Re-open as its own ship after 4.0.6 (strip version surfaces, then bump).
+
+### `the-bridge-g2-people-runtime`
+
+**Preserved.** Dirty unique PeopleRuntime work on `codex/g2-people-runtime` @ `48d6f8fe`. Do not prune.
+
+## Other residuals (named, not silent)
+
+- Live Cloudflare 4-call tunnel smoke vs the release SHA — not run.
+- `install-copy` timestamp-sign vs staged binary SHA256 — Ship Gate item.
+- LaunchReadiness not wired into Packet Runner — residual of DoD 1.
+- Mission-hash Notion writer — residual of DoD 4.


### PR DESCRIPTION
## Summary
- Distinguish PACKETS **binding** vs **consumer-contract** preflight, and apply mission/dependency revision as one transaction (or `partial_ambiguous` / `blocked`).
- Attach LaunchReadiness to existing `registry_entities(includePacketPreflight:true)` — no new MCP product surface. Packet Runner dispatch remains residual (`runtime.browser` = TRANSPORT_UNKNOWN).
- Record the ship-gate identity, residuals, and explicit deferrals in `docs/evidence/pjt-2770-ship-gate-2026-08-27.md`. Isolated floor **3839/0** on `5f97af5` (docs commit `5d739ed` is artifact-only).

**Not in this PR:** version bump, tag, Sparkle, `feat/notion-view-delete` (explicitly deferred from 4.0.6; local 4.0.8/97 residue). `the-bridge-g2-people-runtime` preserved, not pruned.

## Test plan
- [x] Isolated `TheBridgeTests` 3839 passed / 0 failed on `5f97af5`
- [ ] CI `build-and-test` on this PR
- [ ] Merge as merge commit (not squash) so `030d0388` stays an ancestor
- [ ] Do **not** Check-for-Updates on the installed 4.0.5/`030d0388` copy until Ship Gate G publishes a successor SHA
- [ ] Next published install is **4.0.6** / build **95** (separate one-commit identity after merge)


Made with [Cursor](https://cursor.com)