### PR TITLE
feat(mac-ui): limited contacts, notes attachments, Cmd+V paste (#214 #211 #213 #212 #223 #224 #238)

### DIFF
--- a/TheBridge/Core/BridgeDefaults.swift
+++ b/TheBridge/Core/BridgeDefaults.swift
@@ -273,6 +273,9 @@ public enum BridgeDefaults {
     /// When true, extract Apple embedded `tsrp` transcript before Parakeet fallback.
     public static let voiceMemoAppleTranscript = "com.notionbridge.voiceMemo.appleTranscript"
 
+    /// When true, use SpeechAnalyzer between Apple tsrp and Parakeet. DEFAULT OFF.
+    public static let voiceMemoSpeechAnalyzerTranscription = "com.notionbridge.voiceMemo.speechAnalyzerTranscription"
+
     /// Ollama model for one-sentence Memory summaries (Relevant:). Falls back to its quality default.
     public static let ollamaSummarizationModel = "com.notionbridge.ollama.summarizationModel"
 
@@ -341,6 +344,11 @@ public enum BridgeDefaults {
     public static var voiceMemoAppleTranscriptEffective: Bool {
         if UserDefaults.standard.object(forKey: voiceMemoAppleTranscript) == nil { return true }
         return UserDefaults.standard.bool(forKey: voiceMemoAppleTranscript)
+    }
+
+    /// SpeechAnalyzer transcription defaults OFF when unset (Wave 7).
+    public static var voiceMemoSpeechAnalyzerTranscriptionEffective: Bool {
+        UserDefaults.standard.bool(forKey: voiceMemoSpeechAnalyzerTranscription)
     }
 
     public static var ollamaSummarizationModelEffective: String? {

--- a/TheBridge/Modules/Commands/CommandCursorInsert.swift
+++ b/TheBridge/Modules/Commands/CommandCursorInsert.swift
@@ -1,9 +1,11 @@
-// CommandCursorInsert.swift — issue #129 (cursor insert, never clipboard)
+// CommandCursorInsert.swift — issue #129 / #238
 // TheBridge · Modules · Commands
 //
-// Command activation delivers the resolved body into the focused editable
-// control of the previously-frontmost app. The clipboard is not read,
-// written, cleared, or used as a paste vehicle — even temporarily.
+// Native AppKit: AX splice, clipboard untouched.
+// Web-like hosts (Chromium / ProseMirror / ChatGPT composers): Cmd+V paste
+// with pasteboard save → write → delay → layout-resolved Cmd+V (~100ms
+// modifier hold) → restore. Never leave the command body on the pasteboard.
+// Those hosts must not use unicode CGEvent typing.
 //
 // Two layers:
 //   • CommandTextSplicer — pure UTF-16 splice (caret insert / selection
@@ -19,6 +21,7 @@ import AppKit
 import ApplicationServices
 import CoreGraphics
 import Darwin
+import Carbon.HIToolbox
 
 // ============================================================
 // MARK: - Outcome
@@ -237,8 +240,8 @@ public final class RecordingTextInserter: CommandTextInserting, @unchecked Senda
 // ============================================================
 
 /// Inserts via the focused AX element of the destination process.
-/// Never reads or writes `NSPasteboard`. Fail-closed: missing grant or
-/// missing editable target returns a status outcome, not a clipboard copy.
+/// Native AppKit never reads or writes `NSPasteboard`. Web-like Chromium /
+/// ChatGPT composers use a restore-guaranteed Cmd+V paste path.
 public final class AccessibilityCommandInserter: CommandTextInserting, @unchecked Sendable {
     /// Focused element of the destination app, captured before the
     /// palette becomes key. AXUIElement is not Sendable; this class is
@@ -387,52 +390,70 @@ public final class AccessibilityCommandInserter: CommandTextInserting, @unchecke
             chromium: chromium,
             bundleIdentifier: app?.bundleIdentifier
         )
+        let pastePreferred = CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: chromium,
+            bundleIdentifier: app?.bundleIdentifier,
+            role: role,
+            frame: frame
+        )
 
-        if !valueIsPlaceholder, trustAX, isSettable(focused, kAXSelectedTextAttribute as String) {
-            let setErr = AXUIElementSetAttributeValue(
-                focused, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
-            if setErr == .success,
-                axVerifyLanded(
-                focused,
-                before: before,
-                insertion: text,
-                loc: loc,
-                len: len,
-                electron: chromium
-               ) {
-                placeCaret(focused, afterUTF16: loc + text.utf16.count)
-                return .inserted(replacedSelection: replaced, characters: text.count)
+        if !pastePreferred {
+            if !valueIsPlaceholder, trustAX, isSettable(focused, kAXSelectedTextAttribute as String) {
+                let setErr = AXUIElementSetAttributeValue(
+                    focused, kAXSelectedTextAttribute as CFString, text as CFTypeRef)
+                if setErr == .success,
+                    axVerifyLanded(
+                    focused,
+                    before: before,
+                    insertion: text,
+                    loc: loc,
+                    len: len,
+                    electron: chromium
+                   ) {
+                    placeCaret(focused, afterUTF16: loc + text.utf16.count)
+                    return .inserted(replacedSelection: replaced, characters: text.count)
+                }
             }
-        }
 
-        if trustAX, isSettable(focused, kAXValueAttribute as String),
-           let current = before ?? liveValue {
-            let spliced = CommandTextSplicer.splice(
-                value: current,
-                selectedLocationUTF16: loc,
-                selectedLengthUTF16: len,
-                insertion: text
-            )
-            let setErr = AXUIElementSetAttributeValue(
-                focused, kAXValueAttribute as CFString, spliced.newValue as CFTypeRef)
-            if setErr == .success,
-               axVerifyLanded(
-                focused,
-                before: before,
-                insertion: text,
-                loc: loc,
-                len: len,
-                electron: chromium
-               ) {
-                placeCaret(focused, afterUTF16: spliced.newCaretUTF16)
-                return .inserted(replacedSelection: spliced.replacedSelection, characters: text.count)
+            if trustAX, isSettable(focused, kAXValueAttribute as String),
+               let current = before ?? liveValue {
+                let spliced = CommandTextSplicer.splice(
+                    value: current,
+                    selectedLocationUTF16: loc,
+                    selectedLengthUTF16: len,
+                    insertion: text
+                )
+                let setErr = AXUIElementSetAttributeValue(
+                    focused, kAXValueAttribute as CFString, spliced.newValue as CFTypeRef)
+                if setErr == .success,
+                   axVerifyLanded(
+                    focused,
+                    before: before,
+                    insertion: text,
+                    loc: loc,
+                    len: len,
+                    electron: chromium
+                   ) {
+                    placeCaret(focused, afterUTF16: spliced.newCaretUTF16)
+                    return .inserted(replacedSelection: spliced.replacedSelection, characters: text.count)
+                }
             }
         }
 
         // Native AX fields that actually changed are done above. Chromium
-        // AXValue can lag; only type after delayed verify still fails.
-        // Do not type into a captured page-sized AXGroup — that claims
-        // success while the compact composer stays empty (Cursor).
+        // AX-liar / ProseMirror / ChatGPT composers use Cmd+V — never unicode
+        // CGEvent. Cursor compact AXTextArea still lands via AX set.
+        if pastePreferred {
+            restoreFocus(focused, pid: pid)
+            clickForPointerFocus(focused, role: role, electron: chromium, pointer: pointer)
+            do {
+                try CommandInsertPasteboard.pasteViaCommandV(text)
+                return .inserted(replacedSelection: replaced, characters: text.count)
+            } catch {
+                return .insertFailed(reason: "clipboard paste failed")
+            }
+        }
+
         let mayType = looksEditable(role: role, element: focused)
             && !(CommandInsertPointerFocus.isWebLike(role)
                  && (frame?.height ?? 0) >= CommandInsertPointerFocus.tallWebAreaThreshold)
@@ -1124,6 +1145,22 @@ public enum CommandInsertPointerFocus {
         }
     }
 
+    /// Chromium browsers, ProseMirror page composers, and ChatGPT apps get
+    /// Cmd+V paste — not unicode CGEvent. Cursor compact AXTextArea stays AX.
+    public static func prefersCommandVPaste(
+        chromium: Bool,
+        bundleIdentifier: String?,
+        role: String,
+        frame: CGRect? = nil
+    ) -> Bool {
+        if !chromium { return false }
+        if chromiumAXValueIsALie(bundleIdentifier: bundleIdentifier) { return true }
+        let id = bundleIdentifier ?? ""
+        if id == "com.openai.codex" || id == "com.openai.chat" { return true }
+        if isWebLike(role), let frame, frame.height >= tallWebAreaThreshold { return true }
+        return false
+    }
+
     /// Stale AX focus (other Chrome tab, Playwright remap) vs the field
     /// the operator actually clicked. Prefer the control under the pointer.
     /// Tall AXGroup/AXWebArea also retargets: the pointer can sit in a
@@ -1267,3 +1304,126 @@ public enum CommandInsertUnicodeTyping {
         u >= 0xD800 && u <= 0xDBFF
     }
 }
+
+/// Transient pasteboard write with guaranteed restore (never leave the body).
+public enum CommandInsertPasteboard {
+    public static let prePasteDelay: TimeInterval = 0.03
+    public static let modifierHold: TimeInterval = 0.1
+    public static let postPasteDelay: TimeInterval = 0.03
+
+    public static func snapshot(_ pasteboard: NSPasteboard) -> [[String: Data]] {
+        guard let items = pasteboard.pasteboardItems else { return [] }
+        return items.map { item in
+            var map: [String: Data] = [:]
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    map[type.rawValue] = data
+                }
+            }
+            return map
+        }
+    }
+
+    public static func restore(_ snapshot: [[String: Data]], onto pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        let objects: [NSPasteboardItem] = snapshot.map { map in
+            let item = NSPasteboardItem()
+            for (raw, data) in map {
+                item.setData(data, forType: NSPasteboard.PasteboardType(rawValue: raw))
+            }
+            return item
+        }
+        if !objects.isEmpty {
+            pasteboard.writeObjects(objects)
+        }
+    }
+
+    public static func withTransientString(
+        _ body: String,
+        on pasteboard: NSPasteboard,
+        preDelay: TimeInterval = 0,
+        postDelay: TimeInterval = 0,
+        perform: () throws -> Void
+    ) rethrows {
+        let prior = snapshot(pasteboard)
+        defer {
+            if postDelay > 0 { Thread.sleep(forTimeInterval: postDelay) }
+            restore(prior, onto: pasteboard)
+        }
+        pasteboard.clearContents()
+        pasteboard.setString(body, forType: .string)
+        if preDelay > 0 { Thread.sleep(forTimeInterval: preDelay) }
+        try perform()
+    }
+
+    @MainActor
+    public static func pasteViaCommandV(_ text: String, pasteboard: NSPasteboard = .general) throws {
+        try withTransientString(
+            text,
+            on: pasteboard,
+            preDelay: prePasteDelay,
+            postDelay: postPasteDelay
+        ) {
+            try CommandInsertKeyLayout.postCommandV()
+        }
+    }
+}
+
+/// Layout-resolved Cmd+V (virtual key for `v` on the current keyboard).
+public enum CommandInsertKeyLayout {
+    public static func keyCode(forCharacter ch: UniChar, fallback: CGKeyCode) -> CGKeyCode {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let raw = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+            return fallback
+        }
+        let data = Unmanaged<CFData>.fromOpaque(raw).takeUnretainedValue() as Data
+        return data.withUnsafeBytes { rawBuf -> CGKeyCode in
+            guard let layoutPtr = rawBuf.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else {
+                return fallback
+            }
+            var deadKeyState: UInt32 = 0
+            for code in 0..<128 {
+                var chars: [UniChar] = [0, 0, 0, 0]
+                var length = 0
+                let status = UCKeyTranslate(
+                    layoutPtr,
+                    UInt16(code),
+                    UInt16(kUCKeyActionDisplay),
+                    0,
+                    UInt32(LMGetKbdType()),
+                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState,
+                    4,
+                    &length,
+                    &chars
+                )
+                if status == noErr, length > 0, chars[0] == ch {
+                    return CGKeyCode(code)
+                }
+            }
+            return fallback
+        }
+    }
+
+    public static func postCommandV() throws {
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw CommandInsertSynthError.source
+        }
+        let vChar = UniChar(UnicodeScalar("v").value)
+        let vKey = keyCode(forCharacter: vChar, fallback: CGKeyCode(kVK_ANSI_V))
+        let cmd = CGKeyCode(kVK_Command)
+        func post(_ key: CGKeyCode, down: Bool, flags: CGEventFlags) throws {
+            guard let event = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: down) else {
+                throw CommandInsertSynthError.event
+            }
+            event.flags = flags
+            event.post(tap: .cghidEventTap)
+        }
+        try post(cmd, down: true, flags: .maskCommand)
+        Thread.sleep(forTimeInterval: CommandInsertPasteboard.modifierHold)
+        try post(vKey, down: true, flags: .maskCommand)
+        try post(vKey, down: false, flags: .maskCommand)
+        try post(cmd, down: false, flags: [])
+    }
+}
+

--- a/TheBridge/Modules/ContactsModule.swift
+++ b/TheBridge/Modules/ContactsModule.swift
@@ -35,7 +35,8 @@ public enum ContactsModule {
     /// Best-effort exact-handle lookup for Messages attribution. It never
     /// prompts for Contacts access: messages_recent remains a passive read.
     public static func exactHandleAttributionIfAuthorized(_ handle: String) -> HandleAttribution {
-        guard CNContactStore.authorizationStatus(for: .contacts) == .authorized else {
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        guard PermissionManager.isContactsAuthorizationSufficient(status) else {
             return HandleAttribution(
                 resolvedName: nil,
                 source: "contacts",
@@ -94,8 +95,11 @@ public enum ContactsModule {
     /// Throws with remediation message if denied or restricted.
     private static func requireContactsAccess() async throws {
         let status = CNContactStore.authorizationStatus(for: .contacts)
+        if PermissionManager.isContactsAuthorizationSufficient(status) {
+            return
+        }
         switch status {
-        case .authorized:
+        case .authorized, .limited:
             return
         case .notDetermined:
             await MainActor.run {
@@ -195,6 +199,7 @@ public enum ContactsModule {
                 let statusString: String
                 switch status {
                 case .authorized: statusString = "authorized"
+                case .limited: statusString = "limited"
                 case .denied: statusString = "denied"
                 case .restricted: statusString = "restricted"
                 case .notDetermined: statusString = "notDetermined"
@@ -206,7 +211,7 @@ public enum ContactsModule {
                     "settings_url": .string("x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts")
                 ]
 
-                if status == .authorized {
+                if PermissionManager.isContactsAuthorizationSufficient(status) {
                     result["contacts_available"] = .bool(true)
                     // Count contacts with minimal fetch
                     let store = CNContactStore()

--- a/TheBridge/Modules/JobsManager.swift
+++ b/TheBridge/Modules/JobsManager.swift
@@ -933,24 +933,44 @@ public enum LaunchAgentPlist {
 // MARK: - LaunchAgentLifecycle
 
 public enum LaunchAgentLifecycle {
-    /// Register (load) an agent. Tries `SMAppService.agent(plistName:)` first,
-    /// falls back to `launchctl bootstrap` for environments where
-    /// `SMAppService` isn't yet accepted (e.g. unsigned dev builds).
-    public static func register(jobId: String) throws {
+    /// Register (load) an agent. Uses `SMAppService` only when the plist is
+    /// actually bundled under `Contents/Library/LaunchAgents`. User-domain
+    /// job plists (`~/Library/LaunchAgents`) always use `launchctl bootstrap`.
+    @discardableResult
+    public static func register(jobId: String) throws -> String {
         let label = JobsPaths.launchLabel(jobId: jobId)
-        #if canImport(ServiceManagement)
-        if #available(macOS 13.0, *) {
-            let svc = SMAppService.agent(plistName: "\(label).plist")
-            do {
-                try svc.register()
-                return
-            } catch {
-                // Fall through to launchctl fallback — SMAppService can reject
-                // plists that live outside the app bundle on some macOS versions.
+        if isBundledForSMAppService(jobId: jobId) {
+            #if canImport(ServiceManagement)
+            if #available(macOS 13.0, *) {
+                let svc = SMAppService.agent(plistName: "\(label).plist")
+                do {
+                    try svc.register()
+                    return "smappservice"
+                } catch {
+                    // Fall through to launchctl fallback — SMAppService can reject
+                    // plists that live outside the app bundle on some macOS versions.
+                }
             }
+            #endif
         }
-        #endif
         try launchctlBootstrap(jobId: jobId)
+        return "launchagent"
+    }
+
+    /// True only when the LaunchAgent plist is inside this app bundle.
+    public static func isBundledForSMAppService(jobId: String) -> Bool {
+        FileManager.default.fileExists(atPath: bundledLaunchAgentPlistURL(jobId: jobId).path)
+    }
+
+    public static func bundledLaunchAgentPlistURL(jobId: String) -> URL {
+        let label = JobsPaths.launchLabel(jobId: jobId)
+        return Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Library/LaunchAgents", isDirectory: true)
+            .appendingPathComponent("\(label).plist")
+    }
+
+    public static func preferredRegistrationChannel(jobId: String) -> String {
+        isBundledForSMAppService(jobId: jobId) ? "smappservice" : "launchagent"
     }
 
     public static func unregister(jobId: String) throws {
@@ -1179,9 +1199,10 @@ public actor JobsManager {
         try await JobStore.shared.insert(job)
 
         let plist = LaunchAgentPlist.build(jobId: job.id, intervals: intervals, ssePort: Self.ssePort)
+        let channel: String
         do {
             try LaunchAgentPlist.write(jobId: job.id, plist: plist)
-            try LaunchAgentLifecycle.register(jobId: job.id)
+            channel = try LaunchAgentLifecycle.register(jobId: job.id)
         } catch {
             // Roll back DB insert if plist install fails.
             try? await JobStore.shared.delete(id: job.id)
@@ -1196,7 +1217,8 @@ public actor JobsManager {
             "schedule": .string(job.schedule),
             "intervals": .int(intervals.count),
             "status": .string(job.status.rawValue),
-            "plist": .string(JobsPaths.plistURL(jobId: job.id).path)
+            "plist": .string(JobsPaths.plistURL(jobId: job.id).path),
+            "registrationChannel": .string(channel)
         ])
     }
 

--- a/TheBridge/Modules/NotesModule.swift
+++ b/TheBridge/Modules/NotesModule.swift
@@ -144,7 +144,7 @@ public enum NotesModule {
             name: "notes_read",
             module: moduleName,
             tier: .open,
-            description: "Read one Apple Note's full content. Address it by `noteId` (stable AppleScript id) OR `noteName` (title; first case-insensitive match wins). Returns id, name, folder, plain-text body, and the note's HTML body.",
+            description: "Read one Apple Note's full content. Address it by `noteId` (stable AppleScript id) OR `noteName` (title; first case-insensitive match wins). Returns id, name, folder, plain-text body, HTML body, and attachment metadata {id,name,url?,contentIdentifier?}.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -178,8 +178,7 @@ public enum NotesModule {
                 case .failure(let message, let code):
                     return failureValue(message: message, code: code)
                 case .ok(let raw):
-                    let fields = raw.components(separatedBy: fieldSep)
-                    guard fields.count >= 5, !raw.isEmpty else {
+                    guard let parsed = parseReadPayload(raw) else {
                         return .object([
                             "found": .bool(false),
                             "error": .string("No note matched the given \(selector.kindLabel).")
@@ -187,11 +186,12 @@ public enum NotesModule {
                     }
                     return .object([
                         "found": .bool(true),
-                        "id": .string(fields[0]),
-                        "name": .string(fields[1]),
-                        "folder": .string(fields[2]),
-                        "body": .string(fields[3]),
-                        "html": .string(fields[4])
+                        "id": .string(parsed.fields[0]),
+                        "name": .string(parsed.fields[1]),
+                        "folder": .string(parsed.fields[2]),
+                        "body": .string(parsed.fields[3]),
+                        "html": .string(parsed.fields[4]),
+                        "attachments": .array(parsed.attachments.map { attachmentValue($0) })
                     ])
                 }
             }
@@ -509,6 +509,50 @@ public enum NotesModule {
         }
     }
 
+    public struct NoteAttachment: Sendable, Equatable {
+        public let id: String
+        public let name: String
+        public let url: String?
+        public let contentIdentifier: String?
+        public init(id: String, name: String, url: String?, contentIdentifier: String?) {
+            self.id = id
+            self.name = name
+            self.url = url
+            self.contentIdentifier = contentIdentifier
+        }
+    }
+
+    /// Parse `notes_read` script output: first RS-record is id/name/folder/body/html;
+    /// subsequent records are attachments (id/name/url/contentIdentifier).
+    public static func parseReadPayload(_ raw: String) -> (fields: [String], attachments: [NoteAttachment])? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let records = raw.components(separatedBy: recordSep)
+        guard let head = records.first else { return nil }
+        let fields = head.components(separatedBy: fieldSep)
+        guard fields.count >= 5 else { return nil }
+        let attachments: [NoteAttachment] = records.dropFirst().compactMap { chunk in
+            let piece = chunk.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !piece.isEmpty else { return nil }
+            let f = chunk.components(separatedBy: fieldSep)
+            guard f.count >= 2, !f[0].isEmpty else { return nil }
+            let url = f.count > 2 && !f[2].isEmpty ? f[2] : nil
+            let cid = f.count > 3 && !f[3].isEmpty ? f[3] : nil
+            return NoteAttachment(id: f[0], name: f[1], url: url, contentIdentifier: cid)
+        }
+        return (fields, attachments)
+    }
+
+    static func attachmentValue(_ attachment: NoteAttachment) -> Value {
+        var obj: [String: Value] = [
+            "id": .string(attachment.id),
+            "name": .string(attachment.name)
+        ]
+        if let url = attachment.url { obj["url"] = .string(url) }
+        if let cid = attachment.contentIdentifier { obj["contentIdentifier"] = .string(cid) }
+        return .object(obj)
+    }
+
     /// Parse `recordSep`-delimited records of `fieldSep`-delimited fields
     /// (id, name, folder, modified) emitted by the list/search scripts.
     /// Tolerant: short/blank records are skipped. `public` for unit testing.
@@ -586,10 +630,13 @@ public enum NotesModule {
         }
 
         /// Read one note (by id or name): emit
-        /// id‹US›name‹US›folder‹US›plaintext‹US›html. Empty string if no match.
+        /// id‹US›name‹US›folder‹US›plaintext‹US›html, then RS-delimited
+        /// attachment records {id,name,url,contentIdentifier}. Skips the
+        /// Shortcuts folder/pin wrapper attachment.
         public static func read(selector: NoteSelector) -> String {
             return """
             set fs to \(fieldSepLiteral)
+            set rs to \(recordSepLiteral)
             set out to ""
             tell application "Notes"
                 \(resolveNoteClause(selector))
@@ -599,6 +646,26 @@ public enum NotesModule {
                     set noteFolder to name of container of theNote
                 end try
                 set out to (id of theNote) & fs & (name of theNote) & fs & noteFolder & fs & (plaintext of theNote) & fs & (body of theNote)
+                try
+                    repeat with a in attachments of theNote
+                        set attName to ""
+                        try
+                            set attName to name of a
+                        end try
+                        if attName is "Shortcuts" then
+                        else
+                            set attURL to ""
+                            set attCID to ""
+                            try
+                                set attURL to (url of a as string)
+                            end try
+                            try
+                                set attCID to (content identifier of a as string)
+                            end try
+                            set out to out & rs & (id of a) & fs & attName & fs & attURL & fs & attCID
+                        end if
+                    end repeat
+                end try
             end tell
             return out
             """

--- a/TheBridge/Modules/ScreenModule.swift
+++ b/TheBridge/Modules/ScreenModule.swift
@@ -665,6 +665,14 @@ extension ScreenModuleRuntime {
 }
 
 extension ScreenModule {
+    /// Resolve a 0-based display index. Empty display list or out-of-range → nil (fail closed).
+    public static func resolveDisplayIndex(_ requested: Int?, displayCount: Int) -> Int? {
+        guard displayCount > 0 else { return nil }
+        let index = requested ?? 0
+        guard index >= 0, index < displayCount else { return nil }
+        return index
+    }
+
     /// Explicit opt-in bridge for the non-canonical live OCR probe. Canonical
     /// tests cannot accidentally register live dependencies because this path
     /// refuses to run unless the dedicated environment switch is present.
@@ -784,13 +792,12 @@ private enum ScreenModuleLive {
             guard !content.displays.isEmpty else {
                 throw ScreenModuleError.noDisplays
             }
-            let index = request.displayIndex ?? 0
-            guard index >= 0, index < content.displays.count else {
+            guard let index = ScreenModule.resolveDisplayIndex(request.displayIndex, displayCount: content.displays.count) else {
                 let available = content.displays.enumerated()
                     .map { "\($0.offset): \($0.element.width)x\($0.element.height)" }
                     .joined(separator: ", ")
                 throw ScreenModuleError.missingParameter(
-                    "displayIndex \(index) out of range. Available: [\(available)]"
+                    "displayIndex \(request.displayIndex ?? 0) out of range. Available: [\(available)]"
                 )
             }
             let display = content.displays[index]
@@ -864,13 +871,12 @@ private enum ScreenModuleLive {
             guard !content.displays.isEmpty else {
                 throw ScreenModuleError.noDisplays
             }
-            let index = request.displayIndex ?? 0
-            guard index >= 0, index < content.displays.count else {
+            guard let index = ScreenModule.resolveDisplayIndex(request.displayIndex, displayCount: content.displays.count) else {
                 let available = content.displays.enumerated()
                     .map { "\($0.offset): \($0.element.width)x\($0.element.height)" }
                     .joined(separator: ", ")
                 throw ScreenModuleError.missingParameter(
-                    "displayIndex \(index) out of range. Available: [\(available)]"
+                    "displayIndex \(request.displayIndex ?? 0) out of range. Available: [\(available)]"
                 )
             }
             let display = content.displays[index]

--- a/TheBridge/Modules/ScreenRecording.swift
+++ b/TheBridge/Modules/ScreenRecording.swift
@@ -30,13 +30,17 @@ extension ScreenModule {
             name: "screen_record_start",
             module: moduleName,
             tier: .notify,
-            description: "Start a screen recording (60s default, 300s cap). Returns the target filePath immediately. Only one active at a time; end with screen_record_stop.",
+            description: "Start a screen recording (60s default, 300s cap). Returns the target filePath immediately. Only one active at a time; end with screen_record_stop. Optional displayIndex selects the display (display-only; no window/app/region).",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "safetyCap": .object([
                         "type": .string("integer"),
                         "description": .string("Max recording duration in seconds (default: 60, max: 300). Recording auto-stops after this.")
+                    ]),
+                    "displayIndex": .object([
+                        "type": .string("integer"),
+                        "description": .string("Display index to record (default: 0 = main). Out of range or no displays fails closed.")
                     ])
                 ]),
                 "required": .array([])
@@ -50,9 +54,13 @@ extension ScreenModule {
                 var cap: TimeInterval = 60
                 if case .int(let c) = args["safetyCap"] { cap = min(TimeInterval(c), 300) }
                 else if case .double(let c) = args["safetyCap"] { cap = min(c, 300) }
+                let displayIndex: Int? = {
+                    if case .int(let d) = args["displayIndex"] { return d }
+                    return nil
+                }()
 
                 do {
-                    let result = try await RecordingManager.shared.start(safetyCap: cap)
+                    let result = try await RecordingManager.shared.start(safetyCap: cap, displayIndex: displayIndex)
                     var response: [String: Value] = [
                         "status":          .string("recording"),
                         "filePath":        .string(result.path),
@@ -113,6 +121,7 @@ extension ScreenModule {
 private enum RecordingError: Error {
     case screenRecordingDenied
     case noDisplays
+    case displayIndexOutOfRange(Int)
     case recordingAlreadyActive
     case noActiveRecording
     case writerSetupFailed(String)
@@ -130,6 +139,11 @@ private enum RecordingError: Error {
             return .object([
                 "error":   .string("no_displays"),
                 "message": .string("No capturable displays found.")
+            ])
+        case .displayIndexOutOfRange(let index):
+            return .object([
+                "error":   .string("display_index_out_of_range"),
+                "message": .string("displayIndex \(index) is out of range or no displays are available.")
             ])
         case .recordingAlreadyActive:
             return .object([
@@ -293,7 +307,7 @@ private actor RecordingManager {
     var isRecording: Bool { recording != nil }
 
     /// Start a new screen recording. Returns (filePath, width, height).
-    func start(safetyCap: TimeInterval) async throws -> (path: String, width: Int, height: Int, isFallback: Bool) {
+    func start(safetyCap: TimeInterval, displayIndex: Int? = nil) async throws -> (path: String, width: Int, height: Int, isFallback: Bool) {
         guard recording == nil else {
             throw RecordingError.recordingAlreadyActive
         }
@@ -308,9 +322,13 @@ private actor RecordingManager {
         // the continuation and hangs forever. Route through the main-actor
         // boundary (see ScreenCaptureKitBoundary.swift).
         let content = try await SCKBoundary.fetchShareableContent()
-        guard let display = content.displays.first else {
+        guard !content.displays.isEmpty else {
             throw RecordingError.noDisplays
         }
+        guard let index = ScreenModule.resolveDisplayIndex(displayIndex, displayCount: content.displays.count) else {
+            throw RecordingError.displayIndexOutOfRange(displayIndex ?? 0)
+        }
+        let display = content.displays[index]
 
         let width = display.width
         let height = display.height

--- a/TheBridge/Modules/SettingsUIValidationHarness.swift
+++ b/TheBridge/Modules/SettingsUIValidationHarness.swift
@@ -169,6 +169,7 @@ public enum SettingsUIValidationHarness {
                     BridgeAXID.Memory.Settings.curatorMode,
                     BridgeAXID.Memory.Settings.curatorBanner,
                     BridgeAXID.Memory.Settings.ladderApple,
+                    BridgeAXID.Memory.Settings.ladderSpeechAnalyzer,
                     BridgeAXID.Memory.Settings.ladderParakeet,
                     BridgeAXID.Memory.Settings.ladderOllama,
                     BridgeAXID.Memory.Settings.cloudBaseURL,

--- a/TheBridge/Modules/ShortcutsModule.swift
+++ b/TheBridge/Modules/ShortcutsModule.swift
@@ -180,7 +180,8 @@ public enum ShortcutsModule {
                 + "Read-only enumeration — returns { count, shortcuts:[names] } (or { count, folders:[names] }).",
             inputSchema: schemaObj([
                 "folders":    boolProp("List folders instead of shortcuts (default false)."),
-                "folderName": strProp("Scope to one folder by name/identifier, or \"none\" for shortcuts not in a folder.")
+                "folderName": strProp("Scope to one folder by name/identifier, or \"none\" for shortcuts not in a folder."),
+                "showIdentifiers": boolProp("Include shortcut identifiers via --show-identifiers (default false).")
             ], required: []),
             handler: { arguments in
                 let obj = objectArgs(arguments)
@@ -191,11 +192,25 @@ public enum ShortcutsModule {
                 if case .string(let folder) = obj["folderName"], !folder.isEmpty {
                     args.append(contentsOf: ["--folder-name", folder])
                 }
+                let showIdentifiers: Bool = {
+                    if case .bool(true) = obj["showIdentifiers"] { return true }
+                    return false
+                }()
+                if showIdentifiers { args.append("--show-identifiers") }
                 do {
                     let r = try await runner.run(args)
                     if r.exitCode != 0 { return failedValue("shortcuts_list", r) }
-                    let names = parseLines(r.stdout)
                     let key = (args.contains("--folders")) ? "folders" : "shortcuts"
+                    if showIdentifiers {
+                        let items = parseIdentifiedLines(r.stdout)
+                        return .object([
+                            "ok":     .bool(true),
+                            "tool":   .string("shortcuts_list"),
+                            "count":  .int(items.count),
+                            key:      .array(items.map { .object(["name": .string($0.name), "identifier": .string($0.identifier)]) })
+                        ])
+                    }
+                    let names = parseLines(r.stdout)
                     return .object([
                         "ok":     .bool(true),
                         "tool":   .string("shortcuts_list"),
@@ -216,14 +231,18 @@ public enum ShortcutsModule {
             name: "shortcuts_run",
             module: moduleName,
             tier: .notify,
-            description: "Run an Apple Shortcut by name via `shortcuts run <name>` and capture its text output. "
+            description: "Run an Apple Shortcut by name via `shortcuts run <name>` and capture its output. "
                 + "Optional `input` is written to a temp file and passed with --input-path. "
-                + "Output is streamed to stdout (--output-path -) and returned as `output`. "
-                + "SAFETY: a Shortcut can do anything (write files, hit the network, drive apps), so this is a "
+                + "Optional `outputType` is forwarded as --output-type (UTI). Optional `outputPath` is "
+                + "--output-path; default is stdout (`-`) for text. Binary UTIs fail closed unless "
+                + "outputPath is a real file (never `-`). "
+                + "SAFETY: a Shortcut can do anything, so this is a "
                 + ".notify-tier action — never auto-executed silently. Returns { ok, output, exitCode }.",
             inputSchema: schemaObj([
                 "name":  strProp("Shortcut name or identifier to run (required)."),
-                "input": strProp("Optional text input passed to the shortcut via a temp file (--input-path).")
+                "input": strProp("Optional text input passed to the shortcut via a temp file (--input-path)."),
+                "outputType": strProp("Optional UTI for --output-type (e.g. public.plain-text, public.png)."),
+                "outputPath": strProp("Optional file path for --output-path. Default `-` (stdout). Required for binary UTIs.")
             ], required: ["name"]),
             handler: { arguments in
                 let obj = objectArgs(arguments)
@@ -250,8 +269,24 @@ public enum ShortcutsModule {
 
                 var args: [String] = ["run", name]
                 if let inputPath { args.append(contentsOf: ["--input-path", inputPath]) }
-                // `-` streams the shortcut output to stdout so we can capture it.
-                args.append(contentsOf: ["--output-path", "-"])
+                let outputType: String? = {
+                    if case .string(let t) = obj["outputType"], !t.isEmpty { return t }
+                    return nil
+                }()
+                let outputPath: String? = {
+                    if case .string(let p) = obj["outputPath"], !p.isEmpty { return p }
+                    return nil
+                }()
+                if isBinaryOutputType(outputType), outputPath == nil || outputPath == "-" {
+                    return invalidArgsValue(
+                        "shortcuts_run",
+                        "binary outputType '\(outputType ?? "")' requires outputPath (a real file, not stdout '-')")
+                }
+                if let outputType {
+                    args.append(contentsOf: ["--output-type", outputType])
+                }
+                let resolvedOutput = outputPath ?? "-"
+                args.append(contentsOf: ["--output-path", resolvedOutput])
 
                 do {
                     let r = try await runner.run(args)
@@ -261,8 +296,10 @@ public enum ShortcutsModule {
                         "tool":     .string("shortcuts_run"),
                         "name":     .string(name),
                         "exitCode": .int(Int(r.exitCode)),
-                        "output":   .string(r.stdout)
+                        "output":   .string(resolvedOutput == "-" ? r.stdout : "")
                     ]
+                    if resolvedOutput != "-" { dict["outputPath"] = .string(resolvedOutput) }
+                    if let outputType { dict["outputType"] = .string(outputType) }
                     if !r.stderr.isEmpty { dict["stderr"] = .string(r.stderr) }
                     return .object(dict)
                 } catch let e as ShortcutsError {
@@ -292,6 +329,35 @@ public enum ShortcutsModule {
         raw.split(separator: "\n", omittingEmptySubsequences: true)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+    }
+
+    /// Parse `shortcuts list --show-identifiers` lines: `Name (UUID)`.
+    public static func parseIdentifiedLines(_ raw: String) -> [(name: String, identifier: String)] {
+        parseLines(raw).map { line in
+            if let open = line.lastIndex(of: "("), line.hasSuffix(")"), open > line.startIndex {
+                let name = String(line[..<open]).trimmingCharacters(in: .whitespaces)
+                let idStart = line.index(after: open)
+                let idEnd = line.index(before: line.endIndex)
+                let identifier = String(line[idStart..<idEnd]).trimmingCharacters(in: .whitespaces)
+                if !name.isEmpty { return (name, identifier) }
+            }
+            return (line, "")
+        }
+    }
+
+    /// True when a Shortcuts `--output-type` UTI would garble stdout as binary.
+    public static func isBinaryOutputType(_ uti: String?) -> Bool {
+        guard let raw = uti?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return false
+        }
+        let uti = raw.lowercased()
+        let textPrefixes = [
+            "public.text", "public.plain-text", "public.utf8-plain-text", "public.utf16-plain-text",
+            "public.json", "public.xml", "public.html", "public.source-code", "public.yaml"
+        ]
+        if textPrefixes.contains(where: { uti == $0 || uti.hasPrefix($0 + ".") }) { return false }
+        if uti.hasPrefix("public.text") { return false }
+        return true
     }
 
     // MARK: - Envelope builders

--- a/TheBridge/Modules/VoiceMemo/MemoryHubCockpitLabels.swift
+++ b/TheBridge/Modules/VoiceMemo/MemoryHubCockpitLabels.swift
@@ -45,6 +45,7 @@ public enum MemoryHubCockpitLabels {
         guard hasTranscript else { return "No transcript" }
         switch source {
         case .apple:    return "Apple"
+        case .speechAnalyzer: return "Speech Analyzer"
         case .parakeet: return "On-device"
         case .sidecar:  return "Cached"
         case .none:     return "No transcript"

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoDiscovery.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoDiscovery.swift
@@ -6,6 +6,7 @@ import Foundation
 public enum VoiceMemoTranscriptSource: String, Sendable, Codable, Equatable {
     case sidecar
     case apple
+    case speechAnalyzer
     case parakeet
     case none
 }
@@ -106,7 +107,7 @@ public enum VoiceMemoDiscovery {
     /// environment-dependent).
     nonisolated(unsafe) public static var resolveTranscriptOverride: (@Sendable (URL) async throws -> VoiceMemoTranscriptResolution)?
 
-    /// Transcription ladder: sidecar cache → Apple tsrp → Parakeet fallback.
+    /// Transcription ladder: sidecar cache → Apple tsrp → SpeechAnalyzer (opt-in) → Parakeet.
     public static func resolveTranscript(
         for audioURL: URL,
         forceParakeet: Bool = false
@@ -128,6 +129,16 @@ public enum VoiceMemoDiscovery {
                 if !suspicious {
                     try writeTranscriptSidecar(for: audioURL, text: appleText, source: .apple)
                     return VoiceMemoTranscriptResolution(text: appleText, source: .apple)
+                }
+            }
+        }
+
+        if !forceParakeet, BridgeDefaults.voiceMemoSpeechAnalyzerTranscriptionEffective {
+            if let analyzerText = try? await VoiceMemoSpeechAnalyzer.transcribeFile(audioURL) {
+                let trimmed = analyzerText.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    try writeTranscriptSidecar(for: audioURL, text: trimmed, source: .speechAnalyzer)
+                    return VoiceMemoTranscriptResolution(text: trimmed, source: .speechAnalyzer)
                 }
             }
         }

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoModule.swift
@@ -164,7 +164,7 @@ public enum VoiceMemoModule {
             module: moduleName,
             tier: .notify,
             description: """
-            Registry-centric Voice Memos curator: discover recordings → resolve transcript (sidecar → Apple tsrp → Parakeet) → parse → route intents. \
+            Registry-centric Voice Memos curator: discover recordings → resolve transcript (sidecar → Apple tsrp → SpeechAnalyzer opt-in → Parakeet) → parse → route intents. \
             Lanes: reminder (Apple Reminders), memory_keep (Notion Memory registry entity), agent_memory (memory_remember), \
             registry_update (contact/project/packet). Skips memory_keep when the memo says not to create a memory. \
             Idempotent via processed manifest. Use dryRun:true to preview without writes.
@@ -205,7 +205,7 @@ public enum VoiceMemoModule {
                     "route a memo to reminders, memory_keep, or entity updates without storing full transcripts"
                 ],
                 whenNotToUse: [
-                    "live speech-to-text without the transcription ladder (use voice_memo_process which resolves sidecar → Apple → Parakeet)",
+                    "live speech-to-text without the transcription ladder (use voice_memo_process which resolves sidecar → Apple → SpeechAnalyzer → Parakeet)",
                     "Notion Meeting Notes AI (not API-automatable)"
                 ],
                 relatedTools: ["voice_memo_list", "voice_memo_review_list", "reminders_create", "registry_create", "registry_update", "memory_remember"]
@@ -236,11 +236,15 @@ public enum VoiceMemoModule {
             : (defaults.object(forKey: BridgeDefaults.voiceMemoParakeetTranscription) == nil
                 ? true
                 : defaults.bool(forKey: BridgeDefaults.voiceMemoParakeetTranscription))
+        let speechAnalyzerTranscription = useProductionEffectiveAccessors
+            ? BridgeDefaults.voiceMemoSpeechAnalyzerTranscriptionEffective
+            : defaults.bool(forKey: BridgeDefaults.voiceMemoSpeechAnalyzerTranscription)
 
         return .object([
             "curatorMode": .string(curatorMode.rawValue),
             "ollamaRouting": .bool(ollamaRouting),
             "appleTranscript": .bool(appleTranscript),
+            "speechAnalyzerTranscription": .bool(speechAnalyzerTranscription),
             "parakeetTranscription": .bool(parakeetTranscription),
         ])
     }
@@ -257,7 +261,7 @@ public enum VoiceMemoModule {
             name: "voice_memo_settings_get",
             module: moduleName,
             tier: .open,
-            description: "Read the effective Voice Memo curator mode and transcription/routing toggles. Returns curatorMode, ollamaRouting, appleTranscript, and parakeetTranscription.",
+            description: "Read the effective Voice Memo curator mode and transcription/routing toggles. Returns curatorMode, ollamaRouting, appleTranscript, speechAnalyzerTranscription, and parakeetTranscription.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),
@@ -297,6 +301,10 @@ public enum VoiceMemoModule {
                     "appleTranscript": .object([
                         "type": .string("boolean"),
                         "description": .string("Use Apple embedded transcript before fallback transcription."),
+                    ]),
+                    "speechAnalyzerTranscription": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Use SpeechAnalyzer between Apple tsrp and Parakeet (default false)."),
                     ]),
                     "parakeetTranscription": .object([
                         "type": .string("boolean"),
@@ -343,6 +351,7 @@ public enum VoiceMemoModule {
                 for (key, defaultsKey) in [
                     ("ollamaRouting", BridgeDefaults.voiceMemoOllamaRouting),
                     ("appleTranscript", BridgeDefaults.voiceMemoAppleTranscript),
+                    ("speechAnalyzerTranscription", BridgeDefaults.voiceMemoSpeechAnalyzerTranscription),
                     ("parakeetTranscription", BridgeDefaults.voiceMemoParakeetTranscription),
                 ] {
                     guard let value = args[key] else { continue }
@@ -518,7 +527,7 @@ public enum VoiceMemoModule {
             name: "voice_memo_transcript_refresh",
             module: moduleName,
             tier: .notify,
-            description: "Force the transcription ladder for one memo (sidecar cache → Apple tsrp → Parakeet). Use forceParakeet:true to overwrite with Parakeet.",
+            description: "Force the transcription ladder for one memo (sidecar cache → Apple tsrp → SpeechAnalyzer → Parakeet). Use forceParakeet:true to overwrite with Parakeet. Returns the resolved transcript `source`.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([

--- a/TheBridge/Modules/VoiceMemo/VoiceMemoSpeechAnalyzer.swift
+++ b/TheBridge/Modules/VoiceMemo/VoiceMemoSpeechAnalyzer.swift
@@ -1,0 +1,47 @@
+// VoiceMemoSpeechAnalyzer.swift — Apple SpeechAnalyzer (opt-in, default off)
+// TheBridge · Modules · VoiceMemo
+//
+// Sits between Apple tsrp extraction and Parakeet on the transcription ladder.
+// Does not download language assets automatically (skip when not installed).
+
+import AVFoundation
+import Foundation
+import Speech
+
+public enum VoiceMemoSpeechAnalyzer {
+
+    /// Injectable hook for tests. Returns nil when SpeechAnalyzer is unavailable.
+    public nonisolated(unsafe) static var transcribeFile: @Sendable (URL) async throws -> String? = { url in
+        try await Live.transcribe(url)
+    }
+
+    private enum Live {
+        static func transcribe(_ url: URL) async throws -> String? {
+            let transcriber = SpeechTranscriber(locale: Locale.current, preset: .transcription)
+            let status = await AssetInventory.status(forModules: [transcriber])
+            guard status == .installed else { return nil }
+
+            let audioFile = try AVAudioFile(forReading: url)
+            let analyzer = SpeechAnalyzer(modules: [transcriber])
+            let consume = Task { () -> String in
+                var parts: [String] = []
+                for try await result in transcriber.results {
+                    if result.isFinal {
+                        parts.append(String(result.text.characters))
+                    }
+                }
+                return parts.joined(separator: " ")
+            }
+            do {
+                _ = try await analyzer.analyzeSequence(from: audioFile)
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+                let text = try await consume.value
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            } catch {
+                consume.cancel()
+                return nil
+            }
+        }
+    }
+}

--- a/TheBridge/UI/BridgeShell.swift
+++ b/TheBridge/UI/BridgeShell.swift
@@ -218,6 +218,7 @@ public enum BridgeAXID {
             public static let curatorBanner = id("settings.curator.banner")
             /// Transcription ladder toggles.
             public static let ladderApple = id("settings.ladder.apple")
+            public static let ladderSpeechAnalyzer = id("settings.ladder.speechAnalyzer")
             public static let ladderParakeet = id("settings.ladder.parakeet")
             public static let ladderOllama = id("settings.ladder.ollama")
             /// Cloud enhancement card.

--- a/TheBridge/UI/Sections/MemorySettingsTab.swift
+++ b/TheBridge/UI/Sections/MemorySettingsTab.swift
@@ -24,6 +24,7 @@ public struct MemorySettingsTab: View {
     @AppStorage(BridgeDefaults.voiceMemoCuratorMode) private var curatorModeRaw: String = VoiceMemoCuratorMode.auto.rawValue
     @AppStorage(BridgeDefaults.voiceMemoOllamaRouting) private var ollamaRouting = true
     @AppStorage(BridgeDefaults.voiceMemoAppleTranscript) private var appleTranscript = true
+    @AppStorage(BridgeDefaults.voiceMemoSpeechAnalyzerTranscription) private var speechAnalyzerTranscription = false
     @AppStorage(BridgeDefaults.voiceMemoParakeetTranscription) private var parakeetTranscription = true
     @AppStorage(BridgeDefaults.memoryHandshakeAutoInject) private var globalInject = false
 
@@ -160,6 +161,7 @@ public struct MemorySettingsTab: View {
                     .foregroundStyle(BridgeTokens.fg3)
                     .fixedSize(horizontal: false, vertical: true)
                 ladderRow("Apple embedded transcript (tsrp)", isOn: $appleTranscript, axid: BridgeAXID.Memory.Settings.ladderApple)
+                ladderRow("SpeechAnalyzer (opt-in)", isOn: $speechAnalyzerTranscription, axid: BridgeAXID.Memory.Settings.ladderSpeechAnalyzer)
                 ladderRow("Parakeet fallback", isOn: $parakeetTranscription, axid: BridgeAXID.Memory.Settings.ladderParakeet)
                 ladderRow("Ollama routing + summarization", isOn: $ollamaRouting, axid: BridgeAXID.Memory.Settings.ladderOllama)
                 if let mode = VoiceMemoCuratorMode(rawValue: curatorModeRaw),

--- a/TheBridgeTests/CommandCursorInsertTests.swift
+++ b/TheBridgeTests/CommandCursorInsertTests.swift
@@ -585,4 +585,37 @@ func runCommandCursorInsertTests() async {
         try expect(cb.readString() == "user-prior-clip")
         try expect(cb.writeCount == 0)
     }
+
+    await test("prefersCommandVPaste: native AppKit false; Chromium/ChatGPT/tall web true; Cursor compact false") {
+        try expect(!CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: false, bundleIdentifier: "com.apple.TextEdit", role: "AXTextArea"))
+        try expect(CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: true, bundleIdentifier: "com.google.Chrome", role: "AXTextArea",
+            frame: CGRect(x: 0, y: 0, width: 100, height: 40)))
+        try expect(CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: true, bundleIdentifier: "com.openai.chat", role: "AXTextArea",
+            frame: CGRect(x: 0, y: 0, width: 500, height: 43)))
+        try expect(CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: true, bundleIdentifier: "com.todesktop.230313mzl4w4u92", role: "AXWebArea",
+            frame: CGRect(x: 0, y: 0, width: 400, height: 800)))
+        try expect(!CommandInsertPointerFocus.prefersCommandVPaste(
+            chromium: true, bundleIdentifier: "com.todesktop.230313mzl4w4u92", role: "AXTextArea",
+            frame: CGRect(x: 0, y: 0, width: 261, height: 24)))
+    }
+
+    await test("web paste path restores prior pasteboard contents") {
+        let name = NSPasteboard.Name("bridge.wave7.command-insert.\(UUID().uuidString)")
+        let pb = NSPasteboard(name: name)
+        pb.clearContents()
+        pb.setString("PRIOR-CLIP", forType: .string)
+        var sawBody = false
+        try CommandInsertPasteboard.withTransientString("BODY-ONLY", on: pb) {
+            try expect(pb.string(forType: .string) == "BODY-ONLY")
+            sawBody = true
+        }
+        try expect(sawBody)
+        try expect(pb.string(forType: .string) == "PRIOR-CLIP",
+                   "must restore prior pasteboard, got \(pb.string(forType: .string) ?? "nil")")
+        pb.releaseGlobally()
+    }
 }

--- a/TheBridgeTests/JobsModuleTests.swift
+++ b/TheBridgeTests/JobsModuleTests.swift
@@ -129,6 +129,11 @@ func runJobsModuleTests() async {
         }
     }
 
+    await test("LaunchAgentLifecycle: user-domain jobs are not SMAppService") {
+        try expect(!LaunchAgentLifecycle.isBundledForSMAppService(jobId: "wave7-not-bundled"))
+        try expect(LaunchAgentLifecycle.preferredRegistrationChannel(jobId: "wave7-not-bundled") == "launchagent")
+    }
+
     // --- JobStore (uses a temp SQLite file so the real DB is untouched) ---
 
     await test("JobStore: insert + fetch round-trip") {

--- a/TheBridgeTests/MemoryHubCockpitLabelsTests.swift
+++ b/TheBridgeTests/MemoryHubCockpitLabelsTests.swift
@@ -64,6 +64,7 @@ func runMemoryHubCockpitLabelsTests() async {
 
     await test("label_transcriptSource_mappings") {
         try expect(MemoryHubCockpitLabels.transcriptSource(.apple, hasTranscript: true) == "Apple", "apple")
+        try expect(MemoryHubCockpitLabels.transcriptSource(.speechAnalyzer, hasTranscript: true) == "Speech Analyzer", "speechAnalyzer")
         try expect(MemoryHubCockpitLabels.transcriptSource(.parakeet, hasTranscript: true) == "On-device", "parakeet → On-device")
         try expect(MemoryHubCockpitLabels.transcriptSource(.sidecar, hasTranscript: true) == "Cached", "sidecar → Cached")
         try expect(MemoryHubCockpitLabels.transcriptSource(.none, hasTranscript: true) == "No transcript", "none → No transcript")

--- a/TheBridgeTests/NotesModuleTests.swift
+++ b/TheBridgeTests/NotesModuleTests.swift
@@ -172,9 +172,41 @@ func runNotesModuleTests() async {
         try expect(found == true, "should be found")
         try expect(body == "plain body text", "body \(body)")
         try expect(html == "<div>plain body text</div>", "html \(html)")
+        guard case .array(let atts) = dict["attachments"] else {
+            throw TestError.assertion("expected attachments[]")
+        }
+        try expect(atts.isEmpty, "no attachment records in payload")
         // Reading by id must emit a `note id "…"` resolve clause.
         try expect(runner.lastScript.contains("note id \"id://x\""),
                    "id resolve clause missing: \(runner.lastScript)")
+        try expect(runner.lastScript.contains("attachments of theNote"),
+                   "read script must enumerate attachments")
+        try expect(runner.lastScript.contains("if attName is \"Shortcuts\""),
+                   "read script must skip Shortcuts pin wrapper")
+    }
+
+    await test("notes_read parses attachment metadata and skips empty records") {
+        let fs = NotesModule.fieldSep
+        let rs = NotesModule.recordSep
+        let payload = "id://x\(fs)My Note\(fs)Notes\(fs)body\(fs)<div>html</div>\(rs)att-1\(fs)photo.png\(fs)https://example.com/p.png\(fs)cid-1"
+        let parsed = NotesModule.parseReadPayload(payload)
+        try expect(parsed?.attachments.count == 1, "one attachment")
+        try expect(parsed?.attachments.first?.name == "photo.png")
+        try expect(parsed?.attachments.first?.url == "https://example.com/p.png")
+        try expect(parsed?.attachments.first?.contentIdentifier == "cid-1")
+        let runner = MockNotesRunner(.ok(payload))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "notes_read", arguments: .object(["noteId": .string("id://x")]))
+        guard case .object(let dict) = result,
+              case .array(let atts)? = dict["attachments"],
+              case .object(let first) = atts.first else {
+            throw TestError.assertion("expected attachments, got \(result)")
+        }
+        try expect(first["id"] == .string("att-1"))
+        try expect(first["name"] == .string("photo.png"))
+        try expect(first["url"] == .string("https://example.com/p.png"))
+        try expect(first["contentIdentifier"] == .string("cid-1"))
     }
 
     await test("notes_read by name emits case-insensitive name resolve clause") {

--- a/TheBridgeTests/ScreenModuleTests.swift
+++ b/TheBridgeTests/ScreenModuleTests.swift
@@ -213,6 +213,24 @@ func runScreenModuleTests() async {
         let tool = await router.registrations(forModule: "screen")
             .first(where: { $0.name == "screen_record_start" })!
         try expect(tool.tier == .notify, "Expected notify, got \(tool.tier.rawValue)")
+        guard case .object(let schema) = tool.inputSchema,
+              case .object(let properties)? = schema["properties"] else {
+            throw TestError.assertion("missing screen_record_start schema")
+        }
+        try expect(properties["displayIndex"] != nil, "displayIndex must be on screen_record_start")
+        try expect(properties["windowId"] == nil, "window recording is out of scope")
+        try expect(properties["appName"] == nil, "app recording is out of scope")
+        try expect(properties["region"] == nil, "region recording is out of scope")
+    }
+
+    await test("resolveDisplayIndex fails closed on empty and out-of-range") {
+        try expect(ScreenModule.resolveDisplayIndex(nil, displayCount: 0) == nil)
+        try expect(ScreenModule.resolveDisplayIndex(0, displayCount: 0) == nil)
+        try expect(ScreenModule.resolveDisplayIndex(0, displayCount: 2) == 0)
+        try expect(ScreenModule.resolveDisplayIndex(1, displayCount: 2) == 1)
+        try expect(ScreenModule.resolveDisplayIndex(2, displayCount: 2) == nil)
+        try expect(ScreenModule.resolveDisplayIndex(-1, displayCount: 2) == nil)
+        try expect(ScreenModule.resolveDisplayIndex(nil, displayCount: 2) == 0)
     }
 
     await test("screen_record_stop is notify tier") {

--- a/TheBridgeTests/ShortcutsModuleTests.swift
+++ b/TheBridgeTests/ShortcutsModuleTests.swift
@@ -247,4 +247,61 @@ func runShortcutsModuleTests() async {
         try expect(ShortcutsModule.parseLines("").isEmpty, "empty stdout → no names")
         try expect(ShortcutsModule.parseLines("\n  \n").isEmpty, "whitespace-only → no names")
     }
+
+    await test("shortcuts_list showIdentifiers:true adds --show-identifiers and objects") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(
+            exitCode: 0,
+            stdout: "Send iMessage (AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE)\n",
+            stderr: ""
+        ))
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "shortcuts_list",
+            arguments: .object(["showIdentifiers": .bool(true)])
+        )
+        try expect(runner.lastArgs == ["list", "--show-identifiers"], "argv \(runner.lastArgs)")
+        guard case .object(let dict) = result,
+              case .array(let items)? = dict["shortcuts"],
+              case .object(let first) = items.first else {
+            throw TestError.assertion("expected shortcut objects, got \(result)")
+        }
+        try expect(first["name"] == .string("Send iMessage"))
+        try expect(first["identifier"] == .string("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+    }
+
+    await test("shortcuts_run binary outputType without file path fails closed") {
+        let runner = MockShortcutsRunner()
+        let router = await makeRouter(runner)
+        let result = try await router.dispatch(
+            toolName: "shortcuts_run",
+            arguments: .object(["name": .string("Shot"), "outputType": .string("public.png")])
+        )
+        guard case .object(let dict) = result, case .string(let status) = dict["status"] else {
+            throw TestError.assertion("expected status")
+        }
+        try expect(status == "invalid_argument", "got \(status)")
+        try expect(runner.callCount == 0, "must not invoke CLI")
+        try expect(ShortcutsModule.isBinaryOutputType("public.png"))
+        try expect(!ShortcutsModule.isBinaryOutputType("public.utf8-plain-text"))
+        try expect(!ShortcutsModule.isBinaryOutputType(nil))
+    }
+
+    await test("shortcuts_run binary outputType with file outputPath reaches CLI") {
+        let runner = MockShortcutsRunner(result: ShortcutsInvocationResult(exitCode: 0, stdout: "", stderr: ""))
+        let router = await makeRouter(runner)
+        let path = "/tmp/bridge-shortcut-out.png"
+        let result = try await router.dispatch(
+            toolName: "shortcuts_run",
+            arguments: .object([
+                "name": .string("Shot"),
+                "outputType": .string("public.png"),
+                "outputPath": .string(path)
+            ])
+        )
+        guard case .object(let dict) = result else { throw TestError.assertion("expected object") }
+        try expect(runner.lastArgs == ["run", "Shot", "--output-type", "public.png", "--output-path", path],
+                   "argv \(runner.lastArgs)")
+        try expect(dict["outputPath"] == .string(path))
+        try expect(dict["output"] == .string(""))
+    }
 }

--- a/TheBridgeTests/VoiceMemoSettingsToolsTests.swift
+++ b/TheBridgeTests/VoiceMemoSettingsToolsTests.swift
@@ -49,8 +49,9 @@ func runVoiceMemoSettingsToolsTests() async {
             throw TestError.assertion("settings_set schema missing")
         }
         try expect(Set(properties.keys) == Set([
-            "curatorMode", "ollamaRouting", "appleTranscript", "parakeetTranscription",
-        ]), "settings_set must expose exactly four optional keys")
+            "curatorMode", "ollamaRouting", "appleTranscript", "speechAnalyzerTranscription",
+            "parakeetTranscription",
+        ]), "settings_set must expose five optional keys")
         let getAnnotation = ToolAnnotationCatalog.annotations(for: get.name)
         let setAnnotation = ToolAnnotationCatalog.annotations(for: set.name)
         try expect(getAnnotation?.readOnlyHint == true && getAnnotation?.idempotentHint == true,
@@ -59,7 +60,7 @@ func runVoiceMemoSettingsToolsTests() async {
                    "settings_set annotation")
     }
 
-    await test("voice_memo_settings_get returns all four effective defaults") {
+    await test("voice_memo_settings_get returns all five effective defaults") {
         fixture.reset()
         let result = try await router.dispatch(
             toolName: "voice_memo_settings_get",
@@ -70,8 +71,9 @@ func runVoiceMemoSettingsToolsTests() async {
         try expect(snapshot["curatorMode"] == .string("auto"), "default curatorMode")
         try expect(snapshot["ollamaRouting"] == .bool(false), "default ollamaRouting")
         try expect(snapshot["appleTranscript"] == .bool(true), "default appleTranscript")
+        try expect(snapshot["speechAnalyzerTranscription"] == .bool(false), "default speechAnalyzer off")
         try expect(snapshot["parakeetTranscription"] == .bool(true), "default parakeetTranscription")
-        try expect(snapshot.count == 4, "snapshot must contain exactly four values")
+        try expect(snapshot.count == 5, "snapshot must contain exactly five values")
     }
 
     await test("voice_memo_settings_set partially updates mode and preserves ladder toggles") {

--- a/scripts/test-floor-gate.sh
+++ b/scripts/test-floor-gate.sh
@@ -122,7 +122,11 @@
 # 2026-09-02: 3906 → 3912 (+6) — GitHub Wave 6: open-tier issue/PR lists
 #   (no body), parent + duplicateOf, gh_pr_review neverAutoApprove
 #   (#219 #220 #221). Measured 3912 passed, 0 failed on wave6-github.
-FLOOR="${BRIDGE_TEST_FLOOR:-3912}"
+# 2026-09-02: 3912 → 3920 (+8) — Mac/UI Wave 7: limited contacts, notes
+#   attachments, shortcut identifiers, SpeechAnalyzer opt-in off,
+#   registrationChannel, displayIndex, Cmd+V web paste (#214 #211 #213
+#   #212 #223 #224 #238). Measured 3920 passed, 0 failed on wave7-mac-ui.
+FLOOR="${BRIDGE_TEST_FLOOR:-3920}"
 
 echo "🧪 test-floor-gate: building debug test executable + running suite (floor=${FLOOR})..."
 swift build -c debug --product TheBridgeTests


### PR DESCRIPTION
## Summary
- **#214** Contacts `.limited` via existing helper; health reports `permission:"limited"`.
- **#211** `notes_read` attachment metadata.
- **#213** `shortcuts_list` `showIdentifiers`; `shortcuts_run` binary `outputPath` fail-closed if `-`/missing.
- **#212** SpeechAnalyzer opt-in default **off**; ladder sidecar → Apple tsrp → SpeechAnalyzer → Parakeet.
- **#223** `registrationChannel` `smappservice`|`launchagent`.
- **#224** `screen_record_start` `displayIndex`.
- **#238** Web/Chromium/ProseMirror/ChatGPT composers: Cmd+V paste (save pasteboard → write → Command+V → restore). Native AppKit stays AX. No unicode CGEvent on those composers.

No new MCP tools. Floor **3912 → 3920**.

## Test plan
- [x] `make test-floor` 3920 green locally
- [ ] CI `build-and-test` green
- Merge-commit only (no squash)
- UI-ITER / Mac AX for #238 after Wave 8 install
