### PR TITLE
release(v4.0.6): assign marketing 4.0.6 and build 95

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 ## Project Overview
 
-TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.5** (build **94**). It registers **224 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **32 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
+TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.6** (build **95**). It registers **224 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **32 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
 
 Bundle ID: `kup.solutions.the-bridge` (legacy: `kup.solutions.notion-bridge`, `solutions.kup.keepr`)
 
@@ -120,7 +120,7 @@ Trunk = `origin/main`. Branches are short-lived and **rebased onto current main 
 
 ### Release flow (the v3.7.x → 3.8.x pattern)
 
-**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `4.0.9 → 4.1.0`, `4.9.9 → 5.0.0`). From the current `4.0.5`, **the next published version is `4.0.6`**. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
+**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `4.0.9 → 4.1.0`, `4.9.9 → 5.0.0`). From the current `4.0.6`, **the next published version is `4.0.7`**. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
 
 1. `git switch -c release/vX.Y.Z origin/main` (off current main).
 2. One atomic version commit: `Version.swift` (marketing + build) **and** root `Info.plist` (`CFBundleShortVersionString` + `CFBundleVersion`) in the SAME commit (see `### Version surfaces`), plus the `CHANGELOG.md` entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v4.0.6 (build 95) — Bridge v4.1 capability truth — 2026-08-28
+
+- **Identity** — Published install after `v4.0.5` / build `94`. Marketing
+  **4.0.6**, build **95**. Sparkle tag `v4.0.6` is this release. Do not reuse 94.
+  Local-only 4.0.8/97 on `feat/notion-view-delete` is residue, not this identity.
+- **Registry** — Preflight distinguishes configured bindings from consumer-contract
+  completeness (`bindingResult` / `consumerResult`). Packet mission/dependency
+  revisions apply as one transaction or return `partial_ambiguous`.
+- **LaunchReadiness** — `registry_entities(includePacketPreflight:true)` also
+  returns `launchReadiness`. Packet Runner dispatch wiring remains residual
+  (`runtime.browser` = TRANSPORT_UNKNOWN).
+- **Shell** — Background jobs never report terminal failure while the requested
+  workload still runs (`ProcessLifecycleTruth`).
+- **Connectors** — Tool discovery/invocation failures return a stable disposition
+  without disabling unrelated tools (`ConnectorContinuity`).
+- **Floor** — Isolated suite 3839 passed / 0 failed on the DoD-axes SHA that
+  this install contains. `feat/notion-view-delete` is deferred, not merged.
+
 ## v4.0.5 (build 94) — Command Bridge create sheet — 2026-08-18
 
 - **Identity** — Published install after `v4.0.4` / build `93`. Marketing

--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.5</string>
+	<string>4.0.6</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>94</string>
+	<string>95</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -8,8 +8,8 @@
 // VERSIONING (operator rule, 2026-06-15): +1 patch per PUBLISHED INSTALL
 // (release), NOT per branch — several task branches can merge to main and ship
 // together as one install increment. Single-digit segments roll at 9 (4.0.9→
-// 4.1.0, 4.9.9→5.0.0), never double digits. This source is 4.0.5; the next
-// published install is 4.0.6. The 3.7.10–3.7.12 releases were pre-rule legacy. Build
+// 4.1.0, 4.9.9→5.0.0), never double digits. This source is 4.0.6; the next
+// published install is 4.0.7. The 3.7.10–3.7.12 releases were pre-rule legacy. Build
 // (CFBundleVersion) monotonic +1. See AGENTS.md "Release flow" + versioning memory.
 
 import Foundation
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "4.0.5"
+    public static let marketing = "4.0.6"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -321,7 +321,10 @@ public enum AppVersion {
     /// detached worktree_claim contract (#178); Commands Search palette hint.
     /// v4.0.5: 93 -> 94 -- Command Bridge create sheet host expands so Save/Cancel
     /// stay inside the panel (chrome UI-ITER CB-1). 4.0.4/93 stays on the feed.
-    public static let build = "94"
+    /// v4.0.6: 94 -> 95 -- PJT-2770 capability-truth install: binding vs consumer
+    /// preflight, mission revision transaction, LaunchReadiness attach. Local-only
+    /// 4.0.8/97 residue is not this identity. Next published install is 4.0.7.
+    public static let build = "95"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }


### PR DESCRIPTION
## Summary
- One-commit published-install identity for PJT-2770 Ship Gate G: marketing **4.0.6**, build **95** (`Version.swift` + root `Info.plist` + `CHANGELOG.md` + AGENTS.md current/next lines).
- Local-only 4.0.8/97 on `feat/notion-view-delete` is residue and is **not** this identity. That branch stays deferred.
- Isolated `make test-floor` exited 0 on `7f143fef0d8ba978ed8f4a5e98e456b95a6913ba` (floor gate 3790; failed=0).

## Merge
Please **merge commit or rebase/FF** — do not squash. `030d0388` must remain an ancestor of `main`.

## Test plan
- [x] Local `make test-floor` exit 0 on this SHA
- [ ] CI `build-and-test` green
- [ ] After merge: `make install-copy` on `main`, then tag `v4.0.6` at that HEAD (Sparkle via `release.yml`)


Made with [Cursor](https://cursor.com)