### PR TITLE
chore(release): 4.0.7 / build 96

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 
 ## Project Overview
 
-TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.6** (build **95**). It registers **224 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **32 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
+TheBridge is a native macOS menu bar app (Swift 6.2, macOS 26+, Apple Silicon) that runs an MCP (Model Context Protocol) server. The current source version is **4.0.7** (build **96**). It registers **237 static feature-module tools** (`BridgeConstants.staticFeatureModuleToolCount`) across **32 module families** (`BridgeConstants.staticFeatureModuleFamilyCount`) over Streamable HTTP, legacy SSE, and stdio, routing every call through a security gate with an append-only audit log. Conditional tools such as `bridge_status` are outside that static count, and client listings may be filtered by enabled feature groups. The former builtin `echo` and Stripe/payment surfaces are no longer registered.
 
 Bundle ID: `kup.solutions.the-bridge` (legacy: `kup.solutions.notion-bridge`, `solutions.kup.keepr`)
 
@@ -120,7 +120,7 @@ Trunk = `origin/main`. Branches are short-lived and **rebased onto current main 
 
 ### Release flow (the v3.7.x → 3.8.x pattern)
 
-**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `4.0.9 → 4.1.0`, `4.9.9 → 5.0.0`). From the current `4.0.6`, **the next published version is `4.0.7`**. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
+**Versioning (operator rule, 2026-06-15):** each **published install (release)** bumps the marketing version **+1 patch** — NOT per branch merge; several task branches can merge to main and ship together as one install increment (bump only at release/ship-prep). Segments are **single-digit and roll at 9** — never double digits. Patch 9 → `X.(Y+1).0`; minor 9 → `(X+1).0.0` (so `4.0.9 → 4.1.0`, `4.9.9 → 5.0.0`). From the current `4.0.7`, **the next published version is `4.0.8`**. The `3.7.10`–`3.7.12` double-digit patches were pre-rule legacy. `CFBundleVersion` (build) is monotonic +1, independent of the marketing roll. Override only when Isaiah specifies.
 
 1. `git switch -c release/vX.Y.Z origin/main` (off current main).
 2. One atomic version commit: `Version.swift` (marketing + build) **and** root `Info.plist` (`CFBundleShortVersionString` + `CFBundleVersion`) in the SAME commit (see `### Version surfaces`), plus the `CHANGELOG.md` entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v4.0.7 (build 96) — issue-close install — 2026-09-02
+
+- **Identity** — Published local install after `v4.0.6` / build `95`. Marketing
+  **4.0.7**, build **96**. Sparkle tag / appcast is **not** this DoD (Workflow G
+  needs a separate GO). Do not reuse 95.
+- **Registry** — Rename follows property id; writes keyed by id; cache expiry
+  honors `lastEditedTime`; shared Notion URL-or-UUID helper (#234 #233 #232 #235).
+- **Notion REST** — View query/delete, page trash/restore, comment PATCH/DELETE,
+  async tasks, templates XOR children, meeting notes, opt-in >20MB uploads
+  (#225–#231 #236 #237). `staticFeatureModuleToolCount` **224 → 237**.
+- **Messages** — Default lists exclude tapbacks; contact XOR chatIdentifier with
+  LIKE killed; `is_read`/`date_read`; file XOR body; catalog honesty that group
+  **create is not built** (#216 #215 #217 #218 #204).
+- **Calendar / Mail / GitHub / Mac** — Time zone, recurrence+span, alarms;
+  mail headers/reply/forward/junk; gh list/parent/duplicate/review; limited
+  contacts, notes attachments, shortcut ids, SpeechAnalyzer opt-in off,
+  registrationChannel, displayIndex, Cmd+V web paste.
+- **Delivery honesty (#199)** — There is no Apple API to clear Continuity
+  “Not Delivered” on the Mac. Bridge never sets `providerDeliveryConfirmed=true`
+  from local `chat.db` correlation. See
+  `docs/operator/messages-continuity-delivery.md`.
+- **Floor** — 3920 passed / 0 failed. `FLOOR=3920`.
+
 ## v4.0.6 (build 95) — Bridge v4.1 capability truth — 2026-08-28
 
 - **Identity** — Published install after `v4.0.5` / build `94`. Marketing

--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.6</string>
+	<string>4.0.7</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>95</string>
+	<string>96</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/TheBridge/Config/Version.swift
+++ b/TheBridge/Config/Version.swift
@@ -8,8 +8,8 @@
 // VERSIONING (operator rule, 2026-06-15): +1 patch per PUBLISHED INSTALL
 // (release), NOT per branch — several task branches can merge to main and ship
 // together as one install increment. Single-digit segments roll at 9 (4.0.9→
-// 4.1.0, 4.9.9→5.0.0), never double digits. This source is 4.0.6; the next
-// published install is 4.0.7. The 3.7.10–3.7.12 releases were pre-rule legacy. Build
+// 4.1.0, 4.9.9→5.0.0), never double digits. This source is 4.0.7; the next
+// published install is 4.0.8. The 3.7.10–3.7.12 releases were pre-rule legacy. Build
 // (CFBundleVersion) monotonic +1. See AGENTS.md "Release flow" + versioning memory.
 
 import Foundation
@@ -18,7 +18,7 @@ import Foundation
 public enum AppVersion {
     /// Marketing version (CFBundleShortVersionString equivalent).
     /// Format: MAJOR.MINOR.PATCH (Semantic Versioning).
-    public static let marketing = "4.0.6"
+    public static let marketing = "4.0.7"
 
     /// Build number (CFBundleVersion equivalent).
     /// Monotonically increasing integer per release.
@@ -324,7 +324,11 @@ public enum AppVersion {
     /// v4.0.6: 94 -> 95 -- PJT-2770 capability-truth install: binding vs consumer
     /// preflight, mission revision transaction, LaunchReadiness attach. Local-only
     /// 4.0.8/97 residue is not this identity. Next published install is 4.0.7.
-    public static let build = "95"
+    /// v4.0.7: 95 -> 96 -- issue-close install: registry Wave 1, Notion REST Wave 2,
+    /// Messages Wave 3, Calendar Wave 4, Mail Wave 5, GitHub Wave 6, Mac/UI Wave 7.
+    /// staticFeatureModuleToolCount 224 → 237. Floor 3839 → 3920. Sparkle tag
+    /// is out of this install's DoD unless a later Workflow G GO.
+    public static let build = "96"
 
     /// Combined display string for UI and logs.
     public static var display: String { "\(marketing) (\(build))" }

--- a/docs/operator/messages-continuity-delivery.md
+++ b/docs/operator/messages-continuity-delivery.md
@@ -1,0 +1,34 @@
+# Messages: Mac Continuity “Not Delivered” (#199)
+
+## What Bridge can prove
+
+`messages_send` (and THREAD receipts) report **local** evidence only:
+
+- AppleScript / Messages.app accepted the send request.
+- Optional `chat.db` correlation found a matching outbound row.
+
+That correlation is **not** provider delivery. Envelopes always set
+`providerDeliveryConfirmed=false`. Bridge will never flip that flag from a
+local chat.db match, a Messages.app success dialog, or a later read of
+`is_read` / `date_read`.
+
+## What Bridge cannot do
+
+When SMS is sent from a Mac via **Continuity** (iPhone as the radio), Messages
+on the Mac can show **Not Delivered** even after the iPhone actually delivered
+the message. There is **no public Apple API** to:
+
+- clear or rewrite that Mac bubble,
+- query the iPhone’s true SMS delivery state,
+- force Continuity to refresh the Mac transcript.
+
+Closing GitHub #199 is therefore **documentation + honesty**, not a UI wipe.
+
+## Operator / agent contract
+
+- Treat `sent` / local correlation as **consequence-possible**, not delivered.
+- Do not tell the user “delivered” because chat.db has a row.
+- The Mac bubble may still lie after a successful iPhone send. That is an
+  Apple Continuity display bug, not a Bridge send failure.
+- Group **create** is a separate residual (#204): existing-group send via
+  `chatIdentifier` works; creating a new group is not built.


### PR DESCRIPTION
## Summary
- Atomic version identity: marketing **4.0.7**, build **96** (`Version.swift` + root `Info.plist` + `CHANGELOG.md`).
- Documents Continuity “Not Delivered” honesty (#199): no Apple API to clear the Mac bubble; never `providerDeliveryConfirmed=true` from chat.db.
- AGENTS.md source version/tool-count lines synced (237 tools).

`make test-floor` on `3e87ae1`: **3920 passed, 0 failed**, floor 3920.

Sparkle tag / appcast is **out of this PR**. Install-copy happens after merge to main.

## Test plan
- [x] `make test-floor` 3920 on `3e87ae1`
- [ ] CI `build-and-test` green
- Merge-commit only (no squash)
