### PR TITLE
release(v4.0.6): publish Sparkle appcast for v4.0.6

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,14 +3,14 @@
     <channel>
         <title>TheBridge</title>
         <item>
-            <title>4.0.5</title>
-            <pubDate>Wed, 19 Aug 2026 01:20:13 +0000</pubDate>
+            <title>4.0.6</title>
+            <pubDate>Sun, 30 Aug 2026 14:36:13 +0000</pubDate>
             <link>https://github.com/KUP-IP/the-bridge/releases</link>
-            <sparkle:version>94</sparkle:version>
-            <sparkle:shortVersionString>4.0.5</sparkle:shortVersionString>
+            <sparkle:version>95</sparkle:version>
+            <sparkle:shortVersionString>4.0.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/KUP-IP/the-bridge/releases/download/v4.0.5/the-bridge-v4.0.5.dmg" length="24076637" type="application/octet-stream" sparkle:edSignature="rtM8FBKH+8Av4f8mzG2bLnqZwtggoHd4tR7VgIryPMorgIsuUMfB6jQZAyY7/cUoAms+BdiNDNzpDIwDCxVuDg=="/>
+            <enclosure url="https://github.com/KUP-IP/the-bridge/releases/download/v4.0.6/the-bridge-v4.0.6.dmg" length="30352434" type="application/octet-stream" sparkle:edSignature="HPz97Sy0kSoS7SPjg8yGY6Kcfa77rQk7a2jRhb+o3MvHRpDILtNNozmtv5ndCXTk9BasO3urusidB37+eP13Bg=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- Lands the **verified** Sparkle `appcast.xml` from release run [33316149730](https://github.com/KUP-IP/the-bridge/actions/runs/33316149730).
- Notarize + DMG + enclosure verify already succeeded. The Actions bot could not push `appcast.xml` to `main` (repo rules: PR + `build-and-test`).
- Feed: marketing **4.0.6**, `sparkle:version` **95**, enclosure `the-bridge-v4.0.6.dmg` length **30352434** (matches the published GitHub release asset; HTTP 200).

Do not retag. Tag `v4.0.6` / installed `BridgeGitSHA` stay `6ae3152`. This commit is the same pattern as the v4.0.5 appcast follow-up.

## Test plan
- [x] Artifact appcast length == GH release asset size
- [x] Enclosure URL HTTP 200
- [ ] CI `build-and-test` green
- [ ] After merge: live `https://raw.githubusercontent.com/KUP-IP/the-bridge/main/appcast.xml` shows 4.0.6 / 95
- [ ] `./scripts/verify_sparkle_feed.sh` against installed Info.plist


Made with [Cursor](https://cursor.com)